### PR TITLE
Add messaging for indexing queue and logs

### DIFF
--- a/view/adminhtml/layout/algolia_algoliasearch_queue_log.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_queue_log.xml
@@ -3,7 +3,7 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Backend\Block\Template" name="analytics.overview.form" template="Algolia_AlgoliaSearch::queue/log/helper.phtml" />
+            <block class="Magento\Backend\Block\Template" name="algolia.indexing.log.helper" template="Algolia_AlgoliaSearch::queue/log/helper.phtml" />
             <uiComponent name="algolia_algoliasearch_indexing_log_listing"/>
         </referenceContainer>
     </body>

--- a/view/adminhtml/layout/algolia_algoliasearch_queue_log.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_queue_log.xml
@@ -3,6 +3,7 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
+            <block class="Magento\Backend\Block\Template" name="analytics.overview.form" template="Algolia_AlgoliaSearch::queue/log/helper.phtml" />
             <uiComponent name="algolia_algoliasearch_indexing_log_listing"/>
         </referenceContainer>
     </body>

--- a/view/adminhtml/templates/queue/log/helper.phtml
+++ b/view/adminhtml/templates/queue/log/helper.phtml
@@ -1,0 +1,9 @@
+<div class="indexing-queue-logs-message algoblue">
+    <div class="inner">
+        <p>To determine how well your indexing queue is performing, you can review the <code>`algoliasearch_queue_log`</code> table in your database. Each row represents a process of the <code>`algolia_queue_runner`</code> indexer, whether it comes from the cronjob or a manual run.</p>
+
+        <p>The <strong><code>`duration`</code></strong> column is represented in seconds. This duration should be at least a minute shorter than your cronjob interval. For instance, if you have the cronjob set to every 5 minutes, the duration at most should be less than 4 minutes (or 240 seconds). This accounts for any extra processing time.</p>
+
+        <p>If you’re performing over the recommended time, we recommend that you reduce the number of processed jobs and follow the documentation on <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link&language=php#configuring-the-queue">how to optimise your indexing queue</a>.</p>
+    </div>
+</div>

--- a/view/adminhtml/templates/queue/status.phtml
+++ b/view/adminhtml/templates/queue/status.phtml
@@ -37,4 +37,9 @@
             <?php endforeach; ?>
         </div>
     </div>
+    <div class="indexing-queue-logs-message algoblue">
+        <div class="inner">
+            <p><?php echo __('See how well your indexing queue is performing by viewing your %1.', '<a href="' . $block->getUrl('*/*/log') . '">indexing queue run logs</a>') ?></p>
+        </div>
+    </div>
 <?php endif; ?>

--- a/view/adminhtml/web/css/common.css
+++ b/view/adminhtml/web/css/common.css
@@ -434,7 +434,8 @@
 	margin-bottom : 0;
 }
 
-.algolia-notice {
+.algolia-notice,
+.notice.algolia-notice {
 	margin-bottom: 2rem;
 }
 
@@ -563,7 +564,23 @@ form[action*="algoliasearch"] .accordion .config .value {
 	margin-bottom: 20px;
 }
 
-.algoblue{
+.algoblue {
 	background-color: #F5FAFD;
 	border: 1px solid #E2F0FA;
+}
+
+.indexing-queue-logs-message {
+	padding: 20px 20px;
+	margin-bottom: 20px;
+}
+.indexing-queue-logs-message .inner {
+	max-width: 1250px;
+	width: 100%;
+}
+
+.indexing-queue-logs-message p {
+	margin-bottom: 15px;
+}
+.indexing-queue-logs-message p:last-child {
+	margin-bottom: 0;
 }


### PR DESCRIPTION
To help with the support initiatives to improve how to read indexing queue logs to guide customers on optimising their indexing queue. 