### PR TITLE
Update JS for IE11 compatibility 

### DIFF
--- a/view/frontend/layout/algolia_search_handle.xml
+++ b/view/frontend/layout/algolia_search_handle.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
+        <script src="//polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.includes%2CPromise" src_type="url" crossorigin/>
+
         <script src="Algolia_AlgoliaSearch::internals/common.js"/>
 
         <script src="Algolia_AlgoliaSearch::instantsearch.js"/>

--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -556,12 +556,22 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 		// Targeted index is defined by sortBy parameter
 		window.routing = {
 			router: algoliaBundle.instantsearch.routers.history({
-				parseURL({qsModule, location}) {
+				parseURL: function (qsObject) {
+					let location = qsObject.location,
+						qsModule = qsObject.qsModule;
 					const queryString = location.hash ? location.hash : location.search;
 					return qsModule.parse(queryString.slice(1))
 				},
-				createURL({ qsModule, routeState, location }) {
-					const { protocol, hostname, port = '', pathname, hash } = location;
+				createURL: function (qsObject) {
+					let qsModule = qsObject.qsModule,
+						routeState = qsObject.routeState,
+						location = qsObject.location;
+					const protocol = location.protocol,
+						hostname = location.hostname,
+						port = location.port ? location.port : '',
+						pathname = location.pathname,
+						hash = location.hash;
+
 					const queryString = qsModule.stringify(routeState);
 					const portWithPrefix = port === '' ? '' : ':' + port;
 					// IE <= 11 has no location.origin or buggy. Therefore we don't rely on it
@@ -572,7 +582,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 				},
 			}),
 			stateMapping: {
-				stateToRoute(uiState) {
+				stateToRoute: function (uiState) {
 					let map = {};
 					if (algoliaConfig.isCategoryPage) {
 						map['q'] = uiState.query;
@@ -606,7 +616,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 					map['page'] = uiState.page;
 					return map;
 				},
-				routeToState(routeState) {
+				routeToState: function (routeState) {
 					let map = {};
 					routeState = routingBc(routeState);
 					map['query'] = routeState.q == '__empty__' ? '' : routeState.q;


### PR DESCRIPTION
**Summary**
IE11 has some issues with ES6 syntaxes for method definition shorthand and destructuring assignments. You can read more about it here:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment

Related Issues: #677, #659 

**Result**
Converted syntax into IE11 friendly versions. Manually assigning variables instead of the shorthand. 