### PR TITLE
Fix version to 1.12.1 for unsubscribe Mview migration (PR #870)

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -587,7 +587,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $connection->createTable($table);
         }
 
-        if (version_compare($context->getVersion(), '1.12.0', '<')) {
+        if (version_compare($context->getVersion(), '1.12.1', '<')) {
             // @see \Magento\Framework\Mview\View::unsubscribe
             /** @var \Magento\Framework\Indexer\IndexerInterface $indexer */
             $indexer = $this->indexerFactory->create()->load('algolia_products');

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="1.12.0">
+    <module name="Algolia_AlgoliaSearch" setup_version="1.12.1">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
**Summary**

Migration isn't applied for installed version 1.12.0 and fix won't be worked after upgrade to 1.12.1 or higher. 

**Result**
Changed version for migration to 1.12.1 ( the same version as set in PR`s milestone field)  