### PR TITLE
Fixed exploding of line breaks where \r\n was used instead of \n

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -682,7 +682,8 @@ class ConfigHelper
             return true;
         }
 
-        $allowedUserAgents = explode("\n", $allowedUserAgents);
+        $allowedUserAgents = preg_split('/\n|\r\n?/', $allowedUserAgents);
+        $allowedUserAgents = array_filter($allowedUserAgents);
 
         foreach ($allowedUserAgents as $allowedUserAgent) {
             $allowedUserAgent = mb_strtolower($allowedUserAgent, 'utf-8');


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
We noticed the prevent backend rendering functionality did not work correctly; the pages for the Googlebot did not include the HTML of Magento's category listing. We found that it was due to a `\r\n` being present in the `algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents`  value. Probably due to somebody on Windows editing that text. The code only split on `\n`, thereby getting `Googlebot\r` and `Bingbot` as a result. `Googlebot\r` does not match in the user agent string `Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)` and there it *will* prevent backend rendering.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
Backend rendering is *not* prevented for Googlebot.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->