### PR TITLE
Update setUserToken to cap character length

### DIFF
--- a/Helper/InsightsHelper.php
+++ b/Helper/InsightsHelper.php
@@ -150,6 +150,7 @@ class InsightsHelper
     {
         $userToken = base64_encode('customer-' . $customer->getEmail() . '-' . $customer->getId());
         $userToken = 'aa-' . preg_replace('/[^A-Za-z0-9\-]/', '', $userToken);
+        $userToken = substr($userToken, 0, 64); // character limit
 
         try {
             $metaData = $this->cookieMetadataFactory->createPublicCookieMetadata()

--- a/Helper/InsightsHelper.php
+++ b/Helper/InsightsHelper.php
@@ -150,7 +150,7 @@ class InsightsHelper
     {
         $userToken = base64_encode('customer-' . $customer->getEmail() . '-' . $customer->getId());
         $userToken = 'aa-' . preg_replace('/[^A-Za-z0-9\-]/', '', $userToken);
-        $userToken = substr($userToken, 0, 64); // character limit
+        $userToken = mb_substr($userToken, 0, 64); // character limit
 
         try {
             $metaData = $this->cookieMetadataFactory->createPublicCookieMetadata()


### PR DESCRIPTION
HS Ticket: # 271958

To address this error message:
```
[2020-07-06 10:10:55] main.CRITICAL: UserToken must contain only alphanumeric, hyphen, or underscore characters, and be between 1 and 64 characters long {"exception":"[object] (Algolia\\AlgoliaSearch\\Exceptions\\BadRequestException(code: 422): UserToken must contain only alphanumeric, hyphen, or underscore characters, and be between 1 and 64 characters long at /var/www/www.clarosa.fr/web/vendor/algolia/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php:210)"} []
```