### PR TITLE
Added translation in menu, Ui component. Source option models.

### DIFF
--- a/Model/Source/CustomRankingProduct.php
+++ b/Model/Source/CustomRankingProduct.php
@@ -25,7 +25,7 @@ class CustomRankingProduct extends AbstractTable
             ],
             'order' => [
                 'label'  => 'Order',
-                'values' => ['asc' => 'Ascending', 'desc' => 'Descending'],
+                'values' => ['asc' => __('Ascending'), 'desc' => __('Descending')],
             ],
         ];
     }

--- a/Model/Source/JobMethods.php
+++ b/Model/Source/JobMethods.php
@@ -24,7 +24,7 @@ class JobMethods implements \Magento\Framework\Data\OptionSourceInterface
         foreach ($this->methods as $key => $value) {
             $options[] = [
                 'value' => $key,
-                'label' => $value,
+                'label' => __($value),
             ];
         }
 

--- a/Model/Source/JobStatuses.php
+++ b/Model/Source/JobStatuses.php
@@ -12,19 +12,19 @@ class JobStatuses implements \Magento\Framework\Data\OptionSourceInterface
         $options = [
             [
                 'value' => JobInterface::STATUS_NEW,
-                'label' => 'New',
+                'label' => __('New'),
             ],
             [
                 'value' => JobInterface::STATUS_ERROR,
-                'label' => 'Error',
+                'label' => __('Error'),
             ],
             [
                 'value' => JobInterface::STATUS_PROCESSING,
-                'label' => 'Processing',
+                'label' => __('Processing'),
             ],
             [
                 'value' => JobInterface::STATUS_COMPLETE,
-                'label' => 'Complete',
+                'label' => __('Complete'),
             ],
         ];
 

--- a/Model/Source/LandingPageStatuses.php
+++ b/Model/Source/LandingPageStatuses.php
@@ -10,11 +10,11 @@ class LandingPageStatuses implements \Magento\Framework\Data\OptionSourceInterfa
         $options = [
             [
                 'value' => 0,
-                'label' => 'Not Published',
+                'label' => __('Not Published'),
             ],
             [
                 'value' => 1,
-                'label' => 'Published',
+                'label' => __('Published'),
             ],
         ];
 

--- a/Model/Source/RetryValues.php
+++ b/Model/Source/RetryValues.php
@@ -17,7 +17,7 @@ class RetryValues implements ArrayInterface
             ['value' => '20', 'label' => '20'],
             ['value' => '50', 'label' => '50'],
             ['value' => '100', 'label' => '100'],
-            ['value' => '9999999', 'label' => 'unlimited'],
+            ['value' => '9999999', 'label' => __('unlimited')],
         ];
     }
 }

--- a/Model/Source/SortOrderCategory.php
+++ b/Model/Source/SortOrderCategory.php
@@ -24,15 +24,15 @@ class SortOrderCategory extends AbstractTable
             ],
             'searchable' => [
                 'label'  => 'Searchable?',
-                'values' => ['1' => 'Yes', '2' => 'No'],
+                'values' => ['1' => __('Yes'), '2' => __('No')],
             ],
             'order' => [
                 'label'  => 'Ordered?',
-                'values' => ['unordered' => 'Unordered', 'ordered' => 'Ordered'],
+                'values' => ['unordered' => __('Unordered'), 'ordered' => __('Ordered')],
             ],
             'retrievable' => [
                 'label'  => 'Retrievable?',
-                'values' => ['1' => 'Yes', '2' => 'No'],
+                'values' => ['1' => __('Yes'), '2' => __('No')],
             ],
         ];
     }

--- a/Model/Source/SortOrderProduct.php
+++ b/Model/Source/SortOrderProduct.php
@@ -24,15 +24,15 @@ class SortOrderProduct extends AbstractTable
             ],
             'searchable' => [
                 'label'  => 'Searchable?',
-                'values' => ['1' => 'Yes', '2' => 'No'],
+                'values' => ['1' => __('Yes'), '2' => __('No')],
             ],
             'order' => [
                 'label'  => 'Ordered?',
-                'values' => ['unordered' => 'Unordered', 'ordered' => 'Ordered'],
+                'values' => ['unordered' => __('Unordered'), 'ordered' => __('Ordered'),
             ],
             'retrievable' => [
                 'label'  => 'Retrievable?',
-                'values' => ['1' => 'Yes', '2' => 'No'],
+                'values' => ['1' => __('Yes'), '2' => __('No')],
             ],
         ];
     }

