### PR TITLE
add missing label for queue method rebuildCategoryIndex

### DIFF
--- a/Model/Source/JobMethods.php
+++ b/Model/Source/JobMethods.php
@@ -9,6 +9,7 @@ class JobMethods implements \Magento\Framework\Data\OptionSourceInterface
         'moveIndexWithSetSettings' => 'Move Index',
         'deleteObjects' => 'Object deletion',
         'rebuildStoreCategoryIndex' => 'Category Reindex',
+        'rebuildCategoryIndex' => 'Category Reindex',
         'rebuildStoreProductIndex' => 'Product Reindex',
         'rebuildProductIndex' => 'Product Reindex',
         'rebuildStoreAdditionalSectionsIndex' => 'Additional Section Reindex',


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
Label map for queue method `rebuildCategoryIndex` is missing as a result, the queue job list method name is blank.
![Screen Shot 2021-05-21 at 12 37 22 PM](https://user-images.githubusercontent.com/5461675/119087775-de428f80-ba31-11eb-9740-8804c35ef9d9.png)
 
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
![Screen Shot 2021-05-21 at 12 42 15 PM](https://user-images.githubusercontent.com/5461675/119087873-fd412180-ba31-11eb-9ed2-4316b10fafd0.png)

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->