### PR TITLE
chore(ci): do not use cache on the global composer vendor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ jobs:
                     sudo chown circleci:circleci ~/.composer/
             - restore_cache:
                   keys:
-                      - composer-v2-{{ checksum "composer.json" }}
-                      - composer-v2-
+                      - composer-v3-{{ checksum "composer.json" }}
+                      - composer-v3-
                       
             - run:
                   name: Prepare environment
@@ -92,7 +92,7 @@ jobs:
                       cd ~/magento_directory
                       composer dump-autoload
             - save_cache:
-                  key: composer-v2-{{ checksum "composer.json" }}
+                  key: composer-v3-{{ checksum "composer.json" }}
                   paths:
                       - vendor
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,11 +79,11 @@ jobs:
                   command: |
                       sudo composer self-update
                       composer config http-basic.'repo.magento.com' ${MAGENTO_AUTH_USERNAME} ${MAGENTO_AUTH_PASSWORD}
-                      composer install -n --prefer-dist --ignore-platform-reqs --no-progress
+                      composer install -n --prefer-dist --no-progress
                       sudo chown circleci:circleci ~/.composer/
                       composer global config prefer-stable true
                       composer global config minimum-stability dev
-                      composer global require algolia/magento2-tools --ignore-platform-reqs
+                      composer global require algolia/magento2-tools
 
                       # We have to do this again because we restore the cache above, overwriting the vendor with the original.
                       cd ~/magento_directory/vendor/algolia

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,6 @@ jobs:
                   key: composer-v2-{{ checksum "composer.json" }}
                   paths:
                       - vendor
-                      - ~/.composer/vendor
             - run:
                   name: Quality tools
                   command: |


### PR DESCRIPTION
The current circle ci config was assuming that: if the `{extension}/composer.json` do not change, the global vendor should be the same. And that is not true.

The pull request makes the global vendor always start from a clean state.