### PR TITLE
Use ::class instead string name in Job classes

### DIFF
--- a/Model/ResourceModel/Job/Collection.php
+++ b/Model/ResourceModel/Job/Collection.php
@@ -18,8 +18,8 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     protected function _construct()
     {
         $this->_init(
-            'Algolia\AlgoliaSearch\Model\Job',
-            'Algolia\AlgoliaSearch\Model\ResourceModel\Job'
+            \Algolia\AlgoliaSearch\Model\Job::class,
+            \Algolia\AlgoliaSearch\Model\ResourceModel\Job::class
         );
     }
 }


### PR DESCRIPTION
**Summary**
Hi!

Improved small difference in code styling between new classes for Jobs and another models, resource models and collections. In addition, it`s using ::class - it` support of Magento Code style. 

Thnx!