### PR TITLE
Only index pages on active store

### DIFF
--- a/Model/Indexer/Page.php
+++ b/Model/Indexer/Page.php
@@ -56,7 +56,12 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
             return;
         }
 
-        $storeIds = array_keys($this->storeManager->getStores());
+        $stores = array_filter($this->storeManager->getStores(), function ($store) {
+            return $store->isActive();
+        });
+        $storeIds = array_map(function ($store) {
+            return $store->getId();
+        }, $stores);
 
         foreach ($storeIds as $storeId) {
             $this->queue->addToQueue($this->fullAction, 'rebuildStorePageIndex', ['store_id' => $storeId], 1);

--- a/Model/Indexer/Page.php
+++ b/Model/Indexer/Page.php
@@ -21,14 +21,15 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
     private $configHelper;
     private $messageManager;
 
-    public function __construct(StoreManagerInterface $storeManager,
-                                PageHelper $pageHelper,
-                                Data $helper,
-                                AlgoliaHelper $algoliaHelper,
-                                Queue $queue,
-                                ConfigHelper $configHelper,
-                                ManagerInterface $messageManager)
-    {
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        PageHelper $pageHelper,
+        Data $helper,
+        AlgoliaHelper $algoliaHelper,
+        Queue $queue,
+        ConfigHelper $configHelper,
+        ManagerInterface $messageManager
+    ) {
         $this->fullAction = $helper;
         $this->storeManager = $storeManager;
         $this->pageHelper = $pageHelper;
@@ -56,12 +57,12 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
             return;
         }
 
-        $stores = array_filter($this->storeManager->getStores(), function ($store) {
-            return $store->isActive();
-        });
-        $storeIds = array_map(function ($store) {
-            return $store->getId();
-        }, $stores);
+        $storeIds = [];
+        foreach ($this->storeManager->getStores() as $store) {
+            if ($store->isActive()) {
+                $storeIds[] = $store->getId();
+            }
+        }
 
         foreach ($storeIds as $storeId) {
             $this->queue->addToQueue($this->fullAction, 'rebuildStorePageIndex', ['store_id' => $storeId], 1);


### PR DESCRIPTION
Right now all pages on all stores are queued to reindex, But `\Algolia\AlgoliaSearch\Helper\Entity\BaseHelper::getStoreUrl` will result in null instead of `\Magento\Framework\Url` for inactive stores. That's why we have to queue only active stores