### PR TITLE
Customer group id fix

### DIFF
--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -5,7 +5,6 @@ namespace Algolia\AlgoliaSearch\Block;
 use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
-use Magento\Customer\Model\Session;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\Data\Form\FormKey;
 use Magento\Framework\Locale\Currency;
@@ -13,13 +12,13 @@ use Magento\Framework\Registry;
 use Magento\Framework\Url\Helper\Data;
 use Magento\Framework\View\Element\Template;
 use Magento\Search\Helper\Data as CatalogSearchHelper;
-use Magento\Customer\Model\GroupManagement;
+use Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Customer\Model\Context as CustomerContext;
 
 class Algolia extends Template implements \Magento\Framework\Data\CollectionDataSourceInterface
 {
     protected $config;
     protected $catalogSearchHelper;
-    protected $customerSession;
     protected $storeManager;
     protected $objectManager;
     protected $registry;
@@ -28,6 +27,7 @@ class Algolia extends Template implements \Magento\Framework\Data\CollectionData
     protected $algoliaHelper;
     protected $urlHelper;
     protected $formKey;
+    protected $httpContext;
 
     protected $priceKey;
 
@@ -35,24 +35,24 @@ class Algolia extends Template implements \Magento\Framework\Data\CollectionData
         Template\Context $context,
         ConfigHelper $config,
         CatalogSearchHelper $catalogSearchHelper,
-        Session $customerSession,
         ProductHelper $productHelper,
         Currency $currency,
         Registry $registry,
         AlgoliaHelper $algoliaHelper,
         Data $urlHelper,
         FormKey $formKey,
+        HttpContext $httpContext,
         array $data = []
     ) {
         $this->config = $config;
         $this->catalogSearchHelper = $catalogSearchHelper;
-        $this->customerSession = $customerSession;
         $this->productHelper = $productHelper;
         $this->currency = $currency;
         $this->registry = $registry;
         $this->algoliaHelper = $algoliaHelper;
         $this->urlHelper = $urlHelper;
         $this->formKey = $formKey;
+        $this->httpContext = $httpContext;
 
         parent::__construct($context, $data);
     }
@@ -88,7 +88,7 @@ class Algolia extends Template implements \Magento\Framework\Data\CollectionData
 
     public function getGroupId()
     {
-        return $this->customerSession->isLoggedIn() ? $this->customerSession->getCustomer()->getGroupId() : GroupManagement::NOT_LOGGED_IN_ID;
+        return $this->httpContext->getValue(CustomerContext::CONTEXT_GROUP);
     }
 
     public function getPriceKey()

--- a/Block/Instant/Hit.php
+++ b/Block/Instant/Hit.php
@@ -3,23 +3,24 @@
 namespace Algolia\AlgoliaSearch\Block\Instant;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Magento\Customer\Model\Session;
 use Magento\Framework\View\Element\Template;
+use Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Customer\Model\Context as CustomerContext;
 
 class Hit extends Template
 {
     protected $config;
-    protected $customerSession;
     protected $priceKey;
+    protected $httpContext;
 
     public function __construct(
         Template\Context $context,
         ConfigHelper $config,
-        Session $customerSession,
+        HttpContext $httpContext,
         array $data = []
     ) {
         $this->config = $config;
-        $this->customerSession = $customerSession;
+        $this->httpContext = $httpContext;
 
         parent::__construct($context, $data);
     }
@@ -27,11 +28,16 @@ class Hit extends Template
     public function getPriceKey()
     {
         if ($this->priceKey === null) {
-            $groupId = $this->customerSession->getCustomer()->getGroupId();
+            $groupId = $this->getGroupId();
             $currencyCode = $this->_storeManager->getStore()->getCurrentCurrencyCode();
             $this->priceKey = $this->config->isCustomerGroupsEnabled($this->_storeManager->getStore()->getStoreId()) ? '.' . $currencyCode . '.group_' . $groupId : '.' . $currencyCode . '.default';
         }
 
         return $this->priceKey;
+    }
+
+    public function getGroupId()
+    {
+        return $this->httpContext->getValue(CustomerContext::CONTEXT_GROUP);
     }
 }


### PR DESCRIPTION
In order to avoid cache issues it's better to use `Magento\Customer\Model\Context` instead `Magento\Customer\Model\Session` to get customer group id