### PR TITLE
Bugfix searchable attribute configuration not saving correct scope 

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -270,7 +270,7 @@ class ProductHelper
 
     public function setSettings($indexName, $indexNameTmp, $storeId, $saveToTmpIndicesToo = false)
     {
-        $searchableAttributes = $this->getSearchableAttributes();
+        $searchableAttributes = $this->getSearchableAttributes($storeId);
         $customRanking = $this->getCustomRanking($storeId);
         $unretrievableAttributes = $this->getUnretrieveableAttributes();
         $attributesForFaceting = $this->getAttributesForFaceting($storeId);
@@ -898,11 +898,11 @@ class ProductHelper
         return $customData;
     }
 
-    private function getSearchableAttributes()
+    private function getSearchableAttributes($storeId = null)
     {
         $searchableAttributes = [];
 
-        foreach ($this->getAdditionalAttributes() as $attribute) {
+        foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
             if ($attribute['searchable'] === '1') {
                 if (!isset($attribute['order']) || $attribute['order'] === 'ordered') {
                     $searchableAttributes[] = $attribute['attribute'];

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -272,7 +272,7 @@ class ProductHelper
     {
         $searchableAttributes = $this->getSearchableAttributes($storeId);
         $customRanking = $this->getCustomRanking($storeId);
-        $unretrievableAttributes = $this->getUnretrieveableAttributes();
+        $unretrievableAttributes = $this->getUnretrieveableAttributes($storeId);
         $attributesForFaceting = $this->getAttributesForFaceting($storeId);
 
         $indexSettings = [
@@ -934,11 +934,11 @@ class ProductHelper
         return $customRanking;
     }
 
-    private function getUnretrieveableAttributes()
+    private function getUnretrieveableAttributes($storeId = null)
     {
         $unretrievableAttributes = [];
 
-        foreach ($this->getAdditionalAttributes() as $attribute) {
+        foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
             if ($attribute['retrievable'] !== '1') {
                 $unretrievableAttributes[] = $attribute['attribute'];
             }


### PR DESCRIPTION
**Summary**
Helpscout Issue (132804) reported searchable attributes are not respecting scope level and only returning default or current saved. 

**Result**
Added storeID for searchableAttribute so that it pulls correctly the scope. 