### PR TITLE
chore(InstantSearch V3): migrate css

### DIFF
--- a/view/frontend/web/internals/algolia-reset.css
+++ b/view/frontend/web/internals/algolia-reset.css
@@ -1,0 +1,202 @@
+.ais-Breadcrumb-list,
+.ais-CurrentRefinements-list,
+.ais-HierarchicalMenu-list,
+.ais-Hits-list,
+.ais-Results-list,
+.ais-InfiniteHits-list,
+.ais-InfiniteResults-list,
+.ais-Menu-list,
+.ais-NumericMenu-list,
+.ais-Pagination-list,
+.ais-RatingMenu-list,
+.ais-RefinementList-list,
+.ais-ToggleRefinement-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ais-ClearRefinements-button,
+.ais-CurrentRefinements-delete,
+.ais-CurrentRefinements-reset,
+.ais-GeoSearch-redo,
+.ais-GeoSearch-reset,
+.ais-HierarchicalMenu-showMore,
+.ais-InfiniteHits-loadPrevious,
+.ais-InfiniteHits-loadMore,
+.ais-InfiniteResults-loadMore,
+.ais-Menu-showMore,
+.ais-RangeInput-submit,
+.ais-RefinementList-showMore,
+.ais-SearchBox-submit,
+.ais-SearchBox-reset,
+.ais-VoiceSearch-button {
+  padding: 0;
+  overflow: visible;
+  font: inherit;
+  line-height: normal;
+  color: inherit;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.ais-ClearRefinements-button::-moz-focus-inner,
+.ais-CurrentRefinements-delete::-moz-focus-inner,
+.ais-CurrentRefinements-reset::-moz-focus-inner,
+.ais-GeoSearch-redo::-moz-focus-inner,
+.ais-GeoSearch-reset::-moz-focus-inner,
+.ais-HierarchicalMenu-showMore::-moz-focus-inner,
+.ais-InfiniteHits-loadPrevious::-moz-focus-inner,
+.ais-InfiniteHits-loadMore::-moz-focus-inner,
+.ais-InfiniteResults-loadMore::-moz-focus-inner,
+.ais-Menu-showMore::-moz-focus-inner,
+.ais-RangeInput-submit::-moz-focus-inner,
+.ais-RefinementList-showMore::-moz-focus-inner,
+.ais-SearchBox-submit::-moz-focus-inner,
+.ais-SearchBox-reset::-moz-focus-inner,
+.ais-VoiceSearch-button::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+.ais-ClearRefinements-button[disabled],
+.ais-CurrentRefinements-delete[disabled],
+.ais-CurrentRefinements-reset[disabled],
+.ais-GeoSearch-redo[disabled],
+.ais-GeoSearch-reset[disabled],
+.ais-HierarchicalMenu-showMore[disabled],
+.ais-InfiniteHits-loadPrevious[disabled],
+.ais-InfiniteHits-loadMore[disabled],
+.ais-InfiniteResults-loadMore[disabled],
+.ais-Menu-showMore[disabled],
+.ais-RangeInput-submit[disabled],
+.ais-RefinementList-showMore[disabled],
+.ais-SearchBox-submit[disabled],
+.ais-SearchBox-reset[disabled],
+.ais-VoiceSearch-button[disabled] {
+  cursor: default;
+}
+
+.ais-Breadcrumb-list,
+.ais-Breadcrumb-item,
+.ais-Pagination-list,
+.ais-RangeInput-form,
+.ais-RatingMenu-link,
+.ais-PoweredBy {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.ais-GeoSearch,
+.ais-GeoSearch-map {
+  height: 100%;
+}
+
+.ais-HierarchicalMenu-list .ais-HierarchicalMenu-list {
+  margin-left: 1em;
+}
+
+.ais-PoweredBy-logo {
+  display: block;
+  height: 1.2em;
+  width: auto;
+}
+
+.ais-RatingMenu-starIcon {
+  display: block;
+  width: 20px;
+  height: 20px;
+}
+
+.ais-SearchBox-input::-ms-clear,
+.ais-SearchBox-input::-ms-reveal {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.ais-SearchBox-input::-webkit-search-decoration,
+.ais-SearchBox-input::-webkit-search-cancel-button,
+.ais-SearchBox-input::-webkit-search-results-button,
+.ais-SearchBox-input::-webkit-search-results-decoration {
+  display: none;
+}
+
+.ais-RangeSlider .rheostat {
+  overflow: visible;
+  margin-top: 40px;
+  margin-bottom: 40px;
+}
+
+.ais-RangeSlider .rheostat-background {
+  height: 6px;
+  top: 0px;
+  width: 100%;
+}
+
+.ais-RangeSlider .rheostat-handle {
+  margin-left: -12px;
+  top: -7px;
+}
+
+.ais-RangeSlider .rheostat-background {
+  position: relative;
+  background-color: #ffffff;
+  border: 1px solid #aaa;
+}
+
+.ais-RangeSlider .rheostat-progress {
+  position: absolute;
+  top: 1px;
+  height: 4px;
+  background-color: #333;
+}
+
+.rheostat-handle {
+  position: relative;
+  z-index: 1;
+  width: 20px;
+  height: 20px;
+  background-color: #fff;
+  border: 1px solid #333;
+  border-radius: 50%;
+  cursor: -webkit-grab;
+  cursor: grab;
+}
+
+.rheostat-marker {
+  margin-left: -1px;
+  position: absolute;
+  width: 1px;
+  height: 5px;
+  background-color: #aaa;
+}
+
+.rheostat-marker--large {
+  height: 9px;
+}
+
+.rheostat-value {
+  margin-left: 50%;
+  padding-top: 15px;
+  position: absolute;
+  text-align: center;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+.rheostat-tooltip {
+  margin-left: 50%;
+  position: absolute;
+  top: -22px;
+  text-align: center;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+}

--- a/view/frontend/web/internals/autocomplete.css
+++ b/view/frontend/web/internals/autocomplete.css
@@ -1,0 +1,383 @@
+@import "./grid.css";
+
+/** Auto-completion menu */
+
+#algolia-autocomplete-container .aa-dropdown-menu .before_special {
+    color: #aaaaaa;
+    text-decoration: line-through;
+    font-size: 12px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .tier_price {
+    color: #666666;
+    font-size: 10px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .tier_price .tier_value {
+    color: #54A5CD;
+    font-size: 12px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .info-without-thumb .category-tag {
+    color: #3284b6;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .info-without-thumb .details {
+    font-size: 10px;
+    color: #666;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .info-without-thumb .details em {
+    color: #222222;
+}
+
+#algolia-autocomplete-tt.algolia-autocomplete {
+    width: 100%;
+    display: inline-block !important;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu {
+    position: absolute;
+    margin-top: -1px;
+    right: 0;
+    width: 100%;
+    z-index: 1000 !important;
+    border: 1px solid #BBB;
+    border-top: 3px solid #8EB4D0;
+    border-radius: 1px;
+    background: white;
+}
+
+@media (min-width: 992px) {
+    #algolia-autocomplete-container .aa-dropdown-menu {
+        width: 71.1%;
+        min-width: 800px;
+    }
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .col-2 {
+    position: relative;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .col-2 .col-left {
+    width: 67%;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .col-2 .col-right {
+    width: 33%;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .aa-no-results-products {
+    padding: 40px 40px;
+    min-height: 250px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .aa-no-results-products .title {
+    font-weight: bold;
+    margin-bottom: 30px;
+    font-size: 16px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .aa-no-results-products .suggestions {
+    margin-bottom: 30px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .aa-no-results-products .see-all a {
+    color: #636363;
+    font-weight: bold;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .aa-no-results {
+    padding: 10px;
+    font-style: italic;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .category {
+    padding: 4px;
+    color: rgb(166, 166, 166);
+    text-align: left;
+    font-size: 0.8em;
+    text-transform: uppercase;
+    font-weight: bold;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .category-suggestions {
+    padding: 4px;
+    color: #54A5CD;
+    text-align: left;
+    font-size: 0.7em;
+    text-transform: uppercase;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .algoliasearch-autocomplete-hit {
+    display: block;
+    position: relative;
+    padding: 5px 10px;
+    color: #000;
+    text-align: left;
+    text-decoration: none;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .other-sections .aa-dataset-suggestions .algoliasearch-autocomplete-hit {
+    padding-left: 30px;
+}
+
+#algolia-autocomplete-container .aa-suggestions svg.algolia-glass-suggestion.magnifying-glass {
+    position: absolute;
+    right: auto;
+    left: 5px;
+    top: 7px;
+    fill: #A6A6A6;
+    stroke: #A6A6A6;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu.aa-without-products .col9 {
+    background-color: #F9F9F9;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu.aa-without-products #autocomplete-products-footer {
+    display: none;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .aa-dataset-products .aa-suggestion {
+    display: inline-block;
+    width: 100%;
+}
+
+@media (min-width: 768px) {
+    #algolia-autocomplete-container .aa-dropdown-menu .aa-dataset-products .aa-suggestion {
+        display: inline-block;
+        width: 50%;
+    }
+}
+
+
+#algolia-autocomplete-container .aa-dropdown-menu .aa-dataset-products .algoliasearch-autocomplete-hit {
+    padding: 15px 10px;
+}
+
+.autocomplete-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: row-reverse;
+    flex-wrap: wrap;
+}
+
+.autocomplete-wrapper:after {
+    clear: both;
+    content: '';
+}
+
+#algolia-autocomplete-container .col9 {
+    float: right;
+    box-sizing: border-box;
+}
+
+#algolia-autocomplete-container .col3 {
+    float: right;
+    box-sizing: border-box;
+}
+
+#algolia-autocomplete-container.reverse .col3 {
+    float: left;
+    min-width: 100%;
+}
+
+#algolia-autocomplete-container.reverse .col9 {
+    float: left;
+    min-width: 100%;
+    display: flex;
+    height: 100%;
+    flex: 1;
+}
+
+@media (min-width: 768px) {
+    #algolia-autocomplete-container .col9 {
+        border-left: solid 1px #eeeeee;
+        width: 70%;
+        right: 0;
+        height: 100%;
+    }
+
+    #algolia-autocomplete-container .col3 {
+        float: left;
+        width: 30%;
+    }
+
+    #algolia-autocomplete-container.reverse .col3 {
+        float: left;
+        width: 30%;
+    }
+
+    #algolia-autocomplete-container.reverse .col9 {
+        border-right: solid 1px #eeeeee;
+        float: left;
+        width: 70%;
+    }
+}
+
+#algolia-autocomplete-container .other-sections {
+    margin: 20px 10px 70px;
+}
+
+
+.aa-dataset-products .aa-suggestions {
+    margin: 10px auto 10px auto;
+}
+
+.aa-dataset-suggestions {
+    display: none;
+}
+
+@media (min-width: 768px) {
+    .aa-dataset-suggestions {
+        display: block;
+    }
+}
+
+
+@media (min-width: 768px) {
+    .aa-dataset-products .aa-suggestions {
+        margin: 10px auto 50px auto;
+    }
+}
+
+
+.aa-dataset-products .aa-suggestions:after {
+    content: '';
+    display: block;
+    clear: both;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .other-sections .algoliasearch-autocomplete-hit {
+    padding-left: 10px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .other-sections .aa-suggestions {
+    margin-bottom: 20px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .aa-cursor .algoliasearch-autocomplete-hit {
+    background-color: #f2f2f2;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .algoliasearch-autocomplete-hit em {
+    font-weight: bold;
+    font-style: normal;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .algoliasearch-autocomplete-price {
+    font-size: 1.1em;
+    color: #54A5CD;
+    height: 22px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .algoliasearch-autocomplete-hit .thumb {
+    float: left;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .algoliasearch-autocomplete-hit .thumb img {
+    width: 50px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .algoliasearch-autocomplete-hit .info {
+    margin-left: 60px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+#autocomplete-products-footer {
+    background-color: #F9F9F9;
+    text-align: center;
+    display: none;
+    position: absolute;
+    width: 70%;
+    padding: 10px 0;
+    bottom: 0;
+    left: 30%;
+}
+
+#algolia-autocomplete-container.reverse #autocomplete-products-footer {
+    right: auto;
+    left: 0;
+}
+
+@media (min-width: 768px) {
+    #autocomplete-products-footer {
+        display: block;
+    }
+}
+
+#autocomplete-products-footer span {
+    color: #15769c;
+    font-weight: 600;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .algoliasearch-autocomplete-hit .info .algoliasearch-autocomplete-category {
+    font-size: 0.8em;
+    color: #666;
+    white-space: nowrap;
+    overflow: hidden;
+    max-width: 100%;
+    text-overflow: ellipsis;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .algoliasearch-autocomplete-hit .info .algoliasearch-autocomplete-category em {
+    color: #222;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .footer_algolia {
+    position: absolute;
+    width: 100%;
+    padding: 10px;
+    text-align: center;
+    bottom: 0;
+    left: 4px;
+    font-size: 13px;
+}
+
+#algolia-autocomplete-container.reverse .aa-dropdown-menu .footer_algolia {
+    left: auto;
+    right: 4px;
+}
+
+@media (min-width: 768px) {
+    #algolia-autocomplete-container .aa-dropdown-menu .footer_algolia {
+        width: 30%;
+    }
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .footer_algolia span {
+    color: #B8B8B8;
+    font-size: 10px;
+}
+
+#algolia-autocomplete-container .aa-dropdown-menu .footer_algolia img {
+    display: inline;
+    height: 1.5em;
+    vertical-align: bottom;
+    max-width: 130px;
+}
+
+#algolia-searchbox .algolia-search-input:focus:not([value=""]) {
+    background: transparent;
+}
+
+#algolia-searchbox .algolia-search-input {
+    position: static !important;
+}
+
+#algolia-searchbox .algolia-search-input:focus {
+    outline: 0;
+    box-shadow: none;
+    border: solid 1px #54A5CD;
+}
+
+#algolia-autocomplete-container:after, .autocomplete-wrapper:after {
+    clear: both;
+    content: '';
+}

--- a/view/frontend/web/internals/grid.css
+++ b/view/frontend/web/internals/grid.css
@@ -1,0 +1,128 @@
+#algolia_instant_selector,
+#algolia_instant_selector *,
+#search_mini_form,
+#search_mini_form * {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+#algolia_instant_selector:before,
+#algolia_instant_selector:after,
+#algolia_instant_selector *:before,
+#algolia_instant_selector *:after,
+#search_mini_form:before,
+#search_mini_form:after,
+#search_mini_form *:before,
+#search_mini_form *:after {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+#search_mini_form label {
+    display: none;
+}
+
+#algolia_instant_selector .row {
+    margin-left: -15px;
+    margin-right: -15px;
+}
+
+#algolia_instant_selector .col-md-3,
+#algolia_instant_selector .col-md-4,
+#algolia_instant_selector .col-md-9,
+#algolia_instant_selector .col-md-12 {
+    position: relative;
+    min-height: 1px;
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
+@media (min-width: 768px) {
+    #algolia_instant_selector .col-sm-6 {
+        width: 50%;
+        float: left;
+    }
+}
+
+@media (min-width: 992px) {
+    #algolia_instant_selector .col-md-3,
+    #algolia_instant_selector .col-md-4,
+    #algolia_instant_selector .col-md-9,
+    #algolia_instant_selector .col-md-12 {
+        float: left;
+    }
+
+    #algolia_instant_selector .col-md-12 {
+        width: 100%;
+    }
+
+    #algolia_instant_selector .col-md-9 {
+        width: 75%;
+    }
+
+    #algolia_instant_selector .col-md-4 {
+        width: 33.33333333%;
+    }
+
+    #algolia_instant_selector .col-md-3 {
+        width: 25%;
+    }
+}
+
+#algolia_instant_selector .row:before,
+#algolia_instant_selector .row:after {
+    content: " ";
+    display: table;
+}
+
+#algolia_instant_selector .row:after {
+    clear: both;
+}
+
+#algolia_instant_selector .visible-xs,
+#algolia_instant_selector .visible-sm {
+    display: none !important;
+}
+
+#algolia_instant_selector .hidden-xs,
+#algolia_instant_selector .hidden-sm {
+    display: block !important;
+}
+
+@media (max-width: 767px) {
+    #algolia_instant_selector .visible-xs {
+        display: block !important;
+    }
+
+    #algolia_instant_selector .hidden-xs {
+        display: none !important;
+    }
+
+    .algolia-search-block {
+        clear: both;
+    }
+}
+
+@media (max-width: 992px) {
+    #algolia_instant_selector .visible-sm {
+        display: block !important;
+    }
+
+    #algolia_instant_selector .hidden-sm {
+        display: none !important;
+    }
+}
+
+#algolia_instant_selector .pull-left {
+    float: left;
+}
+
+#algolia_instant_selector .pull-right {
+    float: right;
+}
+
+.algolia-clearfix {
+    clear: both;
+}

