### PR TITLE
Fix error when in_stock comes from $defaultData

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -788,7 +788,7 @@ class ProductHelper extends BaseHelper
                             $customData[$attribute['attribute']] = array_values(array_unique($values));
                         }
 
-                        if ($customData['in_stock'] && $all_sub_products_out_of_stock) {
+                        if (isset($customData['in_stock']) && $customData['in_stock'] && $all_sub_products_out_of_stock) {
                             // Set main product out of stock if all
                             // sub-products is out of stock.
                             $customData['in_stock'] = 0;


### PR DESCRIPTION
Reproduce:
Observer for `algolia_product_index_before`:
```
public function execute(\Magento\Framework\Event\Observer $observer)
    {
        /** @var \Magento\Catalog\Model\Product $product */
        $product = $observer->getProduct();
        $data = $observer->getCustomData();
        $data->setData('in_stock', 1);
        $observer->setCustomData($data);
    }
```