### PR TITLE
Fix thumbnail URL when using /pub/ dir as the root dir

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -66,6 +66,7 @@ class ConfigHelper
     const REMOVE_IF_NO_RESULT = 'algoliasearch_advanced/advanced/remove_words_if_no_result';
     const PARTIAL_UPDATES = 'algoliasearch_advanced/advanced/partial_update';
     const CUSTOMER_GROUPS_ENABLE = 'algoliasearch_advanced/advanced/customer_groups_enable';
+    const REMOVE_PUB_DIR_IN_URL = 'algoliasearch_advanced/advanced/remove_pub_dir_in_url';
     const MAKE_SEO_REQUEST = 'algoliasearch_advanced/advanced/make_seo_request';
     const REMOVE_BRANDING = 'algoliasearch_advanced/advanced/remove_branding';
     const AUTOCOMPLETE_SELECTOR = 'algoliasearch_advanced/advanced/autocomplete_selector';
@@ -235,6 +236,11 @@ class ConfigHelper
     public function isCustomerGroupsEnabled($storeId = null)
     {
         return $this->configInterface->isSetFlag(self::CUSTOMER_GROUPS_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function shouldRemovePubDirectory($storeId = null)
+    {
+        return $this->configInterface->isSetFlag(self::REMOVE_PUB_DIR_IN_URL, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     public function isPartialUpdateEnabled($storeId = null)

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -624,37 +624,7 @@ class ProductHelper extends BaseHelper
 
         $customData['categories_without_path'] = $categories;
 
-        /** @var Image $imageHelper */
-        $imageHelper = $this->objectManager->create('Algolia\AlgoliaSearch\Helper\Image');
-
-        if (false === isset($defaultData['thumbnail_url'])) {
-            $thumb = $imageHelper->init($product, 'thumbnail')->resize(75, 75);
-
-            $customData['thumbnail_url'] = $thumb->getUrl();
-        }
-
-        if (false === isset($defaultData['image_url'])) {
-            $image = $imageHelper->init($product, $this->config->getImageType())->resize($this->config->getImageWidth(), $this->config->getImageHeight());
-
-            $customData['image_url'] = $image->getUrl();
-
-            if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
-                $product->load('media_gallery');
-
-                $customData['media_gallery'] = [];
-
-                $images = $product->getMediaGalleryImages();
-                if ($images) {
-                    foreach ($images as $image) {
-                        $url = $image->getUrl();
-                        $url = $imageHelper->removeProtocol($url);
-                        $url = $imageHelper->removeDoubleSlashes($url);
-
-                        $customData['media_gallery'][] = $url;
-                    }
-                }
-            }
-        }
+        $customData = $this->addImageData($customData, $product, $additionalAttributes);
 
         $sub_products = [];
         $ids = null;
@@ -795,6 +765,43 @@ class ProductHelper extends BaseHelper
         $this->castProductObject($customData);
 
         $this->logger->stop('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($product->getStoreId()));
+
+        return $customData;
+    }
+
+    protected function addImageData(array $customData, $product, $additionalAttributes)
+    {
+        /** @var Image $imageHelper */
+        $imageHelper = $this->objectManager->create('Algolia\AlgoliaSearch\Helper\Image');
+
+        if (false === isset($defaultData['thumbnail_url'])) {
+            $thumb = $imageHelper->init($product, 'thumbnail')->resize(75, 75);
+
+            $customData['thumbnail_url'] = $thumb->getUrl();
+        }
+
+        if (false === isset($defaultData['image_url'])) {
+            $image = $imageHelper->init($product, $this->config->getImageType())->resize($this->config->getImageWidth(), $this->config->getImageHeight());
+
+            $customData['image_url'] = $image->getUrl();
+
+            if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
+                $product->load('media_gallery');
+
+                $customData['media_gallery'] = [];
+
+                $images = $product->getMediaGalleryImages();
+                if ($images) {
+                    foreach ($images as $image) {
+                        $url = $image->getUrl();
+                        $url = $imageHelper->removeProtocol($url);
+                        $url = $imageHelper->removeDoubleSlashes($url);
+
+                        $customData['media_gallery'][] = $url;
+                    }
+                }
+            }
+        }
 
         return $customData;
     }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -775,15 +775,18 @@ class ProductHelper extends BaseHelper
         $imageHelper = $this->objectManager->create('Algolia\AlgoliaSearch\Helper\Image');
 
         if (false === isset($defaultData['thumbnail_url'])) {
-            $thumb = $imageHelper->init($product, 'thumbnail')->resize(75, 75);
-
-            $customData['thumbnail_url'] = $thumb->getUrl();
+            $customData['thumbnail_url'] = $imageHelper
+                ->init($product, 'thumbnail')
+                ->resize(75, 75)
+                ->getUrl();
         }
 
         if (false === isset($defaultData['image_url'])) {
-            $image = $imageHelper->init($product, $this->config->getImageType())->resize($this->config->getImageWidth(), $this->config->getImageHeight());
+            $imageHelper
+                ->init($product, $this->config->getImageType())
+                ->resize($this->config->getImageWidth(), $this->config->getImageHeight());
 
-            $customData['image_url'] = $image->getUrl();
+            $customData['image_url'] = $imageHelper->getUrl();
 
             if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
                 $product->load('media_gallery');

--- a/Helper/Image.php
+++ b/Helper/Image.php
@@ -5,15 +5,21 @@ namespace Algolia\AlgoliaSearch\Helper;
 class Image extends \Magento\Catalog\Helper\Image
 {
     protected $logger;
+    protected $options;
 
     public function __construct(\Magento\Framework\App\Helper\Context $context,
                                 \Magento\Catalog\Model\Product\ImageFactory $productImageFactory,
                                 \Magento\Framework\View\Asset\Repository $assetRepo,
                                 \Magento\Framework\View\ConfigInterface $viewConfig,
-                                Logger $logger)
-    {
+                                Logger $logger,
+                                $options = []
+    ) {
         parent::__construct($context, $productImageFactory, $assetRepo, $viewConfig);
         $this->logger = $logger;
+
+        $this->options = array_merge([
+            'shouldRemovePubDir' => false
+        ], $options);
     }
 
     public function getUrl()
@@ -31,6 +37,10 @@ class Image extends \Magento\Catalog\Helper\Image
 
         $url = $this->removeProtocol($url);
         $url = $this->removeDoubleSlashes($url);
+
+        if ($this->options['shouldRemovePubDir']) {
+            $url = $this->removePubDirectory($url);
+        }
 
         return $url;
     }
@@ -61,5 +71,10 @@ class Image extends \Magento\Catalog\Helper\Image
         $url = '/'.$url;
 
         return $url;
+    }
+
+    public function removePubDirectory($url)
+    {
+        return str_replace('/pub/', '/', $url);;
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -534,6 +534,15 @@
                         ]]>
                     </comment>
                 </field>
+                <field id="remove_pub_dir_in_url" translate="label comment" type="select" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Remove /pub/ from image URLs</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                            If enabled, path like example.com/pub/media/image.jpg will become example.com/media/image.jpg. Activate this if your server is set to use the pub/ directory as root directory.
+                        ]]>
+                    </comment>
+                </field>
                 <field id="make_seo_request" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Make SEO request</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>


### PR DESCRIPTION
Fix #214

The problem occurs when you set the `/pub` directory as the server root directory. Because Algolia indexer runs in command line there is no way to know if the server serve request from `index.php` or `pub/index.php`.

The best way to set your server to ignore `/pub/` in URLs but for all the user that can change their server configuration, they can turn on this option. Full reindex is required after this option is modified.

![configuration___settings___stores___magento_admin](https://cloud.githubusercontent.com/assets/1525636/26367184/0bb26444-3fee-11e7-8e9a-42a6a1b62f80.png)


Added FAQ entry here: https://github.com/algolia/magento/pull/49