### PR TITLE
Replace Exception by simple console output line. Fixes the issue when…

### DIFF
--- a/Model/Indexer/AdditionalSection.php
+++ b/Model/Indexer/AdditionalSection.php
@@ -8,6 +8,7 @@ use Algolia\AlgoliaSearch\Model\Queue;
 use Magento;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class AdditionalSection implements Magento\Framework\Indexer\ActionInterface, Magento\Framework\Mview\ActionInterface
 {
@@ -16,14 +17,16 @@ class AdditionalSection implements Magento\Framework\Indexer\ActionInterface, Ma
     private $queue;
     private $configHelper;
     private $messageManager;
+    private $output;
 
-    public function __construct(StoreManagerInterface $storeManager, Data $helper, Queue $queue, ConfigHelper $configHelper, ManagerInterface $messageManager)
+    public function __construct(StoreManagerInterface $storeManager, Data $helper, Queue $queue, ConfigHelper $configHelper, ManagerInterface $messageManager, ConsoleOutput $output)
     {
         $this->fullAction = $helper;
         $this->storeManager = $storeManager;
         $this->queue = $queue;
         $this->configHelper = $configHelper;
         $this->messageManager = $messageManager;
+        $this->output = $output;
     }
 
     public function execute($ids)
@@ -36,7 +39,9 @@ class AdditionalSection implements Magento\Framework\Indexer\ActionInterface, Ma
             $errorMessage = 'Algolia reindexing failed: You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
 
             if (php_sapi_name() === 'cli') {
-                throw new \Exception($errorMessage);
+                $this->output->writeln($errorMessage);
+
+                return;
             }
 
             $this->messageManager->addErrorMessage($errorMessage);

--- a/Model/Indexer/Category.php
+++ b/Model/Indexer/Category.php
@@ -10,6 +10,7 @@ use Algolia\AlgoliaSearch\Model\Queue;
 use Magento;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Category implements Magento\Framework\Indexer\ActionInterface, Magento\Framework\Mview\ActionInterface
 {
@@ -20,6 +21,7 @@ class Category implements Magento\Framework\Indexer\ActionInterface, Magento\Fra
     private $queue;
     private $configHelper;
     private $messageManager;
+    private $output;
 
     public static $affectedProductIds = [];
 
@@ -29,7 +31,8 @@ class Category implements Magento\Framework\Indexer\ActionInterface, Magento\Fra
                                 AlgoliaHelper $algoliaHelper,
                                 Queue $queue,
                                 ConfigHelper $configHelper,
-                                ManagerInterface $messageManager)
+                                ManagerInterface $messageManager,
+                                ConsoleOutput $output)
     {
         $this->fullAction = $helper;
         $this->storeManager = $storeManager;
@@ -38,6 +41,7 @@ class Category implements Magento\Framework\Indexer\ActionInterface, Magento\Fra
         $this->queue = $queue;
         $this->configHelper = $configHelper;
         $this->messageManager = $messageManager;
+        $this->output = $output;
     }
 
     public function execute($categoryIds)
@@ -46,7 +50,9 @@ class Category implements Magento\Framework\Indexer\ActionInterface, Magento\Fra
             $errorMessage = 'Algolia reindexing failed: You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
 
             if (php_sapi_name() === 'cli') {
-                throw new \Exception($errorMessage);
+                $this->output->writeln($errorMessage);
+
+                return;
             }
 
             $this->messageManager->addErrorMessage($errorMessage);

