### PR TITLE
Set correct type IDs for image type selector in configuration

### DIFF
--- a/Model/Source/ImageType.php
+++ b/Model/Source/ImageType.php
@@ -9,9 +9,10 @@ class ImageType implements ArrayInterface
     public function toOptionArray()
     {
         return [
-            ['value' => 'image',         'label' => __('Base Image')],
-            ['value' => 'small_image',   'label' => __('Small Image')],
-            ['value' => 'thumbnail',     'label' => __('Thumbnail')],
+            ['value' => 'product_base_image',         'label' => __('Base Image')],
+            ['value' => 'product_small_image',        'label' => __('Small Image')],
+            ['value' => 'product_thumbnail_image',    'label' => __('Thumbnail')],
         ];
     }
 }
+


### PR DESCRIPTION
When setting 'small image' as the image type for the images used in Algolia, we noticed base image was used. When changing the value in the database to `product_small_image` instead of `small_image`, it worked like we wanted.

Reference for image type ID's can be found in Magento core; `vendor/magento/theme-frontend-blank/etc/view.xml`