### PR TITLE
Remove Object manager and add factories to constructor

### DIFF
--- a/Helper/Entity/AdditionalSectionHelper.php
+++ b/Helper/Entity/AdditionalSectionHelper.php
@@ -5,23 +5,39 @@ namespace Algolia\AlgoliaSearch\Helper\Entity;
 use Magento\Eav\Model\Config;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\ObjectManagerInterface;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 
 class AdditionalSectionHelper
 {
+    /**
+     * @var ManagerInterface
+     */
     private $eventManager;
 
-    private $objectManager;
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
 
+    /**
+     * @var Config
+     */
     private $eavConfig;
 
+    /**
+     * AdditionalSectionHelper constructor.
+     *
+     * @param ManagerInterface $eventManager
+     * @param CollectionFactory $productCollectionFactory
+     * @param Config $eavConfig
+     */
     public function __construct(
         ManagerInterface $eventManager,
-        ObjectManagerInterface $objectManager,
+        CollectionFactory $collectionFactory,
         Config $eavConfig
     ) {
         $this->eventManager = $eventManager;
-        $this->objectManager = $objectManager;
+        $this->collectionFactory = $collectionFactory;
         $this->eavConfig = $eavConfig;
     }
 
@@ -51,8 +67,8 @@ class AdditionalSectionHelper
         $attributeCode = $section['name'];
 
         /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $products */
-        $products = $this->objectManager->create('Magento\Catalog\Model\ResourceModel\Product\Collection');
-        $products = $products->addStoreFilter($storeId)
+        $products = $this->collectionFactory->create()
+            ->addStoreFilter($storeId)
             ->addAttributeToFilter($attributeCode, ['notnull' => true])
             ->addAttributeToFilter($attributeCode, ['neq' => ''])
             ->addAttributeToSelect($attributeCode);

--- a/Helper/Entity/AdditionalSectionHelper.php
+++ b/Helper/Entity/AdditionalSectionHelper.php
@@ -2,10 +2,10 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Eav\Model\Config;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 
 class AdditionalSectionHelper
 {

--- a/Helper/Entity/AdditionalSectionHelper.php
+++ b/Helper/Entity/AdditionalSectionHelper.php
@@ -28,7 +28,7 @@ class AdditionalSectionHelper
      * AdditionalSectionHelper constructor.
      *
      * @param ManagerInterface $eventManager
-     * @param CollectionFactory $productCollectionFactory
+     * @param CollectionFactory $collectionFactory
      * @param Config $eavConfig
      */
     public function __construct(

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -4,38 +4,59 @@ namespace Algolia\AlgoliaSearch\Helper\Entity;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Cms\Model\Page;
+use Magento\Cms\Model\ResourceModel\Page\CollectionFactory as PageCollectionFactory;
 use Magento\Cms\Model\Template\FilterProvider;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 class PageHelper
 {
+    /**
+     * @var ManagerInterface
+     */
     private $eventManager;
 
-    private $objectManager;
+    /**
+     * @var PageCollectionFactory
+     */
+    private $pageCollectionFactory;
 
+    /**
+     * @var ConfigHelper
+     */
     private $configHelper;
 
+    /**
+     * @var FilterProvider
+     */
     private $filterProvider;
 
+    /**
+     * @var StoreManagerInterface
+     */
     private $storeManager;
 
-    private $storeUrls;
+    /**
+     * @var UrlInterface
+     */
+    private $frontendUrlBuilder;
 
     public function __construct(
         ManagerInterface $eventManager,
-        ObjectManagerInterface $objectManager,
+        PageCollectionFactory $pageCollectionFactory,
         ConfigHelper $configHelper,
         FilterProvider $filterProvider,
-        StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        UrlInterface $frontendUrlBuilder
     ) {
         $this->eventManager = $eventManager;
-        $this->objectManager = $objectManager;
+        $this->pageCollectionFactory = $pageCollectionFactory;
         $this->configHelper = $configHelper;
         $this->filterProvider = $filterProvider;
         $this->storeManager = $storeManager;
+        $this->frontendUrlBuilder = $frontendUrlBuilder;
     }
 
     public function getIndexNameSuffix()
@@ -62,12 +83,8 @@ class PageHelper
 
     public function getPages($storeId)
     {
-        /** @var \Magento\Cms\Model\Page $pageModel */
-        $pageModel = $this->objectManager->create('\Magento\Cms\Model\Page');
-
         /** @var \Magento\Cms\Model\ResourceModel\Page\Collection $magentoPages */
-        $magentoPages = $pageModel->getCollection();
-        $magentoPages = $magentoPages
+        $magentoPages = $this->pageCollectionFactory->getCollection()
             ->addStoreFilter($storeId)
             ->addFieldToFilter('is_active', 1);
 
@@ -102,7 +119,7 @@ class PageHelper
             }
 
             $pageObject['objectID'] = $page->getId();
-            $pageObject['url'] = $this->getStoreUrl($storeId)
+            $pageObject['url'] = $this->frontendUrlBuilder->setStore($storeId)
                                       ->getUrl(
                                           null,
                                           [
@@ -123,17 +140,6 @@ class PageHelper
         }
 
         return $pages;
-    }
-
-    private function getStoreUrl($storeId)
-    {
-        if (!isset($this->storeUrls[$storeId])) {
-            $url = $this->objectManager->create('Magento\Framework\Url');
-            $url->setData('store', $storeId);
-            $this->storeUrls[$storeId] = $url;
-        }
-
-        return $this->storeUrls[$storeId];
     }
 
     public function getStores($storeId = null)

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -84,7 +84,7 @@ class PageHelper
     public function getPages($storeId)
     {
         /** @var \Magento\Cms\Model\ResourceModel\Page\Collection $magentoPages */
-        $magentoPages = $this->pageCollectionFactory->getCollection()
+        $magentoPages = $this->pageCollectionFactory->create()
             ->addStoreFilter($storeId)
             ->addFieldToFilter('is_active', 1);
 

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -43,6 +43,16 @@ class PageHelper
      */
     private $frontendUrlBuilder;
 
+    /**
+     * PageHelper constructor.
+     *
+     * @param ManagerInterface $eventManager
+     * @param PageCollectionFactory $pageCollectionFactory
+     * @param ConfigHelper $configHelper
+     * @param FilterProvider $filterProvider
+     * @param StoreManagerInterface $storeManager
+     * @param UrlInterface $frontendUrlBuilder
+     */
     public function __construct(
         ManagerInterface $eventManager,
         PageCollectionFactory $pageCollectionFactory,

--- a/Helper/Entity/SuggestionHelper.php
+++ b/Helper/Entity/SuggestionHelper.php
@@ -128,7 +128,7 @@ class SuggestionHelper
     public function getSuggestionCollectionQuery($storeId)
     {
         /** @var \Magento\Search\Model\ResourceModel\Query\Collection $collection */
-        $collection = $collection = $this->queryCollectionFactory->create()
+        $collection = $this->queryCollectionFactory->create()
             ->addStoreFilter($storeId)
             ->setStoreId($storeId);
 

--- a/Helper/Entity/SuggestionHelper.php
+++ b/Helper/Entity/SuggestionHelper.php
@@ -6,15 +6,18 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Framework\App\Cache\Type\Config as ConfigCache;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Search\Model\Query;
+use Magento\Search\Model\ResourceModel\Query\CollectionFactory as QueryCollectionFactory;
 
 class SuggestionHelper
 {
     private $eventManager;
 
-    private $objectManager;
+    /**
+     * @var QueryCollectionFactory
+     */
+    private $queryCollectionFactory;
 
     private $cache;
 
@@ -26,13 +29,13 @@ class SuggestionHelper
 
     public function __construct(
         ManagerInterface $eventManager,
-        ObjectManagerInterface $objectManager,
+        QueryCollectionFactory $queryCollectionFactory,
         ConfigCache $cache,
         ConfigHelper $configHelper,
         SerializerInterface $serializer
     ) {
         $this->eventManager = $eventManager;
-        $this->objectManager = $objectManager;
+        $this->queryCollectionFactory = $queryCollectionFactory;
         $this->cache = $cache;
         $this->configHelper = $configHelper;
         $this->serializer = $serializer;
@@ -89,7 +92,8 @@ class SuggestionHelper
             return $this->serializer->unserialize($queries);
         }
 
-        $collection = $this->objectManager->create('\Magento\Search\Model\ResourceModel\Query\Collection');
+        /** @var \Magento\Search\Model\ResourceModel\Query\Collection $collection */
+        $collection = $this->queryCollectionFactory->create();
         $collection->getSelect()->where(
             'num_results >= ' . $this->configHelper->getMinNumberOfResults() . ' 
             AND popularity >= ' . $this->configHelper->getMinPopularity() . ' 
@@ -124,8 +128,9 @@ class SuggestionHelper
     public function getSuggestionCollectionQuery($storeId)
     {
         /** @var \Magento\Search\Model\ResourceModel\Query\Collection $collection */
-        $collection = $this->objectManager->create('\Magento\Search\Model\ResourceModel\Query\Collection');
-        $collection = $collection->addStoreFilter($storeId)->setStoreId($storeId);
+        $collection = $collection = $this->queryCollectionFactory->create()
+            ->addStoreFilter($storeId)
+            ->setStoreId($storeId);
 
         $collection->getSelect()->where(
             'num_results >= ' . $this->configHelper->getMinNumberOfResults($storeId) . ' 

--- a/Helper/Entity/SuggestionHelper.php
+++ b/Helper/Entity/SuggestionHelper.php
@@ -27,6 +27,15 @@ class SuggestionHelper
 
     private $popularQueriesCacheId = 'algoliasearch_popular_queries_cache_tag';
 
+    /**
+     * SuggestionHelper constructor.
+     *
+     * @param ManagerInterface $eventManager
+     * @param QueryCollectionFactory $queryCollectionFactory
+     * @param ConfigCache $cache
+     * @param ConfigHelper $configHelper
+     * @param SerializerInterface $serializer
+     */
     public function __construct(
         ManagerInterface $eventManager,
         QueryCollectionFactory $queryCollectionFactory,


### PR DESCRIPTION
Hi!

It's continue from PR #495 and remove ObjectManager use in Pages, Suggestions and Additional sections entity helpers. In addition, It's part of  PR #936 and remove literal class names from model.

Thnx!
 
