### PR TITLE
Fixed Composer requirements and README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Algolia Search for Magento 2
 ==================
 
 ![Latest version](https://img.shields.io/badge/latest-1.12.0-green.svg)
-![Magento 2](https://img.shields.io/badge/Magento-%3E=2.1-blue.svg)
+![Magento 2](https://img.shields.io/badge/Magento-%3E=2.2-blue.svg)
 ![Magento 2](https://img.shields.io/badge/Magento-%3C%202.3.2-blue.svg)
-![PHP >= 5.6.5](https://img.shields.io/badge/PHP-%3E=5.6-green.svg)
+![PHP >= 7.0.6](https://img.shields.io/badge/PHP-%3E=7.0-green.svg)
 [![CircleCI](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/master.svg?style=svg)](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/master)
 
 -------

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "license": ["MIT"],
   "version": "1.12.0",
   "require": {
-    "php": "~5.6.5|~7.0|~7.1|~7.2|~7.3",
-    "magento/framework": "~100.1|~101.0|~102.0",
+    "php": "~7.0|~7.1|~7.2|~7.3",
+    "magento/framework": "~101.0|~102.0",
     "algolia/algoliasearch-client-php": ">=1.27.0 <2.0",
     "ext-json": "*",
     "ext-PDO": "*",


### PR DESCRIPTION
**Summary**

Release 1.12.0 contains BC for Magento 2.1, but Composer requirements aren`t actual and magento/framework": "~100.1" (it`s Magento 2.1) make it possible to install latest release.
In addition, removed PHP from requirements. Magento 2.1-2.3 don`t work on that version and minimal recommended - 7.0.6 in System requirements.