### PR TITLE
Add ACL for Algolia Search Configuration section

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -4,7 +4,14 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::system">
-                    <resource id="Algolia_AlgoliaSearch::manage" title="Algolia Algoliasearch" sortOrder="99999" />
+                    <resource id="Algolia_AlgoliaSearch::manage" title="Algolia Search" sortOrder="99999" />
+                </resource>
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="Algolia_AlgoliaSearch::algolia_algoliasearch" title="Algolia Search"/>
+                        </resource>
+                    </resource>
                 </resource>
             </resource>
         </resources>


### PR DESCRIPTION
**Summary**
Add ACL for Algolia Search Configuration section for non administration users. 

**Result**
- ACL added for extension configuration. 
- Updated title text for menu ACL. 