### PR TITLE
Feat/conversion analytics

### DIFF
--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -147,6 +147,12 @@ class Algolia extends Template implements CollectionDataSourceInterface
         return $this->registry->registry('current_category');
     }
 
+    /** @return \Magento\Catalog\Model\Product */
+    public function getCurrentProduct()
+    {
+        return $this->registry->registry('product');
+    }
+
     public function getAddToCartParams()
     {
         $url = $this->getAddToCartUrl();

--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -7,6 +7,7 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Data as CoreHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Magento\Checkout\Helper\Cart;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\Data\CollectionDataSourceInterface;
 use Magento\Framework\Data\Form\FormKey;
@@ -22,8 +23,6 @@ class Algolia extends Template implements CollectionDataSourceInterface
 {
     private $config;
     private $catalogSearchHelper;
-    private $storeManager;
-    private $objectManager;
     private $registry;
     private $productHelper;
     private $currency;
@@ -33,6 +32,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
     private $httpContext;
     private $coreHelper;
     private $categoryHelper;
+    private $cart;
 
     private $priceKey;
 
@@ -49,6 +49,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
         HttpContext $httpContext,
         CoreHelper $coreHelper,
         CategoryHelper $categoryHelper,
+        Cart $cart,
         array $data = []
     ) {
         $this->config = $config;
@@ -62,6 +63,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
         $this->httpContext = $httpContext;
         $this->coreHelper = $coreHelper;
         $this->categoryHelper = $categoryHelper;
+        $this->cart = $cart;
 
         parent::__construct($context, $data);
     }
@@ -105,6 +107,11 @@ class Algolia extends Template implements CollectionDataSourceInterface
     public function getAlgoliaHelper()
     {
         return $this->algoliaHelper;
+    }
+
+    public function getCart()
+    {
+        return $this->cart;
     }
 
     public function getCurrencySymbol()

--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -7,7 +7,7 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Data as CoreHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
-use Magento\Checkout\Helper\Cart;
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\Data\CollectionDataSourceInterface;
 use Magento\Framework\Data\Form\FormKey;
@@ -32,7 +32,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
     private $httpContext;
     private $coreHelper;
     private $categoryHelper;
-    private $cart;
+    private $checkoutSession;
 
     private $priceKey;
 
@@ -49,7 +49,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
         HttpContext $httpContext,
         CoreHelper $coreHelper,
         CategoryHelper $categoryHelper,
-        Cart $cart,
+        CheckoutSession $checkoutSession,
         array $data = []
     ) {
         $this->config = $config;
@@ -63,7 +63,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
         $this->httpContext = $httpContext;
         $this->coreHelper = $coreHelper;
         $this->categoryHelper = $categoryHelper;
-        $this->cart = $cart;
+        $this->checkoutSession = $checkoutSession;
 
         parent::__construct($context, $data);
     }
@@ -107,11 +107,6 @@ class Algolia extends Template implements CollectionDataSourceInterface
     public function getAlgoliaHelper()
     {
         return $this->algoliaHelper;
-    }
-
-    public function getCart()
-    {
-        return $this->cart;
     }
 
     public function getCurrencySymbol()
@@ -158,6 +153,12 @@ class Algolia extends Template implements CollectionDataSourceInterface
     public function getCurrentProduct()
     {
         return $this->registry->registry('product');
+    }
+
+    /** @return \Magento\Sales\Model\Order */
+    public function getLastOrder()
+    {
+        return $this->checkoutSession->getLastRealOrder();
     }
 
     public function getAddToCartParams()

--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -92,6 +92,11 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
             }
         }
 
+        $productId = null;
+        if ($config->isClickConversionAnalyticsEnabled() && $request->getControllerName() === 'product') {
+            $productId = $this->getCurrentProduct()->getId();
+        }
+
         /**
          * Handle search
          */
@@ -154,6 +159,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
             'isSearchPage' => $this->isSearchPage(),
             'isCategoryPage' => $isCategoryPage,
             'removeBranding' => (bool) $config->isRemoveBranding(),
