### PR TITLE
Remove extra grid.css import

### DIFF
--- a/view/frontend/web/internals/autocomplete.css
+++ b/view/frontend/web/internals/autocomplete.css
@@ -1,5 +1,3 @@
-@import "./grid.css";
-
 /** Auto-completion menu */
 
 #algolia-autocomplete-container .aa-dropdown-menu .before_special {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
grid.css is being included a second time redundantly. 

Also, when Magento has "Minify CSS" enabled, an error occurs because "./grid.css" doesn't exists in the deployed files

---
In the future it would be a good idea to include the css using the _module.less method, so it's available for automatic bundling/minification, and maybe extension and theming