### PR TITLE
Truncate sku field for large configurable products when handling large objects

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -565,7 +565,7 @@ class AlgoliaHelper extends AbstractHelper
      * @param $object
      * @return int
      */
-    private function calculateObjectSize($object): int
+    private function calculateObjectSize($object)
     {
         return mb_strlen(json_encode($object));
     }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -471,7 +471,9 @@ class AlgoliaHelper extends AbstractHelper
                     if (count($object['sku']) === 1) {
                         break;
                     }
+
                     array_pop($object['sku']);
+                    
                     $size = $this->calculateObjectSize($object);
                     if ($size < $this->maxRecordSize) {
                         return $object;

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -466,7 +466,7 @@ class AlgoliaHelper extends AbstractHelper
             // This has the downside that some products cannot be found on some of its childrens' SKU's
             // But at least the config product can be indexed
             // Always keep the original SKU though
-            if ($this->getLongestAttribute($object) == 'sku' && is_array($object['sku'])) {
+            if ($this->getLongestAttribute($object) === 'sku' && is_array($object['sku'])) {
                 foreach ($object['sku'] as $sku) {
                     if (count($object['sku']) === 1) {
                         break;


### PR DESCRIPTION
**Summary**

We have extremely large configurable products (up to 10.000 SKUs). When syncing these products to Algolia, we noticed that these products were being skipped, like this;

```
Algolia reindexing: 
                You have some records which are too big to be indexed in Algolia. 
                They have either been truncated 
                (removed attributes: description, short_description, meta_description, content) 
                or skipped completely: 
magento2_st_de_products 
                    - ID 692545 - skipped - longest attribute: sku
```

This turns out to be because the `sku` attribute in the object is filled with all the child SKU's of the configurable products. This makes sense; it makes the configurable product discoverable through any of its child SKUs. However, in our case, we have thousands of these SKU's and there is a slim chance anyone will search on the child SKU's.

I've therefore added a bit of logic to the `handleTooBigRecord` method that will pop off each of one of the SKUs (starting from the end and work its way forward). Each time it will check whether the object will fit in the index and if so, it will return it to the main thread.

I've also added this slightly more intelligent removal of attributes to the `$potentiallyLongAttributes`, which were removed in one go instead of trying to test whether removing 1 or 2 already makes the object fit.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
It gets indexed;

```
Algolia reindexing: 
                You have some records which are too big to be indexed in Algolia. 
                They have either been truncated 
                (removed attributes: description, short_description, meta_description, content) 
                or skipped completely: 
magento2_st_de_products - ID 692545 - truncated
```

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->