### PR TITLE
Added CSP whitelisted hosts for Magento 2.3.5 or higher

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="polyfill" type="host">polyfill.io</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="algolia" type="host">*.algolia.net</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
**Summary**

In Magento 2.3.5 introduced Content Security Policies (CSP) and Magento also provides default configurations at the application level and for individual core modules that require extra configuration. By default, CSP is configured in report-only mode, but It adds in Browser console errors about non-whitelisted hosts and breaks Instant search  after switch to strict mode.

**Result**
Errors (notices) should be gone and Algolia search will work on Magento 2.3.5. 