### PR TITLE
Move Algolia config menu tab

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../Magento/Config/etc/system_file.xsd">
     <system>
-        <tab id="algolia" translate="label" sortOrder="10">
+        <tab id="algolia" translate="label" sortOrder="100001">
             <label>
                 <![CDATA[
                     Algolia Search


### PR DESCRIPTION
Move Algolia config menu tab from sortOrder="10" (before General config) after Services tab. Adding new menu entries before the General config is not considered as best practise in Magento.