### PR TITLE
Fix ProductHelper for bundle subproducts error

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -550,7 +550,7 @@ class ProductHelper
         if ($typeInstance instanceof Configurable) {
             $subProducts = $typeInstance->getUsedProducts($product);
         } elseif ($typeInstance instanceof BundleProductType) {
-            $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product);
+            $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product)->getItems();
         } else { // Grouped product
             $subProducts = $typeInstance->getAssociatedProducts($product);
         }


### PR DESCRIPTION
Fix issue for PHP fatal error on unset() object from the Bundle Collection. Need to add getItems() to change object to array.

**Fixes Issue(s):** #1008