### PR TITLE
Fixed incorrect replacement of "+" and "-" of toggle button of facet panel when displayed on small screen

### DIFF
--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -486,7 +486,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 		/** Handle small screen **/
 		$('body').on('click', '#refine-toggle', function () {
 			$('#instant-search-facets-container').toggleClass('hidden-sm').toggleClass('hidden-xs');
-			if ($(this).html()[0] === '+')
+			if ($(this).html().trim()[0] === '+')
 				$(this).html('- ' + algoliaConfig.translations.refine);
 			else
 				$(this).html('+ ' + algoliaConfig.translations.refine);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

In https://github.com/algolia/algoliasearch-magento-2/blob/d7482b561eb2f3fe41867c83fef130fd08f8c728/view/frontend/templates/instant/wrapper.phtml ...
```
                <div id="refine-toggle" class="visible-xs visible-sm">
                    + <?php echo $block->escapeHtml(__('Refine')); ?>
                </div>
```
It is line terminator characters that is obtained from the above elements using `$(this).html()[0]`.
If we try to get the string "+" or "-", we need to get rid of the obstacles first.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

Replacement of "+" and "-" is correct.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->