### PR TITLE
Change comparison operator to == instead of === for nonzerodefault price

### DIFF
--- a/Helper/Entity/Product/PriceManager.php
+++ b/Helper/Entity/Product/PriceManager.php
@@ -139,7 +139,7 @@ class PriceManager
                         );
                     }
 
-                    if ($customData[$field][$currencyCode]['default'] === 0) {
+                    if ($customData[$field][$currencyCode]['default'] == 0) {
                         $customData = $this->handleZeroDefaultPrice(
                             $customData,
                             $field,

--- a/Helper/Entity/Product/PriceManager.php
+++ b/Helper/Entity/Product/PriceManager.php
@@ -139,7 +139,7 @@ class PriceManager
                         );
                     }
 
-                    if ($customData[$field][$currencyCode]['default'] == 0) {
+                    if (!$customData[$field][$currencyCode]['default']) {
                         $customData = $this->handleZeroDefaultPrice(
                             $customData,
                             $field,


### PR DESCRIPTION
We were experiencing a number of products having a price of 0 (zero) in the category pages but not on the product pages. After debugging with xdebug, I've found the comparison operator in PriceManager to be the culprit;

```
if ($customData[$field][$currencyCode]['default'] === 0) {
    $customData = $this->handleZeroDefaultPrice(
        $customData,
        $field,
        $currencyCode,
        $baseCurrencyCode,
        $min,
        $max,
        $store
    );
}
```

This checks for a zero default value by `===`. But PHP's `round()` function returns a float, and not an int. Changing this to `==` loosens the comparison and fixes the issue.