### PR TITLE
Queue doesn't update products unless enabled globally

### DIFF
--- a/Model/IndexMover.php
+++ b/Model/IndexMover.php
@@ -35,10 +35,11 @@ class IndexMover
     /**
      * @param string $tmpIndexName
      * @param string $indexName
+     * @param int    $storeId
      */
-    public function moveIndex($tmpIndexName, $indexName)
+    public function moveIndex($tmpIndexName, $indexName, $storeId)
     {
-        if ($this->baseHelper->isIndexingEnabled() === false) {
+        if ($this->baseHelper->isIndexingEnabled($storeId) === false) {
             return;
         }
 
@@ -48,17 +49,17 @@ class IndexMover
     /**
      * @param string $tmpIndexName
      * @param string $indexName
-     * @param int $storeId
+     * @param int    $storeId
      *
      * @throws AlgoliaException
      */
     public function moveIndexWithSetSettings($tmpIndexName, $indexName, $storeId)
     {
-        if ($this->baseHelper->isIndexingEnabled() === false) {
+        if ($this->baseHelper->isIndexingEnabled($storeId) === false) {
             return;
         }
 
         $this->indicesConfigurator->saveConfigurationToAlgolia($storeId, true);
-        $this->moveIndex($tmpIndexName, $indexName);
+        $this->moveIndex($tmpIndexName, $indexName, $storeId);
     }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
Conditions:
* The queue is enabled
* Indexing is disabled on global
* Indexing is enabled on one store/website

In that case, the data for products will never be promoted from _tmp to the index.
The problem is that the queued job is not checking against the $storeId passed with the data and so it's checking against default. It works without the queue because in that case there is current store emulation.


