### PR TITLE
make sure original price range is saved for configurables

### DIFF
--- a/Helper/Entity/Product/PriceManager/Bundle.php
+++ b/Helper/Entity/Product/PriceManager/Bundle.php
@@ -23,6 +23,6 @@ class Bundle extends ProductWithChildren
             }
         }
 
-        return [$min, $max];
+        return [$min, $max, $min, $max];
     }
 }

--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -9,12 +9,15 @@ abstract class ProductWithChildren extends ProductWithoutChildren
 {
     protected function addAdditionalData($product, $withTax, $subProducts, $currencyCode, $field)
     {
-        list($min, $max) = $this->getMinMaxPrices($product, $withTax, $subProducts, $currencyCode);
+        list($min, $max, $minOriginal, $maxOriginal) = $this->getMinMaxPrices(
+            $product, $withTax, $subProducts, $currencyCode);
         $dashedFormat = $this->getDashedPriceFormat($min, $max, $currencyCode);
 
         if ($min !== $max) {
             $this->handleNonEqualMinMaxPrices($field, $currencyCode, $min, $max, $dashedFormat);
         }
+
+        $this->handleOriginalPrice($field, $currencyCode, $min, $max, $minOriginal, $maxOriginal);
 
         if (!$this->customData[$field][$currencyCode]['default']) {
             $this->handleZeroDefaultPrice($field, $currencyCode, $min, $max);
@@ -27,30 +30,39 @@ abstract class ProductWithChildren extends ProductWithoutChildren
 
     protected function getMinMaxPrices(Product $product, $withTax, $subProducts, $currencyCode)
     {
-        $min = PHP_INT_MAX;
-        $max = 0;
+        $min      = PHP_INT_MAX;
+        $max      = 0;
+        $original = $min;
+        $originalMax = $max;
 
         if (count($subProducts) > 0) {
             /** @var Product $subProduct */
             foreach ($subProducts as $subProduct) {
-                $price = $this->getTaxPrice($product, $subProduct->getFinalPrice(), $withTax);
+                $price     = $this->getTaxPrice($product, $subProduct->getFinalPrice(), $withTax);
+                $basePrice = $this->getTaxPrice($product, $subProduct->getPrice(), $withTax);
 
                 $min = min($min, $price);
+                $original = min($original, $basePrice);
+
                 $max = max($max, $price);
+                $originalMax = max($max, $basePrice);
+
             }
         } else {
-            $min = $max;
+            $originalMax = $original = $min = $max;
         }
 
         if ($currencyCode !== $this->baseCurrencyCode) {
-            $min = $this->convertPrice($min, $currencyCode);
+            $min      = $this->convertPrice($min, $currencyCode);
+            $original = $this->convertPrice($original, $currencyCode);
 
             if ($min !== $max) {
                 $max = $this->convertPrice($max, $currencyCode);
+                $originalMax = $this->convertPrice($originalMax, $currencyCode);
             }
         }
 
-        return [$min, $max];
+        return [$min, $max, $original, $originalMax];
     }
 
     protected function getDashedPriceFormat($min, $max, $currencyCode)
@@ -80,7 +92,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
                 $groupId = (int) $group->getData('customer_group_id');
 
                 if ($min !== $max && $min <= $this->customData[$field][$currencyCode]['group_' . $groupId]) {
-                    $this->customData[$field][$currencyCode]['group_' . $groupId] = 0;
+                    $this->customData[$field][$currencyCode]['group_' . $groupId]               = 0;
                     $this->customData[$field][$currencyCode]['group_' . $groupId . '_formated'] = $dashedFormat;
                 }
             }
@@ -95,7 +107,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
             return;
         }
 
-        $this->customData[$field][$currencyCode]['default'] = $min;
+        $this->customData[$field][$currencyCode]['default']          = $min;
         $this->customData[$field][$currencyCode]['default_formated'] = $this->formatPrice($min, $currencyCode);
     }
 
@@ -117,4 +129,25 @@ abstract class ProductWithChildren extends ProductWithoutChildren
             }
         }
     }
+
+    public function handleOriginalPrice($field, $currencyCode, $min, $max, $minOriginal, $maxOriginal)
+    {
+        if ($min !== $max) {
+            if ($min !== $minOriginal || $max !== $maxOriginal) {
+                if($minOriginal !== $maxOriginal) {
+                    $this->customData[$field][$currencyCode]['default_original_formated'] = $this->getDashedPriceFormat(
+                        $minOriginal, $maxOriginal, $currencyCode);
+                }else{
+                    $this->customData[$field][$currencyCode]['default_original_formated'] = $this->formatPrice(
+                        $minOriginal, $currencyCode);
+                }
+            }
+        } else {
+            if ($min < $minOriginal) {
+                $this->customData[$field][$currencyCode]['default_original_formated'] = $this->formatPrice(
+                    $minOriginal, $currencyCode);
+            }
+        }
+    }
+
 }

--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -9,8 +9,9 @@ abstract class ProductWithChildren extends ProductWithoutChildren
 {
     protected function addAdditionalData($product, $withTax, $subProducts, $currencyCode, $field)
     {
-        list($min, $max, $minOriginal, $maxOriginal) = $this->getMinMaxPrices(
-            $product, $withTax, $subProducts, $currencyCode);
+        list($min, $max, $minOriginal, $maxOriginal) =
+            $this->getMinMaxPrices($product, $withTax, $subProducts, $currencyCode);
+
         $dashedFormat = $this->getDashedPriceFormat($min, $max, $currencyCode);
 
         if ($min !== $max) {
@@ -46,7 +47,6 @@ abstract class ProductWithChildren extends ProductWithoutChildren
 
                 $max = max($max, $price);
                 $originalMax = max($max, $basePrice);
-
             }
         } else {
             $originalMax = $original = $min = $max;
@@ -81,7 +81,11 @@ abstract class ProductWithChildren extends ProductWithoutChildren
             $this->customData[$field][$currencyCode]['default_formated'] = $dashedFormat;
 
             //// Do not keep special price that is already taken into account in min max
-            unset($this->customData['price']['special_from_date'], $this->customData['price']['special_to_date'], $this->customData['price']['default_original_formated']);
+            unset(
+                $this->customData['price']['special_from_date'],
+                $this->customData['price']['special_to_date'],
+                $this->customData['price']['default_original_formated']
+            );
 
             $this->customData[$field][$currencyCode]['default'] = 0; // will be reset just after
         }
@@ -134,20 +138,26 @@ abstract class ProductWithChildren extends ProductWithoutChildren
     {
         if ($min !== $max) {
             if ($min !== $minOriginal || $max !== $maxOriginal) {
-                if($minOriginal !== $maxOriginal) {
+                if ($minOriginal !== $maxOriginal) {
                     $this->customData[$field][$currencyCode]['default_original_formated'] = $this->getDashedPriceFormat(
-                        $minOriginal, $maxOriginal, $currencyCode);
-                }else{
+                        $minOriginal,
+                        $maxOriginal,
+                        $currencyCode
+                    );
+                } else {
                     $this->customData[$field][$currencyCode]['default_original_formated'] = $this->formatPrice(
-                        $minOriginal, $currencyCode);
+                        $minOriginal,
+                        $currencyCode
+                    );
                 }
             }
         } else {
             if ($min < $minOriginal) {
                 $this->customData[$field][$currencyCode]['default_original_formated'] = $this->formatPrice(
-                    $minOriginal, $currencyCode);
+                    $minOriginal,
+                    $currencyCode
+                );
             }
         }
     }
-
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
When indexing configurables, the Original / Discount relationship is lost, This saves the original prices to have the discount visible

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->