### PR TITLE
Refactor templates to use ViewModel factory to support M2.1

### DIFF
--- a/Block/Adminhtml/BaseAdminTemplate.php
+++ b/Block/Adminhtml/BaseAdminTemplate.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Block\Adminhtml;
+
+use Algolia\AlgoliaSearch\Factory\ViewModelFactory;
+use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
+
+class BaseAdminTemplate extends Template
+{
+    /** @var ViewModelFactory */
+    private $viewModelFactory;
+
+    /**
+     * @param Context $context
+     * @param ViewModelFactory $viewModelFactory
+     * @param array $data
+     */
+    public function __construct(Context $context, ViewModelFactory $viewModelFactory, array $data = [])
+    {
+        parent::__construct($context, $data);
+
+        $this->viewModelFactory = $viewModelFactory;
+    }
+
+    public function getViewModel()
+    {
+        return $this->viewModelFactory->create($this);
+    }
+}

--- a/Factory/ViewModelFactory.php
+++ b/Factory/ViewModelFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Factory;
+
+use Magento\Backend\Block\Template;
+use Magento\Framework\ObjectManagerInterface;
+
+class ViewModelFactory
+{
+    /** @var ObjectManagerInterface */
+    private $objectManager;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * @param Template $block
+     *
+     * @return object
+     */
+    public function create($block)
+    {
+        $templateName = $block->getTemplate();
+        $classNameSuffix = $this->transformTemplateToClassNameSuffix($templateName);
+
+        // Turns "Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate"
+        // to "Algolia\AlgoliaSearch\ViewModel\Adminhtml\[[specificViewModelName]]"
+        $viewModelClassName = str_replace(
+            ['\Block\\', 'BaseAdminTemplate'],
+            ['\ViewModel\\', $classNameSuffix],
+            get_class($block)
+        );
+
+        return $this->objectManager->create($viewModelClassName);
+    }
+
+    /**
+     * It turns template name (eg. "Algolia_AlgoliaSearch::support/overview.phtml")
+     * to class name suffix (eg. "Support\Overview"),
+     * which is later on used to create ViewModel object
+     *
+     * @param string $templateName
+     *
+     * @return string
+     */
+    private function transformTemplateToClassNameSuffix($templateName)
+    {
+        $className = str_replace(['Algolia_AlgoliaSearch::', '.phtml'], '', $templateName);
+
+        $classNameParts = explode('/', $className);
+        $classNameParts = array_map(function ($part) {
+            return ucfirst($part);
+        }, $classNameParts);
+
+        $className = implode('\\', $classNameParts);
+
+        return $className;
+    }
+}

--- a/ViewModel/Adminhtml/Analytics/Form.php
+++ b/ViewModel/Adminhtml/Analytics/Form.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics;
 
-class Form extends Index
+class Form extends Overview
 {
     /**
      * @return string
@@ -22,6 +22,7 @@ class Form extends Index
     public function getFormValue($key)
     {
         $formData = $this->getBackendView()->getBackendSession()->getAlgoliaAnalyticsFormData();
+
         if ((!isset($formData['to']) && !isset($formData['from']))
             || ($formData['to'] == '' && $formData['from'] == '')) {
             $formData['to'] = date('d M Y', time());

--- a/ViewModel/Adminhtml/Analytics/Overview.php
+++ b/ViewModel/Adminhtml/Analytics/Overview.php
@@ -5,9 +5,11 @@ namespace Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics;
 use Algolia\AlgoliaSearch\DataProvider\Analytics\IndexEntityDataProvider;
 use Algolia\AlgoliaSearch\Helper\AnalyticsHelper;
 use Algolia\AlgoliaSearch\ViewModel\Adminhtml\BackendView;
-use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Api\Data\StoreInterface;
 
-class Index implements ArgumentInterface
+class Overview
 {
     const LIMIT_RESULTS = 5;
 
@@ -55,7 +57,7 @@ class Index implements ArgumentInterface
     }
 
     /**
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws NoSuchEntityException
      *
      * @return mixed
      */
@@ -69,7 +71,7 @@ class Index implements ArgumentInterface
     /**
      * @param array $additional
      *
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws NoSuchEntityException
      *
      * @return array
      */
@@ -127,7 +129,7 @@ class Index implements ArgumentInterface
     /**
      * Click Analytics
      *
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws NoSuchEntityException
      *
      * @return mixed
      */
@@ -225,7 +227,7 @@ class Index implements ArgumentInterface
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      *
      * @return array
      */
@@ -277,7 +279,7 @@ class Index implements ArgumentInterface
     }
 
     /**
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws NoSuchEntityException
      *
      * @return array
      */
