### PR TITLE
Bug - When MSI is disabled a full reindex event is created

### DIFF
--- a/Observer/ReindexProductOnLastItemPurchaseIfMsiDisable.php
+++ b/Observer/ReindexProductOnLastItemPurchaseIfMsiDisable.php
@@ -66,7 +66,10 @@ class ReindexProductOnLastItemPurchaseIfMsiDisable implements ObserverInterface
                         $productToReindex[] = $productId;
                     }
                 }
-                $this->indexer->reindexList($productToReindex);
+                if (count($productToReindex) > 0) {
+                    $this->indexer->reindexList($productToReindex);
+                }
+
             }
         }
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The observer event algoliasearch_reindex_product_on_last_item_purchase_if_msi_disable is fired on each order. If MSI is disabled and the order contains items that are still in stock post order a full reindex event will be created. 

This is due to the array of product ids being empty.

**Result**

I created a simple check to ensure that there were productids in the array.