### PR TITLE
Fix saving and loading data by the wrong cache key for the popular queries

### DIFF
--- a/Helper/Entity/SuggestionHelper.php
+++ b/Helper/Entity/SuggestionHelper.php
@@ -96,7 +96,7 @@ class SuggestionHelper
 
     public function getPopularQueries($storeId)
     {
-        $queries = $this->cache->load($this->popularQueriesCacheId);
+        $queries = $this->cache->load($this->popularQueriesCacheId . '_' . $storeId);
         if ($queries !== false) {
             return $this->serializer->unserialize($queries);
         }
@@ -121,7 +121,12 @@ class SuggestionHelper
 
         $queries = $collection->getColumnValues('query_text');
 
-        $this->cache->save($this->serializer->serialize($queries), $this->popularQueriesCacheId, [], 24*3600);
+        $this->cache->save(
+            $this->serializer->serialize($queries),
+            $this->popularQueriesCacheId . '_' . $storeId,
+            [],
+            24*3600
+        );
 
         return $queries;
     }


### PR DESCRIPTION
**Summary**
Currently, the implementation of the method `\Algolia\AlgoliaSearch\Helper\Entity\SuggestionHelper::getPopularQueries` is incorrect, because it caches the data by a cache tag `$popularQueriesCacheId` which leads to the wrong popular queries search results on different stores.
**Example**
Let's take a look at the next example. 
You have a store with ID 1 and it has `suits, pants` popular query. Store with ID 2 has `Salon de jardin` popular query. After the cache is cleaned, you visit a store with ID 1, and you have a correct popular query search result (here, the result is cached by tag, specified in the `$popularQueriesCacheId` property). But, for the store with ID 2 it won't be a `Salon de jardin` anymore, but `suits, pants` which is incorrect behavior.
**Result**
A fix adds a `store_id` to the cache tag. This will provide correct results for the requested store and the situation described above will be fixed.