### PR TITLE
M2.1 JS Minify Issue

### DIFF
--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -563,12 +563,12 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 				createURL({ qsModule, routeState, location }) {
 					const { protocol, hostname, port = '', pathname, hash } = location;
 					const queryString = qsModule.stringify(routeState);
-					const portWithPrefix = port === '' ? '' : `:${port}`;
+					const portWithPrefix = port === '' ? '' : ':' + port;
 					// IE <= 11 has no location.origin or buggy. Therefore we don't rely on it
 					if (!routeState || Object.keys(routeState).length === 0)
-                        return protocol + '//' + hostname + portWithPrefix + pathname;
+						return protocol + '//' + hostname + portWithPrefix + pathname;
 					else
-                        return protocol + '//' + hostname + portWithPrefix + pathname + '?' + queryString;
+						return protocol + '//' + hostname + portWithPrefix + pathname + '?' + queryString;
 				},
 			}),
 			stateMapping: {

--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -566,9 +566,9 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 					const portWithPrefix = port === '' ? '' : `:${port}`;
 					// IE <= 11 has no location.origin or buggy. Therefore we don't rely on it
 					if (!routeState || Object.keys(routeState).length === 0)
-						return `${protocol}//${hostname}${portWithPrefix}${pathname}`;
+                        return protocol + '//' + hostname + portWithPrefix + pathname;
 					else
-						return `${protocol}//${hostname}${portWithPrefix}${pathname}?${queryString}`;
+                        return protocol + '//' + hostname + portWithPrefix + pathname + '?' + queryString;
 				},
 			}),
 			stateMapping: {


### PR DESCRIPTION
**Summary**
Support Ticket #117914 

There is an issue in M2.1 when javascript is minified and common.js is throwing a syntax error. This is because M2.1's JShrink\Minifier does not consider backtick template literals a string type and thinks the // in the template literal, still a comment line. This is corrected in M2.2. 

https://github.com/algolia/algoliasearch-magento-2/blob/master/view/frontend/web/internals/common.js#L569-L571

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals

**Result**
- Updated return string type to be accepted in 2.1