### PR TITLE
chore: making PHPCompatibility assess no funky <7.1 PHP is used in our project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,33 @@ jobs:
         docker:
             - image: algolia/magento2-circleci:2.3.0
 
+    "phpcompatibility":
+      docker: # run the steps with Docker with PHP 7.2
+      - image: circleci/php:7.2
+      steps:
+        - checkout
+        - run: sudo composer self-update
+        - run: composer config http-basic.repo.magento.com ${MAGENTO_AUTH_USERNAME} ${MAGENTO_AUTH_PASSWORD}
+        - restore_cache:
+            keys:
+            - composer-v1-{{ checksum "composer.lock" }}
+            - composer-v1-
+        - run: composer install -n --prefer-dist --ignore-platform-reqs --no-progress
+        - save_cache:
+            key: composer-v1-{{ checksum "composer.lock" }}
+            paths:
+            - vendor
+        - run:
+            name: PHPCS PHPCompatibility
+            command: |
+              ./vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility/PHPCompatibility/
+              # vendor/ is large and seems to break phpcs, ls+grep+xargs hack is used to send folders to phpcs
+              ls -d */ | grep -vE 'dev|Test|vendor' | xargs ./vendor/bin/phpcs -p --standard=PHPCompatibility --runtime-set testVersion 7.1- --runtime-set ignore_warnings_on_exit true
+
 workflows:
     version: 2
     build:
         jobs:
             - "magento-2.2"
             - "magento-2.3"
+            - "phpcompatibility"

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,15 @@
     "ext-mbstring": "*",
     "ext-dom": "*"
   },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://repo.magento.com/"
+    }
+  ],
+  "require-dev": {
+    "phpcompatibility/php-compatibility": "^9.2"
+  },
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": {


### PR DESCRIPTION
# Chore: Automate tests using PHPCompatibility

Adds a job to test if we're not using PHP in ways that could not work in [versions supported by Magento](https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html#php).