### PR TITLE
Set visibility of getTaxPrice() to public in ProductWithoutChildren

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
@@ -132,7 +132,7 @@ abstract class ProductWithoutChildren
         return $this->priceCurrency->convert($amount, $this->store, $currencyCode);
     }
 
-    protected function getTaxPrice($product, $amount, $withTax)
+    public function getTaxPrice($product, $amount, $withTax)
     {
         return (float) $this->catalogHelper->getTaxPrice(
             $product,


### PR DESCRIPTION
**Summary**
Makes it possible to create plugins instead of creating a preference for alle classes it extends. Will improve further customization of data.

**Result**
Possibility to create plugin instead of multiple preferences.