### PR TITLE
Remove composer self-update from circleCI quality tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
             - run:
                   name: Prepare environment
                   command: |
-                      sudo composer self-update
                       composer config http-basic.'repo.magento.com' ${MAGENTO_AUTH_USERNAME} ${MAGENTO_AUTH_PASSWORD}
                       composer install -n --prefer-dist --no-progress
                       sudo chown circleci:circleci ~/.composer/


### PR DESCRIPTION
For safety to mitigate issues with updates. 