### PR TITLE
Optimize default indexing queue settings

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -28,8 +28,6 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class Data
 {
-    const COLLECTION_PAGE_SIZE = 100;
-
     private $algoliaHelper;
 
     private $pageHelper;

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -52,7 +52,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
         'algoliasearch_images/image/type' => 'image',
 
         'algoliasearch_queue/queue/active' => '0',
-        'algoliasearch_queue/queue/number_of_job_to_run' => '10',
+        'algoliasearch_queue/queue/number_of_job_to_run' => '5',
         'algoliasearch_queue/queue/number_of_retries' => '3',
 
         'algoliasearch_cc_analytics/cc_analytics_group/enable' => '0',
@@ -67,7 +67,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
         'algoliasearch_synonyms/synonyms_group/enable_synonyms' => '0',
 
-        'algoliasearch_advanced/advanced/number_of_element_by_page' => '100',
+        'algoliasearch_advanced/advanced/number_of_element_by_page' => '300',
         'algoliasearch_advanced/advanced/remove_words_if_no_result' => 'allOptional',
         'algoliasearch_advanced/advanced/partial_update' => '0',
         'algoliasearch_advanced/advanced/customer_groups_enable' => '0',

--- a/Test/Integration/QueueTest.php
+++ b/Test/Integration/QueueTest.php
@@ -32,7 +32,7 @@ class QueueTest extends TestCase
         $indexer->executeFull();
 
         $rows = $this->connection->query('SELECT * FROM algoliasearch_queue')->fetchAll();
-        $this->assertEquals(4, count($rows));
+        $this->assertEquals(3, count($rows));
 
         $i = 0;
         foreach ($rows as $row) {
@@ -47,9 +47,9 @@ class QueueTest extends TestCase
                 continue;
             }
 
-            if ($i < 4) {
+            if ($i < 3) {
                 $this->assertEquals('rebuildProductIndex', $row['method']);
-                $this->assertEquals(100, $row['data_size']);
+                $this->assertEquals(300, $row['data_size']);
 
                 continue;
             }
@@ -128,7 +128,7 @@ class QueueTest extends TestCase
         $indexer->executeFull();
 
         $rows = $this->connection->query('SELECT * FROM algoliasearch_queue')->fetchAll();
-        $this->assertEquals(12, count($rows));
+        $this->assertEquals(9, count($rows));
 
         // Process the whole queue
         /** @var QueueRunner $queueRunner */

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -613,7 +613,7 @@
                     <label>Number of jobs to run each time the cron is run</label>
                     <comment>
                         <![CDATA[
-                            Number of queued jobs to run each time the cron is launched. Default value is 10.
+                            Number of queued jobs to run each time the cron is launched. Default value is 5.
                             <br><span class="algolia-config-warning">&#9888;</span> Each time the cron runs it will process ("Max number of element per indexing job" * "Number of jobs to run each time the cron is run")
                             products.
                         ]]>
@@ -840,7 +840,7 @@
                     <label>Maximal number of elements per indexing job</label>
                     <comment>
                         <![CDATA[
-                            Default value is 100.
+                            Default value is 300.
                         ]]>
                     </comment>
                 </field>

--- a/view/adminhtml/templates/common.phtml
+++ b/view/adminhtml/templates/common.phtml
@@ -107,7 +107,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
                                 <div class="heading">Queued indexing jobs</div>
                                 Number of queued jobs: <strong>` + queueInfo.currentSize + `</strong>.
                                 Assuming your queue runner runs every 5 minutes, all jobs will be processed
-                                in approx. 5 minutes.
+                                in approx. ` + queueInfo.eta + `.
                                 You may want to <a href="` + indexingQueuePageUrl + `">clear the queue</a> or <a href="` + indexingQueueConfigUrl + `">configure indexing queue</a>.
                                 <br><br>
                                 Find out more about Indexing Queue in <a href="https://community.algolia.com/magento/doc/m2/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.


### PR DESCRIPTION
Each job to run has overhead with fetching data from database. 

Making it run less jobs (10 -> 5) with bigger page size (100 -> 300) reduces the overhead and improves the indexing performance, especially for simple products.