### PR TITLE
Add product_count to Categories additional attributes default

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -225,6 +225,12 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'order' => 'unordered',
                 'retrievable' => '1',
             ],
+            [
+                'attribute' => 'product_count',
+                'searchable' => '2',
+                'order' => 'unordered',
+                'retrievable' => '1',
+            ],
         ],
         'algoliasearch_categories/categories/custom_ranking_category_attributes' => [
             [


### PR DESCRIPTION
**Summary**
Support Ticket #118627

Autocomplete missing product_count value from response. Recommended to add product_count as a retrievable attribute. Should be added by default to the configuration. 

**Result**
- Added product_count to the UpgradeSchema to match what is added when added manually