### PR TITLE
Bugfix product image only pull base and not type

### DIFF
--- a/Helper/Image.php
+++ b/Helper/Image.php
@@ -61,21 +61,6 @@ class Image extends \Magento\Catalog\Helper\Image
         return $url;
     }
 
-    protected function initBaseFile()
-    {
-        $model = $this->_getModel();
-        $baseFile = $model->getBaseFile();
-        if (!$baseFile) {
-            if ($this->getImageFile()) {
-                $model->setBaseFile($this->getImageFile());
-            } else {
-                $model->setBaseFile($this->getProduct()->getImage());
-            }
-        }
-
-        return $this;
-    }
-
     public function removeProtocol($url)
     {
         return str_replace(['https://', 'http://'], '//', $url);


### PR DESCRIPTION
**Summary**
[MAG-137] Reported bug. Even though product image type is specified it is still using the base image even for thumbnail.

Related Issues: #643 

**Result**
\Algolia\AlgoliaSearch\Helper\Image::initBaseFile() is a rewritten method from \Magento\Catalog\Helper\Image. I removed it since it was setting all images to getImage() [base image] instead of the specified type. That was the only purpose of this method so I removed it to revert to default behaviour. 

[MAG-137]: https://algolia.atlassian.net/browse/MAG-137