### PR TITLE
Fix special price for configurables

### DIFF
--- a/Helper/Entity/Product/PriceManager.php
+++ b/Helper/Entity/Product/PriceManager.php
@@ -139,6 +139,7 @@ class PriceManager
                         );
                     }
 
+
                     if (!$customData[$field][$currencyCode]['default']) {
                         $customData = $this->handleZeroDefaultPrice(
                             $customData,
@@ -147,7 +148,8 @@ class PriceManager
                             $baseCurrencyCode,
                             $min,
                             $max,
-                            $store
+                            $store,
+                            $subProducts
                         );
                     }
 
@@ -503,11 +505,26 @@ class PriceManager
         $baseCurrencyCode,
         $min,
         $max,
-        Store $store
+        Store $store,
+        $subProducts
     ) {
         $customData[$field][$currencyCode]['default'] = $min;
 
+        $defaultOriginals = [];
+        foreach ($subProducts as $subProduct) {
+            $defaultOriginals[] = $subProduct->getPrice();
+        }
+
+        $defaultOriginal = min($defaultOriginals);
+        $defaultOriginalMax = max($defaultOriginals);
+
         if ($min !== $max) {
+            $customData[$field][$currencyCode]['default_min'] = $min;
+            $customData[$field][$currencyCode]['default_max'] = $max;
+            $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
+            $customData[$field][$currencyCode]['default_original_min'] = $defaultOriginal;
+            $customData[$field][$currencyCode]['default_original_max'] = $defaultOriginalMax;
+            $customData[$field][$currencyCode]['default_original_formated'] = $this->getDashedPriceFormat($defaultOriginal, $defaultOriginalMax, $store, $currencyCode);
             return $customData;
         }
 
@@ -523,6 +540,16 @@ class PriceManager
             $currencyCode
         );
 
+        $defaultOriginalFormated = $this->priceCurrency->format(
+            $defaultOriginal,
+            false,
+            PriceCurrencyInterface::DEFAULT_PRECISION,
+            $store,
+            $currencyCode
+        );
+
+        $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
+        $customData[$field][$currencyCode]['default_original_formated'] = $defaultOriginalFormated;
         $customData[$field][$currencyCode]['default'] = $min;
         $customData[$field][$currencyCode]['default_formated'] = $minFormatted;
 

--- a/Helper/Entity/Product/PriceManager.php
+++ b/Helper/Entity/Product/PriceManager.php
@@ -521,6 +521,7 @@ class PriceManager
         if ($min !== $max) {
             $customData[$field][$currencyCode]['default_min'] = $min;
             $customData[$field][$currencyCode]['default_max'] = $max;
+            $customData[$field][$currencyCode]['default_formated'] = $this->getDashedPriceFormat($min, $max, $store, $currencyCode);
             $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
             $customData[$field][$currencyCode]['default_original_min'] = $defaultOriginal;
             $customData[$field][$currencyCode]['default_original_max'] = $defaultOriginalMax;

--- a/Helper/Entity/Product/PriceManager.php
+++ b/Helper/Entity/Product/PriceManager.php
@@ -139,7 +139,6 @@ class PriceManager
                         );
                     }
 
