### PR TITLE
Resolve issue from Magento 2.3.2 causing category pages to break

### DIFF
--- a/Adapter/Algolia.php
+++ b/Adapter/Algolia.php
@@ -120,6 +120,7 @@ class Algolia implements AdapterInterface
         $response = [
             'documents' => $documents,
             'aggregations' => $aggregations,
+            'total' => count($documents)
         ];
 
         return $this->responseFactory->create($response);


### PR DESCRIPTION
**Summary**
The parameter list for \Magento\Framework\Search\Adapter\Mysql\ResponseFactory changed in Magento 2.3.2, causing an exception to be thrown on the category pages. This patch should be backwards compatible, and resolve the issue.