### PR TITLE
Add Max Record Size Limit 

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -29,7 +29,7 @@ class AlgoliaHelper extends AbstractHelper
     private $clientFactory;
 
     /** @var int */
-    private $maxRecordSize = 20000;
+    private $maxRecordSize;
 
     /** @var array */
     private $potentiallyLongAttributes = ['description', 'short_description', 'meta_description', 'content'];
@@ -462,18 +462,27 @@ class AlgoliaHelper extends AbstractHelper
         }
     }
 
+    private function getMaxRecordSize()
+    {
+        if (!$this->maxRecordSize) {
+            $this->maxRecordSize = $this->config->getMaxRecordSizeLimit()
+                ? $this->config->getMaxRecordSizeLimit() : $this->config->getDefaultMaxRecordSize();
+        }
+        return $this->maxRecordSize;
+    }
+
     private function handleTooBigRecord($object)
     {
         $size = $this->calculateObjectSize($object);
 
-        if ($size > $this->maxRecordSize) {
+        if ($size > $this->getMaxRecordSize()) {
             foreach ($this->potentiallyLongAttributes as $attribute) {
                 if (isset($object[$attribute])) {
                     unset($object[$attribute]);
 
                     // Recalculate size and check if it fits in Algolia index
                     $size = $this->calculateObjectSize($object);
-                    if ($size < $this->maxRecordSize) {
+                    if ($size < $this->getMaxRecordSize()) {
                         return $object;
                     }
                 }
@@ -492,7 +501,7 @@ class AlgoliaHelper extends AbstractHelper
                     array_pop($object['sku']);
 
                     $size = $this->calculateObjectSize($object);
-                    if ($size < $this->maxRecordSize) {
+                    if ($size < $this->getMaxRecordSize()) {
                         return $object;
                     }
                 }
@@ -500,7 +509,7 @@ class AlgoliaHelper extends AbstractHelper
 
             // Recalculate size, if it still does not fit, let's skip it
             $size = $this->calculateObjectSize($object);
-            if ($size > $this->maxRecordSize) {
+            if ($size > $this->getMaxRecordSize()) {
                 $object = false;
             }
         }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -468,6 +468,7 @@ class AlgoliaHelper extends AbstractHelper
             $this->maxRecordSize = $this->config->getMaxRecordSizeLimit()
                 ? $this->config->getMaxRecordSizeLimit() : $this->config->getDefaultMaxRecordSize();
         }
+
         return $this->maxRecordSize;
     }
 

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -92,6 +92,7 @@ class ConfigHelper
     const BACKEND_RENDERING_ALLOWED_USER_AGENTS =
         'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents';
     const NON_CASTABLE_ATTRIBUTES = 'algoliasearch_advanced/advanced/non_castable_attributes';
+    const MAX_RECORD_SIZE_LIMIT = 'algoliasearch_advanced/advanced/max_record_size_limit';
 
     const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
 
@@ -103,6 +104,8 @@ class ConfigHelper
     const EXTRA_SETTINGS_SUGGESTIONS = 'algoliasearch_extra_settings/extra_settings/suggestions_extra_settings';
     const EXTRA_SETTINGS_ADDITIONAL_SECTIONS =
         'algoliasearch_extra_settings/extra_settings/additional_sections_extra_settings';
+
+    const DEFAULT_MAX_RECORD_SIZE = 10000;
 
     private $configInterface;
     private $objectManager;
@@ -998,6 +1001,16 @@ class ConfigHelper
         }
 
         return $nonCastableAttributes;
+    }
+
+    public function getDefaultMaxRecordSize()
+    {
+        return self::DEFAULT_MAX_RECORD_SIZE;
+    }
+
+    public function getMaxRecordSizeLimit($storeId = null)
+    {
+        return $this->configInterface->getValue(self::MAX_RECORD_SIZE_LIMIT, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     private function addIndexableAttributes(

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1047,28 +1047,26 @@ class ConfigHelper
 
     public function getMaxRecordSizeLimit($storeId = null)
     {
-
         if ($this->maxRecordSize) {
             return $this->maxRecordSize;
         }
 
         $configValue = $this->configInterface->getValue(self::MAX_RECORD_SIZE_LIMIT, ScopeInterface::SCOPE_STORE, $storeId);
         if ($configValue) {
-
             $this->maxRecordSize = $configValue;
-            return $this->_maxRecordSize;
+
+            return $this->maxRecordSize;
+        }
+        /** @var \Algolia\AlgoliaSearch\Helper\ProxyHelper $proxyHelper */
+        $proxyHelper = $this->objectManager->create('Algolia\AlgoliaSearch\Helper\ProxyHelper');
+        $clientData = $proxyHelper->getClientConfigurationData();
+        if ($clientData && isset($clientData['max_record_size'])) {
+            /** @var \Magento\Framework\App\Config\Storage\Writer $configWriter */
+            $configWriter = $this->objectManager->create('Magento\Framework\App\Config\Storage\Writer');
+            $configWriter->save(self::MAX_RECORD_SIZE_LIMIT, $clientData['max_record_size']);
+            $this->maxRecordSize = $clientData['max_record_size'];
         } else {
-            /** @var \Algolia\AlgoliaSearch\Helper\ProxyHelper $proxyHelper */
-            $proxyHelper = $this->objectManager->create('Algolia\AlgoliaSearch\Helper\ProxyHelper');
-            $clientData = $proxyHelper->getClientConfigurationData();
-            if ($clientData && isset($clientData['max_record_size'])) {
-                /** @var \Magento\Framework\App\Config\Storage\Writer $configWriter */
-                $configWriter = $this->objectManager->create('Magento\Framework\App\Config\Storage\Writer');
-                $configWriter->save(self::MAX_RECORD_SIZE_LIMIT, $clientData['max_record_size']);
-                $this->maxRecordSize = $clientData['max_record_size'];
-            } else {
-                $this->maxRecordSize = self::getDefaultMaxRecordSize();
-            }
+            $this->maxRecordSize = self::getDefaultMaxRecordSize();
         }
 
         return $this->maxRecordSize;

--- a/Model/Source/MaxRecordSize.php
+++ b/Model/Source/MaxRecordSize.php
@@ -37,6 +37,8 @@ class MaxRecordSize implements \Magento\Framework\Option\ArrayInterface
             }
         }
 
+        rsort($options);
+
         $formattedOptions = [];
         foreach ($options as $option) {
             $formattedOptions[] = [

--- a/Model/Source/MaxRecordSize.php
+++ b/Model/Source/MaxRecordSize.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Source;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\ProxyHelper;
+
+class MaxRecordSize implements \Magento\Framework\Option\ArrayInterface
+{
+    /** @var ConfigHelper */
+    private $configHelper;
+
+    /** @var ProxyHelper */
+    private $proxyHelper;
+
+    public function __construct(
+        ConfigHelper $configHelper,
+        ProxyHelper $proxyHelper
+    ) {
+        $this->configHelper = $configHelper;
+        $this->proxyHelper = $proxyHelper;
+    }
+
+    /**
+     * Legacy default is 20000
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $options[] = $this->configHelper->getDefaultMaxRecordSize();
+        $clientData = $this->proxyHelper->getClientConfigurationData();
+
+        if ($clientData && isset($clientData['max_record_size'])) {
+            if (!in_array($clientData['max_record_size'], $options)) {
+                $options[] = $clientData['max_record_size'];
+            }
+        }
+
+        $formattedOptions = [];
+        foreach ($options as $option) {
+            $formattedOptions[] = [
+                'value' => $option,
+                'label' => $option,
+            ];
+        }
+
+        return $formattedOptions;
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -878,6 +878,15 @@
                         ]]>
                     </comment>
                 </field>
+                <field id="max_record_size_limit" translate="label comment" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Max Record Size Limit</label>
+                    <source_model>Algolia\AlgoliaSearch\Model\Source\MaxRecordSize</source_model>
+                    <comment>
+                        <![CDATA[
+                        You can set the max record size limit in bytes here. If you are receiving "Record is too big" errors during indexing, try increasing your limit if it is available for your plan. To learn more, please read <a href="https://www.algolia.com/doc/faq/basics/is-there-a-size-limit-for-my-index-records/" target="_blank">this documentation</a>.
+                        ]]>
+                    </comment>
+                </field>
             </group>
         </section>
         <section id="algoliasearch_extra_settings" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -878,15 +878,6 @@
                         ]]>
                     </comment>
                 </field>
-                <field id="max_record_size_limit" translate="label comment" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Max Record Size Limit</label>
-                    <source_model>Algolia\AlgoliaSearch\Model\Source\MaxRecordSize</source_model>
-                    <comment>
-                        <![CDATA[
-                        You can set the max record size limit in bytes here. If you are receiving "Record is too big" errors during indexing, try increasing your limit if it is available for your plan. To learn more, please read <a href="https://www.algolia.com/doc/faq/basics/is-there-a-size-limit-for-my-index-records/" target="_blank">this documentation</a>.
-                        ]]>
-                    </comment>
-                </field>
             </group>
         </section>
         <section id="algoliasearch_extra_settings" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
**Summary**
[MAG-132] Create a configuration for max_record_size with default size to 10000 and dynamic value added from plan. 

**Result**
Truncate data when necessary according to plan size to reduce "Record is too big" errors and reduce batch indexing process errors. 

[MAG-132]: https://algolia.atlassian.net/browse/MAG-132