### PR TITLE
Remove CircleCI job for Magento 2.1 check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,5 @@ workflows:
     version: 2
     build:
         jobs:
-            - "magento-2.1"
             - "magento-2.2"
             - "magento-2.3"


### PR DESCRIPTION
**Summary**
Remove Magento 2.1 version check from Circle CI jobs. 

**Result** 
Testing for PR should now only run 2.2 and 2.3 checks.
