### PR TITLE
Only reindex pages on active store

### DIFF
--- a/Model/Indexer/Page.php
+++ b/Model/Indexer/Page.php
@@ -56,7 +56,12 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
             return;
         }
 
-        $storeIds = array_keys($this->storeManager->getStores());
+        $stores = array_filter($this->storeManager->getStores(), function ($store) {
+            return $store->isActive();
+        });
+        $storeIds = array_map(function ($store) {
+            return $store->getId();
+        }, $stores);
 
         foreach ($storeIds as $storeId) {
             $this->queue->addToQueue($this->fullAction, 'rebuildStorePageIndex', ['store_id' => $storeId], 1);


### PR DESCRIPTION
Right now all pages on all stores are queued to reindex, But `\Algolia\AlgoliaSearch\Helper\Entity\BaseHelper::getStoreUrl` will result in null instead of `\Magento\Framework\Url` for inactive stores. That's why we have to queue only active stores