### PR TITLE
Fix insights missing indexName for autocomplete sections

### DIFF
--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -292,6 +292,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 
 							hit.displayKey = hit.displayKey || hit.name;
 
+							hit.__indexName = algoliaConfig.indexName + "_" + section.name;
 							hit.__queryID = payload.queryID;
 							hit.__position = payload.hits.indexOf(hit) + 1;
 
@@ -336,6 +337,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 							var toEscape = hit._highlightResult.query.value;
 							hit._highlightResult.query.value = algoliaBundle.autocomplete.escapeHighlightedString(toEscape);
 
+							hit.__indexName = algoliaConfig.indexName + "_" + section.name;
 							hit.__queryID = payload.queryID;
 							hit.__position = payload.hits.indexOf(hit) + 1;
 
@@ -355,6 +357,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 						suggestion: function (hit, payload) {
 							hit.url = algoliaConfig.baseUrl + '/catalogsearch/result/?q=' + hit.value + '&refinement_key=' + encodeURIComponent(section.name);
 
+							hit.__indexName = algoliaConfig.indexName + "_section_" + section.name;
 							hit.__queryID = payload.queryID;
 							hit.__position = payload.hits.indexOf(hit) + 1;
 


### PR DESCRIPTION
HS Ticket # 338995

Missing `__indexName` hit param for autocomplete sections: categories, suggestions, and additional sections indexes. This corrects the insights error on those items for click analytics. 
