### PR TITLE
Clean scope code resolver when starting environment emulation

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -14,6 +14,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeCodeResolver;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Search\Model\Query;
@@ -36,6 +37,7 @@ class Data
     private $emulation;
     private $resource;
     private $eventManager;
+    private $scopeCodeResolver;
     private $storeManager;
 
     private $emulationRuns = false;
@@ -53,6 +55,7 @@ class Data
         Logger $logger,
         ResourceConnection $resource,
         ManagerInterface $eventManager,
+        ScopeCodeResolver $scopeCodeResolver,
         StoreManagerInterface $storeManager
     ) {
         $this->algoliaHelper = $algoliaHelper;
@@ -69,6 +72,7 @@ class Data
         $this->emulation = $emulation;
         $this->resource = $resource;
         $this->eventManager = $eventManager;
+        $this->scopeCodeResolver = $scopeCodeResolver;
         $this->storeManager = $storeManager;
     }
 
@@ -676,6 +680,7 @@ class Data
         $this->logger->start('START EMULATION');
 
         $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
+        $this->scopeCodeResolver->clean();
         $this->emulationRuns = true;
 
         $this->logger->stop('START EMULATION');


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Hi! We came upon a problem with custom uploaded image placeholders in different store views - their configuration is not visible for stores other than first.

Steps to reproduce:
1. Add a product without an image
2. Go to Stores > Configuration > Catalog > Catalog
3. Switch scope to **non-default store view** (e.g. second in the list)
4. Upload custom images in _Product Image Placeholders_ section
5. Reindex Algolia, e.g. single product by SKU - Stores > Algolia > Reindex SKU

Expected: _custom_ image placeholder in Algolia search for this product.
Actual: _default_ image placeholder.

After debug, problem is in [ScopeCodeResolver](https://github.com/magento/magento2/blob/2.3-develop/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php#L43). 

1. Algolia iterates stores: 1 (default store)
2. ScopeCodeResolver resolves and **caches** current store to store 1.
3. Algolia iterates stores: 2 (non-default store with custom placeholder)
4. ScopeCodeResolver resolves **cached** current store to store 1 - here's an error. It fails to pick up that we are emulating store 2 this time.
5. [Placeholder asset](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/View/Asset/Placeholder.php#L156) reads configuration using incorrectly resolved store ID, always returning placeholder for first store in the list.

Please have a look :)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->



<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->