### PR TITLE
Remove PHP requirements from Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
   "license": ["MIT"],
   "version": "2.0.2",
   "require": {
-    "php": "~7.1|~7.2|~7.3|~7.4",
     "magento/framework": "~102.0|~103.0",
     "algolia/algoliasearch-client-php": "^2.4",
     "guzzlehttp/guzzle": "^6.3.3",


### PR DESCRIPTION
Supported PHP are described in magento/framework requirements so no need to duplicate these list twice.