### PR TITLE
Fix Analytic Overview Update Action

### DIFF
--- a/Controller/Adminhtml/Analytics/Update.php
+++ b/Controller/Adminhtml/Analytics/Update.php
@@ -4,7 +4,6 @@ namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Analytics;
 
 use Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate;
 use Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Overview;
-use Magento\Backend\Block\Template;
 use Magento\Framework\DataObject;
 
 class Update extends AbstractAction

--- a/Controller/Adminhtml/Analytics/Update.php
+++ b/Controller/Adminhtml/Analytics/Update.php
@@ -2,7 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Analytics;
 
-use Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Index;
+use Algolia\AlgoliaSearch\Block\Adminhtml\BaseAdminTemplate;
+use Algolia\AlgoliaSearch\ViewModel\Adminhtml\Analytics\Overview;
 use Magento\Backend\Block\Template;
 use Magento\Framework\DataObject;
 
@@ -18,8 +19,8 @@ class Update extends AbstractAction
         $layout = $this->layoutFactory->create();
 
         $block = $layout
-            ->createBlock(Template::class)
-            ->setData('view_model', $this->_objectManager->create(Index::class))
+            ->createBlock(BaseAdminTemplate::class)
+            ->setData('view_model', $this->_objectManager->create(Overview::class))
             ->setTemplate('Algolia_AlgoliaSearch::analytics/overview.phtml')
             ->toHtml();
 


### PR DESCRIPTION
**Summary**
Bug reported internally by @AlexEven. The Update Action was pulling the old class before we switched over to using View_Model classes via block factory.

**Result**
This has been updated to the correct block class and view_model in the Update action file. 