### PR TITLE
[add-storeid-to-facets] Add storeId to getFacets when you send change…

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -953,7 +953,7 @@ class ProductHelper
 
         $currencies = $this->currencyManager->getConfigAllowCurrencies();
 
-        $facets = $this->configHelper->getFacets();
+        $facets = $this->configHelper->getFacets($storeId);
         foreach ($facets as $facet) {
             if ($facet['attribute'] === 'price') {
                 foreach ($currencies as $currency_code) {


### PR DESCRIPTION
…s to algolia (for multistore)

Why this need?

When you have on magento multistore and need different design (on first site price slider, on second - don't need) all your changes on algolia.com set from storeId = null (first your store view) and all facets showed on all sites equal. That's not correct, I think