-
                     if (!$customData[$field][$currencyCode]['default']) {
                         $customData = $this->handleZeroDefaultPrice(
                             $customData,

--- a/Helper/Entity/Product/PriceManager.php
+++ b/Helper/Entity/Product/PriceManager.php
@@ -517,9 +517,27 @@ class PriceManager
         $defaultOriginal = min($defaultOriginals);
         $defaultOriginalMax = max($defaultOriginals);
 
+        $minFormatted = $this->priceCurrency->format(
+            $min,
+            false,
+            PriceCurrencyInterface::DEFAULT_PRECISION,
+            $store,
+            $currencyCode
+        );
+
+        $maxFormatted = $this->priceCurrency->format(
+            $max,
+            false,
+            PriceCurrencyInterface::DEFAULT_PRECISION,
+            $store,
+            $currencyCode
+        );
+
         if ($min !== $max) {
             $customData[$field][$currencyCode]['default_min'] = $min;
+            $customData[$field][$currencyCode]['default_min_formated'] = $minFormatted;
             $customData[$field][$currencyCode]['default_max'] = $max;
+            $customData[$field][$currencyCode]['default_max_formated'] = $maxFormatted;
             $customData[$field][$currencyCode]['default_formated'] = $this->getDashedPriceFormat($min, $max, $store, $currencyCode);
             $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
             $customData[$field][$currencyCode]['default_original_min'] = $defaultOriginal;
@@ -531,14 +549,6 @@ class PriceManager
         if ($currencyCode !== $baseCurrencyCode) {
             $min = $this->priceCurrency->convert($min, $store, $currencyCode);
         }
-
-        $minFormatted = $this->priceCurrency->format(
-            $min,
-            false,
-            PriceCurrencyInterface::DEFAULT_PRECISION,
-            $store,
-            $currencyCode
-        );
 
         $defaultOriginalFormated = $this->priceCurrency->format(
             $defaultOriginal,

--- a/Helper/Entity/Product/PriceManager.php
+++ b/Helper/Entity/Product/PriceManager.php
@@ -555,12 +555,14 @@ class PriceManager
             $customData[$field][$currencyCode]['default_max'] = $max;
             $customData[$field][$currencyCode]['default_max_formated'] = $maxFormatted;
             $customData[$field][$currencyCode]['default_formated'] = $this->getDashedPriceFormat($min, $max, $store, $currencyCode);
-            $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
-            $customData[$field][$currencyCode]['default_original_min'] = $defaultOriginal;
-            $customData[$field][$currencyCode]['default_original_min_formated'] = $defaultMinFormatted;
-            $customData[$field][$currencyCode]['default_original_max'] = $defaultOriginalMax;
-            $customData[$field][$currencyCode]['default_original_max_formated'] = $defaultMaxFormatted;
-            $customData[$field][$currencyCode]['default_original_formated'] = $this->getDashedPriceFormat($defaultOriginal, $defaultOriginalMax, $store, $currencyCode);
+            if ($defaultOriginal != $min && $defaultOriginal < $min) {
+                $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
+                $customData[$field][$currencyCode]['default_original_min'] = $defaultOriginal;
+                $customData[$field][$currencyCode]['default_original_min_formated'] = $defaultMinFormatted;
+                $customData[$field][$currencyCode]['default_original_max'] = $defaultOriginalMax;
+                $customData[$field][$currencyCode]['default_original_max_formated'] = $defaultMaxFormatted;
+                $customData[$field][$currencyCode]['default_original_formated'] = $this->getDashedPriceFormat($defaultOriginal, $defaultOriginalMax, $store, $currencyCode);
+            }
             return $customData;
         }
 
@@ -576,8 +578,11 @@ class PriceManager
             $currencyCode
         );
 
-        $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
-        $customData[$field][$currencyCode]['default_original_formated'] = $defaultOriginalFormated;
+        if ($defaultOriginal != $min && $defaultOriginal < $min) {
+            $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
+            $customData[$field][$currencyCode]['default_original_formated'] = $defaultOriginalFormated;
+        }
+
         $customData[$field][$currencyCode]['default'] = $min;
         $customData[$field][$currencyCode]['default_formated'] = $minFormatted;
 

--- a/Helper/Entity/Product/PriceManager.php
+++ b/Helper/Entity/Product/PriceManager.php
@@ -533,6 +533,22 @@ class PriceManager
             $currencyCode
         );
 
+        $defaultMinFormatted = $this->priceCurrency->format(
+            $defaultOriginal,
+            false,
+            PriceCurrencyInterface::DEFAULT_PRECISION,
+            $store,
+            $currencyCode
+        );
+
+        $defaultMaxFormatted = $this->priceCurrency->format(
+            $defaultOriginalMax,
+            false,
+            PriceCurrencyInterface::DEFAULT_PRECISION,
+            $store,
+            $currencyCode
+        );
+
         if ($min !== $max) {
             $customData[$field][$currencyCode]['default_min'] = $min;
             $customData[$field][$currencyCode]['default_min_formated'] = $minFormatted;
@@ -541,7 +557,9 @@ class PriceManager
             $customData[$field][$currencyCode]['default_formated'] = $this->getDashedPriceFormat($min, $max, $store, $currencyCode);
             $customData[$field][$currencyCode]['default_original'] = $defaultOriginal;
             $customData[$field][$currencyCode]['default_original_min'] = $defaultOriginal;
+            $customData[$field][$currencyCode]['default_original_min_formated'] = $defaultMinFormatted;
             $customData[$field][$currencyCode]['default_original_max'] = $defaultOriginalMax;
+            $customData[$field][$currencyCode]['default_original_max_formated'] = $defaultMaxFormatted;
             $customData[$field][$currencyCode]['default_original_formated'] = $this->getDashedPriceFormat($defaultOriginal, $defaultOriginalMax, $store, $currencyCode);
             return $customData;
         }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
See issue #420. The pricing logic for configurables with a catalog price rule are incorrect. In the `handleZeroDefaultPrice` method the original values are not set, thereby not showing the original price on the frontend (and thus showing the special price as the normal price). This applies to configurables with child products that all have the same price as well as for configurables with child products with differing prices (price range, a.k.a. min/max).

This pull request fixes both issues and adds min/max fields that are synced to Algolia. This way, we can leave it up to the implementation specialist to show the range or just the 'From' price (in `instant/hit.phtml`).

**Before (only example for single price for all children)**

![image](https://user-images.githubusercontent.com/431360/41776491-3fd7cb44-7628-11e8-9edf-4df116369045.png)

JSON:

```
  "price": {
    "EUR": {
      "default": 895,
      "default_formated": "€ 895,00",
      "special_from_date": false,
      "special_to_date": false
    }
  },
```

**After**
*Single price for all children*

![image](https://user-images.githubusercontent.com/431360/41775988-5979506a-7626-11e8-8e56-aa0ab9104cb2.png)

JSON:

```
  "price": {
    "EUR": {
      "default": 863.68,
      "default_formated": "€ 863,68",
      "special_from_date": false,
      "special_to_date": false,
      "default_original": "895.0000",
      "default_original_formated": "€ 895,00"
    }
  },
```

*Differing prices for children (range)*

![image](https://user-images.githubusercontent.com/431360/41776260-4ec1e988-7627-11e8-95c8-18d98231574f.png)

JSON:

```
  "price": {
    "EUR": {
      "default": 800,
      "default_formated": "€ 800,00 - € 863,68",
      "special_from_date": false,
      "special_to_date": false,
      "default_min": 800,
      "default_min_formated": "€ 800,00",
      "default_max": 863.68,
      "default_max_formated": "€ 863,68",
      "default_original": "850.0000",
      "default_original_min": "850.0000",
      "default_original_min_formated": "€ 850,00",
      "default_original_max": "895.0000",
      "default_original_max_formated": "€ 895,00",
      "default_original_formated": "€ 850,00 - € 895,00"
    }
  },
```