### PR TITLE
Add forgotten indexOutOfStockOptions() method behaviour

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1143,7 +1143,8 @@ class ProductHelper
         }
 
         $isInStock = true;
-        if (!$this->configHelper->getShowOutOfStock($storeId)) {
+        if (!$this->configHelper->getShowOutOfStock($storeId)
+            || (!$this->configHelper->indexOutOfStockOptions($storeId) && $isChildProduct === true)) {
             $isInStock = $this->productIsInStock($product, $storeId);
         }
 


### PR DESCRIPTION
Add indexOutOfStockOptions() behaviour (defined by **"Stores -> Configuration -> Algolia Search -> Products: Index out of stock options for configurable products"** ) which has been previously removed during the helper refactoring.

Now, you can have out of stock simple products indexed and out of stock configurable options not indexed (see issue https://github.com/algolia/algoliasearch-magento-2/issues/951 )