### PR TITLE
  Fix configurable product children attributes indexing

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -678,7 +678,7 @@ class ProductHelper
                 /** @var string|array $valueText */
                 $valueText = $subProduct->getAttributeText($attribute['attribute']);
 
-                $values = $this->getValues($valueText, $subProduct, $attributeResource);
+                $values = array_merge($values, $this->getValues($valueText, $subProduct, $attributeResource));
                 $subProductImages = $this->addSubProductImage($subProductImages, $attribute, $subProduct, $valueText);
             }
         }


### PR DESCRIPTION
**Summary**
For configurable product with sub-products, index should contain an array of attribute values, taken from sub-products, for example, color: ['Red', 'Blue', 'Yellow'], size: ['L', 'XL'], but only one attribute value was present in index color: ['Red']  size: ['L'].
As a result, instant search page facets worked incorrectly.
That happened because $values variable in ProductHelper:addNullValue was overwritten on each foreach iteration of sub-products.
I used array_merge to solve that (getValues returns array with numeric keys, that's why array_merge is OK).

**Result**
Product index for configurable product works as intended.
