### PR TITLE
Adding Queue log grid

### DIFF
--- a/Api/Data/RunInterface.php
+++ b/Api/Data/RunInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api\Data;
+
+/**
+ * Run Data Interface
+ *
+ * @api
+ */
+interface RunInterface
+{
+    const TABLE_NAME = 'algoliasearch_queue_log';
+
+    /**#@+
+     * Constants for keys of data array. Identical to the name of the getter in snake case
+     */
+    const FIELD_RUN_ID = 'id';
+    const FIELD_STARTED = 'started';
+    const FIELD_DURATION = 'duration';
+    const FIELD_PROCESSED_JOBS = 'processed_jobs';
+    const FIELD_WITH_EMPTY_QUEUE = 'with_empty_queue';
+    /**#@-*/
+}

--- a/Controller/Adminhtml/Queue/Log.php
+++ b/Controller/Adminhtml/Queue/Log.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Queue;
+
+use Magento\Framework\Controller\ResultFactory;
+
+class Log extends \Magento\Backend\App\Action
+{
+    /** @return \Magento\Framework\View\Result\Page */
+    public function execute()
+    {
+        $breadMain = __('Algolia | Indexing Queue Logs');
+
+        /** @var \Magento\Framework\View\Result\Page $resultPage */
+        $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
+        $resultPage->setActiveMenu('Algolia_AlgoliaSearch::manage');
+        $resultPage->getConfig()->getTitle()->prepend($breadMain);
+
+        return $resultPage;
+    }
+}

--- a/Model/ResourceModel/Run.php
+++ b/Model/ResourceModel/Run.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\ResourceModel;
+
+use Algolia\AlgoliaSearch\Api\Data\RunInterface;
+
+class Run extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+{
+    protected function _construct()
+    {
+        $this->_init(RunInterface::TABLE_NAME, RunInterface::FIELD_RUN_ID);
+    }
+}

