### PR TITLE
Fix autocomplete frontend hook

### DIFF
--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -81,7 +81,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 				options.templates.footer = '<div class="footer_algolia"><a href="https://www.algolia.com/?utm_source=magento&utm_medium=link&utm_campaign=magento_autocompletion_menu" title="Search by Algolia" target="_blank"><img src="' +algoliaConfig.urls.logo + '"  alt="Search by Algolia" /></a></div>';
 			}
 			
-			sources = algolia.triggerHooks('beforeAutocompleteSources', sources, algolia_client);
+			sources = algolia.triggerHooks('beforeAutocompleteSources', sources, algolia_client, algoliaBundle);
 			options = algolia.triggerHooks('beforeAutocompleteOptions', options);
 			
 			// Keep for backward compatibility

--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -36,6 +36,9 @@ var algolia = {
 			hookArguments = Array.prototype.slice.call(arguments, 2);
 
 		var data = this.getRegisteredHooks(hookName).reduce(function(currentData, hook) {
+			if (Array.isArray(currentData)) {
+				currentData = [currentData];
+			}
 			var allParameters = [].concat(currentData).concat(hookArguments);
 			return hook.apply(null, allParameters);
 		}, originalData);


### PR DESCRIPTION
Fix the beforeAutocompleteSources frontend hook for autocomplete (allows to complete the tutorial [How to add external autocomplete source ](https://community.algolia.com/magento/doc/m1/external-autocomplete-source/) )