### PR TITLE
Fix missing 'out of' translation on search results page

### DIFF
--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -36,6 +36,7 @@ Go,Go
 "See products in","See products in"
 "All departments","All departments"
 "or in","or in"
+"out of","out of"
 "
                 
                     Algolia Search

--- a/view/frontend/templates/instant/stats.phtml
+++ b/view/frontend/templates/instant/stats.phtml
@@ -2,7 +2,7 @@
     {{#hasOneResult}}<strong>1</strong> <?php echo $block->escapeHtml(__('result')); ?> found{{/hasOneResult}}
 
     {{#hasManyResults}}
-        {{^hasNoResults}}{{first}}-{{last}} out of{{/hasNoResults}}
+        {{^hasNoResults}}{{first}}-{{last}} <?= __("out of")?>{{/hasNoResults}}
         <strong>
             <span itemprop="numberOfItems">{{nbHits}}</span>
             <?php echo $block->escapeHtml(__('results found')); ?>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
Fixes untranslatable "out of" string on the search results page.
<img width="1260" alt="Screenshot 2021-03-17 at 09 38 39" src="https://user-images.githubusercontent.com/6631170/111439273-7b690b00-8705-11eb-8bfe-1254fd20d01a.png">

**Result**
<img width="1261" alt="Screenshot 2021-03-17 at 09 44 34" src="https://user-images.githubusercontent.com/6631170/111439307-83c14600-8705-11eb-904e-c8cf837d6918.png">

