### PR TITLE
Prevent division by zero in the Notice Helper when configuration is not set

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -389,7 +389,8 @@ class ConfigHelper
 
     public function getNumberOfJobToRun($storeId = null)
     {
-        return (int) $this->configInterface->getValue(self::NUMBER_OF_JOB_TO_RUN, ScopeInterface::SCOPE_STORE, $storeId);
+        $nbJobs = (int) $this->configInterface->getValue(self::NUMBER_OF_JOB_TO_RUN, ScopeInterface::SCOPE_STORE, $storeId);
+        return max($nbJobs, 1);
     }
 
     public function getRetryLimit($storeId = null)

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -390,6 +390,7 @@ class ConfigHelper
     public function getNumberOfJobToRun($storeId = null)
     {
         $nbJobs = (int) $this->configInterface->getValue(self::NUMBER_OF_JOB_TO_RUN, ScopeInterface::SCOPE_STORE, $storeId);
+
         return max($nbJobs, 1);
     }
 


### PR DESCRIPTION
Fixes https://github.com/algolia/algoliasearch-magento-2/issues/1024