### PR TITLE
hitsPerPage gets overwritten for first load fixed

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -98,7 +98,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 				
 				instantsearchOptions.searchParameters['facetsRefinements']['categories.level' + algoliaConfig.request.level] = [algoliaConfig.request.path];
 			} else {
-				instantsearchOptions.searchParameters.hierarchicalFacetsRefinements = {
+				instantsearchOptions.searchParameters['hierarchicalFacetsRefinements'] = {
 					'categories.level0': [algoliaConfig.request.path]
 				}
 			}

--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -98,10 +98,8 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 				
 				instantsearchOptions.searchParameters['facetsRefinements']['categories.level' + algoliaConfig.request.level] = [algoliaConfig.request.path];
 			} else {
-				instantsearchOptions.searchParameters = {
-					hierarchicalFacetsRefinements: {
-						'categories.level0': [algoliaConfig.request.path]
-					}
+				instantsearchOptions.searchParameters.hierarchicalFacetsRefinements = {
+					'categories.level0': [algoliaConfig.request.path]
 				}
 			}
 		}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
On any list page first load, URL does not contain hash segments. Those are added after page load by JS.
This means, code to add hierarchicalFacetsRefinements in searchParameters is executed, which is fine.
Problem is it overwrites parameters set above in instantsearchOptions initialization code e.g. hitsPerPage
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
Result is, for first load, request to Algolia does not contain hitsPerPage parameter and default number of records are loaded i.e. 20 even if you have set 100 in the extension backend

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->