### PR TITLE
bugfix: Fix for Translation in autocomplete (Ready to go)

### DIFF
--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -309,6 +309,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
                 'relevance' => __('Relevance'),
                 'categories' => __('Categories'),
                 'products' => __('Products'),
+                'suggestions' => __('Suggestions'),
                 'searchBy' => __('Search by'),
                 'searchForFacetValuesPlaceholder' => __('Search for other ...'),
                 'showMore' => __('Show more products'),

--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -327,7 +327,7 @@ define(
         }
 
         if (algoliaConfig.autocomplete.nbOfQueriesSuggestions > 0) {
-            algoliaConfig.autocomplete.sections.unshift({ hitsPerPage: algoliaConfig.autocomplete.nbOfQueriesSuggestions, label: '', name: "suggestions"});
+            algoliaConfig.autocomplete.sections.unshift({ hitsPerPage: algoliaConfig.autocomplete.nbOfQueriesSuggestions, label: algoliaConfig.translations.suggestions, name: "suggestions"});
         }
 
         /**

--- a/view/frontend/web/internals/template/autocomplete/additional-section.js
+++ b/view/frontend/web/internals/template/autocomplete/additional-section.js
@@ -1,7 +1,7 @@
 define([], function () {
     return {
         getNoResultHtml: function ({html}) {
-            return html`<p>No Results</p>`;
+            return html`<p>${algoliaConfig.translations.noResults}</p>`;
         },
 
         getHeaderHtml: function ({section}) {

--- a/view/frontend/web/internals/template/autocomplete/categories.js
+++ b/view/frontend/web/internals/template/autocomplete/categories.js
@@ -1,11 +1,11 @@
 define([], function () {
     return {
         getNoResultHtml: function ({html}) {
-            return html`<p>No Results</p>`;
+            return html`<p>${algoliaConfig.translations.noResults}</p>`;
         },
 
         getHeaderHtml: function ({section}) {
-            return section.name;
+            return section.label;
         },
 
         getItemHtml: function ({item, components, html}) {

--- a/view/frontend/web/internals/template/autocomplete/pages.js
+++ b/view/frontend/web/internals/template/autocomplete/pages.js
@@ -1,11 +1,11 @@
 define([], function () {
     return {
         getNoResultHtml: function ({html}) {
-            return html`<p>No Results</p>`;
+            return html`<p>${algoliaConfig.translations.noResults}</p>`;
         },
 
         getHeaderHtml: function ({section}) {
-            return section.label || section.name;
+            return section.label;
         },
 
         getItemHtml: function ({item, components, html}) {

--- a/view/frontend/web/internals/template/autocomplete/products.js
+++ b/view/frontend/web/internals/template/autocomplete/products.js
@@ -6,7 +6,7 @@ define([], function () {
         ////////////////////
 
         getNoResultHtml: function ({html}) {
-            return html`<p>No Results</p>`;
+            return html`<p>${algoliaConfig.translations.noResults}</p>`;
         },
 
         getHeaderHtml: function () {

--- a/view/frontend/web/internals/template/autocomplete/suggestions.js
+++ b/view/frontend/web/internals/template/autocomplete/suggestions.js
@@ -1,11 +1,11 @@
 define([], function () {
     return {
         getNoResultHtml: function ({html}) {
-            return html`<p>No Results</p>`;
+            return html`<p>${algoliaConfig.translations.noResults}</p>`;
         },
 
         getHeaderHtml: function ({section}) {
-            return section.name;
+            return section.label;
         },
 
         getItemHtml: function ({item, html}) {


### PR DESCRIPTION
**Summary**

  This fixes translation issues with the 
  - label for suggestions and categories and pages in autocomplete dropdown
  - and 'no results' translation
