### PR TITLE
Ability to disable Algolia analytics per IP-Address

### DIFF
--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -242,6 +242,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
                 ],
             ],
             'analytics' => $config->getAnalyticsConfig(),
+            'algoliaAnalytics' => $config->enableAlgoliaAnalytics($this->getStoreId()),
             'now' => $this->getTimestamp(),
             'queue' => [
                 'isEnabled' => $config->isQueueActive($this->getStoreId()),

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../Magento/Config/etc/system_file.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <tab id="algolia" translate="label" sortOrder="100001">
             <label>
@@ -985,6 +984,13 @@
                         <![CDATA[
                             (In days - default value is 30) Sets the limit when the oldest records should be cleared from the archive logs (algoliasearch_queue_archive).
                         ]]>
+                    </comment>
+                </field>
+                <field id="exclude_ips_from_analytics" translate="label comment" type="text" sortOrder="105" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Exclude IPs from analytics</label>
+                    <backend_model>Magento\Developer\Model\Config\Backend\AllowedIps</backend_model>
+                    <comment>
+                        <![CDATA[(comma separated) Exclude searches coming from IP addresses from your analytics, such as searches your development team or other employees make.]]>
                     </comment>
                 </field>
             </group>

--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -81,6 +81,7 @@ requirejs(['algoliaBundle', 'Magento_Catalog/js/price-utils'], function (algolia
 		var searchClient = algoliaBundle.algoliasearch(algoliaConfig.applicationId, algoliaConfig.apiKey);
 		var indexName = algoliaConfig.indexName + '_products';
 		var searchParameters = {
+             analytics: algoliaConfig.algoliaAnalytics,
 			hitsPerPage: algoliaConfig.hitsPerPage,
 			ruleContexts: ruleContexts
 		};

--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -203,6 +203,7 @@ requirejs(['algoliaBundle'], function(algoliaBundle) {
 				return null;
 
 			var options = {
+                 analytics: algoliaConfig.algoliaAnalytics,
 				hitsPerPage: section.hitsPerPage,
 				analyticsTags: 'autocomplete',
 				clickAnalytics: true


### PR DESCRIPTION
**Summary**
Ability to exclude certain IP-Addresses from Algolia Analytics. See, https://support.algolia.com/hc/en-us/articles/4406975229969

**Result**
`analytics` parameter is added to search requests. Value is `false` if current IP-Address of customer is in list of added IP-Addresses, otherwise `true`.