--- a/Model/ResourceModel/Run/Collection.php
+++ b/Model/ResourceModel/Run/Collection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\ResourceModel\Run;
+
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+{
+    protected $_idFieldName = 'id';
+
+    protected $_eventPrefix = 'algoliasearch_queue_run_collection';
+
+    protected $_eventObject = 'run_collection';
+
+    /**
+     * Define resource model
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init(
+            'Algolia\AlgoliaSearch\Model\Run',
+            'Algolia\AlgoliaSearch\Model\ResourceModel\Run'
+        );
+    }
+}

--- a/Model/ResourceModel/Run/Grid/Collection.php
+++ b/Model/ResourceModel/Run/Grid/Collection.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\ResourceModel\Run\Grid;
+
+use Algolia\AlgoliaSearch\Model\ResourceModel\Run\Collection as RunCollection;
+use Magento\Framework\Api\Search\AggregationInterface;
+use Magento\Framework\Api\Search\SearchResultInterface;
+
+class Collection extends RunCollection implements SearchResultInterface
+{
+    /** @var AggregationInterface */
+    protected $aggregations;
+
+    /**
+     * @param \Magento\Framework\Data\Collection\EntityFactoryInterface    $entityFactory
+     * @param \Psr\Log\LoggerInterface                                     $logger
+     * @param \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy
+     * @param \Magento\Framework\Event\ManagerInterface                    $eventManager
+     * @param mixed|null                                                   $mainTable
+     * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb         $eventPrefix
+     * @param mixed                                                        $eventObject
+     * @param mixed                                                        $resourceModel
+     * @param string                                                       $model
+     * @param null                                                         $connection
+     * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb|null    $resource
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        \Magento\Framework\Data\Collection\EntityFactoryInterface $entityFactory,
+        \Psr\Log\LoggerInterface $logger,
+        \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy,
+        \Magento\Framework\Event\ManagerInterface $eventManager,
+        $mainTable,
+        $eventPrefix,
+        $eventObject,
+        $resourceModel,
+        $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
+        $connection = null,
+        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+    ) {
+        parent::__construct(
+            $entityFactory,
+            $logger,
+            $fetchStrategy,
+            $eventManager,
+            $connection,
+            $resource
+        );
+        $this->_eventPrefix = $eventPrefix;
+        $this->_eventObject = $eventObject;
+        $this->_init($model, $resourceModel);
+        $this->setMainTable($mainTable);
+    }
+
+    /** @return AggregationInterface */
+    public function getAggregations()
+    {
+        return $this->aggregations;
+    }
+
+    /**
+     * @param AggregationInterface $aggregations
+     *
+     * @return $this
+     */
+    public function setAggregations($aggregations)
+    {
+        $this->aggregations = $aggregations;
+    }
+
+    /** @return \Magento\Framework\Api\SearchCriteriaInterface|null */
+    public function getSearchCriteria()
+    {
+        return null;
+    }
+
+    /**
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     *
+     * @return $this
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
+    {
+        return $this;
+    }
+
+    /** @return int */
+    public function getTotalCount()
+    {
+        return $this->getSize();
+    }
+
+    /**
+     * @param int $totalCount
+     *
+     * @return $this
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function setTotalCount($totalCount)
+    {
+        return $this;
+    }
+
+    /**
+     * @param \Magento\Framework\Api\ExtensibleDataInterface[] $items
+     *
+     * @return $this
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function setItems(array $items = null)
+    {
+        return $this;
+    }
+}

--- a/Model/Run.php
+++ b/Model/Run.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model;
+
+use Algolia\AlgoliaSearch\Api\Data\RunInterface;
+use Magento\Framework\DataObject\IdentityInterface;
+
+class Run extends \Magento\Framework\Model\AbstractModel implements IdentityInterface, RunInterface
+{
+    const CACHE_TAG = 'algoliasearch_queue_run';
+
+    protected $_cacheTag = 'algoliasearch_queue_run';
+
+    protected $_eventPrefix = 'algoliasearch_queue_run';
+
+    /**
+     * Magento Constructor
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init('Algolia\AlgoliaSearch\Model\ResourceModel\Run');
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function getIdentities()
+    {
+        return [self::CACHE_TAG . '_' . $this->getId()];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -29,6 +29,7 @@
         <arguments>
             <argument name="collections" xsi:type="array">
                 <item name="algolia_algoliasearch_job_listing_data_source" xsi:type="string">Algolia\AlgoliaSearch\Model\ResourceModel\Job\Grid\Collection</item>
+                <item name="algolia_algoliasearch_log_listing_data_source" xsi:type="string">Algolia\AlgoliaSearch\Model\ResourceModel\Run\Grid\Collection</item>
                 <item name="algolia_algoliasearch_landingpage_listing_data_source" xsi:type="string">Algolia\AlgoliaSearch\Model\ResourceModel\LandingPage\Grid\Collection</item>
                 <item name="algolia_algoliasearch_query_listing_data_source" xsi:type="string">Algolia\AlgoliaSearch\Model\ResourceModel\Query\Grid\Collection</item>
             </argument>
@@ -40,6 +41,14 @@
             <argument name="eventPrefix" xsi:type="string">algoliasearch_queue_grid_collection</argument>
             <argument name="eventObject" xsi:type="string">algoliasearch_queue_grid_collection</argument>
             <argument name="resourceModel" xsi:type="string">Algolia\AlgoliaSearch\Model\ResourceModel\Job</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Model\ResourceModel\Run\Grid\Collection">
+        <arguments>
+            <argument name="mainTable" xsi:type="string">algoliasearch_queue_log</argument>
+            <argument name="eventPrefix" xsi:type="string">algoliasearch_log_grid_collection</argument>
+            <argument name="eventObject" xsi:type="string">algoliasearch_log_grid_collection</argument>
+            <argument name="resourceModel" xsi:type="string">Algolia\AlgoliaSearch\Model\ResourceModel\Run</argument>
         </arguments>
     </type>
     <type name="Algolia\AlgoliaSearch\Model\ResourceModel\LandingPage\Grid\Collection">

--- a/view/adminhtml/layout/algolia_algoliasearch_queue_log.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_queue_log.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="algolia_algoliasearch_indexing_log_listing"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/ui_component/algolia_algoliasearch_indexing_log_listing.xml
+++ b/view/adminhtml/ui_component/algolia_algoliasearch_indexing_log_listing.xml
@@ -8,7 +8,7 @@
         <item name="buttons" xsi:type="array">
             <item name="back" xsi:type="array">
                 <item name="name" xsi:type="string">logs</item>
-                <item name="label" xsi:type="string" translate="true">Back to Indexing Queue overview</item>
+                <item name="label" xsi:type="string" translate="true">Back to Indexing Queue</item>
                 <item name="class" xsi:type="string">secondary</item>
                 <item name="url" xsi:type="string">*/*/index</item>
             </item>
@@ -80,7 +80,7 @@
                 </item>
             </argument>
         </column>
-        <column name="duration" >
+        <column name="duration">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="filter" xsi:type="string">int</item>
@@ -91,7 +91,7 @@
                 </item>
             </argument>
         </column>
-        <column name="processed_jobs" >
+        <column name="processed_jobs">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="filter" xsi:type="string">int</item>
@@ -102,7 +102,7 @@
                 </item>
             </argument>
         </column>
-        <column name="with_empty_queue" >
+        <column name="with_empty_queue">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="filter" xsi:type="string">int</item>

--- a/view/adminhtml/ui_component/algolia_algoliasearch_indexing_log_listing.xml
+++ b/view/adminhtml/ui_component/algolia_algoliasearch_indexing_log_listing.xml
@@ -1,0 +1,117 @@
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">algolia_algoliasearch_indexing_log_listing.algolia_algoliasearch_log_listing_data_source</item>
+            <item name="deps" xsi:type="string">algolia_algoliasearch_indexing_log_listing.algolia_algoliasearch_log_listing_data_source</item>
+        </item>
+        <item name="spinner" xsi:type="string">algolia_algoliasearch_log_columns</item>
+        <item name="buttons" xsi:type="array">
+            <item name="back" xsi:type="array">
+                <item name="name" xsi:type="string">logs</item>
+                <item name="label" xsi:type="string" translate="true">Back to Indexing Queue overview</item>
+                <item name="class" xsi:type="string">secondary</item>
+                <item name="url" xsi:type="string">*/*/index</item>
+            </item>
+        </item>
+    </argument>
+
+    <dataSource name="nameOfDataSource">
+        <argument name="dataProvider" xsi:type="configurableObject">
+            <argument name="class" xsi:type="string">Algolia\AlgoliaSearch\Ui\Component\Listing\DataProvider</argument>
+            <argument name="name" xsi:type="string">algolia_algoliasearch_log_listing_data_source</argument>
+            <argument name="primaryFieldName" xsi:type="string">id</argument>
+            <argument name="requestFieldName" xsi:type="string">id</argument>
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/provider</item>
+                    <item name="update_url" xsi:type="url" path="mui/index/render"/>
+                    <item name="storageConfig" xsi:type="array">
+                        <item name="indexField" xsi:type="string">id</item>
+                    </item>
+                </item>
+            </argument>
+        </argument>
+    </dataSource>
+
+    <listingToolbar name="listing_top">
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="sticky" xsi:type="boolean">true</item>
+            </item>
+        </argument>
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <filterSearch name="fulltext"/>
+        <filters name="listing_filters">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="templates" xsi:type="array">
+                        <item name="filters" xsi:type="array">
+                            <item name="select" xsi:type="array">
+                                <item name="component" xsi:type="string">Magento_Ui/js/form/element/ui-select</item>
+                                <item name="template" xsi:type="string">ui/grid/filters/elements/ui-select</item>
+                            </item>
+                        </item>
+                    </item>
+                </item>
+            </argument>
+        </filters>
+        <paging name="listing_paging"/>
+        <exportButton name="export_button"/>
+    </listingToolbar>
+
+    <columns name="algolia_algoliasearch_log_columns">
+        <column name="id">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">textRange</item>
+                    <item name="sorting" xsi:type="string">asc</item>
+                    <item name="label" xsi:type="string" translate="true">Run Id</item>
+                </item>
+            </argument>
+        </column>
+        <column name="started" class="Magento\Ui\Component\Listing\Columns\Date">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">dateRange</item>
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/columns/date</item>
+                    <item name="dataType" xsi:type="string">date</item>
+                    <item name="label" xsi:type="string" translate="true">Started</item>
+                </item>
+            </argument>
+        </column>
+        <column name="duration" >
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">int</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">Duration (in seconds)</item>
+                </item>
+            </argument>
+        </column>
+        <column name="processed_jobs" >
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">int</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">Processed Jobs</item>
+                </item>
+            </argument>
+        </column>
+        <column name="with_empty_queue" >
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">int</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">With empty queue</item>
+                </item>
+            </argument>
+        </column>
+    </columns>
+</listing>

--- a/view/adminhtml/ui_component/algolia_algoliasearch_indexing_queue_listing.xml
+++ b/view/adminhtml/ui_component/algolia_algoliasearch_indexing_queue_listing.xml
@@ -12,6 +12,12 @@
                 <item name="class" xsi:type="string">primary</item>
                 <item name="url" xsi:type="string">*/*/clear</item>
             </item>
+            <item name="logs" xsi:type="array">
+                <item name="name" xsi:type="string">logs</item>
+                <item name="label" xsi:type="string" translate="true">See Run Logs</item>
+                <item name="class" xsi:type="string">secondary</item>
+                <item name="url" xsi:type="string">*/*/log</item>
+            </item>
         </item>
     </argument>
 


### PR DESCRIPTION
Added :
- Button "See Run logs" on the Algoliasearch queue overview page that leads to the new queue log grid
- "Queue log grid" that contains a grid populated by the algoliaseach_queue_log table (filterable by data and by run id)