### PR TITLE
Do not call API on non product page

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -56,6 +56,16 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 			urlSync: {
 				useHash: true,
 				trackedParameters: ['query', 'page', 'attribute:*', 'index']
+			},
+			searchFunction: function(helper) {
+				if (helper.state.query === '' && !algoliaConfig.isSearchPage) {
+					$('.algolia-instant-replaced-content').show();
+					$('.algolia-instant-selector-results').hide();
+				} else {
+					helper.search();
+					$('.algolia-instant-replaced-content').hide();
+					$('.algolia-instant-selector-results').show();
+				}
 			}
 		};
 		


### PR DESCRIPTION
Fix #288 

Today, with Instant Search activated,  Algolia is called and the DOM is updated on every page. This PR will only call algolia if you type something is the search bar or if you're on a result page (like category).

It could be nice to add some tests but I haven't really figured out how.