### PR TITLE
Feature/add event product collection event arguments

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -243,8 +243,8 @@ class ProductHelper
             [
                 'store' => $storeId, 
                 'collection' => $products,
-                'onlyVisible' => $onlyVisible, 
-                'includeNotVisibleIndividually' => $includeNotVisibleIndividually
+                'only_visible' => $onlyVisible,
+                'include_not_visible_individually' => $includeNotVisibleIndividually
             ]
         );
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -240,7 +240,12 @@ class ProductHelper
         );
         $this->eventManager->dispatch(
             'algolia_after_products_collection_build',
-            ['store' => $storeId, 'collection' => $products]
+            [
+                'store' => $storeId, 
+                'collection' => $products,
+                'onlyVisible' => $onlyVisible, 
+                'includeNotVisibleIndividually' => $includeNotVisibleIndividually
+            ]
         );
 
         return $products;


### PR DESCRIPTION
**Summary**

Hi! I'ld like to suggest to pass useful arguments in getProductCollectionQuery method for 3rd party code to be able to distinguish different calls.

For example, we have an observer that filters product collection by root category depending on store id. However, this filter must not apply when collection is created for sub products of configurable products. We can rely on parameter `only_visible` for this, but we need to have it dispatched.

Currently we resorted to patch, but it would be nice if this change made it to upstream one day.

Thanks :)