### PR TITLE
Fix deactivated serialized arrays

### DIFF
--- a/Controller/Adminhtml/System/Config/Save.php
+++ b/Controller/Adminhtml/System/Config/Save.php
@@ -18,7 +18,6 @@ class Save extends \Magento\Config\Controller\Adminhtml\System\Config\Save
     {
         if (isset($groups['instant']['fields']['is_instant_enabled']['value'])
                 && $groups['instant']['fields']['is_instant_enabled']['value'] == '0') {
-
             foreach ($this->instantSerializedValues as $field) {
                 if (isset($groups['instant']['fields'][$field])) {
                     unset($groups['instant']['fields'][$field]);
@@ -28,7 +27,6 @@ class Save extends \Magento\Config\Controller\Adminhtml\System\Config\Save
 
         if (isset($groups['autocomplete']['fields']['is_popup_enabled']['value'])
                 && $groups['autocomplete']['fields']['is_popup_enabled']['value'] == '0') {
-
             foreach ($this->autocompleteSerializedValues as $field) {
                 if (isset($groups['autocomplete']['fields'][$field])) {
                     unset($groups['autocomplete']['fields'][$field]);

--- a/Controller/Adminhtml/System/Config/Save.php
+++ b/Controller/Adminhtml/System/Config/Save.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Controller\Adminhtml\System\Config;
+
+class Save extends \Magento\Config\Controller\Adminhtml\System\Config\Save
+{
+    /**
+     * Get groups for save
+     *
+     * @return array|null
+     */
+    protected function _getGroupsForSave()
+    {
+        $groups = parent::_getGroupsForSave();
+
+        return $this->handleDeactivatedSerializedArrays($groups);
+    }
+
+    private function handleDeactivatedSerializedArrays($groups)
+    {
+        if (isset($groups['instant']['fields']['is_instant_enabled']['value'])
+                && $groups['instant']['fields']['is_instant_enabled']['value'] == '0') {
+            if (isset($groups['instant']['fields']['facets'])) {
+                unset($groups['instant']['fields']['facets']);
+            }
+            if (isset($groups['instant']['fields']['sorts'])) {
+                unset($groups['instant']['fields']['sorts']);
+            }
+        }
+
+        if (isset($groups['autocomplete']['fields']['is_popup_enabled']['value'])
+                && $groups['autocomplete']['fields']['is_popup_enabled']['value'] == '0') {
+            if (isset($groups['autocomplete']['fields']['sections'])) {
+                unset($groups['autocomplete']['fields']['sections']);
+            }
+
+            if (isset($groups['autocomplete']['fields']['excluded_pages'])) {
+                unset($groups['autocomplete']['fields']['excluded_pages']);
+            }
+        }
+
+        return $groups;
+    }
+}

--- a/Controller/Adminhtml/System/Config/Save.php
+++ b/Controller/Adminhtml/System/Config/Save.php
@@ -4,11 +4,9 @@ namespace Algolia\AlgoliaSearch\Controller\Adminhtml\System\Config;
 
 class Save extends \Magento\Config\Controller\Adminhtml\System\Config\Save
 {
-    /**
-     * Get groups for save
-     *
-     * @return array|null
-     */
+    private $instantSerializedValues = ['facets', 'sorts'];
+    private $autocompleteSerializedValues = ['sections', 'excluded_pages'];
+
     protected function _getGroupsForSave()
     {
         $groups = parent::_getGroupsForSave();
@@ -20,22 +18,21 @@ class Save extends \Magento\Config\Controller\Adminhtml\System\Config\Save
     {
         if (isset($groups['instant']['fields']['is_instant_enabled']['value'])
                 && $groups['instant']['fields']['is_instant_enabled']['value'] == '0') {
-            if (isset($groups['instant']['fields']['facets'])) {
-                unset($groups['instant']['fields']['facets']);
-            }
-            if (isset($groups['instant']['fields']['sorts'])) {
-                unset($groups['instant']['fields']['sorts']);
+
+            foreach ($this->instantSerializedValues as $field) {
+                if (isset($groups['instant']['fields'][$field])) {
+                    unset($groups['instant']['fields'][$field]);
+                }
             }
         }
 
         if (isset($groups['autocomplete']['fields']['is_popup_enabled']['value'])
                 && $groups['autocomplete']['fields']['is_popup_enabled']['value'] == '0') {
-            if (isset($groups['autocomplete']['fields']['sections'])) {
-                unset($groups['autocomplete']['fields']['sections']);
-            }
 
-            if (isset($groups['autocomplete']['fields']['excluded_pages'])) {
-                unset($groups['autocomplete']['fields']['excluded_pages']);
+            foreach ($this->autocompleteSerializedValues as $field) {
+                if (isset($groups['autocomplete']['fields'][$field])) {
+                    unset($groups['autocomplete']['fields'][$field]);
+                }
             }
         }
 

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Magento\Catalog\Model\Product\Url" type="Algolia\AlgoliaSearch\Model\Product\Url" />
+    <preference for="Magento\Config\Controller\Adminhtml\System\Config\Save" type="Algolia\AlgoliaSearch\Controller\Adminhtml\System\Config\Save" />
     <type name="Magento\Catalog\Model\Category">
         <plugin name="algolia_algoliasearch_plugin_category_url" type="Algolia\AlgoliaSearch\Plugin\CategoryUrlPlugin"/>
     </type>


### PR DESCRIPTION
 Fix deactivated serialized arrays : when IS or autocomplete are turned off in the Magento configuration, prevent serialized array fields to be emptied.