### PR TITLE
Backport: Added algolia/algoliasearch-inventory-magento-2 to suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "ext-dom": "*"
   },
   "suggest": {
-      "algolia/algoliasearch-magento-2-es-compatibility": "Algolia Search ES Compatibility module for Magento >=2.3.1|>=2.2.8"
+      "algolia/algoliasearch-magento-2-es-compatibility": "Algolia Search ES Compatibility module for Magento >=2.3.1|>=2.2.8",
+      "algolia/algoliasearch-inventory-magento-2": "Algolia Search Inventory module for Magento 2.3.x and Algolia Search 1.12+ extension"
   },
   "repositories": [
     {


### PR DESCRIPTION
Backport to 2.x from PR #1040 