### PR TITLE
Configurable product catalog price rule 

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -22,6 +22,10 @@ abstract class ProductWithChildren extends ProductWithoutChildren
 
         if (!$this->customData[$field][$currencyCode]['default']) {
             $this->handleZeroDefaultPrice($field, $currencyCode, $min, $max);
+
+            # need to rehandle specialPrice
+            $specialPrice = $this->getSpecialPrice($product, $currencyCode, $withTax);
+            $this->addSpecialPrices($specialPrice, $field, $currencyCode);
         }
 
         if ($this->areCustomersGroupsEnabled) {


### PR DESCRIPTION
Issue with configurable product catalog price rule regarding special price where default price is zero and special price isn't set correctly. Chose to re add special price after min/max set. WDYT? 