### PR TITLE
Get the correct id to use for the category

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -478,7 +478,7 @@ class CategoryHelper
 
     private function getCategoryById($categoryId)
     {
-        $categories = $this->getCoreCategories();
+        $categories = $this->getCoreCategories(false);
 
         return isset($categories[$categoryId]) ? $categories[$categoryId] : null;
     }


### PR DESCRIPTION
**Summary**

On a system where the category.row_id is not the same as the category.entity_id, if a subcategory has "include_in_menu"="No",
the products will get assigned the wrong category name (because the list is created with row_id but the lookup is done with entity_id), resulting in a mixed-up frontend


**Result**

The change makes sure that when looking for a category, we look at the full list.
I didn't found any other place that uses the filtered list (the category index uses a different function), so maybe we can just remove the parameter and associated logic from it.