### PR TITLE
Fix customer group prices on grouped products

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -105,7 +105,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
         foreach ($this->groups as $group) {
             $groupId = (int) $group->getData('customer_group_id');
 
-            if ((int) $this->customData[$field][$currencyCode]['group_' . $groupId] === 0) {
+            if ($this->customData[$field][$currencyCode]['group_' . $groupId] == 0) {
                 $this->customData[$field][$currencyCode]['group_' . $groupId] = $min;
 
                 if ($min === $max) {

--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -105,7 +105,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
         foreach ($this->groups as $group) {
             $groupId = (int) $group->getData('customer_group_id');
 
-            if ($this->customData[$field][$currencyCode]['group_' . $groupId] === 0) {
+            if ((int) $this->customData[$field][$currencyCode]['group_' . $groupId] === 0) {
                 $this->customData[$field][$currencyCode]['group_' . $groupId] = $min;
 
                 if ($min === $max) {


### PR DESCRIPTION
**Summary**
[MAG-136] Customer group pricing on grouped products are returning 0 instead of min/max values. 

Related issue: #668 

**Result**
Cast type on group price for type comparison in setFinalGroupPrices();

[MAG-136]: https://algolia.atlassian.net/browse/MAG-136