### PR TITLE
Redirect search suggestions to catalogsearch results page

### DIFF
--- a/view/frontend/web/internals/template/autocomplete/suggestions.js
+++ b/view/frontend/web/internals/template/autocomplete/suggestions.js
@@ -1,7 +1,7 @@
 define([], function () {
     return {
         getSuggestionsHtml: function (item, html) {
-            return html`<a class="aa-ItemLink" href="/search?q=${item.query}">
+            return html`<a class="aa-ItemLink" href="/catalogsearch/result?q=${item.query}">
                 ${item.query}
             </a>`;
         },


### PR DESCRIPTION
**Summary**
With search suggestions enabled clinking a suggestion will result a 404 since the URL is set to /search. Maybe I'm missing something but I do not see a route set for /search by the Algolia module. I have changed the url to the catalogsearch results page as I think it's intended this way.

**Result**
```
<ul class="aa-List" role="listbox" aria-labelledby="autocomplete-0-label" id="autocomplete-0-list">
    <li class="aa-Item" id="autocomplete-0-item-0" role="option" aria-selected="false">
        <a class="aa-ItemLink" href="/catalogsearch/result?q=test">test</a>
    </li>
    ...
</ul>
```