### PR TITLE
Encode the search query

### DIFF
--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -450,7 +450,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 				if (algoliaConfig.instant.enabled && query === '')
 					query = '__empty__';
 
-				window.location = $(this).attr('action') + '?q=' + query;
+				window.location = $(this).attr('action') + '?q=' + encodeURIComponent(query);
 
 				return false;
 			});


### PR DESCRIPTION


**Summary**

This PR encodes the search query when a customer submits the search form.
I have noticed this issue when submitted the search form with & symbol.
As a result, the & symbol was not encoded to %26 in URL.

**Result**

<img width="213" alt="Screen Shot 2019-08-17 at 14 56 47" src="https://user-images.githubusercontent.com/31502344/63211415-55c9e900-c0ff-11e9-84c1-79079c34542e.png">
