### PR TITLE
Fix responsive style for wider screens

### DIFF
--- a/view/frontend/web/internals/algoliasearch.css
+++ b/view/frontend/web/internals/algoliasearch.css
@@ -481,13 +481,11 @@ a.ais-current-refined-values--link:hover
 
 .col9 {
   float: right;
-  min-width: 100%;
   box-sizing: border-box;
 }
 
 .col3 {
   float: right;
-  min-width: 100%;
   box-sizing: border-box;
 }
 
@@ -502,7 +500,7 @@ a.ais-current-refined-values--link:hover
 	display: flex;
 	height: 100%;
 	flex: 1;
-	
+
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
The fix was very small in the end. Width for `.col9` and `.col3` is already defined and the lines just below override the default style for mobile (see `#algolia-autocomplete-container.reverse`).

Relates to #215