--- a/Model/Source/Sorts.php
+++ b/Model/Source/Sorts.php
@@ -28,10 +28,7 @@ class Sorts extends AbstractTable
             ],
             'sort' => [
                 'label'  => 'Sort',
-                'values' => [
-                    'asc'  => 'Ascending',
-                    'desc' => 'Descending',
-                ],
+                'values' => ['asc' => __('Ascending'), 'desc' => __('Descending')],
             ],
             'sortLabel' => [
                 'label' => 'Label',

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -4,6 +4,7 @@
         <add
             id="Algolia_AlgoliaSearch::manage"
             title="Algolia Search"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="999"
             parent="Magento_Backend::stores"
@@ -12,6 +13,7 @@
         <add
             id="Algolia_AlgoliaSearch::credentials"
             title="Credentials and Basic Setup"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="10"
             parent="Algolia_AlgoliaSearch::manage"
@@ -21,6 +23,7 @@
         <add
             id="Algolia_AlgoliaSearch::autocomplete"
             title="Autocomplete Menu"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="20"
             parent="Algolia_AlgoliaSearch::manage"
@@ -30,6 +33,7 @@
         <add
             id="Algolia_AlgoliaSearch::instant"
             title="Instant Search Results Page"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="30"
             parent="Algolia_AlgoliaSearch::manage"
@@ -39,6 +43,7 @@
         <add
             id="Algolia_AlgoliaSearch::queue"
             title="Indexing Queue"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="50"
             parent="Algolia_AlgoliaSearch::manage"
@@ -48,6 +53,7 @@
         <add
             id="Algolia_AlgoliaSearch::reindex"
             title="Reindex SKU(s)"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="90"
             parent="Algolia_AlgoliaSearch::manage"
@@ -57,6 +63,7 @@
         <add
             id="Algolia_AlgoliaSearch::merchandising"
             title="Merchandising"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="95"
             parent="Algolia_AlgoliaSearch::manage"
@@ -66,6 +73,7 @@
         <add
             id="Algolia_AlgoliaSearch::analytics"
             title="Analytics Overview"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="110"
             parent="Algolia_AlgoliaSearch::manage"
@@ -75,6 +83,7 @@
         <add
             id="Algolia_AlgoliaSearch::support"
             title="Help &amp; Support"
+            translate="title"
             module="Algolia_AlgoliaSearch"
             sortOrder="120"
             parent="Algolia_AlgoliaSearch::manage"

--- a/view/adminhtml/ui_component/algolia_algoliasearch_landingpage_form.xml
+++ b/view/adminhtml/ui_component/algolia_algoliasearch_landingpage_form.xml
@@ -66,7 +66,7 @@
                     <item name="placeholder" xsi:type="string" translate="true">unique-url-key</item>
                     <item name="notice" xsi:type="string" translate="true">Please ensure that this URL key is unique and not used by another page on your store (products, categories or CMS pages).</item>
                     <item name="tooltip" xsi:type="array">
-                        <item name="description" xsi:type="string">This is where your new landing page can be found: www.mystore.com/unique-url-key</item>
+                        <item name="description" xsi:type="string" translate="true">This is where your new landing page can be found: www.mystore.com/unique-url-key</item>
                     </item>
                     <item name="validation" xsi:type="array">
                         <item name="required-entry" xsi:type="boolean">true</item>
@@ -86,7 +86,7 @@
                     <item name="dataType" xsi:type="string">int</item>
                     <item name="dataScope" xsi:type="string">store_id</item>
                     <item name="tooltip" xsi:type="array">
-                        <item name="description" xsi:type="string">Select the store where the landing page is available. "All Store Views" allows the landing page to be displayed in all your stores.</item>
+                        <item name="description" xsi:type="string" translate="true">Select the store where the landing page is available. "All Store Views" allows the landing page to be displayed in all your stores.</item>
                     </item>
                     <item name="validation" xsi:type="array">
                         <item name="required-entry" xsi:type="boolean">true</item>
@@ -104,7 +104,7 @@
                     <item name="dataScope" xsi:type="string">title</item>
                     <item name="placeholder" xsi:type="string" translate="true">My landing page title</item>
                     <item name="tooltip" xsi:type="array">
-                        <item name="description" xsi:type="string">This is the title that will be displayed on top of the landing page.</item>
+                        <item name="description" xsi:type="string" translate="true">This is the title that will be displayed on top of the landing page.</item>
                     </item>
                     <item name="validation" xsi:type="array">
                         <item name="required-entry" xsi:type="boolean">true</item>
@@ -120,7 +120,7 @@
                     <item name="formElement" xsi:type="string">input</item>
                     <item name="label" xsi:type="string" translate="true">Meta title</item>
                     <item name="tooltip" xsi:type="array">
-                        <item name="description" xsi:type="string">The meta title can be customized to enhance your SEO.</item>
+                        <item name="description" xsi:type="string" translate="true">The meta title can be customized to enhance your SEO.</item>
                     </item>
                     <item name="notice" xsi:type="string" translate="true">If no meta title is set, the page title will be used.</item>
                     <item name="dataScope" xsi:type="string">meta_title</item>
@@ -134,7 +134,7 @@
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">textarea</item>
                     <item name="tooltip" xsi:type="array">
-                        <item name="description" xsi:type="string">The meta description can be customized to enhance your SEO.</item>
+                        <item name="description" xsi:type="string" translate="true">The meta description can be customized to enhance your SEO.</item>
                     </item>
                     <item name="label" xsi:type="string" translate="true">Meta description</item>
                     <item name="dataScope" xsi:type="string">meta_description</item>
@@ -149,7 +149,7 @@
                     <item name="formElement" xsi:type="string">input</item>
                     <item name="label" xsi:type="string" translate="true">Meta keywords</item>
                     <item name="tooltip" xsi:type="array">
-                        <item name="description" xsi:type="string">The meta keywords can be customized to enhance your SEO.</item>
+                        <item name="description" xsi:type="string" translate="true">The meta keywords can be customized to enhance your SEO.</item>
                     </item>
                     <item name="placeholder" xsi:type="string" translate="true">product, red, woman, accessory</item>
                     <item name="dataScope" xsi:type="string">meta_keywords</item>


### PR DESCRIPTION
Hi!

**Summary**

In adminhtml some phrases aren`t available for translation. In PR I added missed tags for menu, UI components descriptions and option grids/models
