### PR TITLE
Category Product Updates for Update on Schedule

### DIFF
--- a/Model/Indexer/CategoryObserver.php
+++ b/Model/Indexer/CategoryObserver.php
@@ -58,7 +58,8 @@ class CategoryObserver
             // To reduce the indexing operation for products, only update if these values have changed
             if ($category->getOrigData('name') !== $category->getData('name')
                 || $category->getOrigData('include_in_menu') !== $category->getData('include_in_menu')
-                || $category->getOrigData('is_active') !== $category->getData('is_active')) {
+                || $category->getOrigData('is_active') !== $category->getData('is_active')
+                || $category->getOrigData('path') !== $category->getData('path')) {
                 /** @var ProductCollection $productCollection */
                 $productCollection = $category->getProductCollection();
                 $collectionIds = (array) $productCollection->getColumnValues('entity_id');
@@ -88,7 +89,8 @@ class CategoryObserver
     public function beforeDelete(CategoryResourceModel $categoryResource, CategoryModel $category)
     {
         $categoryResource->addCommitCallback(function() use ($category) {
-            if (!$this->indexer->isScheduled() || $this->configHelper->isQueueActive()) {
+            // mview should be able to handle the changes for catalog_category_product relationship
+            if (!$this->indexer->isScheduled()) {
                 /* we are using products position because getProductCollection() doesn't use correct store */
                 $productCollection = $category->getProductsPosition();
                 CategoryIndexer::$affectedProductIds = array_keys($productCollection);

--- a/Model/Indexer/CategoryObserver.php
+++ b/Model/Indexer/CategoryObserver.php
@@ -7,24 +7,38 @@ use Algolia\AlgoliaSearch\Model\Indexer\Category as CategoryIndexer;
 use Magento\Catalog\Model\Category as CategoryModel;
 use Magento\Catalog\Model\ResourceModel\Category as CategoryResourceModel;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Indexer\IndexerRegistry;
 
 class CategoryObserver
 {
+    /** @var IndexerRegistry */
+    private $indexerRegistry;
+
     /** @var CategoryIndexer */
     private $indexer;
 
     /** @var ConfigHelper */
     private $configHelper;
 
+    /** @var ResourceConnection */
+    protected $resource;
+
     /**
+     * CategoryObserver constructor.
      * @param IndexerRegistry $indexerRegistry
      * @param ConfigHelper $configHelper
+     * @param ResourceConnection $resource
      */
-    public function __construct(IndexerRegistry $indexerRegistry, ConfigHelper $configHelper)
-    {
+    public function __construct(
+        IndexerRegistry $indexerRegistry,
+        ConfigHelper $configHelper,
+        ResourceConnection $resource
+    ) {
+        $this->indexerRegistry = $indexerRegistry;
         $this->indexer = $indexerRegistry->get('algolia_categories');
         $this->configHelper = $configHelper;
+        $this->resource = $resource;
     }
 
     /**
@@ -40,12 +54,25 @@ class CategoryObserver
     public function beforeSave(CategoryResourceModel $categoryResource, CategoryModel $category)
     {
         $categoryResource->addCommitCallback(function() use ($category) {
-            if (!$this->indexer->isScheduled() || $this->configHelper->isQueueActive()) {
+            $collectionIds = [];
+            // To reduce the indexing operation for products, only update if these values have changed
+            if ($category->getOrigData('name') !== $category->getData('name')
+                || $category->getOrigData('include_in_menu') !== $category->getData('include_in_menu')
+                || $category->getOrigData('is_active') !== $category->getData('is_active')) {
                 /** @var ProductCollection $productCollection */
                 $productCollection = $category->getProductCollection();
-                CategoryIndexer::$affectedProductIds = (array) $productCollection->getColumnValues('entity_id');
+                $collectionIds = (array) $productCollection->getColumnValues('entity_id');
+            }
+            $changedProductIds = ($category->getChangedProductIds() !== null ? (array) $category->getChangedProductIds() : []);
 
+            if (!$this->indexer->isScheduled()) {
+                CategoryIndexer::$affectedProductIds = array_unique(array_merge($changedProductIds, $collectionIds));
                 $this->indexer->reindexRow($category->getId());
+            } else {
+                // missing logic, if scheduled, when category is saved w/out product, products need to be added to _cl
+                if (count($changedProductIds) === 0 && count($collectionIds) > 0) {
+                    $this->updateCategoryProducts($collectionIds);
+                }
             }
         });
 
@@ -71,5 +98,28 @@ class CategoryObserver
         });
 
         return [$category];
+    }
+
+    /**
+     * @param array $productIds
+     */
+    private function updateCategoryProducts(array $productIds)
+    {
+        $productIndexer = $this->indexerRegistry->get('algolia_products');
+        if (!$productIndexer->isScheduled()) {
+            // if the product index is not schedule, it should still index these products
+            $productIndexer->reindexList($productIds);
+        } else {
+            $view = $productIndexer->getView();
+            $changelogTableName = $this->resource->getTableName($view->getChangelog()->getName());
+            $connection = $this->resource->getConnection();
+            if ($connection->isTableExists($changelogTableName)) {
+                $data = [];
+                foreach ($productIds as $productId) {
+                    $data[] = ['entity_id' => $productId];
+                }
+                $connection->insertMultiple($changelogTableName, $data);
+            }
+        }
     }
 }

--- a/Model/Observer/CategoryMoveAfter.php
+++ b/Model/Observer/CategoryMoveAfter.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Observer;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Catalog\Model\Category;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Indexer\IndexerRegistry;
+
+class CategoryMoveAfter implements ObserverInterface
+{
+
+    /** @var IndexerRegistry */
+    private $indexerRegistry;
+
+    /** @var ConfigHelper */
+    private $configHelper;
+
+    /** @var ResourceConnection */
+    protected $resource;
+
+    /**
+     * @param IndexerRegistry $indexerRegistry
+     * @param ConfigHelper $configHelper
+     * @param ResourceConnection $resource
+     */
+    public function __construct(
+        IndexerRegistry $indexerRegistry,
+        ConfigHelper $configHelper,
+        ResourceConnection $resource
+    ) {
+        $this->indexerRegistry = $indexerRegistry;
+        $this->configHelper = $configHelper;
+        $this->resource = $resource;
+    }
+
+    /**
+     * Category::move() does not run save so the plugin observing the save method
+     * is not able to process the products that need updating.
+     *
+     * @param Observer $observer
+     * @return bool|void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var Category $category */
+        $category = $observer->getEvent()->getCategory();
+        if (!$this->configHelper->indexProductOnCategoryProductsUpdate($category->getStoreId())) {
+            return false;
+        }
+
+        $productIndexer = $this->indexerRegistry->get('algolia_products');
+        if ($category->getOrigData('path') !== $category->getData('path')) {
+            $productIds = array_keys($category->getProductsPosition());
+
+            if (!$productIndexer->isScheduled()) {
+                // if the product index is not schedule, it should still index these products
+                $productIndexer->reindexList($productIds);
+            } else {
+                $view = $productIndexer->getView();
+                $changelogTableName = $this->resource->getTableName($view->getChangelog()->getName());
+                $connection = $this->resource->getConnection();
+                if ($connection->isTableExists($changelogTableName)) {
+                    $data = [];
+                    foreach ($productIds as $productId) {
+                        $data[] = ['entity_id' => $productId];
+                    }
+                    $connection->insertMultiple($changelogTableName, $data);
+                }
+            }
+        }
+    }
+}

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -41,6 +41,10 @@
         <observer name="algoliasearch_create_merchandising_query_rule" instance="Algolia\AlgoliaSearch\Model\Observer\Merchandising"/>
     </event>
 
+    <event name="catalog_category_move_after">
+        <observer name="algoliasearch_category_move_after" instance="Algolia\AlgoliaSearch\Model\Observer\CategoryMoveAfter"/>
+    </event>
+
     <event name="algolia_product_collection_add_additional_data">
         <observer name="algoliasearch_product_permissions" instance="Algolia\AlgoliaSearch\Model\Observer\CatalogPermissions\ProductCollectionAddPermissions" />
     </event>


### PR DESCRIPTION
**Summary**
Products within a category needs to be updated when a category name, include_in_menu, and/or is_active attributes are updated. When the algolia indexes are set to Update on Schedule, the mview subscription for categories does not push products into the algolia_products_cl table if a products in the category have not been changed. We need to compensate for this missing condition. 

Related Issues: #758

**Result**
Updated the CategoryObserver beforeSave() method to pass in also deleted or added products as well as condition the product collection to only when there are specific modifications. This is to reduce extra operations on indexing. We also added a new method to update the product depending on the mode of the indexer. 