### PR TITLE
Fix Critical errors: Broken reference

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Algolia_AlgoliaSearch" setup_version="1.0.10">
+        <sequence>
+            <module name="Magento_Theme"/>
+        </sequence>
     </module>
 </config>


### PR DESCRIPTION
This fix solve problem with multiple critical errors in support_report.log

```
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.beforecontent' element cannot be added as child to 'main.content', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.autocomplete.product' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.autocomplete.category' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.autocomplete.page' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.autocomplete.attribute' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.autocomplete.suggestion' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.autocomplete.menu' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.instant.wrapper' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.instant.hit' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.instant.stats' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.instant.facet' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.instant.refinements' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.instant.labels' element cannot be added as child to 'footer', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.internals.configuration.formatprice' element cannot be added as child to 'head.additional', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.internals.configuration.swatches' element cannot be added as child to 'head.additional', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.instant.attributes' element cannot be added as child to 'footer', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.internals.custom' element cannot be added as child to 'head.additional', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.instant.page' element cannot be added as child to 'before.body.end', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'top.search' element cannot be added as child to 'header-wrapper', because the latter doesn't exist [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: the 'algolia.beforecontent' tries to reorder itself towards '', but their parents are different: 'main.content' and '' respectively. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
[2017-04-26 09:53:45] report.CRITICAL: Broken reference: No element found with ID 'before.body.end'. [] []
```
