### PR TITLE
Refactored Queue mechanism

### DIFF
--- a/Model/Indexer/Category.php
+++ b/Model/Indexer/Category.php
@@ -103,7 +103,7 @@ class Category implements Magento\Framework\Indexer\ActionInterface, Magento\Fra
     {
         $affectedProductsCount = count(self::$affectedProductIds);
         if ($affectedProductsCount > 0 && $this->configHelper->indexProductOnCategoryProductsUpdate($storeId)) {
-            /** @uses Data::rebuildStoreProductIndex */
+            /** @uses Data::rebuildStoreProductIndex() */
             $this->queue->addToQueue(
                 Data::class,
                 'rebuildStoreProductIndex',
@@ -146,7 +146,7 @@ class Category implements Magento\Framework\Indexer\ActionInterface, Magento\Fra
      */
     private function processFullReindex($storeId, $categoriesPerPage)
     {
-        /** @uses IndicesConfigurator::saveConfigurationToAlgolia */
+        /** @uses IndicesConfigurator::saveConfigurationToAlgolia() */
         $this->queue->addToQueue(IndicesConfigurator::class, 'saveConfigurationToAlgolia', ['store_id' => $storeId]);
 
         $collection = $this->categoryHelper->getCategoryCollectionQuery($storeId);
@@ -161,8 +161,8 @@ class Category implements Magento\Framework\Indexer\ActionInterface, Magento\Fra
                 'page_size' => $categoriesPerPage,
             ];
 
-            /** @uses Data::rebuildCategoryIndex */
-            $this->queue->addToQueue(Data::class, 'rebuildCategoryIndex', $data, $categoriesPerPage);
+            /** @uses Data::rebuildCategoryIndex() */
+            $this->queue->addToQueue(Data::class, 'rebuildCategoryIndex', $data, $categoriesPerPage, true);
         }
     }
 }

