### PR TITLE
Add Store emulation for full category reindexing

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -398,6 +398,8 @@ class Data
             return;
         }
 
+        $this->startEmulation($storeId);
+
         /** @var \Magento\Catalog\Model\ResourceModel\Category\Collection $collection */
         $collection = clone $collectionDefault;
         $collection->setCurPage($page)->setPageSize($pageSize);
@@ -435,6 +437,8 @@ class Data
         $collection->clear();
 
         unset($collection);
+
+        $this->stopEmulation();
     }
 
     private function getProductsRecords($storeId, $collection, $potentiallyDeletedProductsIds = null)

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -350,8 +350,12 @@ class Data
             return;
         }
 
+        $this->startEmulation($storeId);
+
         $collection = $this->categoryHelper->getCategoryCollectionQuery($storeId, null);
         $this->rebuildStoreCategoryIndexPage($storeId, $collection, $page, $pageSize);
+
+        $this->stopEmulation();
     }
 
     public function rebuildStoreSuggestionIndexPage($storeId, $collectionDefault, $page, $pageSize)
@@ -398,8 +402,6 @@ class Data
             return;
         }
 
-        $this->startEmulation($storeId);
-
         /** @var \Magento\Catalog\Model\ResourceModel\Category\Collection $collection */
         $collection = clone $collectionDefault;
         $collection->setCurPage($page)->setPageSize($pageSize);
@@ -437,8 +439,6 @@ class Data
         $collection->clear();
 
         unset($collection);
-
-        $this->stopEmulation();
     }
 
     private function getProductsRecords($storeId, $collection, $potentiallyDeletedProductsIds = null)


### PR DESCRIPTION
Fix the wrong base url used in the full category reindexing process when there are more than one store.