### PR TITLE
Create replicas if Backend Facet Rendering is enabled

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -346,7 +346,7 @@ class ProductHelper
 
         $replicas = [];
 
-        if ($this->configHelper->isInstantEnabled()) {
+        if ($this->configHelper->isInstantEnabled() || $this->configHelper->isBackendRenderingEnabled()) {
             $replicas = array_values(array_map(function ($sortingIndex) {
                 return $sortingIndex['name'];
             }, $sortingIndices));


### PR DESCRIPTION
**Summary**

Algolia shoud create replicas if backend facet rendering is enabled, otherwise it raises errors when we try to sort because replicas do not exist.