+            'productId' => $productId,
             'priceKey' => $priceKey,
             'currencyCode' => $currencyCode,
             'currencySymbol' => $currencySymbol,

--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -182,6 +182,8 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
             ],
             'ccAnalytics' => [
                 'ISSelector' => $config->getClickConversionAnalyticsISSelector(),
+                'conversionAnalyticsEnabled' => $config->isConversionAnalyticsEnabled(),
+                'addToCartSelector' => $config->getConversionAnalyticsAddToCartSelector(),
             ],
             'analytics' => $config->getAnalyticsConfig(),
             'translations' => [

--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -186,7 +186,6 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
                 'ISSelector' => $config->getClickConversionAnalyticsISSelector(),
                 'conversionAnalyticsMode' => $config->getConversionAnalyticsMode(),
                 'addToCartSelector' => $config->getConversionAnalyticsAddToCartSelector(),
-                'placeOrderSelector' => $config->getConversionAnalyticsPlaceOrderSelector(),
                 'orderedProductIds' => $this->getOrderedProductIds($config, $request),
             ],
             'analytics' => $config->getAnalyticsConfig(),

--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -95,7 +95,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
         }
 
         $productId = null;
-        if ($config->isClickConversionAnalyticsEnabled() && $request->getControllerName() === 'product') {
+        if ($config->isClickConversionAnalyticsEnabled() && $request->getFullActionName() === 'catalog_product_view') {
             $productId = $this->getCurrentProduct()->getId();
         }
 

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -68,6 +68,12 @@ class AlgoliaHelper extends AbstractHelper
         }
     }
 
