### PR TITLE
Check if staging modules are being used

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -51,7 +51,7 @@ class CategoryHelper
     private $rootCategoryId = -1;
     private $activeCategories;
     private $categoryNames;
-	private $moduleManager;
+    private $moduleManager;
 
     /**
      * CategoryHelper constructor.
@@ -75,7 +75,7 @@ class CategoryHelper
         Image $imageHelper,
         CategoryResource $categoryResource,
         CategoryFactory $categoryFactory,
-		Manager $moduleManager
+	Manager $moduleManager
     ) {
         $this->eventManager = $eventManager;
         $this->storeManager = $storeManager;
@@ -86,7 +86,7 @@ class CategoryHelper
         $this->imageHelper = $imageHelper;
         $this->categoryResource = $categoryResource;
         $this->categoryFactory = $categoryFactory;
-		$this->moduleManager = $moduleManager;
+	$this->moduleManager = $moduleManager;
     }
 
     public function getIndexNameSuffix()

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -15,6 +15,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Algolia\AlgoliaSearch\Helper\Image;
 use Magento\Catalog\Model\Category;
 use Magento\Framework\DataObject;
+use Magento\Framework\Module\Manager;
 
 class CategoryHelper
 {
@@ -50,6 +51,7 @@ class CategoryHelper
     private $rootCategoryId = -1;
     private $activeCategories;
     private $categoryNames;
+	private $moduleManager;
 
     /**
      * CategoryHelper constructor.
@@ -72,7 +74,8 @@ class CategoryHelper
         CategoryCollection $categoryCollection,
         Image $imageHelper,
         CategoryResource $categoryResource,
-        CategoryFactory $categoryFactory
+        CategoryFactory $categoryFactory,
+		Manager $moduleManager
     ) {
         $this->eventManager = $eventManager;
         $this->storeManager = $storeManager;
@@ -83,6 +86,7 @@ class CategoryHelper
         $this->imageHelper = $imageHelper;
         $this->categoryResource = $categoryResource;
         $this->categoryFactory = $categoryFactory;
+		$this->moduleManager = $moduleManager;
     }
 
     public function getIndexNameSuffix()
@@ -579,7 +583,7 @@ class CategoryHelper
         $edition = $this->configHelper->getMagentoEdition();
         $version = $this->configHelper->getMagentoVersion();
 
-        if ($edition !== 'Community' && version_compare($version, '2.1.0', '>=')) {
+        if ($edition !== 'Community' && version_compare($version, '2.1.0', '>=') && $this->moduleManager->isEnabled('Magento_Staging')) {
             $this->idColumn = 'row_id';
         }
 

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -75,7 +75,7 @@ class CategoryHelper
         Image $imageHelper,
         CategoryResource $categoryResource,
         CategoryFactory $categoryFactory,
-	Manager $moduleManager
+        Manager $moduleManager
     ) {
         $this->eventManager = $eventManager;
         $this->storeManager = $storeManager;
@@ -86,7 +86,7 @@ class CategoryHelper
         $this->imageHelper = $imageHelper;
         $this->categoryResource = $categoryResource;
         $this->categoryFactory = $categoryFactory;
-	$this->moduleManager = $moduleManager;
+        $this->moduleManager = $moduleManager;
     }
 
     public function getIndexNameSuffix()


### PR DESCRIPTION
Here you are converting entity_id to row_id if customer is using Magento EE and version is greater than 2.1.0 but lots of customer may not use staging modules which actually changes entity_id to row_id.
Like we are using dumpautoload to remove all staging modules. I have just added a check if Magento_Staging module is in play. Because all staging modules are dependent on this one. So if this one exists then we can convert entity_id to row_id. Else we wont.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->