### PR TITLE
Fix page indexing from disabled stores

### DIFF
--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -130,7 +130,7 @@ class PageHelper
     {
         if ($this->storeUrls === null) {
             $this->storeUrls = [];
-            $storeIds = $this->getStores(null);
+            $storeIds = $this->getStores();
 
             foreach ($storeIds as $storeId) {
                 // ObjectManager used instead of UrlFactory because UrlFactory will return UrlInterface which
@@ -150,7 +150,7 @@ class PageHelper
         return null;
     }
 
-    private function getStores($storeId)
+    public function getStores($storeId = null)
     {
         $storeIds = [];
 

--- a/Model/Indexer/Page.php
+++ b/Model/Indexer/Page.php
@@ -66,7 +66,7 @@ class Page implements Magento\Framework\Indexer\ActionInterface, Magento\Framewo
             return;
         }
 
-        $storeIds = array_keys($this->storeManager->getStores());
+        $storeIds = $this->pageHelper->getStores();
 
         foreach ($storeIds as $storeId) {
             if ($this->fullAction->isIndexingEnabled($storeId) === false) {


### PR DESCRIPTION
Fix the page indexing when Magento is configured with disabled store(s). (view issue #459)