### PR TITLE
remove less than IE9 condition from configuration template

### DIFF
--- a/view/frontend/templates/internals/configuration.phtml
+++ b/view/frontend/templates/internals/configuration.phtml
@@ -19,13 +19,3 @@ $configuration = $block->getConfiguration();
 
 	window.algoliaConfig = <?php /* @noEscape */ echo json_encode($configuration); ?>;
 </script>
-
-<!--[if lte IE 9]>
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        algoliaBundle.$(function () {
-            window.algoliaConfig.autofocus = false;
-        });
-    });
-</script>
-<![endif]-->


### PR DESCRIPTION
Having this condition here does more harm than good. Customers who have minified and strip HTML comments come across the algoliaBundle missing error often because of this script. 


Since we support IE 11 and higher, we should drop this. 