### PR TITLE
Using deprecated functionality: explode()

### DIFF
--- a/Block/Adminhtml/Category/Merchandising.php
+++ b/Block/Adminhtml/Category/Merchandising.php
@@ -58,15 +58,21 @@ class Merchandising extends \Magento\Backend\Block\Template
     {
         $category = $this->getCategory();
 
-        if ($category) {
-            $path = $category->getPath();
-
-            $parts = explode('/', $path);
-            if (count($parts) <= 2) {
-                return true;
-            }
+        if (!$category) {
+            return false;
         }
 
+        $path = $category->getPath();
+
+        if (!$path) {
+            return false;
+        }
+        
+        $parts = explode('/', $path);
+        if (count($parts) <= 2) {
+            return true;
+        }
+        
         return false;
     }
 


### PR DESCRIPTION
**Summary**

Magento 2.4.4
PHP 8.1.1

When trying to add a new subcategory I got an error:
`Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /app/vendor/algolia/algoliasearch-magento-2/Block/Adminhtml/Category/Merchandising.php on line 64
`