### PR TITLE
Fix config helper to use ProductMetadataInterface to get the correct dependecy

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -89,7 +89,7 @@ class ConfigHelper
                                 DirCurrency $dirCurrency,
                                 DirectoryList $directoryList,
                                 Magento\Framework\Module\ResourceInterface $moduleResource,
-                                Magento\Framework\App\ProductMetadata $productMetadata)
+                                Magento\Framework\App\ProductMetadataInterface $productMetadata)
     {
         $this->objectManager = $objectManager;
         $this->configInterface = $configInterface;


### PR DESCRIPTION
If `Magento\Framework\App\ProductMetadata` used directly then the `$this->productMetadata->getEdition();` will always return `Community` (see https://github.com/magento/magento2/blob/develop/lib/internal/Magento/Framework/App/ProductMetadata.php#L24).

If `Magento\Framework\App\ProductMetadataInterface` used instead then:
- in Community Edition the object manager will return the `Magento\Framework\App\ProductMetadata` and the `getEdition` will return `Community`
- in Enterprise Edition the object manager will return the `Magento\Enterprise\Model\ProductMetadata` (because of this preference: `<preference for="Magento\Framework\App\ProductMetadataInterface" type="Magento\Enterprise\Model\ProductMetadata"/>`) and the `getEdition` method of that class will return `Enterprise`