### PR TITLE
Insights Analytics - Fix Add to Cart Conversion

### DIFF
--- a/Model/Observer/Insights/CheckoutCartProductAddBefore.php
+++ b/Model/Observer/Insights/CheckoutCartProductAddBefore.php
@@ -36,13 +36,8 @@ class CheckoutCartProductAddBefore implements ObserverInterface
         /** @var \Magento\Catalog\Model\Product $product */
         $product = $observer->getEvent()->getProduct();
         $requestInfo = $observer->getEvent()->getInfo();
-
-        if (!$this->configHelper->isClickConversionAnalyticsEnabled($product->getStoreId())
-            || $this->configHelper->getConversionAnalyticsMode($product->getStoreId()) !== 'place_order') {
-            return;
-        }
-
-        if (isset($requestInfo['queryID']) && $requestInfo['queryID'] == '') {
+        
+        if (isset($requestInfo['queryID']) && $requestInfo['queryID'] != '') {
             $product->setData('queryId', $requestInfo['queryID']);
         }
     }

--- a/Model/Observer/Insights/CheckoutCartProductAddBefore.php
+++ b/Model/Observer/Insights/CheckoutCartProductAddBefore.php
@@ -36,7 +36,7 @@ class CheckoutCartProductAddBefore implements ObserverInterface
         /** @var \Magento\Catalog\Model\Product $product */
         $product = $observer->getEvent()->getProduct();
         $requestInfo = $observer->getEvent()->getInfo();
-        
+
         if (isset($requestInfo['queryID']) && $requestInfo['queryID'] != '') {
             $product->setData('queryId', $requestInfo['queryID']);
         }

--- a/view/frontend/web/insights/add-to-cart-mixin.js
+++ b/view/frontend/web/insights/add-to-cart-mixin.js
@@ -6,7 +6,7 @@ define(['jquery'], function ($) {
         submitForm: function (form) {
             if (window.algoliaConfig
                 && algoliaConfig.ccAnalytics.enabled
-                && algoliaConfig.ccAnalytics.conversionAnalyticsMode == 'place_order'
+                && algoliaConfig.ccAnalytics.conversionAnalyticsMode != 'disabled'
             ) {
                 this._setQueryIdToForm(form)
             }


### PR DESCRIPTION
- Set the queryId value on product if add to cart form contains a queryID value. 
- Add to cart mixin should always add queryID for both add to cart and place order conversion. 