### PR TITLE
Fix/subproduct image data

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -879,6 +879,11 @@ class ProductHelper
                 $this->configHelper->getImageHeight()
             );
 
+        $subImage = $subProduct->getData($image->getType());
+        if (!$subImage || $subImage === 'no_selection') {
+            return $subProductImages;
+        }
+
         try {
             $textValueInLower = mb_strtolower($valueText, 'utf-8');
             $subProductImages[$textValueInLower] = $image->getUrl();

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -829,7 +829,10 @@ class ProductHelper
                 $valueText = $subProduct->getAttributeText($attributeName);
 
                 $values = array_merge($values, $this->getValues($valueText, $subProduct, $attributeResource));
-                $subProductImages = $this->addSubProductImage($subProductImages, $attribute, $subProduct, $valueText);
+                if ($this->configHelper->useAdaptiveImage($attributeResource->getStoreId())) {
+                    $subProductImages = $this->addSubProductImage($subProductImages, $attribute, $subProduct,
+                        $valueText);
+                }
             }
         }
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -869,11 +869,6 @@ class ProductHelper
             return $subProductImages;
         }
 
-        $subImage = $subProduct->getData($this->configHelper->getImageType());
-        if (!$subImage || $subImage === 'no_selection') {
-            return $subProductImages;
-        }
-
         $image = $this->imageHelper
             ->init($subProduct, $this->configHelper->getImageType())
             ->resize(


### PR DESCRIPTION
**Summary**
HS Ticket # 384812

Method `\Algolia\AlgoliaSearch\Helper\Entity\ProductHelper::addSubProductImage()` checks to see if the subproduct data contains the configured image theme attribute. It's a mystery as to why it subproduct data model will contain `product_*` image attribute and sometimes it returns as NULL. 

I have updated the condition to check the correct image type attribute. Additionally, I have added a check to see if "Use Adaptive Images" is enabled before trying to index subproduct image data.

**Result**
Should only index subproduct image data if "Use Adaptive Images" is enabled and if product data contains the correct image type. 