### PR TITLE
Use current store id to get settings for replicas

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -346,7 +346,7 @@ class ProductHelper
 
         $replicas = [];
 
-        if ($this->configHelper->isInstantEnabled() || $this->configHelper->isBackendRenderingEnabled()) {
+        if ($this->configHelper->isInstantEnabled($storeId) || $this->configHelper->isBackendRenderingEnabled($storeId)) {
             $replicas = array_values(array_map(function ($sortingIndex) {
                 return $sortingIndex['name'];
             }, $sortingIndices));


### PR DESCRIPTION
**Summary**

While creating the replicas for sorting, the setting read is not correctly scoped and it can fail depending on other stores configuration.
