### PR TITLE
Magento Cloud Development setup teardown

### DIFF
--- a/dev/cloud/setup.sh
+++ b/dev/cloud/setup.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+php bin/magento config:set algoliasearch_credentials/credentials/application_id "${ALGOLIA_APPLICATION_ID}"
+php bin/magento config:set algoliasearch_credentials/credentials/search_only_api_key "${ALGOLIA_SEARCH_API_KEY}"
+php bin/magento config:set algoliasearch_credentials/credentials/api_key "${ALGOLIA_API_KEY}"
+php bin/magento config:set algoliasearch_credentials/credentials/index_prefix "${MAGENTO_CLOUD_ENVIRONMENT}_"
+php bin/magento config:set algoliasearch_instant/instant/is_instant_enabled "1"
+
+php bin/magento indexer:reindex algolia_products algolia_categories algolia_pages algolia_suggestions algolia_additional_sections

--- a/dev/cloud/setup.sh
+++ b/dev/cloud/setup.sh
@@ -1,14 +1,14 @@
 #! /usr/bin/env bash
 
-php echo 'Saving APPID...'
+echo 'Saving APPID...'
 php bin/magento config:set algoliasearch_credentials/credentials/application_id "${ALGOLIA_APPLICATION_ID}"
-php echo 'Saving Search Key...'
+echo 'Saving Search Key...'
 php bin/magento config:set algoliasearch_credentials/credentials/search_only_api_key "${ALGOLIA_SEARCH_API_KEY}"
-php echo 'Saving API key...'
+echo 'Saving API key...'
 php bin/magento config:set algoliasearch_credentials/credentials/api_key "${ALGOLIA_API_KEY}"
-php echo 'Saving prefix...'
+echo 'Saving prefix...'
 php bin/magento config:set algoliasearch_credentials/credentials/index_prefix "${MAGENTO_CLOUD_ENVIRONMENT}_"
-php echo 'Saving enable instant...'
+echo 'Saving enable instant...'
 php bin/magento config:set algoliasearch_instant/instant/is_instant_enabled "1"
 
 php bin/magento indexer:reindex algolia_products

--- a/dev/cloud/setup.sh
+++ b/dev/cloud/setup.sh
@@ -1,9 +1,18 @@
 #! /usr/bin/env bash
 
+php echo 'Saving APPID...'
 php bin/magento config:set algoliasearch_credentials/credentials/application_id "${ALGOLIA_APPLICATION_ID}"
+php echo 'Saving Search Key...'
 php bin/magento config:set algoliasearch_credentials/credentials/search_only_api_key "${ALGOLIA_SEARCH_API_KEY}"
+php echo 'Saving API key...'
 php bin/magento config:set algoliasearch_credentials/credentials/api_key "${ALGOLIA_API_KEY}"
+php echo 'Saving prefix...'
 php bin/magento config:set algoliasearch_credentials/credentials/index_prefix "${MAGENTO_CLOUD_ENVIRONMENT}_"
+php echo 'Saving enable instant...'
 php bin/magento config:set algoliasearch_instant/instant/is_instant_enabled "1"
 
-php bin/magento indexer:reindex algolia_products algolia_categories algolia_pages algolia_suggestions algolia_additional_sections
+php bin/magento indexer:reindex algolia_products
+php bin/magento indexer:reindex algolia_categories
+php bin/magento indexer:reindex algolia_pages
+php bin/magento indexer:reindex algolia_suggestions
+php bin/magento indexer:reindex algolia_additional_sections

--- a/dev/cloud/teardown.php
+++ b/dev/cloud/teardown.php
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 
 use Magento\Framework\App\Bootstrap;
@@ -10,10 +9,12 @@ $obj = $bootstrap->getObjectManager();
 
 $algoliaHelper = $obj->get('\Algolia\AlgoliaSearch\Helper\AlgoliaHelper');
 
-if ($algoliaHelper) {
-
-    $indices = $algoliaHelper->listIndexes();
-
+/**
+ * @param $algoliaHelper Algolia\AlgoliaSearch\Helper\AlgoliaHelper
+ * @param array $indices
+ */
+function deleteIndexes($algoliaHelper, array $indices)
+{
     foreach ($indices['items'] as $index) {
         $name = $index['name'];
 
@@ -27,21 +28,16 @@ if ($algoliaHelper) {
             }
         }
     }
+}
 
-   $replicas = $algoliaHelper->listIndexes();
-   if (count($replicas) > 0) {
-       foreach ($replicas['items'] as $index) {
-           $name = $index['name'];
-           if (mb_strpos($name, getenv('MAGENTO_CLOUD_ENVIRONMENT')) === 0) {
-               try {
-                   $algoliaHelper->deleteIndex($name);
-                   echo 'Index "' . $name . '" has been deleted.';
-                   echo "\n";
-               } catch (Exception $e) {
-                   // Might be a replica
-               }
-           }
-       }
-   }
+if ($algoliaHelper) {
+    $indices = $algoliaHelper->listIndexes();
+    if (count($indices) > 0) {
+        deleteIndexes($algoliaHelper, $indices);
+    }
 
+    $replicas = $algoliaHelper->listIndexes();
+    if (count($replicas) > 0) {
+        deleteIndexes($algoliaHelper, $replicas);
+    }
 }

--- a/dev/cloud/teardown.php
+++ b/dev/cloud/teardown.php
@@ -3,8 +3,7 @@
 use Magento\Framework\App\Bootstrap;
 require '/app/app/bootstrap.php';
 
