### PR TITLE
Add small change on category indexing for Enterprise Edition

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -465,6 +465,7 @@ class CategoryHelper
 
         if ($this->getCorrectIdColumn() === 'row_id') {
             $category = $this->getCategoryById($categoryId);
+
             return $category ? $category->getRowId() : null;
         }
 

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -465,9 +465,7 @@ class CategoryHelper
 
         if ($this->getCorrectIdColumn() === 'row_id') {
             $category = $this->getCategoryById($categoryId);
-            if ($category) {
-                $categoryKeyId = $category->getRowId();
-            }
+            return $category ? $category->getRowId() : null;
         }
 
         return $categoryKeyId;


### PR DESCRIPTION
Prevents a bug related to confusion between row_id and entity_id in case category isn't fetched (can happen if it's a root category) #337360