+    public function getClient()
+    {
+        $this->checkClient(__FUNCTION__);
+        return $this->client;
+    }
+
     public function getIndex($name)
     {
         $this->checkClient(__FUNCTION__);

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -70,6 +70,8 @@ class ConfigHelper
 
     const CC_ANALYTICS_ENABLE = 'algoliasearch_cc_analytics/cc_analytics_group/enable';
     const CC_ANALYTICS_IS_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/is_selector';
+    const CC_CONVERSION_ANALYTICS_ENABLE = 'algoliasearch_cc_analytics/cc_analytics_group/enable_conversion_analytics';
+    const CC_ADD_TO_CART_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector';
 
     const GA_ENABLE = 'algoliasearch_analytics/analytics_group/enable';
     const GA_DELAY = 'algoliasearch_analytics/analytics_group/delay';
@@ -853,6 +855,20 @@ class ConfigHelper
     public function getClickConversionAnalyticsISSelector($storeId = null)
     {
         return $this->configInterface->getValue(self::CC_ANALYTICS_IS_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function isConversionAnalyticsEnabled($storeId = null)
+    {
+        return $this->configInterface->isSetFlag(
+            self::CC_CONVERSION_ANALYTICS_ENABLE,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    public function getConversionAnalyticsAddToCartSelector($storeId = null)
+    {
+        return $this->configInterface->getValue(self::CC_ADD_TO_CART_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     public function isAnalyticsEnabled($storeId = null)

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -70,8 +70,9 @@ class ConfigHelper
 
     const CC_ANALYTICS_ENABLE = 'algoliasearch_cc_analytics/cc_analytics_group/enable';
     const CC_ANALYTICS_IS_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/is_selector';
-    const CC_CONVERSION_ANALYTICS_ENABLE = 'algoliasearch_cc_analytics/cc_analytics_group/enable_conversion_analytics';
+    const CC_CONVERSION_ANALYTICS_MODE = 'algoliasearch_cc_analytics/cc_analytics_group/conversion_analytics_mode';
     const CC_ADD_TO_CART_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector';
+    const CC_PLACE_ORDER_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/place_order_selector';
 
     const GA_ENABLE = 'algoliasearch_analytics/analytics_group/enable';
     const GA_DELAY = 'algoliasearch_analytics/analytics_group/delay';
@@ -857,10 +858,10 @@ class ConfigHelper
         return $this->configInterface->getValue(self::CC_ANALYTICS_IS_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
-    public function isConversionAnalyticsEnabled($storeId = null)
+    public function getConversionAnalyticsMode($storeId = null)
     {
-        return $this->configInterface->isSetFlag(
-            self::CC_CONVERSION_ANALYTICS_ENABLE,
+        return $this->configInterface->getValue(
+            self::CC_CONVERSION_ANALYTICS_MODE,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
@@ -869,6 +870,11 @@ class ConfigHelper
     public function getConversionAnalyticsAddToCartSelector($storeId = null)
     {
         return $this->configInterface->getValue(self::CC_ADD_TO_CART_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function getConversionAnalyticsPlaceOrderSelector($storeId = null)
+    {
+        return $this->configInterface->getValue(self::CC_PLACE_ORDER_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     public function isAnalyticsEnabled($storeId = null)

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -72,7 +72,6 @@ class ConfigHelper
     const CC_ANALYTICS_IS_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/is_selector';
     const CC_CONVERSION_ANALYTICS_MODE = 'algoliasearch_cc_analytics/cc_analytics_group/conversion_analytics_mode';
     const CC_ADD_TO_CART_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector';
-    const CC_PLACE_ORDER_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/place_order_selector';
 
     const GA_ENABLE = 'algoliasearch_analytics/analytics_group/enable';
     const GA_DELAY = 'algoliasearch_analytics/analytics_group/delay';
@@ -870,11 +869,6 @@ class ConfigHelper
     public function getConversionAnalyticsAddToCartSelector($storeId = null)
     {
         return $this->configInterface->getValue(self::CC_ADD_TO_CART_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    public function getConversionAnalyticsPlaceOrderSelector($storeId = null)
-    {
-        return $this->configInterface->getValue(self::CC_PLACE_ORDER_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     public function isAnalyticsEnabled($storeId = null)

--- a/Model/Backend/EnableClickAnalytics.php
+++ b/Model/Backend/EnableClickAnalytics.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Backend;
+
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Exception\LocalizedException;
+
+class EnableClickAnalytics extends Value
+{
+    private $algoliaHelper;
+    private $productHelper;
+
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\App\Config\ScopeConfigInterface $config,
+        \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
+        AlgoliaHelper $algoliaHelper,
+        ProductHelper $productHelper,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+
+        $this->algoliaHelper = $algoliaHelper;
+        $this->productHelper = $productHelper;
+    }
+
+    public function beforeSave()
+    {
+        $value = trim($this->getData('value'));
+
+        if ($value !== '1') {
+            return parent::beforeSave();
+        }
+
+        $context = $this->algoliaHelper->getClient()->getContext();
+
+        $ch = curl_init();
+
+        $headers = array();
+        $headers[] = 'X-Algolia-Api-Key: '.$context->apiKey;
+        $headers[] = 'X-Algolia-Application-Id: '.$context->applicationID;
+        $headers[] = 'Content-Type: application/x-www-form-urlencoded';
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+        $postFields = json_encode([
+            'timestamp' => time(),
+            'queryID' => 'a',
+            'objectID' => 'non_existent_object_id',
+            'position' => 1,
+        ]);
+
+        curl_setopt($ch, CURLOPT_URL, "https://insights.algolia.io/1/searches/click");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
+        curl_setopt($ch, CURLOPT_POST, 1);
+
+
+        $result = curl_exec($ch);
+        curl_close ($ch);
+
+        if ($result) {
+            $result = json_decode($result);
+            if ($result->status === 401 && $result->message === 'Feature not available') {
+                throw new LocalizedException(
+                    __('Click & Conversion analytics are not supported on your current plan. Please refer to <a target="_blank" href="https://www.algolia.com/pricing/">Algolia\'s pricing page</a> for more details.')
+                );
+            }
+        }
+
+        return parent::beforeSave();
+    }
+}

--- a/Model/Source/ConversionAnalyticsMode.php
+++ b/Model/Source/ConversionAnalyticsMode.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Source;
+
+use Magento\Framework\Option\ArrayInterface;
+
+class ConversionAnalyticsMode implements ArrayInterface
+{
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 'disabled',     'label' => __('[Disabled]')],
+            ['value' => 'add_to_cart',  'label' => __('Track "Add to cart" action as conversion')],
+            ['value' => 'place_order',  'label' => __('Track "Place Order" action as conversion')],
+        ];
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -57,6 +57,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
         'algoliasearch_cc_analytics/cc_analytics_group/enable' => '0',
         'algoliasearch_cc_analytics/cc_analytics_group/is_selector' => '.ais-hits--item a.result',
+        'algoliasearch_cc_analytics/cc_analytics_group/enable_conversion_analytics' => '0',
+        'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector' => '.action.tocart.primary',
 
         'algoliasearch_analytics/analytics_group/enable' => '0',
         'algoliasearch_analytics/analytics_group/delay' => '3000',

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -57,8 +57,9 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
         'algoliasearch_cc_analytics/cc_analytics_group/enable' => '0',
         'algoliasearch_cc_analytics/cc_analytics_group/is_selector' => '.ais-hits--item a.result',
-        'algoliasearch_cc_analytics/cc_analytics_group/enable_conversion_analytics' => '0',
-        'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector' => '.action.tocart.primary',
+        'algoliasearch_cc_analytics/cc_analytics_group/enable_conversion_analytics' => 'disabled',
+        'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector' => '.action.primary.tocart',
+        'algoliasearch_cc_analytics/cc_analytics_group/place_order_selector' => '.action.primary.checkout',
 
         'algoliasearch_analytics/analytics_group/enable' => '0',
         'algoliasearch_analytics/analytics_group/delay' => '3000',

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -59,7 +59,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
         'algoliasearch_cc_analytics/cc_analytics_group/is_selector' => '.ais-hits--item a.result, .ais-infinite-hits--item a.result',
         'algoliasearch_cc_analytics/cc_analytics_group/enable_conversion_analytics' => 'disabled',
         'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector' => '.action.primary.tocart',
-        'algoliasearch_cc_analytics/cc_analytics_group/place_order_selector' => '.action.primary.checkout',
 
         'algoliasearch_analytics/analytics_group/enable' => '0',
         'algoliasearch_analytics/analytics_group/delay' => '3000',

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -56,7 +56,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
         'algoliasearch_queue/queue/number_of_retries' => '3',
 
         'algoliasearch_cc_analytics/cc_analytics_group/enable' => '0',
-        'algoliasearch_cc_analytics/cc_analytics_group/is_selector' => '.ais-hits--item a.result',
+        'algoliasearch_cc_analytics/cc_analytics_group/is_selector' => '.ais-hits--item a.result, .ais-infinite-hits--item a.result',
         'algoliasearch_cc_analytics/cc_analytics_group/enable_conversion_analytics' => 'disabled',
         'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector' => '.action.primary.tocart',
         'algoliasearch_cc_analytics/cc_analytics_group/place_order_selector' => '.action.primary.checkout',

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -669,11 +669,11 @@
             </group>
         </section>
         <section id="algoliasearch_cc_analytics" translate="label" type="text" sortOrder="69" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Click Analytics</label>
+            <label><![CDATA[Click & Conversion Analytics]]></label>
             <tab>algolia</tab>
             <resource>Algolia_AlgoliaSearch::algolia_algoliasearch</resource>
             <group id="cc_analytics_group" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>Click Analytics</label>
+                <label><![CDATA[Click & Conversion Analytics]]></label>
                 <comment>
                     <![CDATA[
                         Click analytics can be tracked only when you're on Business or a higher Algolia plan.
@@ -699,6 +699,31 @@
                         <field id="enable">1</field>
                     </depends>
                 </field>
+                <field id="enable_conversion_analytics" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Conversion Analytics</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                            Conversion is tracked when the product was found and clicked in search results and then added to cart.
+                        ]]>
+                    </comment>
+                    <depends>
+                        <field id="enable">1</field>
+                    </depends>
+                </field>
+                <field id="add_to_cart_selector" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>DOM selector of a "Add to Cart" buttons</label>
+                    <comment>
+                        <![CDATA[
+                            The element has to contain attribute "data-objectid" or a "productId" variable needs to be specified in "frontend" algoliaConfig variable.
+                            <br /><br />
+                            More selectors separate by a comma (,).
+                        ]]>
+                    </comment>
+                    <depends>
+                        <field id="enable_conversion_analytics">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
         <section id="algoliasearch_analytics" translate="label" type="text" sortOrder="69" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -708,7 +733,7 @@
             <group id="analytics_group" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Google Analytics</label>
                 <comment>
-                    <![CDATA[
+                   <![CDATA[
                         Documentation of Magento Google analytics: <a href="https://community.algolia.com/magento/doc/m2/analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">https://community.algolia.com/magento/doc/m2/analytics/</a>
                         <br>
                         <br>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -726,18 +726,6 @@
                         <field id="enable">1</field>
                     </depends>
                 </field>
-                <field id="place_order_selector" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>DOM selector of a "Place Order" button</label>
-                    <comment>
-                        <![CDATA[
-                            More selectors separate by a comma (,).
-                        ]]>
-                    </comment>
-                    <depends>
-                        <field id="conversion_analytics_mode">place_order</field>
-                        <field id="enable">1</field>
-                    </depends>
-                </field>
             </group>
         </section>
         <section id="algoliasearch_analytics" translate="label" type="text" sortOrder="69" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -676,9 +676,9 @@
                 <label><![CDATA[Click & Conversion Analytics]]></label>
                 <comment>
                     <![CDATA[
-                        Click analytics can be tracked only when you're on Business or a higher Algolia plan.
+                        Analyse how your customers are behaving when searching on your website. With <a target="_blank" href="https://www.algolia.com/doc/guides/analytics/click-analytics/">Click & Conversion analytics</a>, you can track which products are clicked more, and which search queries leads to more conversion. Note: this feature is not available on all plans, please refer to <a target="_blank" href="https://www.algolia.com/pricing/">Algolia's pricing page</a> for more details
                         <br><br>
-                        Documentation of click analytics: <a href="https://community.algolia.com/magento/doc/m2/click-analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">https://community.algolia.com/magento/doc/m2/click-analytics/</a>
+                        Documentation of Click & Conversion analytics: <a href="https://community.algolia.com/magento/doc/m2/click-analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">https://community.algolia.com/magento/doc/m2/click-analytics/</a>
                         <br>
                         <br>
                         <hr>
@@ -687,6 +687,7 @@
                 <field id="enable" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Click Analytics</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <backend_model>Algolia\AlgoliaSearch\Model\Backend\EnableClickAnalytics</backend_model>
                 </field>
                 <field id="is_selector" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>DOM selector of a result container on instant search page</label>
@@ -699,9 +700,9 @@
                         <field id="enable">1</field>
                     </depends>
                 </field>
-                <field id="enable_conversion_analytics" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable Conversion Analytics</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                <field id="conversion_analytics_mode" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Conversion Analytics mode</label>
+                    <source_model>Algolia\AlgoliaSearch\Model\Source\ConversionAnalyticsMode</source_model>
                     <comment>
                         <![CDATA[
                             Conversion is tracked when the product was found and clicked in search results and then added to cart.
@@ -721,7 +722,20 @@
                         ]]>
                     </comment>
                     <depends>
-                        <field id="enable_conversion_analytics">1</field>
+                        <field id="conversion_analytics_mode">add_to_cart</field>
+                        <field id="enable">1</field>
+                    </depends>
+                </field>
+                <field id="place_order_selector" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>DOM selector of a "Place Order" button</label>
+                    <comment>
+                        <![CDATA[
+                            More selectors separate by a comma (,).
+                        ]]>
+                    </comment>
+                    <depends>
+                        <field id="conversion_analytics_mode">place_order</field>
+                        <field id="enable">1</field>
                     </depends>
                 </field>
             </group>

--- a/view/frontend/templates/instant/hit.phtml
+++ b/view/frontend/templates/instant/hit.phtml
@@ -62,7 +62,7 @@ $origFormatedVar = 'price' . $priceKey . '_original_formated';
                             <input type="hidden" name="product" value="{{objectID}}">
                             <input type="hidden" name="uenc" value="{{ addToCart.uenc }}">
                             <input name="form_key" type="hidden" value="{{ addToCart.formKey }}">
-                            <button type="submit" title="Add to Cart" class="action tocart primary">
+                            <button type="submit" title="Add to Cart" class="action tocart primary" data-objectid="{{objectID}}" data-position="{{__position}}">
                                 <span>Add to Cart</span>
                             </button>
                         </form>

--- a/view/frontend/web/click_conversion_analytics.js
+++ b/view/frontend/web/click_conversion_analytics.js
@@ -1,4 +1,7 @@
 requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algoliaAnalytics) {
+	var clickedObjectIds = [];
+	var convertedObjectIds = [];
+	
 	algoliaBundle.$(function ($) {
 		algoliaAnalytics.init({
 			applicationID: algoliaConfig.applicationId,
@@ -15,13 +18,25 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 			});
 		});
 		
+		// "Click" in list
 		$(document).on('click', algoliaConfig.ccAnalytics.ISSelector, function() {
 			var $this = $(this);
 			
-			algoliaAnalytics.click({
-				objectID: $this.data('objectid').toString(),
-				position: parseInt($this.data('position'))
-			});
+			trackClick($this.data('objectid'), $this.data('position'));
+		});
+		
+		// "Add to cart" in list
+		$(document).on('click', '.action.tocart.primary', function() {
+			var objectId = $(this).data('objectid');
+			
+			setTimeout(function() {
+				trackConversion(objectId);
+			}, 0);
+		});
+		
+		// "Add to cart" in detail
+		$(document).on('click', '#product-addtocart-button', function () {
+			trackConversion(algoliaConfig.productId);
 		});
 	});
 	
@@ -42,4 +57,31 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 		
 		return search;
 	});
+	
+	function trackClick(objectID, position) {
+		objectID = objectID.toString();
+		
+		if (!clickedObjectIds[objectID]) {
+			algoliaAnalytics.click({
+				objectID: objectID.toString(),
+				position: parseInt(position)
+			});
+			
+			clickedObjectIds[objectID] = 1;
+			delete convertedObjectIds[objectID];
+		}
+	}
+	
+	function trackConversion(objectID) {
+		objectID = objectID.toString();
+		
+		if (!convertedObjectIds[objectID]) {
+			algoliaAnalytics.conversion({
+				objectID: objectID
+			});
+			
+			convertedObjectIds[objectID] = 1;
+			delete clickedObjectIds[objectID];
+		}
+	}
 });

--- a/view/frontend/web/click_conversion_analytics.js
+++ b/view/frontend/web/click_conversion_analytics.js
@@ -10,11 +10,7 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 		// "Click" in autocomplete
 		$(algoliaConfig.autocomplete.selector).each(function () {
 			$(this).on('autocomplete:selected', function (e, suggestion) {
-				algoliaAnalytics.click({
-					queryID: suggestion.__queryID,
-					objectID: suggestion.objectID,
-					position: suggestion.__position
-				});
+				trackClick(suggestion.objectID, suggestion.__position, suggestion.__queryID);
 			});
 		});
 		
@@ -74,17 +70,23 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 		return search;
 	});
 	
-	function trackClick(objectID, position) {
+	function trackClick(objectID, position, queryId) {
 		objectID = objectID.toString();
 		
 		var arrayIndex = getArrayIndex(objectID);
 		
 		var clickedObjectIds = getObjectIds('clicked');
 		if (!clickedObjectIds[arrayIndex]) {
-			algoliaAnalytics.click({
+			var clickData = {
 				objectID: objectID,
 				position: parseInt(position)
-			});
+			};
+			
+			if (queryId) {
+				clickData.queryID = queryId;
+			}
+			
+			algoliaAnalytics.click(clickData);
 			
 			
 			clickedObjectIds[arrayIndex] = 1;

--- a/view/frontend/web/click_conversion_analytics.js
+++ b/view/frontend/web/click_conversion_analytics.js
@@ -36,13 +36,14 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 			});
 		}
 		
-		// "Place order" conversion
+		// "Place order" conversions
 		if (algoliaConfig.ccAnalytics.conversionAnalyticsMode === 'place_order') {
-			$(document).on('click', algoliaConfig.ccAnalytics.placeOrderSelector, function () {
-				$.each(algoliaConfig.ccAnalytics.productIdsInCart, function (i, objectId) {
+			// "algoliaConfig.ccAnalytics.orderedProductIds" are set only on checkout success page
+			if (algoliaConfig.ccAnalytics.orderedProductIds.length > 0) {
+				$.each(algoliaConfig.ccAnalytics.orderedProductIds, function (i, objectId) {
 					trackConversion(objectId);
 				});
-			});
+			}
 		}
 	});
 	

--- a/view/frontend/web/click_conversion_analytics.js
+++ b/view/frontend/web/click_conversion_analytics.js
@@ -35,6 +35,8 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 					objectId = postData.data.product;
 				}
 				
+				// "setTimeout" ensures "trackConversion" is always triggered AFTER "trackClick"
+				// when clicking "Add to cart" on instant search results page
 				setTimeout(function () {
 					trackConversion(objectId);
 				}, 0);

--- a/view/frontend/web/click_conversion_analytics.js
+++ b/view/frontend/web/click_conversion_analytics.js
@@ -75,10 +75,10 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 	function trackClick(objectID, position, queryId) {
 		objectID = objectID.toString();
 		
-		var arrayIndex = getArrayIndex(objectID);
+		var propertyName = getPropertyName(objectID);
 		
 		var clickedObjectIds = getObjectIds('clicked');
-		if (!clickedObjectIds[arrayIndex]) {
+		if (!clickedObjectIds[propertyName]) {
 			var clickData = {
 				objectID: objectID,
 				position: parseInt(position)
@@ -91,10 +91,10 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 			algoliaAnalytics.click(clickData);
 			
 			
-			clickedObjectIds[arrayIndex] = 1;
+			clickedObjectIds[propertyName] = 1;
 			
 			var convertedObjectIds = getObjectIds('converted');
-			delete convertedObjectIds[arrayIndex];
+			delete convertedObjectIds[propertyName];
 			
 			setObjectIds('clicked', clickedObjectIds);
 			setObjectIds('converted', convertedObjectIds);
@@ -104,18 +104,18 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 	function trackConversion(objectID) {
 		objectID = objectID.toString();
 		
-		var arrayIndex = getArrayIndex(objectID);
+		var propertyName = getPropertyName(objectID);
 		
 		var convertedObjectIds = getObjectIds('converted');
-		if (!convertedObjectIds[arrayIndex]) {
+		if (!convertedObjectIds[propertyName]) {
 			algoliaAnalytics.conversion({
 				objectID: objectID
 			});
 			
-			convertedObjectIds[arrayIndex] = 1;
+			convertedObjectIds[propertyName] = 1;
 			
 			var clickedObjectIds = getObjectIds('clicked');
-			delete clickedObjectIds[arrayIndex];
+			delete clickedObjectIds[propertyName];
 			
 			setObjectIds('clicked', clickedObjectIds);
 			setObjectIds('converted', convertedObjectIds);
@@ -126,7 +126,7 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 		var objectIds = localStorage.getItem(objectIdsStorageKey + '_' + type);
 		
 		if (!objectIds) {
-			return [];
+			return {};
 		}
 		
 		return JSON.parse(objectIds);
@@ -136,7 +136,7 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 		localStorage.setItem(objectIdsStorageKey + '_' + type, JSON.stringify(objectIds));
 	}
 	
-	function getArrayIndex(objectID) {
+	function getPropertyName(objectID) {
 		return 'product-' + objectID;
 	}
 });

--- a/view/frontend/web/click_conversion_analytics.js
+++ b/view/frontend/web/click_conversion_analytics.js
@@ -30,6 +30,15 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 			$(document).on('click', algoliaConfig.ccAnalytics.addToCartSelector, function () {
 				var objectId = $(this).data('objectid') || algoliaConfig.productId;
 				
+				if (!objectId) {
+					var postData = $(this).data('post');
+					if (!postData || !postData.data.product) {
+						return;
+					}
+					
+					objectId = postData.data.product;
+				}
+				
 				setTimeout(function () {
 					trackConversion(objectId);
 				}, 0);
@@ -68,17 +77,20 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 	function trackClick(objectID, position) {
 		objectID = objectID.toString();
 		
+		var arrayIndex = getArrayIndex(objectID);
+		
 		var clickedObjectIds = getObjectIds('clicked');
-		if (!clickedObjectIds[objectID]) {
+		if (!clickedObjectIds[arrayIndex]) {
 			algoliaAnalytics.click({
-				objectID: objectID.toString(),
+				objectID: objectID,
 				position: parseInt(position)
 			});
 			
-			clickedObjectIds[objectID] = 1;
+			
+			clickedObjectIds[arrayIndex] = 1;
 			
 			var convertedObjectIds = getObjectIds('converted');
-			delete convertedObjectIds[objectID];
+			delete convertedObjectIds[arrayIndex];
 			
 			setObjectIds('clicked', clickedObjectIds);
 			setObjectIds('converted', convertedObjectIds);
@@ -88,16 +100,18 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 	function trackConversion(objectID) {
 		objectID = objectID.toString();
 		
+		var arrayIndex = getArrayIndex(objectID);
+		
 		var convertedObjectIds = getObjectIds('converted');
-		if (!convertedObjectIds[objectID]) {
+		if (!convertedObjectIds[arrayIndex]) {
 			algoliaAnalytics.conversion({
 				objectID: objectID
 			});
 			
-			convertedObjectIds[objectID] = 1;
+			convertedObjectIds[arrayIndex] = 1;
 			
 			var clickedObjectIds = getObjectIds('clicked');
-			delete clickedObjectIds[objectID];
+			delete clickedObjectIds[arrayIndex];
 			
 			setObjectIds('clicked', clickedObjectIds);
 			setObjectIds('converted', convertedObjectIds);
@@ -116,5 +130,9 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 	
 	function setObjectIds(type, objectIds) {
 		localStorage.setItem(objectIdsStorageKey + '_' + type, JSON.stringify(objectIds));
+	}
+	
+	function getArrayIndex(objectID) {
+		return 'product-' + objectID;
 	}
 });

--- a/view/frontend/web/click_conversion_analytics.js
+++ b/view/frontend/web/click_conversion_analytics.js
@@ -25,14 +25,23 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 			trackClick($this.data('objectid'), $this.data('position'));
 		});
 		
-		
-		if (algoliaConfig.ccAnalytics.conversionAnalyticsEnabled) {
+		// "Add to cart" conversion
+		if (algoliaConfig.ccAnalytics.conversionAnalyticsMode === 'add_to_cart') {
 			$(document).on('click', algoliaConfig.ccAnalytics.addToCartSelector, function () {
 				var objectId = $(this).data('objectid') || algoliaConfig.productId;
 				
 				setTimeout(function () {
 					trackConversion(objectId);
 				}, 0);
+			});
+		}
+		
+		// "Place order" conversion
+		if (algoliaConfig.ccAnalytics.conversionAnalyticsMode === 'place_order') {
+			$(document).on('click', algoliaConfig.ccAnalytics.placeOrderSelector, function () {
+				$.each(algoliaConfig.ccAnalytics.productIdsInCart, function (i, objectId) {
+					trackConversion(objectId);
+				});
 			});
 		}
 	});


### PR DESCRIPTION
This PR implements [conversion analytics](https://www.algolia.com/doc/guides/analytics/click-analytics/#conversion) based on click analytics.

The conversion is pushed only when a product was found and clicked in search results before an then added to cart. Or if it was added to cart directly from search results.

If it was found, but was added to cart, the conversion shouldn't be pushed to Algolia.