### PR TITLE
Stop a full reindex being triggered after order is placed

### DIFF
--- a/Observer/ReindexProductOnLastItemPurchaseIfMsiDisable.php
+++ b/Observer/ReindexProductOnLastItemPurchaseIfMsiDisable.php
@@ -66,7 +66,9 @@ class ReindexProductOnLastItemPurchaseIfMsiDisable implements ObserverInterface
                         $productToReindex[] = $productId;
                     }
                 }
-                $this->indexer->reindexList($productToReindex);
+                if ($productToReindex) {
+                    $this->indexer->reindexList($productToReindex);
+                }
             }
         }
     }


### PR DESCRIPTION
**Summary**

We have encountered an issue where the `algoliasearch_queue` table kept growing rapidly and the cron job responsible for consuming the data was not able to process it quickly enough. A full reindex of data was getting added to the table very often. After investigation we were able to find that the observer was causing this issue and a full reindex was being scheduled after almost every order.

I believe the current implementation has a bug - if no item in an order goes out-of-stock it triggers a full reindex of data instead of skipping the reindex.

**Result**

I added a check to verifies if any products need to be reindexed and if not, the reindex is not triggered. Without this check, the reindex is called with an empty array as an argument which behaves the same was as triggering it with `null` as an argument - it causes a full reindex.