### PR TITLE
When customer groups are enabled, send missing replicas and indexers for non-price sort attributes

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -282,6 +282,8 @@ class ProductHelper extends BaseHelper
                             $this->algoliaHelper->setSettings($this->getIndexName($storeId) . '_' . $values['attribute'] . '_' . $suffix_index_name . '_' . $values['sort'], $mergeSettings);
                         }
                     } else {
+                        $mergeSettings['ranking'] = [$values['sort'] . '(' . $values['attribute'] . ')', 'typo', 'geo', 'words', 'proximity', 'attribute', 'exact', 'custom'];
+
                         $this->algoliaHelper->setSettings($this->getIndexName($storeId) . '_' . $values['attribute'] . '_' . $values['sort'], $mergeSettings);
                     }
                 } else {

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -251,6 +251,8 @@ class ProductHelper extends BaseHelper
 
                             $replicas[] = $this->getIndexName($storeId) . '_' . $values['attribute'] . '_' . $suffix_index_name . '_' . $values['sort'];
                         }
+                    } else {
+                        $replicas[] = $this->getIndexName($storeId) . '_' . $values['attribute'] . '_' . $values['sort'];
                     }
                 } else {
                     if ($values['attribute'] === 'price') {
@@ -279,6 +281,8 @@ class ProductHelper extends BaseHelper
 
                             $this->algoliaHelper->setSettings($this->getIndexName($storeId) . '_' . $values['attribute'] . '_' . $suffix_index_name . '_' . $values['sort'], $mergeSettings);
                         }
+                    } else {
+                        $this->algoliaHelper->setSettings($this->getIndexName($storeId) . '_' . $values['attribute'] . '_' . $values['sort'], $mergeSettings);
                     }
                 } else {
                     $sort_attribute = strpos($values['attribute'], 'price') !== false ? $values['attribute'] . '.' . $currencies[0] . '.' . 'default' : $values['attribute'];


### PR DESCRIPTION
When I enable customer groups, sorting doesn't work for all sort attributes other then price. If I delete all indexes in Algolia and reindex Magento, I see that indexes for them are even not created. This is because of missing 'else' cases.