### PR TITLE
Indexing Queue export button

### DIFF
--- a/view/adminhtml/ui_component/algolia_algoliasearch_indexing_queue_listing.xml
+++ b/view/adminhtml/ui_component/algolia_algoliasearch_indexing_queue_listing.xml
@@ -57,6 +57,7 @@
             </argument>
         </filters>
         <paging name="listing_paging"/>
+        <exportButton name="export_button"/>
     </listingToolbar>
 
     <columns name="algolia_algoliasearch_job_columns">


### PR DESCRIPTION
**Summary**
For troubleshooting, it might be helpful to have a button to export the indexing queue table so that the client can send over upon request for those who do not have DB access.

**Result**
Added a button to the indexing queue page. 