--- a/Model/Indexer/Product.php
+++ b/Model/Indexer/Product.php
@@ -78,8 +78,9 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
 
             if (is_array($productIds) && count($productIds) > 0) {
                 foreach (array_chunk($productIds, $productsPerPage) as $chunk) {
+                    /** @uses Data::rebuildStoreProductIndex() */
                     $this->queue->addToQueue(
-                        $this->fullAction,
+                        Data::class,
                         'rebuildStoreProductIndex',
                         ['store_id' => $storeId, 'product_ids' => $chunk],
                         count($chunk)
@@ -96,6 +97,7 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
 
             $pages = ceil($size / $productsPerPage);
 
+            /** @uses IndicesConfigurator::saveConfigurationToAlgolia() */
             $this->queue->addToQueue(IndicesConfigurator::class, 'saveConfigurationToAlgolia', [
                 'store_id' => $storeId,
                 'useTmpIndex' => $useTmpIndex,
@@ -110,13 +112,15 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
                     'useTmpIndex' => $useTmpIndex,
                 ];
 
-                $this->queue->addToQueue($this->fullAction, 'rebuildProductIndex', $data, $productsPerPage, true);
+                /** @uses Data::rebuildProductIndex() */
+                $this->queue->addToQueue(Data::class, 'rebuildProductIndex', $data, $productsPerPage, true);
             }
 
             if ($useTmpIndex) {
                 $suffix = $this->productHelper->getIndexNameSuffix();
 
-                $this->queue->addToQueue($this->fullAction, 'moveIndex', [
+                /** @uses Data::moveIndex() */
+                $this->queue->addToQueue(Data::class, 'moveIndex', [
                     'tmpIndexName' => $this->fullAction->getIndexName($suffix, $storeId, true),
                     'indexName' => $this->fullAction->getIndexName($suffix, $storeId, false),
                     'store_id' => $storeId,

--- a/Model/Indexer/Product.php
+++ b/Model/Indexer/Product.php
@@ -103,7 +103,7 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
             $this->queue->addToQueue(IndicesConfigurator::class, 'saveConfigurationToAlgolia', [
                 'store_id' => $storeId,
                 'useTmpIndex' => $useTmpIndex,
-            ]);
+            ], 1, true);
 
             for ($i = 1; $i <= $pages; $i++) {
                 $data = [
@@ -114,7 +114,7 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
                     'useTmpIndex' => $useTmpIndex,
                 ];
 
-                $this->queue->addToQueue($this->fullAction, 'rebuildProductIndex', $data, $productsPerPage);
+                $this->queue->addToQueue($this->fullAction, 'rebuildProductIndex', $data, $productsPerPage, true);
             }
 
             if ($useTmpIndex) {
@@ -124,7 +124,7 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
                     'tmpIndexName' => $this->fullAction->getIndexName($suffix, $storeId, true),
                     'indexName' => $this->fullAction->getIndexName($suffix, $storeId, false),
                     'store_id' => $storeId,
-                ]);
+                ], 1, true);
             }
         }
     }

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -10,16 +10,30 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Queue
 {
+    const REALTIME_TO_FULL_REINDEX_JOBS_RATIO = 0.66;
+
     const SUCCESS_LOG = 'algoliasearch_queue_log.txt';
     const ERROR_LOG = 'algoliasearch_queue_errors.log';
 
+    /** @var \Magento\Framework\DB\Adapter\AdapterInterface */
     private $db;
+
+    /** @var string */
     private $table;
+
+    /** @var string */
     private $logTable;
+
+    /** @var string */
     private $archiveTable;
+
+    /** @var ObjectManagerInterface */
     private $objectManager;
+
+    /** @var ConsoleOutput */
     private $output;
 
+    /** @var int */
     private $elementsPerPage;
 
     /** @var ConfigHelper */
@@ -28,16 +42,20 @@ class Queue
     /** @var Logger */
     private $logger;
 
+    /** @var int */
     private $maxSingleJobDataSize;
 
+    /** @var int */
     private $noOfFailedJobs = 0;
 
+    /** @var array */
     private $staticJobMethods = [
         'saveConfigurationToAlgolia',
         'moveIndex',
         'deleteObjects',
     ];
 
+    /** @var array */
     private $logRecord;
 
     public function __construct(
@@ -64,30 +82,33 @@ class Queue
         $this->maxSingleJobDataSize = $this->configHelper->getNumberOfElementByPage();
     }
 
-    public function addToQueue($className, $method, $data, $data_size = 1)
+    /**
+     * @param $className
+     * @param $method
+     * @param $data
+     * @param int $dataSize
+     * @param bool $isFullReindex
+     */
+    public function addToQueue($className, $method, $data, $dataSize = 1, $isFullReindex = false)
     {
         if (is_object($className)) {
             $className = get_class($className);
         }
 
         if ($this->configHelper->isQueueActive()) {
-            $this->insert($className, $method, $data, $data_size);
+            $this->db->insert($this->table, [
+                'created'   => date('Y-m-d H:i:s'),
+                'class'     => $className,
+                'method'    => $method,
+                'data'      => json_encode($data),
+                'data_size' => $dataSize,
+                'pid'       => null,
+                'is_full_reindex' => $isFullReindex ? 1 : 0,
+            ]);
         } else {
             $object = $this->objectManager->get($className);
             call_user_func_array([$object, $method], $data);
         }
-    }
-
-    private function insert($class, $method, $data, $data_size)
-    {
-        $this->db->insert($this->table, [
-            'created'   => date('Y-m-d H:i:s'),
-            'class'     => $class,
-            'method'    => $method,
-            'data'      => json_encode($data),
-            'data_size' => $data_size,
-            'pid'       => null,
-        ]);
     }
 
     /**
@@ -100,18 +121,23 @@ class Queue
      */
     public function getAverageProcessingTime()
     {
-        $data = $this->db->query(
-            $this->db->select()
-                ->from($this->logTable, ['number_of_runs' => 'COUNT(duration)', 'average_time' => 'AVG(duration)'])
-                ->where('processed_jobs > 0 AND with_empty_queue = 0 AND started >= (CURDATE() - INTERVAL 2 DAY)')
-        );
-        $result = $data->fetch();
+        $select = $this->db->select()
+           ->from($this->logTable, ['number_of_runs' => 'COUNT(duration)', 'average_time' => 'AVG(duration)'])
+           ->where('processed_jobs > 0 AND with_empty_queue = 0 AND started >= (CURDATE() - INTERVAL 2 DAY)');
 
-        return (int) $result['number_of_runs'] >= 100 && isset($result['average_time']) ?
-            (float) $result['average_time'] :
+        $data = $this->db->query($select)->fetch();
+
+        return (int) $data['number_of_runs'] >= 100 && isset($data['average_time']) ?
+            (float) $data['average_time'] :
             null;
     }
 
+    /**
+     * @param int|null $nbJobs
+     * @param bool $force
+     *
+     * @throws \Exception
+     */
     public function runCron($nbJobs = null, $force = false)
     {
         if (!$this->configHelper->isQueueActive() && $force === false) {
@@ -150,11 +176,16 @@ class Queue
         $this->db->insert($this->logTable, $this->logRecord);
     }
 
+    /**
+     * @param $maxJobs
+     *
+     * @throws \Exception
+     */
     public function run($maxJobs)
     {
-        $pid = getmypid();
+        $this->clearOldFailingJobs();
 
-        $jobs = $this->getJobs($maxJobs, $pid);
+        $jobs = $this->getJobs($maxJobs);
 
         if ($jobs === []) {
             return;
@@ -167,7 +198,7 @@ class Queue
             // and therefore are not indexed yet in TMP index
             if ($job['method'] === 'moveIndex' && $this->noOfFailedJobs > 0) {
                 // Set pid to NULL so it's not deleted after
-                $this->db->query("UPDATE {$this->table} SET pid = NULL WHERE job_id = " . $job['job_id']);
+                $this->db->update($this->table, ['pid' => null], ['job_id = ?' => $job['job_id']]);
 
                 continue;
             }
@@ -181,8 +212,7 @@ class Queue
                 call_user_func_array([$model, $method], $data);
 
                 // Delete one by one
-                $where = $this->db->quoteInto('job_id IN (?)', $job['merged_ids']);
-                $this->db->delete($this->table, $where);
+                $this->db->delete($this->table, ['job_id IN (?)' => $job['merged_ids']]);
 
                 $this->logRecord['processed_jobs'] += count($job['merged_ids']);
             } catch (\Exception $e) {
@@ -200,11 +230,11 @@ class Queue
                     "\nStack trace:\n" . $e->getTraceAsString();
                 $this->logger->log($logMessage);
 
-                // Increment retries, set the job ID back to NULL
-                $updateQuery = "UPDATE {$this->table} 
-                    SET pid = NULL, retries = retries + 1 , error_log = '" . addslashes($logMessage) . "' 
-                    WHERE job_id IN (" . implode(', ', (array) $job['merged_ids']) . ')';
-                $this->db->query($updateQuery);
+                $this->db->update($this->table, [
+                    'pid' => null,
+                    'retries' => new \Zend_Db_Expr('retries + 1'),
+                    'error_log' => $logMessage,
+                ], ['job_id IN (?)' => $job['merged_ids']]);
 
                 if (php_sapi_name() === 'cli') {
                     $this->output->writeln($logMessage);
@@ -220,94 +250,50 @@ class Queue
         }
     }
 
+    /**
+     * @param string $whereClause
+     */
     private function archiveFailedJobs($whereClause)
     {
-        $this->db->query(
-            "INSERT INTO {$this->archiveTable} (pid, class, method, data, error_log, data_size, created_at) 
-                  SELECT pid, class, method, data, error_log, data_size, NOW()
-                  FROM {$this->table}
-                  WHERE " . $whereClause
+        $select = $this->db->select()
+           ->from($this->table, ['pid', 'class', 'method', 'data', 'error_log', 'data_size', 'NOW()'])
+           ->where($whereClause);
+
+        $query = $this->db->insertFromSelect(
+            $select,
+            $this->archiveTable,
+            ['pid', 'class', 'method', 'data', 'error_log', 'data_size', 'created_at']
         );
+
+        $this->db->query($query);
     }
 
-    private function getJobs($maxJobs, $pid)
+    /**
+     * @param int $maxJobs
+     *
+     * @return array
+     *
+     * @throws \Exception
+     */
+    private function getJobs($maxJobs)
     {
-        // Clear jobs with crossed max retries count
-        $retryLimit = $this->configHelper->getRetryLimit();
-        if ($retryLimit > 0) {
-            $where = $this->db->quoteInto('retries >= ?', $retryLimit);
-            $this->archiveFailedJobs($where);
-            $this->db->delete($this->table, $where);
-        } else {
-            $this->archiveFailedJobs('retries > max_retries');
-            $this->db->delete($this->table, 'retries > max_retries');
-        }
+        $maxJobs = ($maxJobs === -1) ? $this->configHelper->getNumberOfJobToRun() : $maxJobs;
 
-        $jobs = [];
-
-        $limit = $maxJobs = ($maxJobs === -1) ? $this->configHelper->getNumberOfJobToRun() : $maxJobs;
-        $offset = 0;
-
-        $maxBatchSize = $this->configHelper->getNumberOfElementByPage() * $limit;
-        $actualBatchSize = 0;
+        $realtimeJobsLimit = (int) ceil(self::REALTIME_TO_FULL_REINDEX_JOBS_RATIO * $maxJobs);
 
         try {
             $this->db->beginTransaction();
 
-            while ($actualBatchSize < $maxBatchSize) {
-                $data = $this->db->query($this->db->select()->from($this->table, '*')->where('pid IS NULL')
-                                                  ->order(['job_id'])->limit($limit, $offset)
-                                                  ->forUpdate());
-                $rawJobs = $data->fetchAll();
-                $rowsCount = count($rawJobs);
+            $realtimeJobs = $this->fetchJobs($realtimeJobsLimit, false);
 
-                if ($rowsCount <= 0) {
-                    break;
-                }
+            $realtimeJobsCount = count($realtimeJobs);
+            $fullReindexJobsLimit = (int) $maxJobs - $realtimeJobsCount;
 
-                // If $jobs is empty, it's the first run
-                if ($jobs === []) {
-                    $firstJobId = $rawJobs[0]['job_id'];
-                }
+            $fullReindexJobs = $this->fetchJobs($fullReindexJobsLimit, true);
 
-                $rawJobs = $this->prepareJobs($rawJobs);
-                $rawJobs = array_merge($jobs, $rawJobs);
-                $rawJobs = $this->mergeJobs($rawJobs);
+            $jobs = array_merge($realtimeJobs, $fullReindexJobs);
 
-                $rawJobsCount = count($rawJobs);
-
-                $offset += $limit;
-                $limit = max(0, $maxJobs - $rawJobsCount);
-
-                // $jobs will always be completely set from $rawJobs
-                // Without resetting not-merged jobs would be stacked
-                $jobs = [];
-
-                if (count($rawJobs) === $maxJobs) {
-                    $jobs = $rawJobs;
-                    break;
-                }
-
-                foreach ($rawJobs as $job) {
-                    $jobSize = (int) $job['data_size'];
-
-                    if ($actualBatchSize + $jobSize <= $maxBatchSize || !$jobs) {
-                        $jobs[] = $job;
-                        $actualBatchSize += $jobSize;
-                    } else {
-                        break 2;
-                    }
-                }
-            }
-
-            if (isset($firstJobId)) {
-                $lastJobId = $this->maxValueInArray($jobs, 'job_id');
-
-                // Reserve all new jobs since last run
-                $this->db->query("UPDATE {$this->db->quoteIdentifier($this->table, true)} 
-                SET pid = " . $pid . ' 
-                WHERE job_id >= ' . $firstJobId . " AND job_id <= $lastJobId");
-            }
+            $this->lockJobs($jobs);
 
             $this->db->commit();
         } catch (\Exception $e) {
@@ -319,6 +305,79 @@ class Queue
         return $jobs;
     }
 
+    /**
+     * @param int $jobsLimit
+     * @param bool $fetchFullReindexJobs
+     *
+     * @return array
+     *
+     * @throws \Zend_Db_Statement_Exception
+     */
+    private function fetchJobs($jobsLimit, $fetchFullReindexJobs = false)
+    {
+        $jobs = [];
+
+        $actualBatchSize = 0;
+        $maxBatchSize = $this->configHelper->getNumberOfElementByPage() * $jobsLimit;
+
+        $limit = $maxJobs = $jobsLimit;
+        $offset = 0;
+
+        $fetchFullReindexJobs = $fetchFullReindexJobs ? 1 : 0;
+
+        while ($actualBatchSize < $maxBatchSize) {
+            $select = $this->db->select()
+               ->from($this->table, '*')
+               ->where('pid IS NULL AND is_full_reindex = ' . $fetchFullReindexJobs)
+               ->order(['job_id'])
+               ->limit($limit, $offset)
+               ->forUpdate();
+
+            $data = $this->db->query($select);
+            $rawJobs = $data->fetchAll();
+            $rowsCount = count($rawJobs);
+
+            if ($rowsCount <= 0) {
+                break;
+            }
+
+            $rawJobs = $this->prepareJobs($rawJobs);
+            $rawJobs = array_merge($jobs, $rawJobs);
+            $rawJobs = $this->mergeJobs($rawJobs);
+
+            $rawJobsCount = count($rawJobs);
+
+            $offset += $limit;
+            $limit = max(0, $maxJobs - $rawJobsCount);
+
+            // $jobs will always be completely set from $rawJobs
+            // Without resetting not-merged jobs would be stacked
+            $jobs = [];
+
+            if (count($rawJobs) === $maxJobs) {
+                $jobs = $rawJobs;
+                break;
+            }
+
+            foreach ($rawJobs as $job) {
+                $jobSize = (int) $job['data_size'];
+
+                if ($actualBatchSize + $jobSize <= $maxBatchSize || !$jobs) {
+                    $jobs[] = $job;
+                    $actualBatchSize += $jobSize;
+                } else {
+                    break 2;
+                }
+            }
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * @param array $jobs
+     * @return array
+     */
     private function prepareJobs($jobs)
     {
         foreach ($jobs as &$job) {
@@ -329,6 +388,10 @@ class Queue
         return $jobs;
     }
 
+    /**
+     * @param array $oldJobs
+     * @return array
+     */
     private function mergeJobs($oldJobs)
     {
         $oldJobs = $this->sortJobs($oldJobs);
@@ -385,10 +448,14 @@ class Queue
         return $jobs;
     }
 
+    /**
+     * Sorts the jobs and preserves the order of jobs with static methods defined in $this->staticJobMethods
+     *
+     * @param array $oldJobs
+     * @return array
+     */
     private function sortJobs($oldJobs)
     {
-        // Method sorts the jobs and preserves the order of jobs with static methods defined in $this->staticJobMethods
-
         $sortedJobs = [];
 
         $tempSortableJobs = [];
@@ -413,6 +480,13 @@ class Queue
         return $sortedJobs;
     }
 
+    /**
+     * @param array $sortedJobs
+     * @param array $tempSortableJobs
+     * @param array|null $job
+     *
+     * @return array
+     */
     private function stackSortedJobs($sortedJobs, $tempSortableJobs, $job = null)
     {
         if ($tempSortableJobs && $tempSortableJobs !== []) {
@@ -438,6 +512,12 @@ class Queue
         return $sortedJobs;
     }
 
+    /**
+     * @param array $j1
+     * @param array $j2
+     *
+     * @return bool
+     */
     private function mergeable($j1, $j2)
     {
         if ($j1['class'] !== $j2['class']) {
@@ -477,6 +557,9 @@ class Queue
         return true;
     }
 
+    /**
+     * @return array
+     */
     private function arrayMultisort()
     {
         $args = func_get_args();
@@ -502,34 +585,58 @@ class Queue
         return array_pop($args);
     }
 
-    private function maxValueInArray($array, $keyToSearch)
+    /**
+     * @param array $jobs
+     */
+    private function lockJobs($jobs)
     {
-        $currentMax = null;
-
-        foreach ($array as $arr) {
-            foreach ($arr as $key => $value) {
-                if ($key === $keyToSearch && ($value >= $currentMax)) {
-                    $currentMax = $value;
-                }
-            }
+        $jobsIds = [];
+        foreach ($jobs as $job) {
+            $jobsIds = array_merge($jobsIds, $job['merged_ids']);
         }
 
-        return $currentMax;
+        if ($jobsIds !== []) {
+            $pid = getmypid();
+            $this->db->update($this->table, ['pid' => $pid], ['job_id IN (?)' => $jobsIds]);
+        }
     }
 
+    private function clearOldFailingJobs()
+    {
+        $retryLimit = $this->configHelper->getRetryLimit();
+
+        if ($retryLimit > 0 || true) {
+            $retryLimit = 0;
+            $where = $this->db->quoteInto('retries >= ?', $retryLimit);
+            $this->archiveFailedJobs($where);
+
+            return;
+        }
+
+        $this->archiveFailedJobs('retries > max_retries');
+        $this->db->delete($this->table, 'retries > max_retries');
+    }
+
+    /**
+     * @throws \Zend_Db_Statement_Exception
+     */
     private function clearOldLogRecords()
     {
-        $idsToDelete = $this->db->query("SELECT id 
-                                    FROM {$this->logTable} 
-                                    ORDER BY started DESC, id DESC 
-                                    LIMIT 25000, " . PHP_INT_MAX)
-                                ->fetchAll(\PDO::FETCH_COLUMN, 0);
+        $select = $this->db->select()
+           ->from($this->logTable, ['id'])
+           ->order(['started DESC', 'id DESC'])
+           ->limit(PHP_INT_MAX, 25000);
+
+        $idsToDelete = $this->db->query($select)->fetchAll(\PDO::FETCH_COLUMN, 0);
 
         if ($idsToDelete) {
-            $this->db->query("DELETE FROM {$this->logTable} WHERE id IN (" . implode(', ', $idsToDelete) . ')');
+            $this->db->delete($this->logTable, ['id IN (?)' => $idsToDelete]);
         }
     }
 
+    /**
+     * @return bool
+     */
     private function shouldEmptyQueue()
     {
         if (getenv('PROCESS_FULL_QUEUE') && getenv('PROCESS_FULL_QUEUE') === '1') {

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -83,9 +83,9 @@ class Queue
     }
 
     /**
-     * @param $className
-     * @param $method
-     * @param $data
+     * @param string $className
+     * @param string $method
+     * @param array $data
      * @param int $dataSize
      * @param bool $isFullReindex
      */
@@ -177,7 +177,7 @@ class Queue
     }
 
     /**
-     * @param $maxJobs
+     * @param int $maxJobs
      *
      * @throws \Exception
      */

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -271,9 +271,10 @@ class Queue
     /**
      * @param int $maxJobs
      *
+     * @throws \Exception
+     *
      * @return array
      *
-     * @throws \Exception
      */
     private function getJobs($maxJobs)
     {
@@ -309,9 +310,10 @@ class Queue
      * @param int $jobsLimit
      * @param bool $fetchFullReindexJobs
      *
+     * @throws \Zend_Db_Statement_Exception
+     *
      * @return array
      *
-     * @throws \Zend_Db_Statement_Exception
      */
     private function fetchJobs($jobsLimit, $fetchFullReindexJobs = false)
     {
@@ -376,6 +378,7 @@ class Queue
 
     /**
      * @param array $jobs
+     *
      * @return array
      */
     private function prepareJobs($jobs)
@@ -390,6 +393,7 @@ class Queue
 
     /**
      * @param array $oldJobs
+     *
      * @return array
      */
     private function mergeJobs($oldJobs)
@@ -452,6 +456,7 @@ class Queue
      * Sorts the jobs and preserves the order of jobs with static methods defined in $this->staticJobMethods
      *
      * @param array $oldJobs
+     *
      * @return array
      */
     private function sortJobs($oldJobs)
@@ -605,7 +610,7 @@ class Queue
     {
         $retryLimit = $this->configHelper->getRetryLimit();
 
-        if ($retryLimit > 0 || true) {
+        if ($retryLimit > 0) {
             $retryLimit = 0;
             $where = $this->db->quoteInto('retries >= ?', $retryLimit);
             $this->archiveFailedJobs($where);

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Setup;
 
+use Algolia\AlgoliaSearch\Api\Data\LandingPageInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\UninstallInterface;
@@ -13,7 +14,11 @@ class Uninstall implements UninstallInterface
         $setup->startSetup();
 
         $connection = $setup->getConnection();
+
         $connection->dropTable($setup->getTable('algoliasearch_queue'));
+        $connection->dropTable($setup->getTable('algoliasearch_queue_log'));
+        $connection->dropTable($setup->getTable('algoliasearch_queue_archive'));
+        $connection->dropTable($setup->getTable(LandingPageInterface::TABLE_NAME));
 
         $setup->endSetup();
     }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -477,6 +477,21 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $connection->createTable($table);
         }
 
+        $algoliaSeachQueueTable = $setup->getTable('algoliasearch_queue');
+        if (!$connection->tableColumnExists($algoliaSeachQueueTable, 'is_full_reindex')) {
+            $connection->addColumn(
+                $algoliaSeachQueueTable,
+                'is_full_reindex',
+                [
+                    'type' => Table::TYPE_INTEGER,
+                    'size' => 1,
+                    'default' => 0,
+                    'nullable' => false,
+                    'comment' => 'Indicates if the job is part of a full reindex',
+                ]
+            );
+        }
+
         $setup->endSetup();
     }
 

--- a/Test/Integration/QueueTest.php
+++ b/Test/Integration/QueueTest.php
@@ -319,6 +319,7 @@ class QueueTest extends TestCase
             'data_size' => 3,
             'merged_ids' => ['1', '7'],
             'store_id' => '1',
+            'is_full_reindex' => 0,
         ];
 
         $this->assertEquals($expectedCategoryJob, $mergedJobs[0]);
@@ -342,6 +343,7 @@ class QueueTest extends TestCase
             'data_size' => 2,
             'merged_ids' => ['4', '10'],
             'store_id' => '1',
+            'is_full_reindex' => 0,
         ];
 
         $this->assertEquals($expectedProductJob, $mergedJobs[3]);
@@ -669,6 +671,7 @@ class QueueTest extends TestCase
             'data_size' => 3,
             'merged_ids' => ['1', '7'],
             'store_id' => '1',
+            'is_full_reindex' => 0,
         ];
 
         $expectedLastJob = [
@@ -690,6 +693,7 @@ class QueueTest extends TestCase
             'data_size' => 2,
             'merged_ids' => ['6', '12'],
             'store_id' => '3',
+            'is_full_reindex' => 0,
         ];
 
         $this->assertEquals($expectedFirstJob, reset($jobs));


### PR DESCRIPTION
- Jobs are now split into 2 types - realtime and full reindex
- Realtime jobs have higher priority and will be processed before full reindex queue
- At least 1/3 of processed jobs will be jobs of full-reindex
- Removed raw SQL queries
- Added PHP doc annotations
- Slightly better readability

TODO:
- [x] Add "isFullReindex" flag to categories when #696 is merged