### PR TITLE
Remove image URL manipulation

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -295,9 +295,6 @@ class CategoryHelper
         ];
 
         if (!empty($imageUrl)) {
-            $imageUrl = $this->imageHelper->removeProtocol($imageUrl);
-            $imageUrl = $this->imageHelper->removeDoubleSlashes($imageUrl);
-
             $data['image_url'] = $imageUrl;
         }
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -735,11 +735,7 @@ class ProductHelper
                 $images = $product->getMediaGalleryImages();
                 if ($images) {
                     foreach ($images as $image) {
-                        $url = $image->getUrl();
-                        $url = $this->imageHelper->removeProtocol($url);
-                        $url = $this->imageHelper->removeDoubleSlashes($url);
-
-                        $customData['media_gallery'][] = $url;
+                        $customData['media_gallery'][] = $image->getUrl();
                     }
                 }
             }

--- a/Helper/Image.php
+++ b/Helper/Image.php
@@ -52,9 +52,6 @@ class Image extends \Magento\Catalog\Helper\Image
             $url = $this->getDefaultPlaceholderUrl();
         }
 
-        $url = $this->removeProtocol($url);
-        $url = $this->removeDoubleSlashes($url);
-
         if ($this->configHelper->shouldRemovePubDirectory()) {
             $url = $this->removePubDirectory($url);
         }
@@ -107,19 +104,6 @@ class Image extends \Magento\Catalog\Helper\Image
         }
 
         return null;
-    }
-
-    public function removeProtocol($url)
-    {
-        return str_replace(['https://', 'http://'], '//', $url);
-    }
-
-    public function removeDoubleSlashes($url)
-    {
-        $url = str_replace('//', '/', $url);
-        $url = '/' . $url;
-
-        return $url;
     }
 
     public function removePubDirectory($url)

--- a/Test/Integration/ProductsIndexingTest.php
+++ b/Test/Integration/ProductsIndexingTest.php
@@ -81,44 +81,6 @@ class ProductsIndexingTest extends IndexingTestCase
         $this->assertEmpty($hit, 'Extra products attributes (' . $extraAttributes . ') are indexed and should not be.');
     }
 
-    public function testNoProtocolImageUrls()
-    {
-        $additionAttributes = $this->configHelper->getProductAdditionalAttributes();
-        $additionAttributes[] = [
-            'attribute' => 'media_gallery',
-            'searchable' => '0',
-            'retrievable' => '1',
-            'order' => 'unordered',
-        ];
-
-        $this->setConfig(
-            'algoliasearch_products/products/product_additional_attributes',
-            $this->getSerializer()->serialize($additionAttributes)
-        );
-
-        /** @var Product $indexer */
-        $indexer = $this->getObjectManager()->create(Product::class);
-        $indexer->executeRow($this->getValidTestProduct());
-
-        $this->algoliaHelper->waitLastTask();
-
-        $results = $this->algoliaHelper->getObjects($this->indexPrefix . 'default_products', [$this->getValidTestProduct()]);
-        $hit = reset($results['results']);
-
-        if (!$hit || !array_key_exists('image_url', $hit)) {
-            $this->markTestIncomplete('Hit was not returned correctly from Algolia. No Hit to run assetions on.');
-        }
-
-        $this->assertStringStartsWith('//', $hit['image_url']);
-        $this->assertStringStartsWith('//', $hit['thumbnail_url']);
-
-        $this->assertArrayHasKey('media_gallery', $hit);
-
-        foreach ($hit['media_gallery'] as $galleryImageUrl) {
-            $this->assertStringStartsWith('//', $galleryImageUrl);
-        }
-    }
-
     public function testNoSpecialPrice()
     {
         /** @var Product $indexer */


### PR DESCRIPTION
**Summary**

`removeProtocol()` should not be required. This was introduced in 2017 when both HTTP & HTTPS were in general use. Nowadays, only HTTPS is in general use for ecommerce websites. Browsers will typically display passive mixed content such
as images. If websites are having trouble with mixed content this will not be only because of Algolia search.
https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content
See also #211

`removeDoubleSlashes()` is introducing a bug: a URL which is a full path only is having an additional slash added to the start, producing a valid-but-wrong URL. For example, '/media//wysiwyg//search.png' becomes '//media/wysiwyg/search.png'. Browsers cope just fine with URLs containing multiple slashes, so no manipulation is required here.
See also #234

**Result**

Better handling of image URLs.