### PR TITLE
Implement multi threaded indexer

### DIFF
--- a/Setup/Patch/Schema/AddStoreColumnWithIndex.php
+++ b/Setup/Patch/Schema/AddStoreColumnWithIndex.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * Copyright © Reach Digital (https://www.reachdigital.io/)
+ * See LICENSE.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Algolia\AlgoliaSearch\Setup\Patch\Schema;
+
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Setup\Patch\SchemaPatchInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+
+class AddStoreColumnWithIndex implements SchemaPatchInterface
+{
+    /** @var SchemaSetupInterface $schemaSetup */
+    private $schemaSetup;
+
+    /**
+     * @param SchemaSetupInterface $schemaSetup
+     */
+    public function __construct(SchemaSetupInterface $schemaSetup)
+    {
+        $this->schemaSetup = $schemaSetup;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply()
+    {
+        $connection = $this->schemaSetup->getConnection();
+        $connection->startSetup();
+
+        $connection->addColumn($this->schemaSetup->getTable('algoliasearch_queue'), 'store_id', [
+            'type'     => \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+            'unsigned' => true,
+            'nullable' => true,
+            'comment'  => 'Store ID'
+        ]);
+
+        $connection->addForeignKey(
+            $this->schemaSetup->getFkName(
+                $this->schemaSetup->getTable('algoliasearch_queue'),
+                'store_id',
+                $this->schemaSetup->getTable('store'),
+                'store_id'
+            ),
+            $this->schemaSetup->getTable('algoliasearch_queue'),
+            'store_id',
+            $this->schemaSetup->getTable('store'),
+            'store_id'
+        );
+
+        $connection->addIndex(
+            $this->schemaSetup->getTable('algoliasearch_queue'),
+            $this->schemaSetup->getIdxName(
+                $this->schemaSetup->getTable('algoliasearch_queue'),
+                ['locked_at'],
+                AdapterInterface::INDEX_TYPE_INDEX
+            ),
+            ['locked_at'],
+            AdapterInterface::INDEX_TYPE_INDEX
+        );
+        $connection->addIndex(
+            $this->schemaSetup->getTable('algoliasearch_queue'),
+            $this->schemaSetup->getIdxName(
+                $this->schemaSetup->getTable('algoliasearch_queue'),
+                ['pid'],
+                AdapterInterface::INDEX_TYPE_INDEX
+            ),
+            ['pid'],
+            AdapterInterface::INDEX_TYPE_INDEX
+        );
+
+        $connection->endSetup();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -523,17 +523,21 @@
                             If enabled, all indexing operations (add, remove & update operations) will be done asynchronously using the CRON mechanism.<br>
                             <br>
                             To schedule the run you need to add this in your crontab:<br>
-                            <code>*/5 * * * * php /absolute/path/to/magento/bin/magento indexer:reindex algolia_queue_runner</code>
-                            <br><span class="algolia-config-warning">&#9888;</span> Enabling this option is recommended in production or if your store has a lot of products.
+                            <code>*/5 * * * * php /absolute/path/to/magento/bin/magento indexer:reindex algolia_queue_runner</code><br>
+                            <br>
+                            To executes queue indexer across multiple threads add this in your crontab:<br>
+                            <code>*/5 * * * * MAGE_INDEXER_THREADS_COUNT=x php /absolute/path/to/magento/bin/magento indexer:reindex algolia_queue_runner</code><br>
+                            where "x" is the amount of threads.<br>
+                            <span class="algolia-config-warning">&#9888;</span> Enabling this option is recommended in production or if your store has a lot of products.
                         ]]>
                     </comment>
                 </field>
                 <field id="number_of_job_to_run" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <validate>validate-digits</validate>
-                    <label>Number of jobs to run each time the cron is run</label>
+                    <label>Number of jobs to run each time the indexer is run</label>
                     <comment>
                         <![CDATA[
-                            Number of queued jobs to run each time the cron is launched. Default value is 5.
+                            Number of queued jobs to run each time the indexer is launched. Default value is 5.
                             <br><span class="algolia-config-warning">&#9888;</span> Each time the cron runs it will process ("Max number of element per indexing job" * "Number of jobs to run each time the cron is run")
                             products.
                         ]]>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -27,6 +27,12 @@
     <preference for="Algolia\AlgoliaSearch\Api\Data\LandingPageInterface" type="Algolia\AlgoliaSearch\Model\LandingPage" />
     <preference for="Algolia\AlgoliaSearch\Api\Data\QueryInterface" type="Algolia\AlgoliaSearch\Model\Query" />
 
+    <type name="Algolia\AlgoliaSearch\Model\Indexer\QueueRunner">
+        <arguments>
+            <argument name="threadsCount" xsi:type="init_parameter">Magento\Indexer\Model\ProcessManager::THREADS_COUNT</argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
         <arguments>
             <argument name="collections" xsi:type="array">


### PR DESCRIPTION
**Summary**
Queue is too slow when data is changed 24/7. I've implemented the ability to use multiple threads to improve indexation speed. PR is open to discussion so let me know what you think. Also, everyone is free to make code changes.

**Todo**
- [x] How to deal with `moveIndexWithSetSettings` method. When executing a full reindex over multiple threads it's possible that the `moveIndexWithSetSettings` is executed while other threads all still processing data to `TmpIndex`?
- [x] Add index to `pid` and `is_full_reindex` column.
- [ ] Cleanup code.

**Result**
Much faster processing of queue.