### PR TITLE
Update Category Plugin 

### DIFF
--- a/Model/Indexer/CategoryObserver.php
+++ b/Model/Indexer/CategoryObserver.php
@@ -11,9 +11,8 @@ class CategoryObserver
 {
     private $indexer;
 
-    public function __construct(
-        IndexerRegistry $indexerRegistry
-    ) {
+    public function __construct(IndexerRegistry $indexerRegistry)
+    {
         $this->indexer = $indexerRegistry->get('algolia_categories');
     }
 
@@ -25,7 +24,7 @@ class CategoryObserver
         if (!$this->indexer->isScheduled()) {
             /** @var Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection */
             $productCollection = $category->getProductCollection();
-            CategoryIndexer::$affectedProductIds = $ids = (array) $productCollection->getColumnValues('entity_id');
+            CategoryIndexer::$affectedProductIds = (array) $productCollection->getColumnValues('entity_id');
 
             $this->indexer->reindexRow($category->getId());
         }
@@ -38,7 +37,7 @@ class CategoryObserver
         if (!$this->indexer->isScheduled()) {
             /* we are using products position because getProductCollection() does use correct store */
             $productCollection = $category->getProductsPosition();
-            CategoryIndexer::$affectedProductIds = $ids = array_keys($productCollection);
+            CategoryIndexer::$affectedProductIds = array_keys($productCollection);
 
             $this->indexer->reindexRow($category->getId());
         }

--- a/Model/Indexer/CategoryObserver.php
+++ b/Model/Indexer/CategoryObserver.php
@@ -3,68 +3,46 @@
 namespace Algolia\AlgoliaSearch\Model\Indexer;
 
 use Algolia\AlgoliaSearch\Model\Indexer\Category as CategoryIndexer;
-use Closure;
 use Magento\Catalog\Model\Category as Category;
 use Magento\Catalog\Model\ResourceModel\Category as CategoryResourceModel;
-use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Framework\Indexer\IndexerRegistry;
 
 class CategoryObserver
 {
     private $indexer;
+    private $logger;
 
-    public function __construct(IndexerRegistry $indexerRegistry)
-    {
+    public function __construct(
+        IndexerRegistry $indexerRegistry,
+        Logger $logger
+    ) {
         $this->indexer = $indexerRegistry->get('algolia_categories');
     }
 
-    /**
-     * @param CategoryResourceModel $categoryResource
-     * @param Closure $proceed
-     * @param Category $category
-     *
-     * @return mixed
-     */
-    public function aroundSave(
+    public function afterSave(
         CategoryResourceModel $categoryResource,
-        Closure $proceed,
+        $result,
         Category $category
     ) {
-        $categoryResource->addCommitCallback(function () use ($category) {
-            if (!$this->indexer->isScheduled()) {
-                /** @var ProductCollection $productCollection */
-                $productCollection = $category->getProductCollection();
-                CategoryIndexer::$affectedProductIds = (array) $productCollection->getAllIds();
+        if (!$this->indexer->isScheduled()) {
+            /** @var Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection */
+            $productCollection = $category->getProductCollection();
+            CategoryIndexer::$affectedProductIds = $ids = (array) $productCollection->getColumnValues('entity_id');
 
-                $this->indexer->reindexRow($category->getId());
-            }
-        });
-
-        return $proceed($category);
+            $this->indexer->reindexRow($category->getId());
+        }
     }
 
-    /**
-     * @param CategoryResourceModel $categoryResource
-     * @param Closure $proceed
-     * @param Category $category
-     *
-     * @return mixed
-     */
-    public function aroundDelete(
+    public function beforeDelete(
         CategoryResourceModel $categoryResource,
-        Closure $proceed,
         Category $category
     ) {
-        $categoryResource->addCommitCallback(function () use ($category) {
-            if (!$this->indexer->isScheduled()) {
-                /** @var ProductCollection $productCollection */
-                $productCollection = $category->getProductCollection();
-                CategoryIndexer::$affectedProductIds = (array) $productCollection->getAllIds();
+        if (!$this->indexer->isScheduled()) {
+            /* we are using products position because getProductCollection() does use correct store */
+            $productCollection = $category->getProductsPosition();
+            CategoryIndexer::$affectedProductIds = $ids = array_keys($productCollection);
 
-                $this->indexer->reindexRow($category->getId());
-            }
-        });
-
-        return $proceed($category);
+            $this->indexer->reindexRow($category->getId());
+        }
     }
 }

--- a/Model/Indexer/CategoryObserver.php
+++ b/Model/Indexer/CategoryObserver.php
@@ -10,11 +10,9 @@ use Magento\Framework\Indexer\IndexerRegistry;
 class CategoryObserver
 {
     private $indexer;
-    private $logger;
 
     public function __construct(
-        IndexerRegistry $indexerRegistry,
-        Logger $logger
+        IndexerRegistry $indexerRegistry
     ) {
         $this->indexer = $indexerRegistry->get('algolia_categories');
     }


### PR DESCRIPTION
Improving PR #759

Following best practice in Magento to avoid using around for plugin by changing to the appropriate before/after method. 

Previous aroundDelete getProductCollection() was not fetching the correct store view product collection for category and in some cases not returning any products. Since we only require product_ids, I used the getProductsPosition() to fetch the product IDs to be passed into the $affectedProductIds variable for indexing.  