### PR TITLE
Fix bundle product selections for subproducts

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -550,7 +550,7 @@ class ProductHelper
         if ($typeInstance instanceof Configurable) {
             $subProducts = $typeInstance->getUsedProducts($product);
         } elseif ($typeInstance instanceof BundleProductType) {
-            $subProducts = $typeInstance->getOptions($product);
+            $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product);
         } else { // Grouped product
             $subProducts = $typeInstance->getAssociatedProducts($product);
         }


### PR DESCRIPTION
Bundle products were reported to not have child SKUs indexed. This was originally pulling the option types for the selections instead of the selections products themselves. 

HS Ticket # 231950