### PR TITLE
Add primary key to algoliasearch_queue_archive table

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -34,6 +34,7 @@
         </constraint>
     </table>
     <table name="algoliasearch_queue_archive" resource="default" engine="innodb" comment="Algoliasearch Queue Archive Table">
+        <column xsi:type="int" name="id" unsigned="false" nullable="false" identity="true" comment="Archive Id"/>
         <column xsi:type="int" name="pid" unsigned="true" nullable="true" identity="false" comment="PID"/>
         <column xsi:type="varchar" name="class" nullable="false" length="50" comment="class"/>
         <column xsi:type="text" name="method" nullable="false" comment="Method"/>
@@ -41,6 +42,9 @@
         <column xsi:type="text" name="error_log" nullable="false" comment="Error Log"/>
         <column xsi:type="int" name="data_size" unsigned="true" nullable="true" identity="false" comment="Data Size"/>
         <column xsi:type="datetime" name="created_at" on_update="true" nullable="true" comment="Date and time of job creation"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="id"/>
+        </constraint>
     </table>
     <table name="algoliasearch_landing_page" resource="default" engine="innodb" comment="Algoliasearch Landing Page Table">
         <column xsi:type="int" name="landing_page_id" unsigned="false" nullable="false" identity="true" comment="Landing Page Id"/>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -32,6 +32,7 @@
     },
     "algoliasearch_queue_archive": {
         "column": {
+            "id": true,
             "pid": true,
             "class": true,
             "method": true,
@@ -39,6 +40,9 @@
             "error_log": true,
             "data_size": true,
             "created_at": true
+        },
+        "constraint": {
+            "PRIMARY": true
         }
     },
     "algoliasearch_landing_page": {


### PR DESCRIPTION
The MySQL documentation can explain to you why it is desirable to enforce primary keys on all tables:

https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_sql_require_primary_key

Observing the code it seems this table is inserted to using "INSERT..SELECT" with columns specified, so ID will populate automatically by auto increment. Haven't tested the alter table to see if it populates, leave that up to you. From memory should be fine