@@ -338,7 +340,7 @@ class Index implements ArgumentInterface
     }
 
     /**
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws NoSuchEntityException
      *
      * @return array
      */
@@ -409,9 +411,9 @@ class Index implements ArgumentInterface
     }
 
     /**
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws NoSuchEntityException
      *
-     * @return \Magento\Store\Api\Data\StoreInterface|null|string
+     * @return StoreInterface|null|string
      */
     public function getStore()
     {

--- a/ViewModel/Adminhtml/BackendView.php
+++ b/ViewModel/Adminhtml/BackendView.php
@@ -10,7 +10,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Framework\View\LayoutInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
-class BackendView implements \Magento\Framework\View\Element\Block\ArgumentInterface
+class BackendView
 {
     /** @var RequestInterface */
     private $request;

--- a/ViewModel/Adminhtml/Support/Contact.php
+++ b/ViewModel/Adminhtml/Support/Contact.php
@@ -7,10 +7,9 @@ use Algolia\AlgoliaSearch\ViewModel\Adminhtml\BackendView;
 use Magento\Backend\Block\Template;
 use Magento\Backend\Model\Auth\Session;
 use Magento\Framework\Module\ModuleListInterface;
-use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\User\Model\User;
 
-class Contact implements ArgumentInterface
+class Contact
 {
     /** @var BackendView */
     private $backendView;

--- a/ViewModel/Adminhtml/Support/Overview.php
+++ b/ViewModel/Adminhtml/Support/Overview.php
@@ -5,9 +5,8 @@ namespace Algolia\AlgoliaSearch\ViewModel\Adminhtml\Support;
 use Algolia\AlgoliaSearch\Helper\SupportHelper;
 use Algolia\AlgoliaSearch\ViewModel\Adminhtml\BackendView;
 use Magento\Backend\Block\Template;
-use Magento\Framework\View\Element\Block\ArgumentInterface;
 
-class Index implements ArgumentInterface
+class Overview
 {
     /** @var BackendView */
     private $backendView;

--- a/view/adminhtml/layout/algolia_algoliasearch_analytics_index.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_analytics_index.xml
@@ -14,20 +14,10 @@
                     <argument name="default_selection_name" xsi:type="string" translate="true">Default Store View</argument>
                 </arguments>
             </block>
-            <block class="Magento\Backend\Block\Template"
-                    name="analytics.overview.form" template="Algolia_AlgoliaSearch::analytics/form.phtml">
-                <arguments>
-                    <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Form</argument>
-                </arguments>
-            </block>
+            <block class="Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate" name="analytics.overview.form" template="Algolia_AlgoliaSearch::analytics/form.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Backend\Block\Template"
-                   name="analytics_overview" template="Algolia_AlgoliaSearch::analytics/overview.phtml">
-                <arguments>
-                    <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Index</argument>
-                </arguments>
-            </block>
+            <block class="Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate" name="analytics_overview" template="Algolia_AlgoliaSearch::analytics/overview.phtml" />
         </referenceContainer>
     </body>
 </page>

--- a/view/adminhtml/layout/algolia_algoliasearch_support_contact.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_support_contact.xml
@@ -7,12 +7,7 @@
     </head>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Backend\Block\Template"
-                   name="support_contact" template="Algolia_AlgoliaSearch::support/contact.phtml">
-                <arguments>
-                    <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Support\Contact</argument>
-                </arguments>
-            </block>
+            <block class="Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate" name="support_contact" template="Algolia_AlgoliaSearch::support/contact.phtml" />
         </referenceContainer>
     </body>
 </page>

--- a/view/adminhtml/layout/algolia_algoliasearch_support_index.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_support_index.xml
@@ -8,12 +8,7 @@
     <body>
 
         <referenceContainer name="content">
-            <block class="Magento\Backend\Block\Template"
-                   name="support_overview" template="Algolia_AlgoliaSearch::support/overview.phtml">
-                <arguments>
-                    <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Support\Index</argument>
-                </arguments>
-            </block>
+            <block class="Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate" name="support_overview" template="Algolia_AlgoliaSearch::support/overview.phtml" />
         </referenceContainer>
     </body>
 </page>

--- a/view/adminhtml/templates/analytics/form.phtml
+++ b/view/adminhtml/templates/analytics/form.phtml
@@ -1,5 +1,12 @@
-<?php /** @var $form Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Form */ ?>
-<?php $form = $block->getViewModel() ?>
+<?php
+
+/** @var $this \Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate */
+
+/** @var Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Form $form */
+$form = $this->getViewModel();
+
+?>
+
 <?php $isFormDisabled = !$form->isAnalyticsApiEnabled() ? ' disabled' : '' ?>
 <div class="algolia-analytics-form" id="algolia-analytics-daterange">
     <form id="algolia-analytics-form" data-mage-init='{"validation":{}}' action="<?php echo $form->getFormAction() ?>"  method="post">

--- a/view/adminhtml/templates/analytics/graph.phtml
+++ b/view/adminhtml/templates/analytics/graph.phtml
@@ -1,59 +1,60 @@
 <?php if (!empty($block->getAnalytics())): ?>
-<div id="algolia-analyatics-diagram"></div>
-<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-<script type="text/javascript">
-    google.charts.load("current", {packages:['corechart']});
-    google.charts.setOnLoadCallback(drawChart);
-    function drawChart() {
+    <div id="algolia-analyatics-diagram"></div>
 
-        var data = new google.visualization.arrayToDataTable([
-            ['Date', 'Searches', {type: 'string', role: 'tooltip', p: {'html': true}}, {role: 'style'}],
-            <?php foreach ($block->getAnalytics() as $item): ?>
-            ['<?php echo $item['formatted'] ?>', <?php echo $item['count'] ?>,
-                "<div style='padding: 1.5rem; line-height: 18px;'><strong style='font-size: 14px;'><?php echo $item['formatted'] ?></strong><br/><br/>" +
-                "<p>Searches: <strong style='color: #5468ff; padding-left: 3px;'><?php echo $item['count'] ?></strong></p>" +
-                "<p>Users: <strong style='color: #3a46a1; padding-left: 3px;'><?php echo $item['users'] ?></strong></p>" +
-                "<p>No Result Rate: <strong style='color: #3ab2bd; padding-left: 3px;'><?php echo round((int) $item['rate'] * 100, 2) . '%' ?></strong></p>" +
-                <?php if (isset($item['ctr'])): ?>
-                    "<br/>" +
-                    "<p>CTR: <strong style='color: #5468ff; padding-left: 3px;'><?php echo round((int) $item['ctr'] * 100, 2) . '%' ?></strong></p>" +
-                    "<p>Conversion Rate: <strong style='color: #3a46a1; padding-left: 3px;'><?php echo round((int) $item['conversion'] * 100, 2) . '%' ?></strong></p>" +
-                    "<p>Avg Click Position: <strong style='color: #3ab2bd; padding-left: 3px;'><?php echo $item['clickPos'] ? $item['clickPos'] : '-' ?></strong></p>" +
-                <?php endif ?>
-                "</div>",
-                'stroke-opacity: 0; fill-opacity: 0.75;'
-            ],
-            <?php endforeach ?>
-        ]);
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script type="text/javascript">
+        google.charts.load("current", {packages:['corechart']});
+        google.charts.setOnLoadCallback(drawChart);
+        function drawChart() {
 
-        var options = {
-            chart: {
-                subtitle: 'Searches, Users, and No Result Rates',
-            },
-            colors: ['#5468ff', '#3a46a1', '#3ab2bd'],
-            hAxis: {
-                baselineColor: 'grey',
-                textStyle: {
-                    color: 'grey'
-                }
-            },
-            vAxis: {
-                baselineColor: 'grey',
-                minValue: 0,
-                textStyle: {
-                    color: 'grey'
-                }
-            },
-            legend: {position: 'none'},
-            tooltip: {isHtml: true},
-            fontSize: 12,
-            fontName: 'Open Sans'
-        };
+            var data = new google.visualization.arrayToDataTable([
+                ['Date', 'Searches', {type: 'string', role: 'tooltip', p: {'html': true}}, {role: 'style'}],
+                <?php foreach ($block->getAnalytics() as $item): ?>
+                ['<?php echo $item['formatted'] ?>', <?php echo $item['count'] ?>,
+                    "<div style='padding: 1.5rem; line-height: 18px;'><strong style='font-size: 14px;'><?php echo $item['formatted'] ?></strong><br/><br/>" +
+                    "<p>Searches: <strong style='color: #5468ff; padding-left: 3px;'><?php echo $item['count'] ?></strong></p>" +
+                    "<p>Users: <strong style='color: #3a46a1; padding-left: 3px;'><?php echo $item['users'] ?></strong></p>" +
+                    "<p>No Result Rate: <strong style='color: #3ab2bd; padding-left: 3px;'><?php echo round((int) $item['rate'] * 100, 2) . '%' ?></strong></p>" +
+                    <?php if (isset($item['ctr'])): ?>
+                        "<br/>" +
+                        "<p>CTR: <strong style='color: #5468ff; padding-left: 3px;'><?php echo round((int) $item['ctr'] * 100, 2) . '%' ?></strong></p>" +
+                        "<p>Conversion Rate: <strong style='color: #3a46a1; padding-left: 3px;'><?php echo round((int) $item['conversion'] * 100, 2) . '%' ?></strong></p>" +
+                        "<p>Avg Click Position: <strong style='color: #3ab2bd; padding-left: 3px;'><?php echo $item['clickPos'] ? $item['clickPos'] : '-' ?></strong></p>" +
+                    <?php endif ?>
+                    "</div>",
+                    'stroke-opacity: 0; fill-opacity: 0.75;'
+                ],
+                <?php endforeach ?>
+            ]);
 
-        var chart = new google.visualization.ColumnChart(document.getElementById('algolia-analyatics-diagram'));
-        chart.draw(data, options);
-    }
-</script>
+            var options = {
+                chart: {
+                    subtitle: 'Searches, Users, and No Result Rates',
+                },
+                colors: ['#5468ff', '#3a46a1', '#3ab2bd'],
+                hAxis: {
+                    baselineColor: 'grey',
+                    textStyle: {
+                        color: 'grey'
+                    }
+                },
+                vAxis: {
+                    baselineColor: 'grey',
+                    minValue: 0,
+                    textStyle: {
+                        color: 'grey'
+                    }
+                },
+                legend: {position: 'none'},
+                tooltip: {isHtml: true},
+                fontSize: 12,
+                fontName: 'Open Sans'
+            };
+
+            var chart = new google.visualization.ColumnChart(document.getElementById('algolia-analyatics-diagram'));
+            chart.draw(data, options);
+        }
+    </script>
 <?php else: ?>
     <div class="dashboard-diagram-nodata">
         <span><?php echo __('No Data Found') ?></span>

--- a/view/adminhtml/templates/analytics/overview.phtml
+++ b/view/adminhtml/templates/analytics/overview.phtml
@@ -1,6 +1,14 @@
-<?php /** @var $view Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Index */ ?>
-<?php $view = $block->getViewModel() ?>
+<?php
+
+/** @var $this \Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate */
+
+/** @var Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Overview $view */
+$view = $this->getViewModel();
+
+?>
+
 <?php echo $view->getMessagesHtml(); ?>
+
 <?php if ($view->isAnalyticsApiEnabled()): ?>
     <div class="algoliasearch-analytics-overview">
         <div class="row section">
@@ -180,11 +188,11 @@
         </div>
     </div>
 <?php else: ?>
-<div class="analytics-not-available">
-    <p><?php echo __('Your current plan doesn\'t make it possible for you to access analytic data from your Magento extension. You can however access it from your Algolia dashboard.') ?></p>
-    <p><?php echo __('Upgrading to a higher plan will give you access to this data and more.') ?></p>
-    <div class="button-wrapper">
-        <a href="https://www.algolia.com/billing/overview/" target="_blank" class="button"><?php echo __('Upgrade') ?></a>
+    <div class="analytics-not-available">
+        <p><?php echo __('Your current plan doesn\'t make it possible for you to access analytic data from your Magento extension. You can however access it from your Algolia dashboard.') ?></p>
+        <p><?php echo __('Upgrading to a higher plan will give you access to this data and more.') ?></p>
+        <div class="button-wrapper">
+            <a href="https://www.algolia.com/billing/overview/" target="_blank" class="button"><?php echo __('Upgrade') ?></a>
+        </div>
     </div>
-</div>
 <?php endif ?>

--- a/view/adminhtml/templates/support/components/legacy-version.phtml
+++ b/view/adminhtml/templates/support/components/legacy-version.phtml
@@ -1,7 +1,7 @@
-<?php /** @var $this \Algolia\AlgoliaSearch\Block\Adminhtml\Support\Components\LegacyVersion */ ?>
+<?php /** @var $this \Magento\Backend\Block\Template */ ?>
 
 <script>
-	var algoliaSearchExtentionsVersion = "<?php echo $this->getExtensionVersion(); ?>"
+	var algoliaSearchExtentionsVersion = "<?php echo $this->getData('extension_version'); ?>"
 </script>
 
 <div class="legacy_version">

--- a/view/adminhtml/templates/support/contact.phtml
+++ b/view/adminhtml/templates/support/contact.phtml
@@ -1,9 +1,9 @@
 <?php
 
-/** @var $this \Magento\Backend\Block\Template */
+/** @var $this \Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate */
 
 /** @var \Algolia\AlgoliaSearch\ViewModel\Adminhtml\Support\Contact $view */
-$view = $block->getViewModel();
+$view = $this->getViewModel();
 
 ?>
 

--- a/view/adminhtml/templates/support/overview.phtml
+++ b/view/adminhtml/templates/support/overview.phtml
@@ -1,9 +1,9 @@
 <?php
 
-/** @var $this \Magento\Backend\Block\Template */
+/** @var $this \Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate */
 
-/** @var \Algolia\AlgoliaSearch\ViewModel\Adminhtml\Support\Index $view */
-$view = $block->getViewModel();
+/** @var \Algolia\AlgoliaSearch\ViewModel\Adminhtml\Support\Overview $view */
+$view = $this->getViewModel();
 
 $docIllustration = $this->getViewFileUrl('Algolia_AlgoliaSearch::images/support-documentation.svg');
 $comIllustration = $this->getViewFileUrl('Algolia_AlgoliaSearch::images/support-community.svg');


### PR DESCRIPTION
Magento 2.2 suggests [to use ViewModels instead of inheriting Magento's template class](https://firegento.com/blog/2017/12/07/better-blocks-magento-2-php-view-models/) (thank you @damcou for spotting that).
However, this approach is not backward compatible with Magento 2.1.

This PR "hacks" Magento 2.1 and gives templates ability to load ViewModels via the same method, but with [a BaseTemplate and it's Factory as dependency](https://www.yireo.com/blog/2017-08-12-viewmodels-in-magento-2) (thank you @bsuravech for finding this solution).

It's not the best solution for Magento 2.2 and higher, but will give us the best (easiest) solution for the future when we decide to drop support of Magento 2.1 and rely only on ViewModels.

Could you please review and let me know what you think, @bsuravech and @damcou? Thank you! ❤️ 