### PR TITLE
Create Url object once per emulated store

### DIFF
--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -128,26 +128,13 @@ class PageHelper
 
     private function getStoreUrl($storeId)
     {
-        if ($this->storeUrls === null) {
-            $this->storeUrls = [];
-            $storeIds = $this->getStores();
-
-            foreach ($storeIds as $storeId) {
-                // ObjectManager used instead of UrlFactory because UrlFactory will return UrlInterface which
-                // may cause a backend Url object to be returned
-
-                /** @var Url $url */
-                $url = $this->objectManager->create('Magento\Framework\Url');
-                $url->setData('store', $storeId);
-                $this->storeUrls[$storeId] = $url;
-            }
+        if (!isset($this->storeUrls[$storeId])) {
+            $url = $this->objectManager->create('Magento\Framework\Url');
+            $url->setData('store', $storeId);
+            $this->storeUrls[$storeId] = $url;
         }
 
-        if (array_key_exists($storeId, $this->storeUrls)) {
-            return $this->storeUrls[$storeId];
-        }
-
-        return null;
+        return $this->storeUrls[$storeId];
     }
 
     public function getStores($storeId = null)


### PR DESCRIPTION
**Summary**
This function is run per store within an emulated environment. It does not make sense to loop through the stores again. 

This change makes sure there's only one Url object per store which will return the correct Urls.

**Motivation**
Issue with indexing on multistore: https://github.com/algolia/algoliasearch-magento-2/issues/540

**Result**

From a multistore setup with 2 websites and 3 stores, just run these commands:
bin/magento indexer:reindex algolia_pages
bin/magento indexer:reindex algolia_queue_runner
All page urls are now entered into Algolia correctly.