### PR TITLE
Autocomplete add new hook for product source search options

### DIFF
--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -7,7 +7,8 @@ var algolia = {
 		'beforeWidgetInitialization',
 		'beforeInstantsearchStart',
 		'afterInstantsearchStart',
-		'afterInsightsBindEvents'
+		'afterInsightsBindEvents',
+		'beforeAutocompleteProductSourceOptions'
 	],
 	registeredHooks: [],
 	registerHook: function (hookName, callback) {
@@ -214,6 +215,8 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 				options.facets = ['categories.level0'];
 				options.numericFilters = 'visibility_search=1';
 				options.ruleContexts = ['magento_filters', '']; // Empty context to keep BC for already create rules in dashboard
+
+				options = algolia.triggerHooks('beforeAutocompleteProductSourceOptions', options);
 
 				source =  {
 					source: $.fn.autocomplete.sources.hits(algolia_client.initIndex(algoliaConfig.indexName + "_" + section.name), options),


### PR DESCRIPTION
Add the ability to modify search options for autocomplete product source to allow ease of customisation. 

New event: `beforeAutocompleteProductSourceOptions` 