### PR TITLE
Prevent backend rendering only for category pages

### DIFF
--- a/Model/Observer.php
+++ b/Model/Observer.php
@@ -53,8 +53,12 @@ class Observer implements ObserverInterface
 
         /** @var \Magento\Catalog\Model\Category $category */
         $category = $this->registry->registry('current_category');
+        if (!$category) {
+            return;
+        }
+
         $displayMode = $this->config->getBackendRenderingDisplayMode();
-        if ($category && $displayMode === 'only_products' && $category->getDisplayMode() === 'PAGE') {
+        if ($displayMode === 'only_products' && $category->getDisplayMode() === 'PAGE') {
             return;
         }
 


### PR DESCRIPTION
The prevent backend rendering functionality is only needed for category pages, so when there is no current_category from the registry the observer can return.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

I found that the sidebar in the account pages in magento 2 where missing, caused by this bug.

**Result**

Sidebar will only be removed on category pages and if the algolia prevent backend settings apply