### PR TITLE
Sales Data - change getAllIds() to getColumnValues() for optimization

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -707,7 +707,7 @@ class Data
 
         $ordersTableName = $this->resource->getTableName('sales_order_item');
 
-        $ids = $collection->getAllIds();
+        $ids = $collection->getColumnValues('entity_id');
         $ids[] = '0'; // Makes sure the imploded string is not empty
 
         $ids = implode(', ', $ids);


### PR DESCRIPTION
**Summary**
$collection->getAllIds() unsets the select query and retrieves the entire collection IDs. For the getSalesData() method, we should filter the collection IDs down to the current page and limit in the query. Use getColumnValues() to retrieve all entity_ids of the queried product collection.

**Result**
Optimized select query for getSalesData();