--- a/view/frontend/web/internals/instantsearch.v3.css
+++ b/view/frontend/web/internals/instantsearch.v3.css
@@ -1,0 +1,204 @@
+@import "./algolia-reset.css";
+@import "./grid.css";
+
+/* infos */
+.algolia-infos {
+    padding: 6px 10px;
+    color: #aaa;
+    text-align: center;
+    background: #f4f4f4;
+    font-size: 12px;
+    clear: both;
+    line-height: 32px;
+}
+
+/* SearchBox */
+.ais-SearchBox {
+    margin-bottom: 1em;
+}
+
+.ais-SearchBox-submit {
+    display: none;
+}
+
+.ais-SearchBox-form {
+    position: relative;
+}
+
+.ais-SearchBox-reset {
+    position: absolute;
+    right: 0;
+}
+
+button.ais-SearchBox-reset {
+    box-shadow: none;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    background: transparent;
+}
+
+button.ais-SearchBox-reset:focus,
+button.ais-SearchBox-reset:active,
+button.ais-SearchBox-reset:hover {
+    border: 0;
+}
+
+input.ais-SearchBox-input {
+    padding-right: 2em;
+}
+
+.ais-SearchBox-reset,
+input.ais-SearchBox-input {
+    height: 32px;
+}
+
+/* Hits */
+.ais-Hits--empty {
+    margin: 40px 0;
+    color: #636363;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.ais-Hits--empty q:before,
+.ais-Hits--empty q:after {
+    content: "\""
+}
+
+
+.ais-Hits-item a:hover {
+    color: #666666;
+}
+
+.ais-Hits-list .no-results .clear-button {
+    cursor: pointer;
+}
+
+.ais-Hits-list .no-results .popular-searches {
+    text-align: left;
+    margin-top: 20px;
+    margin-bottom: 30px;
+}
+
+.ais-Hits-item .product-reviews-summary {
+    text-align: center;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+.ais-InfiniteHits-loadMore {
+    clear: both;
+}
+
+/* HierarchicalMenu */
+.ais-HierarchicalMenu-item {
+    margin: 0;
+}
+
+.ais-HierarchicalMenu-link--selected {
+    font-weight: bold;
+}
+
+.ais-HierarchicalMenu-link--selected .cross-circle {
+    display: inline-block;
+    width: 0.8em;
+    height: 0.8em;
+    background: url("data:image/svg+xml;utf8,<svg width='34' height='34' viewBox='0 0 34 34' xmlns='http://www.w3.org/2000/svg'><title>testvg</title><g fill='%23000' fill-rule='evenodd'><path d='M17.163 0C7.95 0 .41 7.578.353 16.893c-.03 4.542 1.693 8.82 4.847 12.053 3.156 3.23 7.367 5.026 11.857 5.054h.11c9.21 0 16.75-7.578 16.81-16.893C34.035 7.735 26.54.06 17.163 0zm.015 30.842v1.08l-.09-1.08c-3.656-.023-7.085-1.485-9.654-4.115-2.57-2.63-3.97-6.116-3.948-9.814C3.533 9.33 9.673 3.158 17.262 3.158c7.548.048 13.65 6.297 13.605 13.93-.05 7.585-6.19 13.754-13.69 13.754z'/><path d='M22.362 10.23l-5.186 5.245-5.186-5.244c-.417-.42-1.092-.42-1.51 0-.416.422-.416 1.105 0 1.526L15.668 17l-5.186 5.244c-.416.42-.416 1.104 0 1.525.21.21.483.316.755.316.273 0 .546-.106.755-.317l5.186-5.245 5.186 5.244c.208.21.482.316.754.316.273 0 .546-.106.755-.317.417-.422.417-1.105 0-1.526L18.685 17l5.187-5.244c.417-.42.417-1.104 0-1.525-.416-.42-1.09-.42-1.508 0z'/></g></svg>") no-repeat center center / contain;
+    opacity: 0;
+}
+
+.ais-HierarchicalMenu-link--selected:hover .cross-circle {
+    opacity: 1;
+}
+
+/* RefinementList */
+.ais-RefinementList-searchBox {
+    padding-bottom: 7px;
+}
+
+/* Panel */
+.ais-Panel {
+    border: solid 1px #efefef;
+    margin-bottom: 7px;
+}
+
+.ais-Panel-header {
+    background-color: #efefef;
+    padding: 7px;
+}
+
+.ais-Panel-body {
+    padding: 4px 7px;
+}
+
+/* RangeSlider */
+.ais-RangeSlider {
+    margin: 0 20px;
+}
+
+.ais-RangeSlider .rheostat-background {
+    border: 0;
+}
+
+.ais-RangeSlider .rheostat-progress {
+    background-color: #006bb4;
+}
+
+/* Pagination */
+.ais-Pagination-list {
+    margin: 2em 0;
+    justify-content: center;
+}
+
+.ais-Pagination-item {
+    padding: 1em;
+}
+
+.ais-Pagination-item--selected {
+    color: black;
+    font-weight: bold;
+}
+
+/* CurrentRefinements */
+.ais-CurrentRefinements-item {
+    color: #636363;
+    border-radius: 2px;
+    border: solid 1px #ddd;
+    background-color: #f4f4f4;
+    display: inline-block;
+    max-width: 100%;
+    white-space: nowrap;
+    padding: 0.2em 0.5em;
+    overflow: hidden;
+}
+
+.ais-CurrentRefinements-label {
+    font-weight: bold;
+}
+
+.ais-CurrentRefinements-category {
+    margin: 0 0.5em;
+}
+
+.ais-CurrentRefinements-categoryLabel {
+}
+
+button.ais-CurrentRefinements-delete {
+    line-height: inherit;
+    box-shadow: none;
+    margin-left: 0.2em;
+}
+
+button.ais-CurrentRefinements-delete:hover,
+button.ais-CurrentRefinements-delete:active,
+button.ais-CurrentRefinements-delete:focus {
+    box-shadow: none;
+    background: none;
+    border: none;
+}
+
+/* ClearRefinements */
+.ais-ClearRefinements {
+    float: right;
+    padding: 7px;
+}


### PR DESCRIPTION
**Summary**

- split algoliasearch.css into
  * grid.css
  * autocomplete.css
  * instantsearch.v3.css

- introduced algolia reset theme:
  see https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/js/#style-your-widgets

- deleted algoliasearch.css as no longer needed

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->



<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

N/A