### PR TITLE
Remove ES compat from suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "ext-dom": "*"
   },
   "suggest": {
-      "algolia/algoliasearch-magento-2-es-compatibility": "Algolia Search ES Compatibility module for Magento >=2.3.1|>=2.2.8",
       "algolia/algoliasearch-inventory-magento-2": "Algolia Search Inventory module for Magento 2.3.x and Algolia Search 1.12+ extension"
   },
   "repositories": [


### PR DESCRIPTION
The ES compatibility module was experimental. Currently is not compatible for ES7 adapter. Will add back when it's updated at some point. For now, we will remove it. 