### PR TITLE
Add algoliaBundle to Instantsearch hooks

### DIFF
--- a/view/frontend/web/click_conversion_analytics.js
+++ b/view/frontend/web/click_conversion_analytics.js
@@ -51,13 +51,13 @@ requirejs(['algoliaBundle', 'algoliaAnalytics'], function(algoliaBundle, algolia
 		}
 	});
 	
-	algolia.registerHook('beforeInstantsearchInit', function (instantsearchOptions) {
+	algolia.registerHook('beforeInstantsearchInit', function (instantsearchOptions, algoliaBundle) {
 		instantsearchOptions.searchParameters['clickAnalytics'] = true;
 		
 		return instantsearchOptions;
 	});
 	
-	algolia.registerHook('beforeInstantsearchStart', function (search) {
+	algolia.registerHook('beforeInstantsearchStart', function (search, algoliaBundle) {
 		search.once('render', function() {
 			algoliaAnalytics.initSearch({
 				getQueryID: function() {

--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -111,7 +111,7 @@ requirejs(['algoliaBundle','Magento_Catalog/js/price-utils'], function(algoliaBu
 			}
 		}
 		
-		instantsearchOptions = algolia.triggerHooks('beforeInstantsearchInit', instantsearchOptions);
+		instantsearchOptions = algolia.triggerHooks('beforeInstantsearchInit', instantsearchOptions, algoliaBundle);
 		
 		var search = algoliaBundle.instantsearch(instantsearchOptions);
 		
@@ -515,7 +515,7 @@ requirejs(['algoliaBundle','Magento_Catalog/js/price-utils'], function(algoliaBu
 			};
 		}
 		
-		allWidgetConfiguration = algolia.triggerHooks('beforeWidgetInitialization', allWidgetConfiguration);
+		allWidgetConfiguration = algolia.triggerHooks('beforeWidgetInitialization', allWidgetConfiguration, algoliaBundle);
 		
 		$.each(allWidgetConfiguration, function (widgetType, widgetConfig) {
 			if (Array.isArray(widgetConfig) === true) {
@@ -533,11 +533,11 @@ requirejs(['algoliaBundle','Magento_Catalog/js/price-utils'], function(algoliaBu
 				return;
 			}
 			
-			search = algolia.triggerHooks('beforeInstantsearchStart', search);
+			search = algolia.triggerHooks('beforeInstantsearchStart', search, algoliaBundle);
 			
 			search.start();
 			
-			search = algolia.triggerHooks('afterInstantsearchStart', search);
+			search = algolia.triggerHooks('afterInstantsearchStart', search, algoliaBundle);
 			
 			var instant_search_bar = $(instant_selector);
 			if (instant_search_bar.is(":focus") === false) {


### PR DESCRIPTION
**Summary**
A helpful suggestion from our community with regards to our instantsearch hooks to allow the ability to use instant search connectors via the algoliaBundle 

Related issue: #724

**Result**
Additional parameter for instantsearch hooks for algoliaBundle. 