### PR TITLE
Fix microdata on instantsearch

### DIFF
--- a/Block/Instant/Hit.php
+++ b/Block/Instant/Hit.php
@@ -41,6 +41,14 @@ class Hit extends Template
         return $this->priceKey;
     }
 
+    public function getCurrencyCode()
+    {
+        /** @var \Magento\Store\Model\Store $store */
+        $store = $this->_storeManager->getStore();
+
+        return $store->getCurrentCurrencyCode();
+    }
+
     public function getGroupId()
     {
         return $this->httpContext->getValue(CustomerContext::CONTEXT_GROUP);

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -903,11 +903,13 @@ class ConfigHelper
         foreach ($currencies as $currency) {
             $attributes[] = 'price.' . $currency . '.default';
             $attributes[] = 'price.' . $currency . '.default_tier';
+            $attributes[] = 'price.' . $currency . '.default_max';
             $attributes[] = 'price.' . $currency . '.default_formated';
             $attributes[] = 'price.' . $currency . '.default_original_formated';
             $attributes[] = 'price.' . $currency . '.default_tier_formated';
             $attributes[] = 'price.' . $currency . '.group_' . $groupId;
             $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_tier';
+            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_max';
             $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_formated';
             $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_tier_formated';
             $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_original_formated';

--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -90,6 +90,8 @@ abstract class ProductWithChildren extends ProductWithoutChildren
             $this->customData[$field][$currencyCode]['default'] = 0; // will be reset just after
         }
 
+        $this->customData[$field][$currencyCode]['default_max'] = $max;
+
         if ($this->areCustomersGroupsEnabled) {
             /** @var Group $group */
             foreach ($this->groups as $group) {
@@ -99,6 +101,8 @@ abstract class ProductWithChildren extends ProductWithoutChildren
                     $this->customData[$field][$currencyCode]['group_' . $groupId]               = 0;
                     $this->customData[$field][$currencyCode]['group_' . $groupId . '_formated'] = $dashedFormat;
                 }
+
+                $this->customData[$field][$currencyCode]['group_' . $groupId . '_max'] = $max;
             }
         }
     }

--- a/view/frontend/templates/instant/hit.phtml
+++ b/view/frontend/templates/instant/hit.phtml
@@ -14,10 +14,14 @@ $tierFormatedVar = $block->escapeHtml('price' . $priceKey . '_tier_formated');
 ?>
 
 <script type="text/template" id="instant-hit-template">
-    <div class="col-md-4 col-sm-6">
-        <div class="result-wrapper" itemprop="itemListElement" itemscope itemtype="http://schema.org/Product">
-            <a itemprop="url"
-                class="result"
+    <div class="col-md-4 col-sm-6" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <meta itemprop="position" content="{{__position}}" />
+        <div class="result-wrapper" itemprop="item" itemscope itemtype="http://schema.org/Product">
+            <meta itemprop="url"
+                {{^__queryID}} content="{{url}}" {{/__queryID}}
+                {{#__queryID}} content="{{urlForInsights}}" {{/__queryID}}
+                />
+            <a class="result"
                 {{^__queryID}} href="{{url}}" {{/__queryID}}
                 {{#__queryID}} href="{{urlForInsights}}" {{/__queryID}}
                 data-objectid="{{objectID}}"

--- a/view/frontend/templates/instant/hit.phtml
+++ b/view/frontend/templates/instant/hit.phtml
@@ -2,10 +2,14 @@
 
 /** @var \Algolia\AlgoliaSearch\Block\Instant\Hit $block */
 
-$priceKey = $block->getPriceKey();
+$priceKey     = $block->getPriceKey();
+$currencyCode = $block->getCurrencyCode();
 
-$origFormatedVar = 'price' . $priceKey . '_original_formated';
-$tierFormatedVar = 'price' . $priceKey . '_tier_formated'
+$baseVar         = $block->escapeHtml('price' . $priceKey);
+$maxVar          = $block->escapeHtml('price' . $priceKey . '_max');
+$baseFormatedVar = $block->escapeHtml('price' . $priceKey . '_formated');
+$origFormatedVar = $block->escapeHtml('price' . $priceKey . '_original_formated');
+$tierFormatedVar = $block->escapeHtml('price' . $priceKey . '_tier_formated');
 
 ?>
 
@@ -42,26 +46,37 @@ $tierFormatedVar = 'price' . $priceKey . '_tier_formated'
                                     </div>
                                 </div>
 
+
+                                {{^<?php echo $maxVar; ?>}}
+                                <div itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="price">
+                                    <meta itemprop="price" content="{{<?php echo $baseVar; ?>}}" />
+                                {{/<?php echo $maxVar; ?>}}
+                                {{#<?php echo $maxVar; ?>}}
                                 <div itemprop="offers" itemscope itemtype="http://schema.org/AggregateOffer" class="price">
+                                    <meta itemprop="lowPrice" content="{{<?php echo $baseVar; ?>}}" />
+                                    <meta itemprop="highPrice" content="{{<?php echo $maxVar; ?>}}" />
+                                {{/<?php echo $maxVar; ?>}}
+                                    <meta itemprop="priceCurrency" content="<?php echo $currencyCode; ?>" />
                                     <div class="price-wrapper">
                                         <div>
-                                            <span itemprop="lowPrice" class="after_special
-                                                    {{#<?php echo $block->escapeHtml($origFormatedVar); ?>}}
+
+                                            <span class="after_special
+                                                    {{#<?php echo $origFormatedVar; ?>}}
                                                         promotion
-                                                    {{/<?php echo $block->escapeHtml($origFormatedVar); ?>}}">
-                                                {{price<?php echo $block->escapeHtml($priceKey); ?>_formated}}
+                                                    {{/<?php echo $origFormatedVar; ?>}}">
+                                                {{<?php echo $baseFormatedVar; ?>}}
                                             </span>
-                                            {{#<?php echo $block->escapeHtml($origFormatedVar); ?>}}
-                                                <span itemprop="highPrice" class="before_special">
-                                                    {{<?php echo $block->escapeHtml($origFormatedVar); ?>}}
+                                            {{#<?php echo $origFormatedVar; ?>}}
+                                                <span class="before_special">
+                                                    {{<?php echo $origFormatedVar; ?>}}
                                                 </span>
-                                            {{/<?php echo $block->escapeHtml($origFormatedVar); ?>}}
-                                            {{#<?php echo $block->escapeHtml($tierFormatedVar); ?>}}
+                                            {{/<?php echo $origFormatedVar; ?>}}
+                                            {{#<?php echo $tierFormatedVar; ?>}}
                                                 <span class="tier_price">
                                                     <?php echo __('As low as') ?>
-                                                    <span class="tier_value">{{<?php echo $block->escapeHtml($tierFormatedVar); ?>}}</span>
+                                                    <span class="tier_value">{{<?php echo $tierFormatedVar; ?>}}</span>
                                                 </span>
-                                            {{/<?php echo $block->escapeHtml($tierFormatedVar); ?>}}
+                                            {{/<?php echo $tierFormatedVar; ?>}}
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
This PR fixes invalid values on the price metadata (price and currency should be separated and unformatted).

It also changes:
* separate Offer from AggregateOffer, for products with a single price or a range. Also, highPrice should not be used for price without discount (for that you need to create different offers with different validity dates or conditions)
* add required fields from Google analysis tool:
  * Proper formatting of ListItem (Product should be a child of it)
  * ListItem.position
  * Product.url

A different PR is needed to fix the correctness of the rest of the html, since `<button>` can't be a child of `<a>`