### PR TITLE
Fix setSettings on TMP index

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -126,17 +126,23 @@ class AlgoliaHelper extends AbstractHelper
      * @param $settings
      * @param bool $forwardToReplicas
      * @param bool $mergeSettings
+     * @param string $mergeSettingsFrom
      *
      * @throws AlgoliaException
      */
-    public function setSettings($indexName, $settings, $forwardToReplicas = false, $mergeSettings = false)
-    {
+    public function setSettings(
+        $indexName,
+        $settings,
+        $forwardToReplicas = false,
+        $mergeSettings = false,
+        $mergeSettingsFrom = ''
+    ) {
         $this->checkClient(__FUNCTION__);
 
         $index = $this->getIndex($indexName);
 
         if ($mergeSettings === true) {
-            $settings = $this->mergeSettings($indexName, $settings);
+            $settings = $this->mergeSettings($indexName, $settings, $mergeSettingsFrom);
         }
 
         $res = $index->setSettings($settings, $forwardToReplicas);
@@ -185,12 +191,17 @@ class AlgoliaHelper extends AbstractHelper
         return $this->getIndex($indexName)->getSettings();
     }
 
-    public function mergeSettings($indexName, $settings)
+    public function mergeSettings($indexName, $settings, $mergeSettingsFrom = '')
     {
         $onlineSettings = [];
 
         try {
-            $onlineSettings = $this->getSettings($indexName);
+            $sourceIndex = $indexName;
+            if ($mergeSettingsFrom !== '') {
+                $sourceIndex = $mergeSettingsFrom;
+            }
+
+            $onlineSettings = $this->getSettings($sourceIndex);
         } catch (\Exception $e) {
         }
 

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch\Helper;
 use AlgoliaSearch\AlgoliaException;
 use AlgoliaSearch\Client;
 use AlgoliaSearch\ClientFactory;
+use AlgoliaSearch\Index;
 use AlgoliaSearch\Version;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
@@ -413,6 +414,9 @@ class AlgoliaHelper extends AbstractHelper
     {
         if ($lastUsedIndexName === null && isset(self::$lastUsedIndexName)) {
             $lastUsedIndexName = self::$lastUsedIndexName;
+            if ($lastUsedIndexName instanceof Index) {
+                $lastUsedIndexName = $lastUsedIndexName->indexName;
+            }
         }
 
         if ($lastTaskId === null && isset(self::$lastTaskId)) {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -258,15 +258,6 @@ class Data
         $this->moveStoreSuggestionIndex($storeId);
     }
 
-    public function moveIndex($tmpIndexName, $indexName)
-    {
-        if ($this->isIndexingEnabled() === false) {
-            return;
-        }
-
-        $this->algoliaHelper->moveIndex($tmpIndexName, $indexName);
-    }
-
     public function moveStoreSuggestionIndex($storeId)
     {
         if ($this->isIndexingEnabled($storeId) === false) {

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -303,7 +303,7 @@ class ProductHelper
         $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
         $this->logger->log('Settings: ' . json_encode($indexSettings));
         if ($saveToTmpIndicesToo === true) {
-            $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true);
+            $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true, $indexName);
             $this->logger->log('Pushing the same settings to TMP index as well');
         }
 

--- a/Model/IndexMover.php
+++ b/Model/IndexMover.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model;
+
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
+use Algolia\AlgoliaSearch\Helper\Data;
+use AlgoliaSearch\AlgoliaException;
+
+class IndexMover
+{
+    /** @var Data */
+    private $baseHelper;
+
+    /** @var AlgoliaHelper */
+    private $algoliaHelper;
+
+    /** @var IndicesConfigurator */
+    private $indicesConfigurator;
+
+    /**
+     * @param Data $baseHelper
+     * @param AlgoliaHelper $algoliaHelper
+     * @param IndicesConfigurator $indicesConfigurator
+     */
+    public function __construct(
+        Data $baseHelper,
+        AlgoliaHelper $algoliaHelper,
+        IndicesConfigurator $indicesConfigurator
+    ) {
+        $this->baseHelper = $baseHelper;
+        $this->algoliaHelper = $algoliaHelper;
+        $this->indicesConfigurator = $indicesConfigurator;
+    }
+
+    /**
+     * @param string $tmpIndexName
+     * @param string $indexName
+     */
+    public function moveIndex($tmpIndexName, $indexName)
+    {
+        if ($this->baseHelper->isIndexingEnabled() === false) {
+            return;
+        }
+
+        $this->algoliaHelper->moveIndex($tmpIndexName, $indexName);
+    }
+
+    /**
+     * @param string $tmpIndexName
+     * @param string $indexName
+     * @param int $storeId
+     *
+     * @throws AlgoliaException
+     */
+    public function moveIndexWithSetSettings($tmpIndexName, $indexName, $storeId)
+    {
+        if ($this->baseHelper->isIndexingEnabled() === false) {
+            return;
+        }
+
+        $this->indicesConfigurator->saveConfigurationToAlgolia($storeId, true);
+        $this->moveIndex($tmpIndexName, $indexName);
+    }
+}

--- a/Model/Indexer/Product.php
+++ b/Model/Indexer/Product.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Data;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Model\IndexMover;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Model\Queue;
 use Magento;
@@ -119,10 +120,10 @@ class Product implements Magento\Framework\Indexer\ActionInterface, Magento\Fram
             if ($useTmpIndex) {
                 $suffix = $this->productHelper->getIndexNameSuffix();
 
-                /** @uses Data::moveIndex() */
-                $this->queue->addToQueue(Data::class, 'moveIndex', [
+                /** @uses IndexMover::moveIndexWithSetSettings() */
+                $this->queue->addToQueue(IndexMover::class, 'moveIndexWithSetSettings', [
                     'tmpIndexName' => $this->fullAction->getIndexName($suffix, $storeId, true),
-                    'indexName' => $this->fullAction->getIndexName($suffix, $storeId, false),
+                    'indexName' => $this->fullAction->getIndexName($suffix, $storeId),
                     'store_id' => $storeId,
                 ], 1, true);
             }

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -61,7 +61,7 @@ class Queue
     /** @var array */
     private $staticJobMethods = [
         'saveConfigurationToAlgolia',
-        'moveIndex',
+        'moveIndexWithSetSettings',
         'deleteObjects',
     ];
 

--- a/Model/Source/JobMethods.php
+++ b/Model/Source/JobMethods.php
@@ -6,7 +6,7 @@ class JobMethods implements \Magento\Framework\Data\OptionSourceInterface
 {
     private $methods = [
         'saveConfigurationToAlgolia' => 'Save Configuration',
-        'moveIndex' => 'Move Index',
+        'moveIndexWithSetSettings' => 'Move Index',
         'deleteObjects' => 'Object deletion',
         'rebuildStoreCategoryIndex' => 'Category Reindex',
         'rebuildStoreProductIndex' => 'Product Reindex',

--- a/Test/Integration/QueueTest.php
+++ b/Test/Integration/QueueTest.php
@@ -62,7 +62,7 @@ class QueueTest extends TestCase
                 continue;
             }
 
-            $this->assertEquals('moveIndex', $row['method']);
+            $this->assertEquals('moveIndexWithSetSettings', $row['method']);
             $this->assertEquals(1, $row['data_size']);
         }
     }
@@ -452,8 +452,8 @@ class QueueTest extends TestCase
             ], [
                 'job_id' => 9,
                 'pid' => null,
-                'class' => 'Algolia\AlgoliaSearch\Helper\Data',
-                'method' => 'moveIndex',
+                'class' => 'Algolia\AlgoliaSearch\Model\IndexMover',
+                'method' => 'moveIndexWithSetSettings',
                 'data' => '{"store_id":"3","category_ids":["40"]}',
                 'max_retries' => 3,
                 'retries' => 0,
@@ -472,8 +472,8 @@ class QueueTest extends TestCase
             ], [
                 'job_id' => 11,
                 'pid' => null,
-                'class' => 'Algolia\AlgoliaSearch\Helper\Data',
-                'method' => 'moveIndex',
+                'class' => 'Algolia\AlgoliaSearch\Model\IndexMover',
+                'method' => 'moveIndexWithSetSettings',
                 'data' => '{"store_id":"2","product_ids":["405"]}',
                 'max_retries' => 3,
                 'retries' => 0,
@@ -511,9 +511,9 @@ class QueueTest extends TestCase
         $this->assertEquals('rebuildStoreProductIndex', $jobs[5]->getMethod());
         $this->assertEquals('saveConfigurationToAlgolia', $jobs[6]->getMethod());
         $this->assertEquals('rebuildStoreCategoryIndex', $jobs[7]->getMethod());
-        $this->assertEquals('moveIndex', $jobs[8]->getMethod());
+        $this->assertEquals('moveIndexWithSetSettings', $jobs[8]->getMethod());
         $this->assertEquals('rebuildStoreProductIndex', $jobs[9]->getMethod());
-        $this->assertEquals('moveIndex', $jobs[10]->getMethod());
+        $this->assertEquals('moveIndexWithSetSettings', $jobs[10]->getMethod());
         $this->assertEquals('rebuildStoreProductIndex', $jobs[11]->getMethod());
     }
 


### PR DESCRIPTION
**Merge settings from production index to TMP index**
Fixes issue when settings to TMP index were "merged" from non-existing TMP index. Therefore it reset the settings set on production index when TMP index was moved to production as those settings were never set there.

**Set settings to TMP index immediately before the move**
Fixes issue when settings were applied to a production index and full reindex process was in progress (TMP index was already existing). Those settings were not propagated to TMP index and during the move of TMP index, the settings were overridden.