--- a/Model/Indexer/Page.php
+++ b/Model/Indexer/Page.php
@@ -10,6 +10,7 @@ use Algolia\AlgoliaSearch\Model\Queue;
 use Magento;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framework\Mview\ActionInterface
 {
@@ -20,6 +21,7 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
     private $queue;
     private $configHelper;
     private $messageManager;
+    private $output;
 
     public function __construct(
         StoreManagerInterface $storeManager,
@@ -28,7 +30,8 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
         AlgoliaHelper $algoliaHelper,
         Queue $queue,
         ConfigHelper $configHelper,
-        ManagerInterface $messageManager
+        ManagerInterface $messageManager,
+        ConsoleOutput $output
     ) {
         $this->fullAction = $helper;
         $this->storeManager = $storeManager;
@@ -37,6 +40,7 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
         $this->queue = $queue;
         $this->configHelper = $configHelper;
         $this->messageManager = $messageManager;
+        $this->output = $output;
     }
 
     public function execute($ids)
@@ -49,7 +53,9 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
             $errorMessage = 'Algolia reindexing failed: You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
 
             if (php_sapi_name() === 'cli') {
-                throw new \Exception($errorMessage);
+                $this->output->writeln($errorMessage);
+
+                return;
             }
 
             $this->messageManager->addErrorMessage($errorMessage);

--- a/Model/Indexer/Product.php
+++ b/Model/Indexer/Product.php
@@ -10,6 +10,7 @@ use Algolia\AlgoliaSearch\Model\Queue;
 use Magento;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Framework\Mview\ActionInterface
 {
@@ -20,15 +21,18 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
     private $configHelper;
     private $queue;
     private $messageManager;
+    private $output;
 
-    public function __construct(StoreManagerInterface $storeManager,
-                                ProductHelper $productHelper,
-                                Data $helper,
-                                AlgoliaHelper $algoliaHelper,
-                                ConfigHelper $configHelper,
-                                Queue $queue,
-                                ManagerInterface $messageManager)
-    {
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        ProductHelper $productHelper,
+        Data $helper,
+        AlgoliaHelper $algoliaHelper,
+        ConfigHelper $configHelper,
+        Queue $queue,
+        ManagerInterface $messageManager,
+        ConsoleOutput $output
+    ) {
         $this->fullAction = $helper;
         $this->storeManager = $storeManager;
         $this->productHelper = $productHelper;
@@ -36,6 +40,7 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
         $this->configHelper = $configHelper;
         $this->queue = $queue;
         $this->messageManager = $messageManager;
+        $this->output = $output;
     }
 
     public function execute($productIds)
@@ -44,10 +49,12 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
             $errorMessage = 'Algolia reindexing failed: You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
 
             if (php_sapi_name() === 'cli') {
-                throw new \Exception($errorMessage);
+                $this->output->writeln($errorMessage);
+
+                return;
             }
 
-            $this->messageManager->addErrorMessage($errorMessage);
+            $this->messageManager->addWarning($errorMessage);
 
             return;
         }

--- a/Model/Indexer/QueueRunner.php
+++ b/Model/Indexer/QueueRunner.php
@@ -10,18 +10,21 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Model\Queue;
 use Magento;
 use Magento\Framework\Message\ManagerInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class QueueRunner implements Magento\Framework\Indexer\ActionInterface, Magento\Framework\Mview\ActionInterface
 {
     private $configHelper;
     private $queue;
     private $messageManager;
+    private $output;
 
-    public function __construct(ConfigHelper $configHelper, Queue $queue, ManagerInterface $messageManager)
+    public function __construct(ConfigHelper $configHelper, Queue $queue, ManagerInterface $messageManager, ConsoleOutput $output)
     {
         $this->configHelper = $configHelper;
         $this->queue = $queue;
         $this->messageManager = $messageManager;
+        $this->output = $output;
     }
 
     public function execute($ids)
@@ -34,7 +37,9 @@ class QueueRunner implements Magento\Framework\Indexer\ActionInterface, Magento\
             $errorMessage = 'Algolia reindexing failed: You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
 
             if (php_sapi_name() === 'cli') {
-                throw new \Exception($errorMessage);
+                $this->output->writeln($errorMessage);
+
+                return;
             }
 
             $this->messageManager->addErrorMessage($errorMessage);

--- a/Model/Indexer/Suggestion.php
+++ b/Model/Indexer/Suggestion.php
@@ -10,6 +10,7 @@ use Algolia\AlgoliaSearch\Model\Queue;
 use Magento;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Suggestion implements Magento\Framework\Indexer\ActionInterface, Magento\Framework\Mview\ActionInterface
 {
@@ -20,15 +21,18 @@ class Suggestion implements Magento\Framework\Indexer\ActionInterface, Magento\F
     private $queue;
     private $configHelper;
     private $messageManager;
+    private $output;
 
-    public function __construct(StoreManagerInterface $storeManager,
-                                SuggestionHelper $suggestionHelper,
-                                Data $helper,
-                                AlgoliaHelper $algoliaHelper,
-                                Queue $queue,
-                                ConfigHelper $configHelper,
-                                ManagerInterface $messageManager)
-    {
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        SuggestionHelper $suggestionHelper,
+        Data $helper,
+        AlgoliaHelper $algoliaHelper,
+        Queue $queue,
+        ConfigHelper $configHelper,
+        ManagerInterface $messageManager,
+        ConsoleOutput $output
+    ) {
         $this->fullAction = $helper;
         $this->storeManager = $storeManager;
         $this->suggestionHelper = $suggestionHelper;
@@ -36,6 +40,7 @@ class Suggestion implements Magento\Framework\Indexer\ActionInterface, Magento\F
         $this->queue = $queue;
         $this->configHelper = $configHelper;
         $this->messageManager = $messageManager;
+        $this->output = $output;
     }
 
     public function execute($ids)
@@ -48,7 +53,9 @@ class Suggestion implements Magento\Framework\Indexer\ActionInterface, Magento\F
             $errorMessage = 'Algolia reindexing failed: You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
 
             if (php_sapi_name() === 'cli') {
-                throw new \Exception($errorMessage);
+                $this->output->writeln($errorMessage);
+
+                return;
             }
 
             $this->messageManager->addErrorMessage($errorMessage);


### PR DESCRIPTION
… Magento installation failed when Algolia extension was already added to Magento.

Fixes #146