### PR TITLE
Bugfix: Configurable product with broken image when set to "no_selection"

### DIFF
--- a/Helper/Image.php
+++ b/Helper/Image.php
@@ -88,7 +88,9 @@ class Image extends \Magento\Catalog\Helper\Image
     private function getProductImage(\Magento\Catalog\Model\Product\Image $model)
     {
         $imageUrl = $this->getProduct()->getData($model->getDestinationSubdir());
-        if (($imageUrl === null || $imageUrl == '') && $this->getProduct()->getTypeId() == ProductTypeConfigurable::TYPE_CODE) {
+        if (($imageUrl === null || $imageUrl == '' || $imageUrl == 'no_selection') && 
+            $this->getProduct()->getTypeId() == ProductTypeConfigurable::TYPE_CODE) 
+        {
             $imageUrl = $this->getType() !== 'image' && $this->getConfigurableProductImage() ?
                 $this->getConfigurableProductImage() : $this->getProduct()->getImage();
         }


### PR DESCRIPTION
**Summary**

Currently when a config product image is set to "no_selection" it will not look at the images of the child product to determine to images of the product.

**Result**

With the change the behaviour is as expected. 