### PR TITLE
Use getTable from ModuleDataSetupInterface to get table name with prefix

### DIFF
--- a/Setup/Patch/Schema/AutocompleteConfigPatch.php
+++ b/Setup/Patch/Schema/AutocompleteConfigPatch.php
@@ -37,7 +37,7 @@ class AutocompleteConfigPatch implements SchemaPatchInterface
         ];
         $this->moduleDataSetup->getConnection()->startSetup();
         $connection = $this->moduleDataSetup->getConnection();
-        $table = $connection->getTableName('core_config_data');
+        $table = $this->moduleDataSetup->getTable('core_config_data');
         foreach ($movedConfigDirectives as $from => $to) {
             try {
                 $connection->query('UPDATE ' . $table . ' SET path = "' . $to . '" WHERE path = "' . $from . '"');


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
If a table prefix is configured, the AutocompliteConfigPatch will throw an Error because the table 'core_config_data' (without prefix) can't be found.


**Result**
After the Change, the AutocompliteConfigPatch can be applied if a table prefix ist configured.