### PR TITLE
chore(ignores-phpstan-fixed-errors): sets reportUnmatchedIgnoredError…

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 0
+    reportUnmatchedIgnoredErrors: false
     paths:
         - vendor/algolia/algoliasearch-magento-2/Adapter
         - vendor/algolia/algoliasearch-magento-2/Api


### PR DESCRIPTION
This pull requests makes phpstan do not fail when we actually fixed ignored errors.