### PR TITLE
Use getTable from ModuleDataSetupInterface to get table name with prefix

### DIFF
--- a/Setup/Patch/Schema/RecommendConfigPatch.php
+++ b/Setup/Patch/Schema/RecommendConfigPatch.php
@@ -62,7 +62,7 @@ class RecommendConfigPatch implements SchemaPatchInterface
 
         $this->moduleDataSetup->getConnection()->startSetup();
         $connection = $this->moduleDataSetup->getConnection();
-        $table = $connection->getTableName('core_config_data');
+        $table = $this->moduleDataSetup->getTable('core_config_data');
         foreach ($movedConfigDirectives as $from => $to) {
             try {
                 $connection->query('UPDATE ' . $table . ' SET path = "' . $to . '" WHERE path = "' . $from . '"');


### PR DESCRIPTION
This is a follow up to #1313 which handles the same issue for another patch.

**Summary**
If a table prefix is configured, the RecommendConfigPatch will throw an Error because the table 'core_config_data' (without prefix) can't be found.

**Result**
* After the Change, the RecommendConfigPatch can be applied if a table prefix ist configured.
* After the change an integration test sandbox can be set up with a table prefix.