### PR TITLE
Reset the index connection on emulate to allow for different credentials per storeview

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -683,6 +683,9 @@ class Data
 
         $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
         $this->scopeCodeResolver->clean();
+        $this->storeManager->setCurrentStore($storeId);
+        $this->algoliaHelper->resetCredentialsFromConfig();
+
         $this->emulationRuns = true;
 
         $this->logger->stop('START EMULATION');


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

When having multiple stores, with different appId/key per store and using the queue runner, it can happen that one store index ends up in the wrong account, because the index connection is created only once at the start.

This resets the index connection between runs during store emulation, to make sure to use the right credentials.

It might be possible that some other type of operation needs a similar treatment, I'm still checking for that.
