### PR TITLE
Indexing pages stop emulation on error

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -164,21 +164,26 @@ class Data
             return;
         }
 
-        $this->startEmulation($storeId);
-
         $indexName = $this->getIndexName($this->pageHelper->getIndexNameSuffix(), $storeId);
+
+        $this->startEmulation($storeId);
 
         $pages = $this->pageHelper->getPages($storeId);
 
+        $this->stopEmulation();
+
         foreach (array_chunk($pages, 100) as $chunk) {
-            $this->algoliaHelper->addObjects($chunk, $indexName . '_tmp');
+            try {
+                $this->algoliaHelper->addObjects($chunk, $indexName . '_tmp');
+            } catch (\Exception $e) {
+                $this->logger->log($e->getMessage());
+                continue;
+            }
         }
 
         $this->algoliaHelper->moveIndex($indexName . '_tmp', $indexName);
 
         $this->algoliaHelper->setSettings($indexName, $this->pageHelper->getIndexSettings($storeId));
-
-        $this->stopEmulation();
     }
 
     public function rebuildStoreCategoryIndex($storeId, $categoryIds = null)

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -408,7 +408,7 @@ class CategoryHelper
             $categoryId = $categoryId->getId();
         }
 
-        if ($storeId instanceof  Store) {
+        if ($storeId instanceof Store) {
             $storeId = $storeId->getId();
         }
 


### PR DESCRIPTION
**Summary**
[MAG-138] Page emulation does not stop on exception error and will persist into other indexing operations. 

Related Issues: #613

**Result**
Relocate emulation functions around getPages and add try/catch debugging for issues related to CMS pages on addObjects. Also threw in a spacing fix that was bothering me. 

[MAG-138]: https://algolia.atlassian.net/browse/MAG-138