### PR TITLE
DO NOT MERGE: Test logging for category products indexing

### DIFF
--- a/Model/Indexer/CategoryObserver.php
+++ b/Model/Indexer/CategoryObserver.php
@@ -21,10 +21,16 @@ class CategoryObserver
         $result,
         CategoryModel $category
     ) {
+        \Magento\Framework\App\ObjectManager::getInstance()->get(\Psr\Log\LoggerInterface::class)->info('ALGOLIA: category afterSave triggered');
         if (!$this->indexer->isScheduled()) {
+            \Magento\Framework\App\ObjectManager::getInstance()->get(\Psr\Log\LoggerInterface::class)->info('ALGOLIA: indexer is not in "On schedule" mode, proceeding with indexing');
+
+            \Magento\Framework\App\ObjectManager::getInstance()->get(\Psr\Log\LoggerInterface::class)->info('ALGOLIA: reindexing category id "' . $category->getId() .'"');
+
             /** @var Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection */
             $productCollection = $category->getProductCollection();
             CategoryIndexer::$affectedProductIds = (array) $productCollection->getColumnValues('entity_id');
+            \Magento\Framework\App\ObjectManager::getInstance()->get(\Psr\Log\LoggerInterface::class)->info('ALGOLIA: affected product ids by category save: ' . implode(', ', CategoryIndexer::$affectedProductIds));
 
             $this->indexer->reindexRow($category->getId());
         }


### PR DESCRIPTION
Add logging to for category product's indexing. Outputs logs to `var/log/system.log` file.

Example of logs for correct indexing:
```
[2019-05-31 14:37:49] report.INFO: ALGOLIA: category afterSave triggered [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: indexer is not in "On schedule" mode, proceeding with indexing [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: reindexing category id "5" [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: affected product ids by category save: 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 45, 46 [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: in execute method of indexer [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: reindexing category to store ids: 1 [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: processing specific categories indexing [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: adding to queue chunk of categories, store id: "1", category ids: 5 [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: about to process affected products [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: number of affected products: 23 [] []
[2019-05-31 14:37:49] report.INFO: ALGOLIA: adding product to queue, store id: "1", product ids: 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 45, 46 [] []
```