### PR TITLE
Fix Landing Page Builder feature wysiwyg/pagebuilder editor

### DIFF
--- a/view/adminhtml/layout/algolia_algoliasearch_landingpage_edit.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_landingpage_edit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="editor"/>
     <head>
         <css src="Algolia_AlgoliaSearch::css/landing-page.css"/>
     </head>


### PR DESCRIPTION
Added missing handle for cms editor layout needed for pagebuilder.


As you can see in: vendor/magento/module-page-builder/view/adminhtml/layout/editor.xml
```
<referenceContainer name="before.body.end">
    <uiComponent name="pagebuilder_modal_form" />
</referenceContainer>
```

We are missing the modal form at the bottom for the UI to toggle the aside editor. 

Solution was to add update handle to the LPB layout:
```
<update handle="editor"/>
```

This is tested in commerce and community 2.3
