### PR TITLE
Update CC Analytics description for insights parameters 

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -664,7 +664,9 @@
                     <source_model>Algolia\AlgoliaSearch\Model\Source\ConversionAnalyticsMode</source_model>
                     <comment>
                         <![CDATA[
-                            Conversion is tracked when a product was found and clicked in search results and then added to cart / ordered.
+                            Conversion is tracked when a product was found and clicked in search results and then added to cart / ordered. </br></br>
+
+                            If conversion is tracked, URL parameters will be appended to your searched product links. The `queryID` parameter is required for insights to tie a conversion event to a search. For best SEO practice, we recommend you to use canonical links for your product pages. You can enable this setting by going to <strong>Stores > Configuration > Catalog > Catalog > Search Engine Optimization > Use Canonical Link Meta Tag For Products</strong>.
                         ]]>
                     </comment>
                     <depends>

--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -180,7 +180,8 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 
 				hit.urlForInsights = hit.url;
 
-				if (algoliaConfig.ccAnalytics.enabled) {
+				if (algoliaConfig.ccAnalytics.enabled
+					&& algoliaConfig.ccAnalytics.conversionAnalyticsMode !== 'disabled') {
 					var insightsDataUrlString = $.param({
 						queryID: hit.__queryID,
 						objectID: hit.objectID,


### PR DESCRIPTION
For conversion tracking for CC Analytics, we now append URL parameters to searched results. This update is to add a description explaining this change and to recommend they enable the canonical links for product settings in Magento.  

Additionally, I added an extra condition so that the insights URL params should only be added if conversion mode has been set. 