### PR TITLE
Add tags for merchandising queries to use VM if applicable

### DIFF
--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -54,12 +54,16 @@ class MerchandisingHelper
             $condition['pattern'] = $query;
         }
 
-        if (! is_null($banner)) {
+        if (!is_null($banner)) {
             $rule['consequence']['userData']['banner'] = $banner;
         }
 
         if ($entityType == 'query') {
             unset($condition['context']);
+        }
+
+        if (in_array($entityType, ['query', 'landingpage'])) {
+            $rule['tags'] = ['visual-editor'];
         }
 
         $rule['conditions'] = [$condition];


### PR DESCRIPTION
[MAGE-63] Add rules tag for visual editor on Query Merchandising and Landing Page Builder features

This will allow the usage of the Visual Editor, if added to customer plan. Adding the visual editor tag will not effect rules for customers who do not have the Visual Editor enabled. 

**NOTE:**
Customers should know that if you edit the rule in the Algolia Dashboard, advanced options other than promote are not supported in the extension. Editing the rule in Magento will override changes in made in Algolia. Adding advance options means that the rule should only be edited in Algolia moving forward. 

[MAGE-63]: https://algolia.atlassian.net/browse/MAGE-63