### PR TITLE
Product URL Model: Check request path to empty

### DIFF
--- a/Model/Product/Url.php
+++ b/Model/Product/Url.php
@@ -62,7 +62,7 @@ class Url extends ProductUrl
             $routeParams['_scope'] = $urlDataObject->getStoreId();
         } else {
             $requestPath = $product->getRequestPath();
-            if ($requestPath === '') {
+            if (empty($requestPath) && $requestPath !== false) {
                 $filterData = [
                     UrlRewrite::ENTITY_ID   => $product->getId(),
                     UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,


### PR DESCRIPTION
Hi!

In some cases   $product->getRequestPath() returns as NULL and URL Rewrite isn't loaded for product. As result, product gets url with /catalog/product/view/id/*** format. I suggest to use the same expression as in original file and
 check to empty value. 

Please review,