### PR TITLE
Always process at least one queue job

### DIFF
--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -90,7 +90,7 @@ class Queue
             foreach ($data as $job) {
                 $job_size = (int) $job['data_size'];
 
-                if ($element_count + $job_size <= $max_size) {
+                if ($element_count + $job_size <= $max_size || empty($jobs)) {
                     $jobs[] = $job;
                     $element_count += $job_size;
                 } else {


### PR DESCRIPTION
Fixes the issue, when queue settings are set high, jobs are created and then put back to low. Currently it won't process any jobs and jobs are stuck in DB table.

This PR will ensure that at least one job will be processed every time queue runner runs no matter what data size of the job is.