### PR TITLE
Set  ACL resource titles are translatable.

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -4,12 +4,12 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::system">
-                    <resource id="Algolia_AlgoliaSearch::manage" title="Algolia Search" sortOrder="99999" />
+                    <resource id="Algolia_AlgoliaSearch::manage" title="Algolia Search" translate="title" sortOrder="99999" />
                 </resource>
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">
-                            <resource id="Algolia_AlgoliaSearch::algolia_algoliasearch" title="Algolia Search"/>
+                            <resource id="Algolia_AlgoliaSearch::algolia_algoliasearch" title="Algolia Search" translate="title"/>
                         </resource>
                     </resource>
                 </resource>


### PR DESCRIPTION
Hi!

It's available since Magento 2.1.3 and translate ACL resource label in the tree to selected Admin locale. For ex, for Norwegain "Algolia søk", or "Algolia" for another locales.
ofc, It'll be great to port this thing to 2.0.x version too.

Please review,