### PR TITLE
Removed obsolete trigger for catalog_product_entity_media_gallery

### DIFF
--- a/etc/mview.xml
+++ b/etc/mview.xml
@@ -27,7 +27,6 @@
             <table name="catalog_product_entity_decimal" entity_column="entity_id" />
             <table name="catalog_product_entity_gallery" entity_column="entity_id" />
             <table name="catalog_product_entity_int" entity_column="entity_id" />
-            <table name="catalog_product_entity_media_gallery" entity_column="value_id" />
             <table name="catalog_product_entity_media_gallery_value" entity_column="entity_id" />
             <table name="catalog_product_entity_text" entity_column="entity_id" />
             <table name="catalog_product_entity_tier_price" entity_column="entity_id" />


### PR DESCRIPTION
Hi!

**Summary**

Magento version: 2.2.x-2.3.x  

Sometimes We get  reports from clients about stuck  on re-index products from Magento to Algolia. All indices are "On Schedule" mode. After research We found reason - It's related with trigger to "catalog_product_entity_media_gallery" table and value_id column. If Images are updated often on huge catalog you can get in algolia_products_cl table next case:   
 version_id	entity_id,
14	17500,
15	17500,
16	17500,
17	17500,
18	17500,
19	17500,
20	17500,
21	17500,
22	17500,
*23	1193238,* (it's value_id and it blocks updates)
24	17500, 
25	17500

after checking in Magneto code, I found difference - This trigger was added in Magento 2.1 and It was removed in Magento 2.2.0:
Magento 2.1: https://github.com/magento/magento2/blob/2.1/app/code/Magento/Catalog/etc/mview.xml 
Magent 2.2 (since 2.2.0-RC1.1) : https://github.com/magento/magento2/commit/9fe3b8a0cdff5c9f4677c1890ca2bf52718acae5#diff-b82ecede1475a66d3135943308251166 

**Result**

I've removed obsolete mview subscription to wrong column.

Please review,Thnx 