### PR TITLE
Added alt attribute for img tags

### DIFF
--- a/view/frontend/templates/autocomplete/category.phtml
+++ b/view/frontend/templates/autocomplete/category.phtml
@@ -3,7 +3,7 @@
     <a class="algoliasearch-autocomplete-hit" href="{{url}}">
         {{#image_url}}
         <div class="thumb">
-            <img src="{{image_url}}" />
+            <img src="{{{image_url}}}" alt="{{{name}}}" />
         </div>
         {{/image_url}}
 

--- a/view/frontend/templates/autocomplete/product.phtml
+++ b/view/frontend/templates/autocomplete/product.phtml
@@ -12,7 +12,7 @@ $tierFormatedVar = 'price' . $priceKey . '_tier_formated'
 <script type="text/template" id="autocomplete_products_template">
     <a class="algoliasearch-autocomplete-hit" href="{{url}}">
         {{#thumbnail_url}}
-        <div class="thumb"><img src="{{thumbnail_url}}" /></div>
+        <div class="thumb"><img src="{{thumbnail_url}}" alt="{{{name}}}" /></div>
         {{/thumbnail_url}}
 
         <div class="info">

--- a/view/frontend/templates/instant/hit.phtml
+++ b/view/frontend/templates/instant/hit.phtml
@@ -15,7 +15,7 @@ $tierFormatedVar = 'price' . $priceKey . '_tier_formated'
             <a itemprop="url" href="{{url}}" class="result" data-objectid="{{objectID}}" data-position="{{__position}}">
                 <div class="result-content">
                     <div class="result-thumbnail">
-                        {{#image_url}}<img itemprop="image" src="{{{ image_url }}}" />{{/image_url}}
+                        {{#image_url}}<img itemprop="image" src="{{{image_url}}}" alt="{{{name}}}" />{{/image_url}}
                         {{^image_url}}<span class="no-image"></span>{{/image_url}}
                     </div>
                     <div class="result-sub-content">


### PR DESCRIPTION
**Summary**

ALT attribute is missed on Algolia Search page or Category page. 

**Result**

ALT attribute has been added in Hit template and for categories and images in autocomplete menu. 