### PR TITLE
Fix warning on missing taskID array key

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -264,7 +264,7 @@ class AlgoliaHelper extends AbstractHelper
             $response = $response->getBody();
         }
 
-        self::$lastTaskId = $response['taskID'];
+        self::$lastTaskId = isset($response['taskID']) ? $response['taskID'] : null;
     }
 
     public function saveRule($rule, $indexName, $forwardToReplicas = false)


### PR DESCRIPTION
PHP v2 Client Update taskID array key warning. Added condition to prevent warning. 