### PR TITLE
Exclude category facet from clearRefinement on category pages

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -302,7 +302,9 @@ requirejs(['algoliaBundle', 'Magento_Catalog/js/price-utils'], function (algolia
 					resetLabel: algoliaConfig.translations.clearAll,
 				},
 				includedAttributes: attributes.map(function (attribute) {
-					return attribute.name
+					if (!(algoliaConfig.isCategoryPage && attribute.name.indexOf('categories') > -1)) {
+						return attribute.name;
+					}
 				}),
 				cssClasses: {
 					button: ['action', 'primary']


### PR DESCRIPTION
JIRA Ticket: [MAGE-48] exclude category facets from clearRefinement on category page
HS Ticket: #289608

Test Cases:

/category
- enable category facet for instantsearch and instantsearch on category pages
- go to any category page
- filter on another attribute like color
- hit clear all 

Expected result is that category filter should not be removed from clearRefinment action on category pages. 

/catalogsearch/results
- enable category facet for instantsearch
- go to search results page
- filter on another attribute like color
- hit clear all 

Expected result should clear all filters including category filter

[MAGE-48]: https://algolia.atlassian.net/browse/MAGE-48