### PR TITLE
Update docs links to lead to new documentation

### DIFF
--- a/Block/Adminhtml/Queue/Status.php
+++ b/Block/Adminhtml/Queue/Status.php
@@ -109,7 +109,7 @@ class Status extends Template
             );
             $notices[] =  __(
                 'To help you, please read our <a href="%1" target="_blank">documentation</a>.',
-                'https://community.algolia.com/magento/doc/m2/indexing-queue/'
+                'https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/'
             );
         }
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ It's possible to use it for versions >= 2.1.0, but some unexpected issues might 
 Documentation
 --------------
 
-Check out the [Algolia Search for Magento 2 documentation](https://community.algolia.com/magento/doc/m2/getting-started/).
+Check out the [Algolia Search for Magento 2 documentation](https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/).
 
 
 Installation
 ------------
 
-The easiest way to install the extension is to use [Composer](https://getcomposer.org/) and follow our [getting started guide](https://community.algolia.com/magento/doc/m2/getting-started/).
+The easiest way to install the extension is to use [Composer](https://getcomposer.org/) and follow our [getting started guide](https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/).
 
 Run the following commands:
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,15 +21,15 @@
                         <table class="algolia">
                             <tr>
                                 <td>Documentation:</td>
-                                <td><a target="_blank" href="https://community.algolia.com/magento/doc/m2/getting-started/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">https://community.algolia.com/magento/documentation</a></td>
+                                <td><a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/</a></td>
                             </tr>
                             <tr>
                                 <td>FAQ: </td>
-                                <td><a target="_blank" href="https://community.algolia.com/magento/faq/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">https://community.algolia.com/magento/faq/</a></td>
+                                <td><a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/troubleshooting/general-faq/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">https://www.algolia.com/doc/integration/magento-2/troubleshooting/general-faq/</a></td>
                             </tr>
                             <tr>
                                 <td>Issues: </td>
-                                <td><a target="_blank" href="https://github.com/algolia/algoliasearch-magento-2/issues/">https://github.com/algoliasearch-magento/issues</a></td>
+                                <td><a target="_blank" href="https://github.com/algolia/algoliasearch-magento-2/issues/">https://github.com/algoliasearch-magento-2/issues/</a></td>
                             </tr>
                         </table>
                         <br>
@@ -110,9 +110,9 @@
                 <comment>
                     <![CDATA[
                         To customize the autocomplete menu beyond its configuration, you can read tutorials:
-                        <a target="_blank" href="https://community.algolia.com/magento/doc/m2/customize-autocomplete/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to customize autocomplete</a>,
-                        <a target="_blank" href="https://community.algolia.com/magento/doc/m1/external-autocomplete-source/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to add an external data source</a>,
-                        <a target="_blank" href="https://community.algolia.com/magento/doc/m2/backend/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to use backend events</a>
+                        <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/customize/autocomplete-menu/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to customize autocomplete</a>,
+                        <a target="_blank" href="https://www.algolia.com/doc/integration/magento-1/guides/adding-autocomplete-source/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to add an external data source</a>,
+                        <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/customize/custom-back-end-events/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to use backend events</a>
                         <br>
                         <br>
                         <hr>
@@ -213,7 +213,7 @@
                     <comment>
                         <![CDATA[
                             Specify pages you don't want to search in.<br>
-                            Pages' indexing documentation: <a target="_blank" href="https://community.algolia.com/magento/doc/m2/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#pages-indexing">https://community.algolia.com/magento/doc/m2/indexing/#pages-indexing</a>
+                            Pages' indexing documentation: <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#pages-indexing">https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/#pages-indexing</a>
                             <br><span class="algolia-config-warning">&#9888;</span> Do not forget to reindex the Algolia Search Pages indexer after you've modified this panel.
                         ]]>
                     </comment>
@@ -258,8 +258,8 @@
                 <comment>
                     <![CDATA[
                         To customize the instant search results page beyond its configuration, you can read these tutorials:<br >
-                         &nbsp; - <a target="_blank" href="https://community.algolia.com/magento/doc/m2/customize-instantsearch/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to customize InstantSearch</a><br>
-                         &nbsp; - <a target="_blank" href="https://community.algolia.com/magento/doc/m2/backend/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to use backend events</a>
+                         &nbsp; - <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/customize/instant-search-page/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to customize InstantSearch</a><br>
+                         &nbsp; - <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/customize/custom-back-end-events/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">How to use backend events</a>
                         <br>
                         <br>
                         <hr>
@@ -320,7 +320,7 @@
                                 This query rule is applied for both autocomplete and instant search results.
                                 <br><br>
                                 Find out more about Facets in
-                                <a href="https://community.algolia.com/magento/doc/m2/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#facets" target="_blank">documentation</a>.
+                                <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#facets" target="_blank">documentation</a>.
                             </div>
                         ]]>
                     </comment>
@@ -348,7 +348,7 @@
                         <![CDATA[
                             Specify different sorting options you want to offer on a search results page.<br>
                             Each sort will significantly increase the number of records you store in Algolia.<br>
-                            Read more in <a target="_blank" href="https://community.algolia.com/magento/doc/m2/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#sorting-strategies">documentation</a>.
+                            Read more in <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#sorting-strategies">documentation</a>.
                         ]]>
                     </comment>
                     <depends>
@@ -416,7 +416,7 @@
                         <table class="algolia">
                             <tr>
                                 <td>Products' indexing documentation:</td>
-                                <td><a target="_blank" href="https://community.algolia.com/magento/doc/m2/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#products-indexing">https://community.algolia.com/magento/doc/m2/indexing/#products-indexing</a></td>
+                                <td><a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#products-indexing">https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/#products-indexing</a></td>
                             </tr>
                         </table>
                         <br>
@@ -432,7 +432,7 @@
                         <![CDATA[
                             Specify a product's attributes your users can search on (searchable) and the ones required to display search results.
                             The order of the searchable attributes matters: a query matching the first searchable attribute of a product will put this product before the others in the results.<br><br>
-                            Searchable attributes' documentation: <a target="_blank" href="https://community.algolia.com/magento/doc/m2/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#searchable-attributes">Products' searchable attributes</a>
+                            Searchable attributes' documentation: <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#searchable-attributes">Products' searchable attributes</a>
                             <br><span class="algolia-config-warning">&#9888;</span> Do not forget to reindex the Algolia Search Products indexer after you've modified this panel.
                         ]]>
                     </comment>
@@ -476,7 +476,7 @@
                         <table class="algolia">
                             <tr>
                                 <td>Categories' indexing documentation:</td>
-                                <td><a target="_blank" href="https://community.algolia.com/magento/doc/m2/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#categories-indexing">https://community.algolia.com/magento/doc/m2/indexing/#categories-indexing</a></td>
+                                <td><a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#categories-indexing">https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/#categories-indexing</a></td>
                             </tr>
                         </table>
                         <br>
@@ -492,7 +492,7 @@
                         <![CDATA[
                             Specify a category's attributes your users can search on (searchable).
                             The order of the searchable attributes matters: a query matching the first searchable attribute of a category will put this category before the others in the results.<br><br>
-                            Searchable attributes' documentation: <a target="_blank" href="https://community.algolia.com/magento/doc/m2/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#searchable-attributes-1">Categories's searchable attributes</a>
+                            Searchable attributes' documentation: <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#searchable-attributes-1">Categories's searchable attributes</a>
                             <br><span class="algolia-config-warning">&#9888;</span> Do not forget to reindex the Algolia Search Categories indexer after you've modified this panel.
                         ]]>
                     </comment>
@@ -539,7 +539,7 @@
                         <table class="algolia">
                             <tr>
                                 <td>If you have issues with images:</td>
-                                <td><a target="_blank" href="https://community.algolia.com/magento/faq/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#why-are-images-not-showing-up">https://community.algolia.com/magento/faq/#why-are-images-not-showing-up</a></td>
+                                <td><a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/troubleshooting/general-faq/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#why-are-images-not-showing-up">https://www.algolia.com/doc/integration/magento-2/troubleshooting/general-faq/#why-are-images-not-showing-up</a></td>
                             </tr>
                         </table>
                         <br>
@@ -583,11 +583,11 @@
                         <table class="algolia">
                             <tr>
                                 <td>Indexing queue documentation:</td>
-                                <td><a target="_blank" href="https://community.algolia.com/magento/doc/m2/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#general-information">https://community.algolia.com/magento/doc/m2/indexing-queue/#general-information</a></td>
+                                <td><a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#general-information">https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/#general-information</a></td>
                             </tr>
                             <tr>
                                 <td>Indexing troubleshooting guide:</td>
-                                <td><a target="_blank" href="https://community.algolia.com/magento/doc/m2/faq-support-data/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#general-information">https://community.algolia.com/magento/doc/m2/faq-support-data/#general-information</a></td>
+                                <td><a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/troubleshooting/data-indexes-queues/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link#general-information">https://www.algolia.com/doc/integration/magento-2/troubleshooting/data-indexes-queues/#general-information</a></td>
                             </tr>
                         </table>
                         <br>
@@ -719,7 +719,7 @@
                             With <a target="_blank" href="https://www.algolia.com/doc/guides/getting-insights-and-analytics/click-analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">Click & Conversion analytics</a>,
                             you can track which products are clicked more, and which search queries lead to more conversions.
                             <br><br>
-                            Find out more Click & Conversion Analytics in <a href="https://community.algolia.com/magento/doc/m2/click-analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
+                            Find out more Click & Conversion Analytics in <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/click-and-conversion-analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
                         </div>
                     ]]>
                 </comment>
@@ -776,7 +776,7 @@
                 <label>Google Analytics</label>
                 <comment>
                    <![CDATA[
-                        Documentation of Magento Google analytics: <a href="https://community.algolia.com/magento/doc/m2/analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">https://community.algolia.com/magento/doc/m2/analytics/</a>
+                        Documentation of Magento Google analytics: <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/google-analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">https://www.algolia.com/doc/integration/magento-2/how-it-works/google-analytics/</a>
                         <br>
                         <br>
                         <hr>
@@ -934,7 +934,7 @@
                         <![CDATA[
                             <span class="algolia-config-warning">&#9888;</span>
                             By preventing your store from backend rendering you might break your SEO and accessibility of your store by search crawlers.
-                            Please, read <a target="_blank" href="https://community.algolia.com/magento/doc/m2/prevent-backend-rendering/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">the documentation</a> before you turn backend rendering off.
+                            Please, read <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/prevent-back-end-rendering/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link">the documentation</a> before you turn backend rendering off.
                         ]]>
                     </comment>
                 </field>

--- a/view/adminhtml/templates/analytics/overview.phtml
+++ b/view/adminhtml/templates/analytics/overview.phtml
@@ -192,6 +192,6 @@ $view = $this->getViewModel();
         like Click-through Rate, Conversion Rate from searches and average click position.
         Click Analytics are only available for higher plans and require only minor additional settings.
         <br><br>
-        Find more information in <a href="https://community.algolia.com/magento/doc/m2/click-analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
+        Find more information in <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/click-and-conversion-analytics/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
     </div>
 <?php endif ?>

--- a/view/adminhtml/templates/catalog/category/edit/merchandising.phtml
+++ b/view/adminhtml/templates/catalog/category/edit/merchandising.phtml
@@ -11,7 +11,7 @@ $configHelper = $this->getConfigHelper();
     It is based on <b>query rules</b>, as it helps you influence the results for a given query
     (here, an empty search on a category). For each category you merchandize, a new query rule will be created.
     <br><br>
-    Find out more about Algolia Merchandising, please refer to <a href="https://community.algolia.com/magento/doc/m2/visual-category-merchandising/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
+    Find out more about Algolia Merchandising, please refer to <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/visual-category-merchandising/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
 </div>
 
 <?php if (!$this->isQueryRulesEnabled()): ?>

--- a/view/adminhtml/templates/common.phtml
+++ b/view/adminhtml/templates/common.phtml
@@ -101,7 +101,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 							<div class="heading"><a href="` + indexingQueueConfigUrl + `">Indexing Queue</a> is not enabled</div>
 							It is highly recommended that you enable it, especially if you are on a production environment.
 							<br><br>
-							Find out more about Indexing Queue in <a href="https://community.algolia.com/magento/doc/m2/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
+							Find out more about Indexing Queue in <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
 						</div>`;
 
 					if (queueInfo.isEnabled === true) {
@@ -113,7 +113,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 								in approx. ` + queueInfo.eta + `.
 								You may want to <a href="` + indexingQueuePageUrl + `">clear the queue</a> or <a href="` + indexingQueueConfigUrl + `">configure indexing queue</a>.
 								<br><br>
-								Find out more about Indexing Queue in <a href="https://community.algolia.com/magento/doc/m2/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
+								Find out more about Indexing Queue in <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.
 							</div>`;
 					}
 

--- a/view/adminhtml/templates/support/components/legacy-version.phtml
+++ b/view/adminhtml/templates/support/components/legacy-version.phtml
@@ -8,5 +8,5 @@
     You’re running version <span id="current_version" class="version"></span> Algolia for Magento 2 extension.
     The latest version is <span class="version latest_version"></span>.
     Please update to <span class="version latest_version"></span> for new features and bug fixes that could solve your current issues.
-    <a href="https://community.algolia.com/magento/doc/m2/upgrade/" target="_blank">How to update?</a>
+    <a href="https://www.algolia.com/doc/integration/magento-2/getting-started/upgrading/" target="_blank">How to update?</a>
 </div>

--- a/view/adminhtml/templates/support/overview.phtml
+++ b/view/adminhtml/templates/support/overview.phtml
@@ -79,7 +79,7 @@ $videoFeatures = $this->getViewFileUrl('Algolia_AlgoliaSearch::images/video-feat
             </div>
         </div>
         <div class="links">
-            <a href="https://community.algolia.com/magento/doc/m2/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
+            <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
                 <span class="heading">
                     Indexing
                 </span>
@@ -87,7 +87,7 @@ $videoFeatures = $this->getViewFileUrl('Algolia_AlgoliaSearch::images/video-feat
                     In order to provide fast and relevant search, Algolia restructures your data in a special way, via Indexing.
                 </span>
             </a>
-            <a href="https://community.algolia.com/magento/doc/m2/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
+            <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
                 <span class="heading">
                     Indexing Queue
                 </span>
@@ -95,7 +95,7 @@ $videoFeatures = $this->getViewFileUrl('Algolia_AlgoliaSearch::images/video-feat
                     The index queue manages all uploads to Algolia. Before your data can be searched, it must be uploaded to Algolia. This process is called indexing, which the extension does automatically - via the queue.
                 </span>
             </a>
-            <a href="https://community.algolia.com/magento/doc/m2/customize-autocomplete/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
+            <a href="https://www.algolia.com/doc/integration/magento-2/customize/autocomplete-menu/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
                 <span class="heading">
                     Autocomplete menu
                 </span>
@@ -103,7 +103,7 @@ $videoFeatures = $this->getViewFileUrl('Algolia_AlgoliaSearch::images/video-feat
                     Customize the autocomplete drop-down menu which appears underneath the search bar on your Magento site.
                 </span>
             </a>
-            <a href="https://community.algolia.com/magento/doc/m2/customize-backend/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
+            <a href="https://www.algolia.com/doc/integration/magento-2/customize/custom-back-end-events/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
                 <span class="heading">
                     Customize the extension
                 </span>
@@ -111,7 +111,7 @@ $videoFeatures = $this->getViewFileUrl('Algolia_AlgoliaSearch::images/video-feat
                     In this guide you’ll learn how to attach hooks to the events fired by the Algolia extension. It should only take a few minutes. Let’s get started!
                 </span>
             </a>
-            <a href="https://community.algolia.com/magento/doc/faq-support-data/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
+            <a href="https://www.algolia.com/doc/integration/magento-2/troubleshooting/data-indexes-queues/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">
                 <span class="heading">
                     Troubleshooting
                 </span>
@@ -121,7 +121,7 @@ $videoFeatures = $this->getViewFileUrl('Algolia_AlgoliaSearch::images/video-feat
             </a>
         </div>
 
-        <a href="https://community.algolia.com/magento/doc/m2/getting-started/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" class="footer" target="_blank">
+        <a href="https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" class="footer" target="_blank">
             Go to documentation homepage ...
         </a>
     </div>

--- a/view/adminhtml/web/js/support.js
+++ b/view/adminhtml/web/js/support.js
@@ -34,7 +34,7 @@ requirejs(['algoliaAdminBundle'], function(algoliaBundle) {
 							<div class="no-results">
 								<img src="` + noResultsIllustration + `" /><br>
 								Sorry, no results found. Try using more general words,<br>
-								fewer words or visit the <a href="https://community.algolia.com/magento/doc/m2/getting-started/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">Algolia documentation</a>.
+								fewer words or visit the <a href="https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">Algolia documentation</a>.
 							</div>
 						`
 					}
@@ -61,7 +61,7 @@ requirejs(['algoliaAdminBundle'], function(algoliaBundle) {
 					templates: {
 						body: `
 					{{#morePages}}
-				        <a href="https://community.algolia.com/magento/doc/m2/getting-started/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" class="footer" target="_blank">
+				        <a href="https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" class="footer" target="_blank">
 				            Go to documentation homepage ...
 				        </a>
 					{{/morePages}}
@@ -199,7 +199,7 @@ requirejs(['algoliaAdminBundle'], function(algoliaBundle) {
 					container: '.contact_results',
 					templates: {
 						item: getDocumentationTemplate(),
-						empty: 'No results. Please change your search query or visit <a href="https://community.algolia.com/magento/doc/m2/getting-started/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">documentation</a>.'
+						empty: 'No results. Please change your search query or visit <a href="https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/?utm_source=magento&utm_medium=extension&utm_campaign=support-page" target="_blank">documentation</a>.'
 					}
 				})
 			);

--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -88,7 +88,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 			if (typeof algoliaHookBeforeAutocompleteStart === 'function') {
 				console.warn('Deprecated! You are using an old API for Algolia\'s front end hooks. ' +
 					'Please, replace your hook method with new hook API. ' +
-					'More information you can find on https://community.algolia.com/magento/doc/m2/frontend-events/');
+					'More information you can find on https://www.algolia.com/doc/integration/magento-2/customize/custom-front-end-events/');
 				
 				var hookResult = algoliaHookBeforeAutocompleteStart(sources, options, algolia_client);
 				


### PR DESCRIPTION
We moved Magento documentation from it's [community website](https://community.algolia.com/magento/) to [official Algolia's documentation](https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/).

The legacy links are redirected, but it's better to link directly to new documentation pages. This commit changes the links.