### PR TITLE
Resolves issue stemming from skipping too big record attempting to ca…

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -357,6 +357,7 @@ class AlgoliaHelper extends AbstractHelper
                     - ID '.$previousObject['objectID'].' - skipped - longest attribute: '.$longestAttribute;
 
                 unset($objects[$key]);
+                continue;
             } elseif ($previousObject !== $object) {
                 $modifiedIds[] = $indexName.' - ID '.$previousObject['objectID'].' - truncated';
             }


### PR DESCRIPTION
…st false rather than skipping/continuing.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

We've noticed that during reindexing when you skip records which are too big you set `$object` to `false` but then attempt to cast the `$object` which will `foreach (false...` which obviously throws an exception and prevents an entire batch from indexing.

**Result**

I'd hope the result should be clear from the basic code change, but this will skip casting of a record which isn't going to be indexed anyways.