### PR TITLE
Update Product Interceptor Condition

### DIFF
--- a/Model/Indexer/ProductObserver.php
+++ b/Model/Indexer/ProductObserver.php
@@ -39,7 +39,7 @@ class ProductObserver
     public function beforeSave(ProductResource $productResource, ProductModel $product)
     {
         $productResource->addCommitCallback(function () use ($product) {
-            if (!$this->indexer->isScheduled() || $this->configHelper->isQueueActive()) {
+            if (!$this->indexer->isScheduled()) {
                 $this->indexer->reindexRow($product->getId());
             }
         });
@@ -60,7 +60,7 @@ class ProductObserver
     public function beforeDelete(ProductResource $productResource, ProductModel $product)
     {
         $productResource->addCommitCallback(function () use ($product) {
-            if (!$this->indexer->isScheduled() || $this->configHelper->isQueueActive()) {
+            if (!$this->indexer->isScheduled()) {
                 $this->indexer->reindexRow($product->getId());
             }
         });
@@ -77,7 +77,7 @@ class ProductObserver
      */
     public function afterUpdateAttributes(Action $subject, Action $result = null, $productIds)
     {
-        if (!$this->indexer->isScheduled() || $this->configHelper->isQueueActive()) {
+        if (!$this->indexer->isScheduled()) {
             $this->indexer->reindexList(array_unique($productIds));
         }
 
@@ -93,7 +93,7 @@ class ProductObserver
      */
     public function afterUpdateWebsites(Action $subject, Action $result = null, array $productIds)
     {
-        if (!$this->indexer->isScheduled() || $this->configHelper->isQueueActive()) {
+        if (!$this->indexer->isScheduled()) {
             $this->indexer->reindexList(array_unique($productIds));
         }
 


### PR DESCRIPTION
**Summary**
Remove the isQueueActive() check for the product interceptor. This issue was raised in a historical PR by a community member, @peterjaap. Thanks! 

https://github.com/algolia/algoliasearch-magento-2/pull/783

**Result**
Removed condition and made sure that all interceptors for Product are running as expected for both Update on Schedule and Update on Save. 
