### PR TITLE
Prevent infinite recursion when EMPTY_QUEUE=1

### DIFF
--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -93,6 +93,10 @@ class Queue
 
         $jobs = $this->getJobs($maxJobs, $pid);
 
+        if (empty($jobs)) {
+            return;
+        }
+
         // Run all reserved jobs
         foreach ($jobs as $job) {
             try {


### PR DESCRIPTION
When the full queue is being processed, this function recurses after
handling a set of jobs - so we need to quit when we run out of jobs to
process.

This resolves GH-285

For comparison, the M1 module implements this as: https://github.com/algolia/algoliasearch-magento/blame/a0200a39403dd13e0f4820e325e772f985bcccbc/app/code/community/Algolia/Algoliasearch/Model/Queue.php#L77-L79