### PR TITLE
Store scope Category Merchandising

### DIFF
--- a/Model/Observer/Merchandising.php
+++ b/Model/Observer/Merchandising.php
@@ -38,8 +38,15 @@ class Merchandising implements ObserverInterface
 
         $positions = json_decode($positions, true);
 
+        $storeId = $this->request->getParam('store_id');
+        if ($storeId > 0) {
+            $stores[] = $this->storeManager->getStore($storeId);
+        } else {
+            $stores = $this->storeManager->getStores();
+        }
+
         try {
-            foreach ($this->storeManager->getStores() as $store) {
+            foreach ($stores as $store) {
                 if (!$store->getIsActive()) {
                     continue;
                 }


### PR DESCRIPTION
**Summary**
HS Ticket # 381786

Category Merchandising is not store scoped. Will save all store views with changes regardless of scope. 

**Result**
Event observer `\Algolia\AlgoliaSearch\Model\Observer\Merchandising` will now scope changes to the correct storeview, if selected. If no storeview, it will save to all. 