### PR TITLE
Archive logs cleaning

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -95,7 +95,7 @@ class ConfigHelper
         'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents';
     const NON_CASTABLE_ATTRIBUTES = 'algoliasearch_advanced/advanced/non_castable_attributes';
     const MAX_RECORD_SIZE_LIMIT = 'algoliasearch_advanced/advanced/max_record_size_limit';
-    const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/advanced/archive_clear_Limit';
+    const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/advanced/archive_clear_limit';
 
     const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
 

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -95,6 +95,7 @@ class ConfigHelper
         'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents';
     const NON_CASTABLE_ATTRIBUTES = 'algoliasearch_advanced/advanced/non_castable_attributes';
     const MAX_RECORD_SIZE_LIMIT = 'algoliasearch_advanced/advanced/max_record_size_limit';
+    const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/advanced/archive_clear_Limit';
 
     const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
 
@@ -1110,6 +1111,15 @@ class ConfigHelper
         }
 
         return $this->maxRecordSize;
+    }
+
+    public function getArchiveLogClearLimit($storeId = null)
+    {
+        return (int) $this->configInterface->getValue(
+            self::ARCHIVE_LOG_CLEAR_LIMIT,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 
     public function getCatalogSearchEngine($storeId = null)

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -19,7 +19,6 @@ class Queue
 {
     const FULL_REINDEX_TO_REALTIME_JOBS_RATIO = 0.33;
     const UNLOCK_STACKED_JOBS_AFTER_MINUTES = 15;
-    const CLEAR_ARCHIVE_LOGS_AFTER_DAYS = 30;
 
     const SUCCESS_LOG = 'algoliasearch_queue_log.txt';
     const ERROR_LOG = 'algoliasearch_queue_errors.log';
@@ -592,9 +591,11 @@ class Queue
 
     private function clearOldArchiveRecords()
     {
+        $archiveLogClearLimit = $this->configHelper->getArchiveLogClearLimit();
+
         $this->db->delete(
             $this->archiveTable,
-            'created_at < (NOW() - INTERVAL ' . self::CLEAR_ARCHIVE_LOGS_AFTER_DAYS . ' DAY)'
+            'created_at < (NOW() - INTERVAL ' . $archiveLogClearLimit . ' DAY)'
         );
     }
 

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -19,6 +19,7 @@ class Queue
 {
     const FULL_REINDEX_TO_REALTIME_JOBS_RATIO = 0.33;
     const UNLOCK_STACKED_JOBS_AFTER_MINUTES = 15;
+    const CLEAR_ARCHIVE_LOGS_AFTER_DAYS = 30;
 
     const SUCCESS_LOG = 'algoliasearch_queue_log.txt';
     const ERROR_LOG = 'algoliasearch_queue_errors.log';
@@ -592,6 +593,10 @@ class Queue
     private function clearOldArchiveRecords()
     {
         $archiveLogClearLimit = $this->configHelper->getArchiveLogClearLimit();
+        // Adding a fallback in case this configuration was not set in a consistent way
+        if ($archiveLogClearLimit < 1) {
+            $archiveLogClearLimit = self::CLEAR_ARCHIVE_LOGS_AFTER_DAYS;
+        }
 
         $this->db->delete(
             $this->archiveTable,

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -19,6 +19,7 @@ class Queue
 {
     const FULL_REINDEX_TO_REALTIME_JOBS_RATIO = 0.33;
     const UNLOCK_STACKED_JOBS_AFTER_MINUTES = 15;
+    const CLEAR_ARCHIVE_LOGS_AFTER_DAYS = 30;
 
     const SUCCESS_LOG = 'algoliasearch_queue_log.txt';
     const ERROR_LOG = 'algoliasearch_queue_errors.log';
@@ -157,6 +158,7 @@ class Queue
         }
 
         $this->clearOldLogRecords();
+        $this->clearOldArchiveRecords();
         $this->unlockStackedJobs();
 
         $this->logRecord = [
@@ -586,6 +588,14 @@ class Queue
         if ($idsToDelete) {
             $this->db->delete($this->logTable, ['id IN (?)' => $idsToDelete]);
         }
+    }
+
+    private function clearOldArchiveRecords()
+    {
+        $this->db->delete(
+            $this->archiveTable,
+            'created_at < (NOW() - INTERVAL ' . self::CLEAR_ARCHIVE_LOGS_AFTER_DAYS . ' DAY)'
+        );
     }
 
     private function unlockStackedJobs()

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -98,7 +98,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
         'algoliasearch_advanced/advanced/prevent_backend_rendering' => '0',
         'algoliasearch_advanced/advanced/prevent_backend_rendering_display_mode' => 'all',
         'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents' => "Googlebot\nBingbot",
-        'algoliasearch_advanced/advanced/archive_clear_Limit' => '30',
+        'algoliasearch_advanced/advanced/archive_clear_limit' => '30',
     ];
 
     private $defaultArrayConfigData = [

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -98,6 +98,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
         'algoliasearch_advanced/advanced/prevent_backend_rendering' => '0',
         'algoliasearch_advanced/advanced/prevent_backend_rendering_display_mode' => 'all',
         'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents' => "Googlebot\nBingbot",
+        'algoliasearch_advanced/advanced/archive_clear_Limit' => '30',
     ];
 
     private $defaultArrayConfigData = [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -880,6 +880,14 @@
                         ]]>
                     </comment>
                 </field>
+                <field id="archive_clear_Limit" translate="label comment" type="text" sortOrder="95" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Archive log clean limit</label>
+                    <comment>
+                        <![CDATA[
+                            (In days - default value is 30) Sets the limit when the oldest records should be cleared from the archive logs (algoliasearch_queue_archive).
+                        ]]>
+                    </comment>
+                </field>
             </group>
         </section>
         <section id="algoliasearch_extra_settings" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -880,7 +880,7 @@
                         ]]>
                     </comment>
                 </field>
-                <field id="archive_clear_Limit" translate="label comment" type="text" sortOrder="95" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="archive_clear_limit" translate="label comment" type="text" sortOrder="95" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Archive log clean limit</label>
                     <comment>
                         <![CDATA[


### PR DESCRIPTION
Added a logic which clears the archive logs (from algoliasearch_queue_archive) older than 30 days.