### PR TITLE
Unfilter getCoreCategories() from private getCategoryById() 

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -470,7 +470,7 @@ class CategoryHelper
 
     private function getCategoryById($categoryId)
     {
-        $categories = $this->getCoreCategories();
+        $categories = $this->getCoreCategories(false);
 
         return isset($categories[$categoryId]) ? $categories[$categoryId] : null;
     }


### PR DESCRIPTION
HS Ticket: #380520

If customer has disabled filtering Include in Category attribute for categories, the path names for these category types are coming up empty. Need to get categories regardless of this status by getting unfiltered core categories in `getCategoryById()` method. 