### PR TITLE
Fix error on URL during Pages indexing

### DIFF
--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -8,7 +8,6 @@ use Magento\Cms\Model\ResourceModel\Page\CollectionFactory as PageCollectionFact
 use Magento\Cms\Model\Template\FilterProvider;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\UrlInterface;
 use Magento\Framework\UrlFactory;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -132,14 +131,13 @@ class PageHelper
             }
 
             $pageObject['objectID'] = $page->getId();
-            $pageObject['url'] = $frontendUrlBuilder
-                                                          ->getUrl(
-                                          null,
-                                          [
-                                              '_direct' => $page->getIdentifier(),
-                                              '_secure' => $this->configHelper->useSecureUrlsInFrontend($storeId),
-                                          ]
-                                      );
+            $pageObject['url'] = $frontendUrlBuilder->getUrl(
+                null,
+                [
+                    '_direct' => $page->getIdentifier(),
+                    '_secure' => $this->configHelper->useSecureUrlsInFrontend($storeId),
+                ]
+            );
             $pageObject['content'] = $this->strip($content, ['script', 'style']);
 
             $transport = new DataObject($pageObject);

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -9,6 +9,7 @@ use Magento\Cms\Model\Template\FilterProvider;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\UrlInterface;
+use Magento\Framework\UrlFactory;
 use Magento\Store\Model\StoreManagerInterface;
 
 class PageHelper
@@ -39,19 +40,19 @@ class PageHelper
     private $storeManager;
 
     /**
-     * @var UrlInterface
+     * @var UrlFactory
      */
-    private $frontendUrlBuilder;
+    private $frontendUrlFactory;
 
     /**
      * PageHelper constructor.
      *
-     * @param ManagerInterface $eventManager
+     * @param ManagerInterface      $eventManager
      * @param PageCollectionFactory $pageCollectionFactory
-     * @param ConfigHelper $configHelper
-     * @param FilterProvider $filterProvider
+     * @param ConfigHelper          $configHelper
+     * @param FilterProvider        $filterProvider
      * @param StoreManagerInterface $storeManager
-     * @param UrlInterface $frontendUrlBuilder
+     * @param UrlFactory          $frontendUrlFactory
      */
     public function __construct(
         ManagerInterface $eventManager,
@@ -59,14 +60,14 @@ class PageHelper
         ConfigHelper $configHelper,
         FilterProvider $filterProvider,
         StoreManagerInterface $storeManager,
-        UrlInterface $frontendUrlBuilder
+        UrlFactory $frontendUrlFactory
     ) {
         $this->eventManager = $eventManager;
         $this->pageCollectionFactory = $pageCollectionFactory;
         $this->configHelper = $configHelper;
         $this->filterProvider = $filterProvider;
         $this->storeManager = $storeManager;
-        $this->frontendUrlBuilder = $frontendUrlBuilder;
+        $this->frontendUrlFactory = $frontendUrlFactory;
     }
 
     public function getIndexNameSuffix()
@@ -106,6 +107,8 @@ class PageHelper
 
         $pages = [];
 
+        $frontendUrlBuilder = $this->frontendUrlFactory->create()->setScope($storeId);
+
         /** @var Page $page */
         foreach ($magentoPages as $page) {
             if (in_array($page->getIdentifier(), $excludedPages)) {
@@ -129,8 +132,8 @@ class PageHelper
             }
 
             $pageObject['objectID'] = $page->getId();
-            $pageObject['url'] = $this->frontendUrlBuilder->setStore($storeId)
-                                      ->getUrl(
+            $pageObject['url'] = $frontendUrlBuilder
+                                                          ->getUrl(
                                           null,
                                           [
                                               '_direct' => $page->getIdentifier(),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

* Set store scope using correct function to avoid using Default store domain
* Get a clean UrlInterface instance to avoid problem where domain from previous store in the loop is used.
