### PR TITLE
Make sure to delete product in Algolia when it goes out of stock

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -174,10 +174,6 @@ class ProductHelper extends BaseHelper
             $products = $products->addAttributeToFilter('visibility', ['in' => $this->visibility->getVisibleInSiteIds()]);
         }
 
-        if ($this->config->getShowOutOfStock($storeId) === false) {
-            $this->stock->addInStockFilterToCollection($products);
-        }
-
         /* @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
         $products = $products->addFinalPrice()
             ->addAttributeToSelect('special_price')


### PR DESCRIPTION
Hi again,

I noticed that when product goes out of stock, it's doesn't get updated in Algolia.
Deleting out of stock is handled in \Algolia\AlgoliaSearch\Helper\Data::getProductsRecords , but that code doesn't get executed because we filter such products prematurely.

Please review :)
Thanks