### PR TITLE
Instantsearch Category Filter when category facet is not configured

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -107,7 +107,6 @@ requirejs(['algoliaBundle', 'Magento_Catalog/js/price-utils'], function (algolia
 			}
 		}
 
-
 		instantsearchOptions = algolia.triggerHooks('beforeInstantsearchInit', instantsearchOptions, algoliaBundle);
 
 		var search = algoliaBundle.instantsearch(instantsearchOptions);

--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -100,6 +100,14 @@ requirejs(['algoliaBundle', 'Magento_Catalog/js/price-utils'], function (algolia
 			routing: window.routing,
 		};
 
+		if (algoliaConfig.request.path.length > 0 && window.location.hash.indexOf('categories.level0') === -1) {
+			if (algoliaConfig.areCategoriesInFacets === false) {
+				searchParameters['facetsRefinements'] = { };
+				searchParameters['facetsRefinements']['categories.level' + algoliaConfig.request.level] = [algoliaConfig.request.path];
+			}
+		}
+
+
 		instantsearchOptions = algolia.triggerHooks('beforeInstantsearchInit', instantsearchOptions, algoliaBundle);
 
 		var search = algoliaBundle.instantsearch(instantsearchOptions);


### PR DESCRIPTION
HS Ticket: 284619

Category Filtering when facet is not configured was removed accidentally in favour for UiState of the category facet. We need to add back this line to add facetParameters when facet is not configured for categories:

https://github.com/algolia/algoliasearch-magento-2/blob/1.13.2/view/frontend/web/instantsearch.js#L103-L112
