### PR TITLE
chore: adds `/.php_cs.cache` under gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dev/frontend/node_modules/
 dev/bin/auth.json
 composer.lock
 vendor/
+.php_cs.cache


### PR DESCRIPTION
This pull request adds `/.php_cs.cache` under gitignore.