### PR TITLE
Replace referenceBlock by referenceContainer following standard in adobe commerce / magento source code

### DIFF
--- a/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -4,11 +4,11 @@
     <head>
         <link src="Algolia_AlgoliaSearch::js/config.js"/>
     </head>
-    <referenceBlock name="before.body.end">
+    <referenceContainer name="before.body.end">
         <block class="Magento\Backend\Block\Template" name="algolia_configuration" template="Algolia_AlgoliaSearch::configuration.phtml">
             <arguments>
                 <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Configuration</argument>
             </arguments>
         </block>
-    </referenceBlock>
+    </referenceContainer>
 </page>

--- a/view/adminhtml/layout/algolia_algoliasearch_landingpage_edit.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_landingpage_edit.xml
@@ -9,12 +9,12 @@
         <referenceContainer name="content">
             <uiComponent name="algolia_algoliasearch_landingpage_form"/>
         </referenceContainer>
-        <referenceBlock name="before.body.end">
+        <referenceContainer name="before.body.end">
             <block class="Magento\Backend\Block\Template" name="algolia_common" template="Algolia_AlgoliaSearch::common.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Common</argument>
                 </arguments>
             </block>
-        </referenceBlock>
+        </referenceContainer>
     </body>
 </page>

--- a/view/adminhtml/layout/algolia_algoliasearch_landingpage_index.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_landingpage_index.xml
@@ -13,7 +13,7 @@
             </block>
             <uiComponent name="algolia_algoliasearch_landingpage_listing"/>
         </referenceContainer>
-        <referenceBlock name="before.body.end">
+        <referenceContainer name="before.body.end">
             <block class="Magento\Backend\Block\Template" name="algolia_common" template="Algolia_AlgoliaSearch::common.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Common</argument>

--- a/view/adminhtml/layout/algolia_algoliasearch_query_edit.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_query_edit.xml
@@ -8,12 +8,12 @@
         <referenceContainer name="content">
             <uiComponent name="algolia_algoliasearch_query_form"/>
         </referenceContainer>
-        <referenceBlock name="before.body.end">
+        <referenceContainer name="before.body.end">
             <block class="Magento\Backend\Block\Template" name="algolia_common" template="Algolia_AlgoliaSearch::common.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Common</argument>
                 </arguments>
             </block>
-        </referenceBlock>
+        </referenceContainer>
     </body>
 </page>

--- a/view/adminhtml/layout/algolia_algoliasearch_query_index.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_query_index.xml
@@ -13,12 +13,12 @@
             </block>
             <uiComponent name="algolia_algoliasearch_query_listing"/>
         </referenceContainer>
-        <referenceBlock name="before.body.end">
+        <referenceContainer name="before.body.end">
             <block class="Magento\Backend\Block\Template" name="algolia_common" template="Algolia_AlgoliaSearch::common.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Algolia\AlgoliaSearch\ViewModel\Adminhtml\Common</argument>
                 </arguments>
             </block>
-        </referenceBlock>
+        </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/algolia_search_handle.xml
+++ b/view/frontend/layout/algolia_search_handle.xml
@@ -17,11 +17,11 @@
             <block class="Algolia\AlgoliaSearch\Block\Configuration" name="algolia.internals.configuration" template="Algolia_AlgoliaSearch::internals/configuration.phtml"/>
         </referenceBlock>
 
-        <referenceBlock name="main.content">
+        <referenceContainer name="main.content">
             <block class="Magento\Framework\View\Element\Template" before="-" name="algolia.beforecontent" template="Algolia_AlgoliaSearch::internals/beforecontent.phtml"/>
-        </referenceBlock>
+        </referenceContainer>
 
-        <referenceBlock name="before.body.end">
+        <referenceContainer name="before.body.end">
             <!-- Instant search results page templates -->
             <block class="Algolia\AlgoliaSearch\Block\Instant\Wrapper" name="algolia.instant.wrapper" template="Algolia_AlgoliaSearch::instant/wrapper.phtml"/>
             <block class="Algolia\AlgoliaSearch\Block\Instant\Hit" name="algolia.instant.hit" template="Algolia_AlgoliaSearch::instant/hit.phtml"/>
@@ -29,7 +29,7 @@
             <block class="Magento\Framework\View\Element\Template" name="algolia.instant.facet" template="Algolia_AlgoliaSearch::instant/facet.phtml"/>
             <block class="Magento\Framework\View\Element\Template" name="algolia.instant.refinements" template="Algolia_AlgoliaSearch::instant/refinements.phtml"/>
 
-        </referenceBlock>
+        </referenceContainer>
         <referenceBlock name="top.search">
             <action method="setTemplate" ifconfig="algoliasearch_autocomplete/autocomplete/is_popup_enabled">
                 <argument name="setTemplate" xsi:type="string">Algolia_AlgoliaSearch::autocomplete.phtml</argument>


### PR DESCRIPTION
Replace referenceBlock by referenceContainer following standard in adobe commerce / magento source code

**Summary**

According to adobe commerce / magento source code:

https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Theme/view/base/page_layout/empty.xml#L13

https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Theme/view/base/page_layout/empty.xml#L20

https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Theme/view/adminhtml/page_layout/admin-1column.xml#L45

https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Theme/view/adminhtml/page_layout/admin-2columns-left.xml#L48

The names "main.content" and "before.body.end" are containers and not blocks so it should use referenceContainer and not referenceBlock.
