### PR TITLE
[magento2.4-requirements]:

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "version": "2.0.2",
   "require": {
     "php": "~7.0|~7.1|~7.2|~7.3",
-    "magento/framework": "~101.0|~102.0",
+    "magento/framework": "~101.0|~102.0|~103.0",
     "algolia/algoliasearch-client-php": "^2.4",
     "guzzlehttp/guzzle": "^6.3.3",
     "ext-json": "*",


### PR DESCRIPTION
- Added correct magento framework requirement for magento2.4


**Summary**
This PR adds the possibility to install the module with composer for Magento 2.4
