### PR TITLE
infiniteHits update showMoreLabel to showMoreText

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -344,6 +344,7 @@ requirejs(['algoliaBundle', 'Magento_Catalog/js/price-utils'], function (algolia
 				templates: {
 					empty: '',
 					item: $('#instant-hit-template').html(),
+					showMoreText: algoliaConfig.translations.showMore
 				},
 				cssClasses: {
 					loadPrevious: ['action', 'primary'],
@@ -358,7 +359,6 @@ requirejs(['algoliaBundle', 'Magento_Catalog/js/price-utils'], function (algolia
 						return item;
 					});
 				},
-				showMoreLabel: algoliaConfig.translations.showMore,
 				showPrevious: true,
 				escapeHits: true
 			};


### PR DESCRIPTION
Community member identified that the showMoreLabel was updated in ISv4 to templates.showMoreText. This has been corrected. 


https://discourse.algolia.com/t/showmorelabel-not-translatable-since-instantsearch-v3-magento-2/11337

