### PR TITLE
Restore "search as you type" feature for v2

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -586,6 +586,33 @@ requirejs(['algoliaBundle', 'Magento_Catalog/js/price-utils'], function (algolia
 			};
 		}
 
+		if (!algoliaConfig.autocomplete.enabled) {
+			var customSearchBox = algoliaBundle.instantsearch.connectors.connectSearchBox(function(renderOptions, isFirstRendering) {
+				if (isFirstRendering) {
+					var input = document.querySelector(instant_selector);
+					var clearBtn = input.parentElement.getElementsByClassName('clear-query-autocomplete')[0];
+
+					input.addEventListener('input', function (event) {
+						var query = event.target.value;
+						renderOptions.refine(query);
+						if (query.length > 0) {
+							$(clearBtn).show();
+						} else {
+							$(clearBtn).hide();
+						}
+					});
+
+					clearBtn.addEventListener('click', function () {
+						renderOptions.refine('');
+						input.value = '';
+					});
+				}
+			});
+
+			delete allWidgetConfiguration['searchBox'];
+			allWidgetConfiguration.custom.push(customSearchBox());
+		}
+
 		allWidgetConfiguration = algolia.triggerHooks('beforeWidgetInitialization', allWidgetConfiguration, algoliaBundle);
 
 		$.each(allWidgetConfiguration, function (widgetType, widgetConfig) {

--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -595,17 +595,21 @@ requirejs(['algoliaBundle', 'Magento_Catalog/js/price-utils'], function (algolia
 					input.addEventListener('input', function (event) {
 						var query = event.target.value;
 						renderOptions.refine(query);
-						if (query.length > 0) {
-							$(clearBtn).show();
-						} else {
-							$(clearBtn).hide();
+						if (clearBtn) {
+							if (query.length > 0) {
+								$(clearBtn).show();
+							} else {
+								$(clearBtn).hide();
+							}
 						}
 					});
 
-					clearBtn.addEventListener('click', function () {
-						renderOptions.refine('');
-						input.value = '';
-					});
+					if (clearBtn) {
+						clearBtn.addEventListener('click', function () {
+							renderOptions.refine('');
+							input.value = '';
+						});
+					}
 				}
 			});
 

--- a/view/frontend/web/internals/autocomplete.css
+++ b/view/frontend/web/internals/autocomplete.css
@@ -379,3 +379,28 @@
     clear: both;
     content: '';
 }
+
+#algolia-searchbox {
+    position: relative;
+}
+
+#algolia-searchbox .clear-cross, #algolia_instant_selector .clear-cross {
+    position: absolute;
+    display: none;
+    background: url("data:image/svg+xml;utf8,<svg width=\'12\' height=\'12\' viewBox=\'0 0 12 12\' xmlns=\'http://www.w3.org/2000/svg\' opacity=\'0.6\'><path d=\'M.566 1.698L0 1.13 1.132 0l.565.566L6 4.868 10.302.566 10.868 0 12 1.132l-.566.565L7.132 6l4.302 4.3.566.568L10.868 12l-.565-.566L6 7.132l-4.3 4.302L1.13 12 0 10.868l.566-.565L4.868 6 .566 1.698z\'></path></svg>") no-repeat center center / contain;
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+}
+
+#algolia-searchbox .clear-query-autocomplete {
+    bottom: 8px;
+    right: 9px;
+}
+
+#algolia_instant_selector .cross-wrapper .clear-refinement {
+    display: block;
+    position: relative;
+    top: 5px;
+    left: 5px;
+}


### PR DESCRIPTION
In version 2.x, we upgrade instantsearch library from v2 -> v4. With this upgrade, the functionality of the searchBox widget has changed to only accept a container instead of using your own input field has it did before. This change was documented here:

https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/js/#searchbox

![Screenshot 2020-07-10 at 15 40 03](https://user-images.githubusercontent.com/7048136/87160693-a623d980-c2c3-11ea-9a47-c76b279ddddc.png)

With @eunjae-lee, we were able to restore this dropped feature by creating a customSearchBox.

HS Ticket: #271451