### PR TITLE
Add additional attributes for customer groups 

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -889,6 +889,8 @@ class ConfigHelper
             'in_stock',
             'type_id',
             'value',
+            'query', # suggestions
+            'path', # categories
         ]);
 
         $currencies = $this->dirCurrency->getConfigAllowCurrencies();


### PR DESCRIPTION
If customer groups are enabled, the generatedAPI key filters need to include the attributes for autocomplete indexes as well. 

We shouldn't have the same generatedAPIKey for all datasets in autocomplete so this is a quickfix and needs to be evaluated later. 