### PR TITLE
Add warning after image cache is flushed

### DIFF
--- a/Model/Observer/CleanCatalogImagesCacheAfter.php
+++ b/Model/Observer/CleanCatalogImagesCacheAfter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Observer;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Message\ManagerInterface;
+
+class CleanCatalogImagesCacheAfter implements ObserverInterface
+{
+    /** @var ConfigHelper */
+    private $configHelper;
+
+    /** @var ManagerInterface */
+    private $messageManager;
+
+    /**
+     * @param ConfigHelper $configHelper
+     * @param ManagerInterface $messageManager
+     */
+    public function __construct(
+        ConfigHelper $configHelper,
+        ManagerInterface $messageManager
+    ) {
+        $this->configHelper = $configHelper;
+        $this->messageManager = $messageManager;
+    }
+
+    /**
+     * Add Notice for Product Reindexing after image flush
+     *
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        $this->messageManager->addWarningMessage(__('
+            Algolia Warning: The image cache has been cleared. 
+            All indexed image links will become invalid because the file will be nonexistent. 
+            Please run a full reindex of your catalog data to resolve broken images in your Algolia Search.
+        '));
+    }
+}

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -57,4 +57,9 @@
     <event name="algolia_after_create_category_object">
         <observer name="algoliasearch_category_permissions" instance="Algolia\AlgoliaSearch\Model\Observer\CatalogPermissions\CategoryPermissions" />
     </event>
+
+    <event name="clean_catalog_images_cache_after">
+        <observer name="algoliasearch_flush_catalog_image_cache_after" instance="Algolia\AlgoliaSearch\Model\Observer\CleanCatalogImagesCacheAfter" />
+    </event>
+
 </config>


### PR DESCRIPTION
After a user has flushed image cache, image links that have been indexed will not work causing broken image links. Due to performance, we have chosen not to perform an automatic full reindex of their catalog indexes but to throw a warning message after the event has fired. 

HS Ticket #232908