### PR TITLE
Fix configurable price that breaks special price

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -398,7 +398,7 @@ class ProductHelper extends BaseHelper
 
                 $specialPrices = [];
                 $specialPrices[] = (double) $this->rule->getRulePrice(new \DateTime(), $store->getWebsiteId(), 0, $product->getId()); // The price with applied catalog rules
-                $specialPrices[] = (double) $product->getFinalPrice(); // The product's special price
+                $specialPrices[] = (double) $product->getPriceInfo()->getPrice('final_price')->getValue(); // The product's special price
 
                 $specialPrices = array_filter($specialPrices, function($price) {
                     return $price > 0;

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -386,7 +386,7 @@ class ProductHelper extends BaseHelper
             foreach ($currencies as $currencyCode) {
                 $customData[$field][$currencyCode] = [];
 
-                $price = $product->getPrice();
+                $price = $product->getPriceInfo()->getPrice('regular_price')->getValue();
                 if ($currencyCode !== $baseCurrencyCode) {
                     $price = $this->priceCurrency->convert($price, $store, $currencyCode);
                 }


### PR DESCRIPTION
For configurable product, $product->getPrice() returns 0, and so any special prices are not added because of the check
```$specialPrice < $customData[$field][$currencyCode]['default']```

Further in the code configurable price falls back to $min price
```
if ($customData[$field][$currencyCode]['default'] == 0) {
    $customData[$field][$currencyCode]['default'] = $min;
```
but special price is already missed. It looks like more relevant approach is to use priceInfo structure.

Please review. Looking forward to your comments,
Roman