### PR TITLE
Hide out of stock for configurable products (move PR #378)

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1172,6 +1172,6 @@ class ProductHelper
     {
         $stockItem = $this->stockRegistry->getStockItem($product->getId());
 
-        return ($product->isSaleable() && $stockItem->getIsInStock());
+        return $product->isSaleable() && $stockItem->getIsInStock();
     }
 }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1163,10 +1163,15 @@ class ProductHelper
         return true;
     }
 
+    /**
+     * @param Product $product
+     * @param int $storeId
+     * @return bool|int
+     */
     public function productIsInStock($product, $storeId)
     {
         $stockItem = $this->stockRegistry->getStockItem($product->getId());
 
-        return $stockItem->getIsInStock();
+        return ($product->isSaleable() && $stockItem->getIsInStock());
     }
 }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1164,9 +1164,12 @@ class ProductHelper
     }
 
     /**
+     * Returns is product in stock
+     *
      * @param Product $product
      * @param int $storeId
-     * @return bool|int
+     *
+     * @return bool
      */
     public function productIsInStock($product, $storeId)
     {


### PR DESCRIPTION
**Summary**

After 1.12.0 and PR #841  Issue is back. Configurable product is set "In stock" but all its simple variations have qty 0, this product in fact shows as not available on frontend and shouldn't go to Algolia.
 
**Result**

Applied fix from #378 to new method productIsInStock.
PR is created for 1.x branches, but Fix is actual for 2.0 too.