-$params = $_SERVER;
-$bootstrap = Bootstrap::create(BP, $params);
+$bootstrap = Bootstrap::create(BP, $_SERVER);
 $obj = $bootstrap->getObjectManager();
 
 $algoliaHelper = $obj->get('\Algolia\AlgoliaSearch\Helper\AlgoliaHelper');

--- a/dev/cloud/teardown.php
+++ b/dev/cloud/teardown.php
@@ -4,20 +4,21 @@ use Magento\Framework\App\Bootstrap;
 require '/app/app/bootstrap.php';
 
 $bootstrap = Bootstrap::create(BP, $_SERVER);
-$obj = $bootstrap->getObjectManager();
+$objectManager = $bootstrap->getObjectManager();
 
-$algoliaHelper = $obj->get('\Algolia\AlgoliaSearch\Helper\AlgoliaHelper');
+$algoliaHelper = $objectManager->get('\Algolia\AlgoliaSearch\Helper\AlgoliaHelper');
+$indexNamePrefix = getenv('MAGENTO_CLOUD_ENVIRONMENT');
 
 /**
  * @param $algoliaHelper Algolia\AlgoliaSearch\Helper\AlgoliaHelper
  * @param array $indices
  */
-function deleteIndexes($algoliaHelper, array $indices)
+function deleteIndexes($algoliaHelper, array $indices, $indexNamePrefix)
 {
     foreach ($indices['items'] as $index) {
         $name = $index['name'];
 
-        if (mb_strpos($name, getenv('MAGENTO_CLOUD_ENVIRONMENT')) === 0) {
+        if (mb_strpos($name, $indexNamePrefix) === 0) {
             try {
                 $algoliaHelper->deleteIndex($name);
                 echo 'Index "' . $name . '" has been deleted.';
@@ -32,11 +33,11 @@ function deleteIndexes($algoliaHelper, array $indices)
 if ($algoliaHelper) {
     $indices = $algoliaHelper->listIndexes();
     if (count($indices) > 0) {
-        deleteIndexes($algoliaHelper, $indices);
+        deleteIndexes($algoliaHelper, $indices, $indexNamePrefix);
     }
 
     $replicas = $algoliaHelper->listIndexes();
     if (count($replicas) > 0) {
-        deleteIndexes($algoliaHelper, $replicas);
+        deleteIndexes($algoliaHelper, $replicas, $indexNamePrefix);
     }
 }

--- a/dev/cloud/teardown.sh
+++ b/dev/cloud/teardown.sh
@@ -2,7 +2,7 @@
 <?php
 
 use Magento\Framework\App\Bootstrap;
-require '/app/bootstrap.php';
+require '/app/app/bootstrap.php';
 
 $params = $_SERVER;
 $bootstrap = Bootstrap::create(BP, $params);

--- a/dev/cloud/teardown.sh
+++ b/dev/cloud/teardown.sh
@@ -27,4 +27,21 @@ if ($algoliaHelper) {
             }
         }
     }
+
+   $replicas = $algoliaHelper->listIndexes();
+   if (count($replicas) > 0) {
+       foreach ($replicas['items'] as $index) {
+           $name = $index['name'];
+           if (mb_strpos($name, getenv('MAGENTO_CLOUD_ENVIRONMENT')) === 0) {
+               try {
+                   $algoliaHelper->deleteIndex($name);
+                   echo 'Index "' . $name . '" has been deleted.';
+                   echo "\n";
+               } catch (Exception $e) {
+                   // Might be a replica
+               }
+           }
+       }
+   }
+
 }

--- a/dev/cloud/teardown.sh
+++ b/dev/cloud/teardown.sh
@@ -17,7 +17,7 @@ if ($algoliaHelper) {
     foreach ($indices['items'] as $index) {
         $name = $index['name'];
 
-        if (mb_strpos($name, $this->indexPrefix) === 0) {
+        if (mb_strpos($name, getenv('MAGENTO_CLOUD_ENVIRONMENT')) === 0) {
             try {
                 $algoliaHelper->deleteIndex($name);
                 echo 'Index "' . $name . '" has been deleted.';

--- a/dev/cloud/teardown.sh
+++ b/dev/cloud/teardown.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env php
+<?php
+
+use Magento\Framework\App\Bootstrap;
+require __DIR__ . '/app/bootstrap.php';
+
+$params = $_SERVER;
+$bootstrap = Bootstrap::create(BP, $params);
+$obj = $bootstrap->getObjectManager();
+
+$algoliaHelper = $obj->get('\Algolia\AlgoliaSearch\Helper\AlgoliaHelper');
+
+if ($algoliaHelper) {
+
+    $indices = $algoliaHelper->listIndexes();
+
+    foreach ($indices['items'] as $index) {
+        $name = $index['name'];
+
+        if (mb_strpos($name, $this->indexPrefix) === 0) {
+            try {
+                $algoliaHelper->deleteIndex($name);
+                echo 'Index "' . $name . '" has been deleted.';
+                echo "\n";
+            } catch (Exception $e) {
+                // Might be a replica
+            }
+        }
+    }
+}

--- a/dev/cloud/teardown.sh
+++ b/dev/cloud/teardown.sh
@@ -2,7 +2,7 @@
 <?php
 
 use Magento\Framework\App\Bootstrap;
-require __DIR__ . '/app/bootstrap.php';
+require '/app/bootstrap.php';
 
 $params = $_SERVER;
 $bootstrap = Bootstrap::create(BP, $params);


### PR DESCRIPTION
**INTERNAL DEV ONLY** 

Scripts to run for setting up and tearing down algoliasearch in the development Magento Commerce Cloud environment. This sets the environment prefix to the environment variable `MAGENTO_CLOUD_ENVIRONMENT` that is provided by the cloud. The teardown script will remove indexes and its replicas in a double iteration.