### PR TITLE
Fixing order of setting parameters

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -175,9 +175,9 @@ class CategoryHelper
         $categories = $this->categoryCollectionFactory->create()
             ->distinct(true)
             ->addNameToResult()
+            ->setStoreId($storeId)
             ->addUrlRewriteToResult()
             ->addAttributeToFilter('level', ['gt' => 1])
-            ->setStoreId($storeId)
             ->addPathFilter($storeRootCategoryPath)
             ->addAttributeToSelect(array_merge(['name', 'is_active', 'include_in_menu', 'image'], $additionalAttr))
             ->addOrderField('entity_id');


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
When working with a multi-store-view application, I found that the default request path (from the `url_rewrite`) table was selected. This caused the `request_path` from the default store to be loaded instead of the one associated with the current store.

![image](https://user-images.githubusercontent.com/1151186/65548100-692b5980-dee0-11e9-92d3-4f0ea70aa2a7.png)

*Before:*
![image](https://user-images.githubusercontent.com/1151186/65548090-616bb500-dee0-11e9-8786-17fc8d208898.png)


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
![image](https://user-images.githubusercontent.com/1151186/65547649-81e73f80-dedf-11e9-974e-81a528ab9350.png)

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->