### PR TITLE
Fix IE11 polyfill crossorigin attribute

### DIFF
--- a/view/frontend/layout/algolia_search_handle.xml
+++ b/view/frontend/layout/algolia_search_handle.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <script src="//polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.includes%2CPromise" src_type="url" crossorigin/>
-
         <script src="Algolia_AlgoliaSearch::internals/common.js"/>
 
         <script src="Algolia_AlgoliaSearch::instantsearch.js"/>

--- a/view/frontend/templates/internals/configuration.phtml
+++ b/view/frontend/templates/internals/configuration.phtml
@@ -5,7 +5,7 @@
 $configuration = $block->getConfiguration();
 
 ?>
-
+<script src="//polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.includes%2CPromise" crossorigin="anonymous"></script>
 <script>
     <?php
     if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true) :

--- a/view/frontend/templates/internals/configuration.phtml
+++ b/view/frontend/templates/internals/configuration.phtml
@@ -5,7 +5,7 @@
 $configuration = $block->getConfiguration();
 
 ?>
-<script src="//polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.includes%2CPromise" crossorigin="anonymous"></script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.includes%2CPromise" crossorigin="anonymous"></script>
 <script>
     <?php
     if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true) :


### PR DESCRIPTION
**Summary**
Add crossorigin attribute to prevent CORS.

**Result**
Magento threw an error for crossorigin as an attribute for <script>. I had to move it to the configuration.phtml file to add that parameter.