### PR TITLE
Make product thumbnail configurable

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -570,8 +570,7 @@ class ProductHelper
     {
         if (false === isset($customData['thumbnail_url'])) {
             $customData['thumbnail_url'] = $this->imageHelper
-                ->init($product, 'thumbnail')
-                ->resize(75, 75)
+                ->init($product, 'product_thumbnail_image')
                 ->getUrl();
         }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

As it is now the product thumbnail image is hardcoded to 75x75 so if you want to display larger images on the autocomplete list the only choice is to use CSS but this will make images look blurry.

It would make sense to use the `product_thumbnail_image` image size here instead which is already 75x75 by default and, if anyone needs a different custom size, it can be overwritten using the `etc/view.xml` file.

**Result**

Notice image quality is increased after the image size change.

| Before | After |
| --- | --- |
| <img width="529" alt="screen shot 2018-03-22 at 10 42 18" src="https://user-images.githubusercontent.com/661330/37766071-c3f16362-2dbd-11e8-887b-5ad2a1739b6b.png"> | <img width="526" alt="screen shot 2018-03-22 at 10 40 28" src="https://user-images.githubusercontent.com/661330/37765960-887cee32-2dbd-11e8-9bd8-de6b2f14becd.png"> |