### PR TITLE
Fixed active categories for stores with a different root category ID

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -471,6 +471,7 @@ class CategoryHelper
                 ->from([$connection->getTableName('store'), 'store'], ['store_id', 'store_group.root_category_id'])
                 ->joinInner([$connection->getTableName('store_group'), 'store_group'], 'store.group_id = store_group.group_id')
                 ->where('store.store_id != ?', 0)
+                ->where('store_group.root_category_id != ?', 2)
         );
 
         $fixedCategories = [];


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
We noticed having categories in our category indexes that belonged to a different storeview.

The problem is that the extension expects that all categories are available in the default scope (0).

This isn't always the case since we can set a website to a separate category root with completely different category structure.

The current situation causes ALL categories to show up in ALL stores, a lot of them without a rewrite since the rewrite doesn't exist since the category isn't associated to that store.

This method walks through all active store groups and fetches the category root ID. It then walks through the activeCategories array looking for categories that are assigned to that root ID and then changes the prefix (which is almost certainly `0-`) to the correct prefix, causing these categories only to show up in that store.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
Correct categories only show up in the correct indexes.

The solution I provided here probably isn't the nicest since it fixes a wrong output instead of generating a correct output in the first place. However, this was the easiest and quickest for me to fix the issue short-term so I could create a module or a patch. I'll leave the refactoring to you guys.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->