### PR TITLE
Fetch plan level from internal API proxy

### DIFF
--- a/Helper/ProxyHelper.php
+++ b/Helper/ProxyHelper.php
@@ -10,6 +10,7 @@ class ProxyHelper
 
     const INFO_TYPE_EXTENSION_SUPPORT = 'extension_support';
     const INFO_TYPE_ANALYTICS = 'analytics';
+    const INFO_TYPE_PLAN_LEVEL = 'plan_level';
 
     /** @var ConfigHelper */
     private $configHelper;


### PR DESCRIPTION
Hey @damcou,

feel free to Squash & Merge and you can get the plan level by calling:

```
$planLevelInfo = $proxyHelper->getInfo(ProxyHelper::INFO_TYPE_PLAN_LEVEL);
```