### PR TITLE
Add get/set methods for job instance

### DIFF
--- a/Api/Data/JobInterface.php
+++ b/Api/Data/JobInterface.php
@@ -29,5 +29,48 @@ interface JobInterface
     const FIELD_RETRIES = 'retries';
     const FIELD_ERROR_LOG = 'error_log';
     const FIELD_DATA_SIZE = 'data_size';
-    /**#@-*/
+
+    /**
+     * @return string
+     */
+    public function getClass(): string;
+
+    /**
+     * @param string $class
+     * @return $this
+     */
+    public function setClass(string $class): self;
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string;
+
+    /**
+     * @param string $method
+     * @return $this
+     */
+    public function setMethod(string $method): self;
+
+    /**
+     * @return string
+     */
+    public function getBody(): string;
+
+    /**
+     * @param string $data
+     * @return $this
+     */
+    public function setBody(string $data): self;
+
+    /**
+     * @return int
+     */
+    public function getBodySize(): int;
+
+    /**
+     * @param int $size
+     * @return $this
+     */
+    public function setBodySize(int $size): self;
 }

--- a/Api/Data/JobInterface.php
+++ b/Api/Data/JobInterface.php
@@ -37,6 +37,7 @@ interface JobInterface
 
     /**
      * @param string $class
+     *
      * @return $this
      */
     public function setClass(string $class): self;
@@ -48,6 +49,7 @@ interface JobInterface
 
     /**
      * @param string $method
+     *
      * @return $this
      */
     public function setMethod(string $method): self;
@@ -59,6 +61,7 @@ interface JobInterface
 
     /**
      * @param string $data
+     *
      * @return $this
      */
     public function setBody(string $data): self;
@@ -70,6 +73,7 @@ interface JobInterface
 
     /**
      * @param int $size
+     *
      * @return $this
      */
     public function setBodySize(int $size): self;

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -248,7 +248,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getClass(): string
     {
@@ -256,7 +256,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function setClass(string $class): JobInterface
     {
@@ -264,7 +264,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getMethod(): string
     {
@@ -272,7 +272,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function setMethod(string $method): JobInterface
     {
@@ -280,7 +280,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getBody(): string
     {
@@ -288,7 +288,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function setBody(string $data): JobInterface
     {
@@ -296,7 +296,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getBodySize(): int
     {
@@ -304,7 +304,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function setBodySize(int $size): JobInterface
     {

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -9,8 +9,6 @@ use Algolia\AlgoliaSearch\Api\Data\JobInterface;
  *
  * @method int getPid()
  * @method int getStoreId()
- * @method string getClass()
- * @method string getMethod()
  * @method int getDataSize()
  * @method int getRetries()
  * @method int getMaxRetries()
@@ -247,5 +245,69 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
         $this->getResource()->save($this);
 
         return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getClass(): string
+    {
+        return $this->getData(self::FIELD_CLASS);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setClass(string $class): JobInterface
+    {
+        return $this->setData(self::FIELD_CLASS, $class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMethod(): string
+    {
+        return $this->getData(self::FIELD_METHOD);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setMethod(string $method): JobInterface
+    {
+        return $this->setData(self::FIELD_METHOD, $method);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBody(): string
+    {
+        return $this->getData(self::FIELD_DATA);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBody(string $data): JobInterface
+    {
+        return $this->setData(self::FIELD_DATA, $data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBodySize(): int
+    {
+        return $this->getData(self::FIELD_DATA_SIZE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBodySize(int $size): JobInterface
+    {
+        return $this->setData(self::FIELD_DATA_SIZE, $size);
     }
 }


### PR DESCRIPTION
**Summary**
Add set/get methods to job class. We need this methods in order to use entity in API and Magento queue.

I've chosen to use `body` instead of `data` since `data` is already use in the global `getData()`/`setData()` methods.

**Result**
Able to use job instance in API and Magento queue.