### PR TITLE
Set forwardToReplicas for copy rules to false

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -402,7 +402,7 @@ class AlgoliaHelper extends AbstractHelper
     public function copyQueryRules($fromIndexName, $toIndexName)
     {
         $res = $this->getClient()->copyRules($fromIndexName, $toIndexName, [
-            'forwardToReplicas'  => true,
+            'forwardToReplicas'  => false,
             'clearExistingRules' => true,
         ]);
 


### PR DESCRIPTION
We should not forward query rules to the replica indexes. 

HS Ticket #268254