### PR TITLE
Subscribe to stock item change and reindex product

### DIFF
--- a/Model/Indexer/StockItemObserver.php
+++ b/Model/Indexer/StockItemObserver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Indexer;
+
+use Magento\Framework\Indexer\IndexerRegistry;
+
+class StockItemObserver
+{
+    private $indexer;
+
+    public function __construct(IndexerRegistry $indexerRegistry)
+    {
+        $this->indexer = $indexerRegistry->get('algolia_products');
+    }
+
+    public function aroundSave(
+        \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $stockItemModel,
+        \Closure $proceed,
+        \Magento\CatalogInventory\Api\Data\StockItemInterface $stockItem
+    ) {
+        $stockItemModel->addCommitCallback(function () use ($stockItem) {
+            if (!$this->indexer->isScheduled()) {
+                $this->indexer->reindexRow($stockItem->getProductId());
+            }
+        });
+
+        return $proceed($stockItem);
+    }
+
+    public function aroundDelete(
+        \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $stockItemResource,
+        \Closure $proceed,
+        \Magento\CatalogInventory\Api\Data\StockItemInterface $stockItem
+    ) {
+        $stockItemResource->addCommitCallback(function () use ($stockItem) {
+            if (!$this->indexer->isScheduled()) {
+                $this->indexer->reindexRow($stockItem->getProductId());
+            }
+        });
+
+        return $proceed($stockItem);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -6,6 +6,9 @@
     <type name="Magento\Catalog\Model\Product\Action">
         <plugin name="algoliaProductsMassAction" type="Algolia\AlgoliaSearch\Model\Indexer\ProductObserver"/>
     </type>
+    <type name="Magento\CatalogInventory\Model\ResourceModel\Stock\Item">
+        <plugin name="algoliaProducts" type="Algolia\AlgoliaSearch\Model\Indexer\StockItemObserver"/>
+    </type>
 
     <type name="Magento\Catalog\Model\ResourceModel\Category">
         <plugin name="algoliaCategories" type="Algolia\AlgoliaSearch\Model\Indexer\CategoryObserver"/>

--- a/etc/mview.xml
+++ b/etc/mview.xml
@@ -34,6 +34,7 @@
             <table name="catalog_product_entity_varchar" entity_column="entity_id" />
             <table name="catalog_product_website" entity_column="product_id" />
             <table name="catalog_category_product" entity_column="product_id" />
+            <table name="cataloginventory_stock_item" entity_column="product_id" />
         </subscriptions>
     </view>
 </config>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

When customers purchase last product item in inventory on frontend, the product becomes out of stock. However, Algolia fails to see this change and doesn't reindex.

My suggestion is to subscribe to stock_item change (both on save and by schedule). This seems to remedy situation.

The only drawback seems to be that sometimes product might reindex twice, after saving product and then after saving stock item. But this should be the case only when algolia index is in save mode and queue mode is disabled. Otherwise duplicate product IDs should be skipped.

Please review :)