### PR TITLE
update minimal version to 1.27 for analytics dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": "~5.6.5|~7.0|~7.1|~7.2",
     "magento/framework": "~100.1|~101.0|~102.0",
-    "algolia/algoliasearch-client-php": ">=1.10.2 <2.0",
+    "algolia/algoliasearch-client-php": ">=1.27.0 <2.0",
     "ext-json": "*",
     "ext-PDO": "*",
     "ext-mbstring": "*",


### PR DESCRIPTION
**Summary**
https://discourse.algolia.com/t/magento-2-error-after-upgrading-module/7059/3

Need to update minimal version of the algoliasearch-client-php to 1.27 to include Analytics class for our analytics features. 

**Result**
- Updated minimal version in composer.json