### PR TITLE
Fix/mage 604 - handle pricing dependencies

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -179,15 +179,15 @@ class Data
         }
 
         $params = [
-            'hitsPerPage' => $numberOfResults, // retrieve all the hits (hard limit is 1000)
-            'attributesToRetrieve' => 'objectID',
-            'attributesToHighlight' => '',
-            'attributesToSnippet' => '',
-            'numericFilters' => ['visibility_search=1'],
+            'hitsPerPage'            => $numberOfResults, // retrieve all the hits (hard limit is 1000)
+            'attributesToRetrieve'   => 'objectID',
+            'attributesToHighlight'  => '',
+            'attributesToSnippet'    => '',
+            'numericFilters'         => ['visibility_search=1'],
             'removeWordsIfNoResults' => $this->configHelper->getRemoveWordsIfNoResult($storeId),
-            'analyticsTags' => 'backend-search',
-            'facets' => $facetsToRetrieve,
-            'maxValuesPerFacet' => 100,
+            'analyticsTags'          => 'backend-search',
+            'facets'                 => $facetsToRetrieve,
+            'maxValuesPerFacet'      => 100,
         ];
 
         if (is_array($searchParams)) {
@@ -579,7 +579,11 @@ class Data
         $transport = new ProductDataArray();
         $this->eventManager->dispatch(
             'algolia_product_collection_add_additional_data',
-            ['collection' => $collection, 'store_id' => $storeId, 'additional_data' => $transport]
+            [
+                'collection'      => $collection,
+                'store_id'        => $storeId,
+                'additional_data' => $transport
+            ]
         );
 
         /** @var Product $product */
@@ -680,7 +684,7 @@ class Data
         }
 
         return [
-            'toIndex' => $categoriesToIndex,
+            'toIndex'  => $categoriesToIndex,
             'toRemove' => array_unique($categoriesToRemove),
         ];
     }
@@ -734,7 +738,10 @@ class Data
 
         $this->eventManager->dispatch(
             'algolia_before_products_collection_load',
-            ['collection' => $collection, 'store' => $storeId]
+            [
+                'collection' => $collection,
+                'store'      => $storeId
+            ]
         );
         $logMessage = 'LOADING: ' . $this->logger->getStoreName($storeId) . ',
             collection page: ' . $page . ',
@@ -884,7 +891,7 @@ class Data
         $objectIds = [];
         $counter = 0;
         $browseOptions = [
-            'query' => '',
+            'query'                => '',
             'attributesToRetrieve' => ['objectID'],
         ];
         foreach ($index->browseObjects($browseOptions) as $hit) {
@@ -931,7 +938,7 @@ class Data
         $indexNames = [];
         $indexNames[0] = [
             'indexName' => $this->getBaseIndexName(),
-            'priceKey' => '.' . $this->configHelper->getCurrencyCode() . '.default',
+            'priceKey'  => '.' . $this->configHelper->getCurrencyCode() . '.default',
         ];
         foreach ($this->storeManager->getStores() as $store) {
             $indexNames[$store->getId()] = [

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -374,7 +374,7 @@ class ProductHelper
      * @param $products
      * @return void
      */
-    protected function addMandatoryAttributes(ProductCollection $products) : void
+    protected function addMandatoryAttributes(ProductCollection $products): void
     {
         /** @var ProductCollection $products */
         $products->addFinalPrice()
@@ -385,148 +385,936 @@ class ProductHelper
             ->addAttributeToSelect('status');
     }
 
-/**
- * @param $storeId
- * @return array
- */
-public
-function getAdditionalAttributes($storeId = null)
-{
-    return $this->configHelper->getProductAdditionalAttributes($storeId);
-}
-
-/**
- * @param $indexName
- * @param $indexNameTmp
- * @param $storeId
- * @param $saveToTmpIndicesToo
- * @return void
- * @throws AlgoliaException
- */
-public
-function setSettings($indexName, $indexNameTmp, $storeId, $saveToTmpIndicesToo = false)
-{
-    $searchableAttributes = $this->getSearchableAttributes($storeId);
-    $customRanking = $this->getCustomRanking($storeId);
-    $unretrievableAttributes = $this->getUnretrieveableAttributes($storeId);
-    $attributesForFaceting = $this->getAttributesForFaceting($storeId);
-
-    $indexSettings = [
-        'searchableAttributes' => $searchableAttributes,
-        'customRanking' => $customRanking,
-        'unretrievableAttributes' => $unretrievableAttributes,
-        'attributesForFaceting' => $attributesForFaceting,
-        'maxValuesPerFacet' => (int)$this->configHelper->getMaxValuesPerFacet($storeId),
-        'removeWordsIfNoResults' => $this->configHelper->getRemoveWordsIfNoResult($storeId),
-    ];
-
-    // Additional index settings from event observer
-    $transport = new DataObject($indexSettings);
-    // Only for backward compatibility
-    $this->eventManager->dispatch(
-        'algolia_index_settings_prepare',
-        ['store_id' => $storeId, 'index_settings' => $transport]
-    );
-    $this->eventManager->dispatch(
-        'algolia_products_index_before_set_settings',
-        [
-            'store_id' => $storeId,
-            'index_settings' => $transport,
-        ]
-    );
-
-    $indexSettings = $transport->getData();
-
-    $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
-    $this->logger->log('Settings: ' . json_encode($indexSettings));
-    if ($saveToTmpIndicesToo === true) {
-        $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true, $indexName);
-        $this->logger->log('Pushing the same settings to TMP index as well');
-    }
-
-    $this->setFacetsQueryRules($indexName);
-    if ($saveToTmpIndicesToo === true) {
-        $this->setFacetsQueryRules($indexNameTmp);
-    }
-
-    /*
-     * Handle replicas
+    /**
+     * @param $storeId
+     * @return array
      */
-    $sortingIndices = $this->configHelper->getSortingIndices($indexName, $storeId);
-
-    $replicas = [];
-
-    if ($this->configHelper->isInstantEnabled($storeId)) {
-        $replicas = array_values(array_map(function ($sortingIndex) {
-            return $sortingIndex['name'];
-        }, $sortingIndices));
+    public function getAdditionalAttributes($storeId = null)
+    {
+        return $this->configHelper->getProductAdditionalAttributes($storeId);
     }
 
-    // Managing Virtual Replica
-    if ($this->configHelper->useVirtualReplica($storeId)) {
-        $replicas = $this->handleVirtualReplica($replicas, $indexName);
-    }
+    /**
+     * @param $indexName
+     * @param $indexNameTmp
+     * @param $storeId
+     * @param $saveToTmpIndicesToo
+     * @return void
+     * @throws AlgoliaException
+     */
+    public function setSettings($indexName, $indexNameTmp, $storeId, $saveToTmpIndicesToo = false)
+    {
+        $searchableAttributes = $this->getSearchableAttributes($storeId);
+        $customRanking = $this->getCustomRanking($storeId);
+        $unretrievableAttributes = $this->getUnretrieveableAttributes($storeId);
+        $attributesForFaceting = $this->getAttributesForFaceting($storeId);
 
-    // Merge current replicas with sorting replicas to not delete A/B testing replica indices
-    try {
-        $currentSettings = $this->algoliaHelper->getSettings($indexName);
-        if (array_key_exists('replicas', $currentSettings)) {
-            $replicas = array_values(array_unique(array_merge($replicas, $currentSettings['replicas'])));
+        $indexSettings = [
+            'searchableAttributes' => $searchableAttributes,
+            'customRanking' => $customRanking,
+            'unretrievableAttributes' => $unretrievableAttributes,
+            'attributesForFaceting' => $attributesForFaceting,
+            'maxValuesPerFacet' => (int)$this->configHelper->getMaxValuesPerFacet($storeId),
+            'removeWordsIfNoResults' => $this->configHelper->getRemoveWordsIfNoResult($storeId),
+        ];
+
+        // Additional index settings from event observer
+        $transport = new DataObject($indexSettings);
+        // Only for backward compatibility
+        $this->eventManager->dispatch(
+            'algolia_index_settings_prepare',
+            ['store_id' => $storeId, 'index_settings' => $transport]
+        );
+        $this->eventManager->dispatch(
+            'algolia_products_index_before_set_settings',
+            [
+                'store_id' => $storeId,
+                'index_settings' => $transport,
+            ]
+        );
+
+        $indexSettings = $transport->getData();
+
+        $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
+        $this->logger->log('Settings: ' . json_encode($indexSettings));
+        if ($saveToTmpIndicesToo === true) {
+            $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true, $indexName);
+            $this->logger->log('Pushing the same settings to TMP index as well');
         }
-    } catch (AlgoliaException $e) {
-        if ($e->getMessage() !== 'Index does not exist') {
-            throw $e;
+
+        $this->setFacetsQueryRules($indexName);
+        if ($saveToTmpIndicesToo === true) {
+            $this->setFacetsQueryRules($indexNameTmp);
         }
-    }
 
-    if (count($replicas) > 0) {
-        $this->algoliaHelper->setSettings($indexName, ['replicas' => $replicas]);
-        $this->logger->log('Setting replicas to "' . $indexName . '" index.');
-        $this->logger->log('Replicas: ' . json_encode($replicas));
-        $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
+        /*
+         * Handle replicas
+         */
+        $sortingIndices = $this->configHelper->getSortingIndices($indexName, $storeId);
 
-        if (!$this->configHelper->useVirtualReplica($storeId)) {
-            foreach ($sortingIndices as $values) {
-                $replicaName = $values['name'];
-                $indexSettings['ranking'] = $values['ranking'];
-                $this->algoliaHelper->setSettings($replicaName, $indexSettings, false, true);
-                $this->logger->log('Setting settings to "' . $replicaName . '" replica.');
-                $this->logger->log('Settings: ' . json_encode($indexSettings));
+        $replicas = [];
+
+        if ($this->configHelper->isInstantEnabled($storeId)) {
+            $replicas = array_values(array_map(function ($sortingIndex) {
+                return $sortingIndex['name'];
+            }, $sortingIndices));
+        }
+
+        // Managing Virtual Replica
+        if ($this->configHelper->useVirtualReplica($storeId)) {
+            $replicas = $this->handleVirtualReplica($replicas, $indexName);
+        }
+
+        // Merge current replicas with sorting replicas to not delete A/B testing replica indices
+        try {
+            $currentSettings = $this->algoliaHelper->getSettings($indexName);
+            if (array_key_exists('replicas', $currentSettings)) {
+                $replicas = array_values(array_unique(array_merge($replicas, $currentSettings['replicas'])));
+            }
+        } catch (AlgoliaException $e) {
+            if ($e->getMessage() !== 'Index does not exist') {
+                throw $e;
+            }
+        }
+
+        if (count($replicas) > 0) {
+            $this->algoliaHelper->setSettings($indexName, ['replicas' => $replicas]);
+            $this->logger->log('Setting replicas to "' . $indexName . '" index.');
+            $this->logger->log('Replicas: ' . json_encode($replicas));
+            $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
+
+            if (!$this->configHelper->useVirtualReplica($storeId)) {
+                foreach ($sortingIndices as $values) {
+                    $replicaName = $values['name'];
+                    $indexSettings['ranking'] = $values['ranking'];
+                    $this->algoliaHelper->setSettings($replicaName, $indexSettings, false, true);
+                    $this->logger->log('Setting settings to "' . $replicaName . '" replica.');
+                    $this->logger->log('Settings: ' . json_encode($indexSettings));
+                }
+            } else {
+                foreach ($sortingIndices as $values) {
+                    $replicaName = $values['name'];
+                    array_unshift($customRanking, $values['ranking'][0]);
+                    $replicaSetting['customRanking'] = $customRanking;
+                    $this->algoliaHelper->setSettings($replicaName, $replicaSetting, false, false);
+                    $this->logger->log('Setting settings to "' . $replicaName . '" replica.');
+                    $this->logger->log('Settings: ' . json_encode($replicaSetting));
+                }
             }
         } else {
-            foreach ($sortingIndices as $values) {
-                $replicaName = $values['name'];
-                array_unshift($customRanking, $values['ranking'][0]);
-                $replicaSetting['customRanking'] = $customRanking;
-                $this->algoliaHelper->setSettings($replicaName, $replicaSetting, false, false);
-                $this->logger->log('Setting settings to "' . $replicaName . '" replica.');
-                $this->logger->log('Settings: ' . json_encode($replicaSetting));
-            }
+            $this->algoliaHelper->setSettings($indexName, ['replicas' => []]);
+            $this->logger->log('Removing replicas from "' . $indexName . '" index');
+            $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
         }
-    } else {
-        $this->algoliaHelper->setSettings($indexName, ['replicas' => []]);
-        $this->logger->log('Removing replicas from "' . $indexName . '" index');
-        $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
-    }
 
-    // Commented out as it doesn't delete anything now because of merging replica indices earlier
-    // $this->deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId);
+        // Commented out as it doesn't delete anything now because of merging replica indices earlier
+        // $this->deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId);
 
-    if ($saveToTmpIndicesToo === true) {
-        try {
-            $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
-            $this->logger->log('
+        if ($saveToTmpIndicesToo === true) {
+            try {
+                $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
+                $this->logger->log('
                     Copying synonyms from production index to TMP one to not erase them with the index move.
                 ');
-        } catch (AlgoliaException $e) {
-            $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
+            } catch (AlgoliaException $e) {
+                $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
+            }
+
+            try {
+                $this->algoliaHelper->copyQueryRules($indexName, $indexNameTmp);
+                $this->logger->log('
+                    Copying query rules to "' . $indexNameTmp . '" to not to erase them with the index move.
+                ');
+            } catch (AlgoliaException $e) {
+                // Fail silently if query rules are disabled on the app
+                // If QRs are disabled, nothing will happen and the extension will work as expected
+                if ($e->getMessage() !== 'Query Rules are not enabled on this application') {
+                    throw $e;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $categoryIds
+     * @param $storeId
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getAllCategories($categoryIds, $storeId)
+    {
+        $filterNotIncludedCategories = $this->configHelper->showCatsNotIncludedInNavigation($storeId);
+        $categories = $this->categoryHelper->getCoreCategories($filterNotIncludedCategories, $storeId);
+
+        $selectedCategories = [];
+        foreach ($categoryIds as $id) {
+            if (isset($categories[$id])) {
+                $selectedCategories[] = $categories[$id];
+            }
+        }
+
+        return $selectedCategories;
+    }
+
+    /**
+     * @param Product $product
+     * @return array|mixed|null
+     * @throws \Exception
+     */
+    public function getObject(Product $product)
+    {
+        $storeId = $product->getStoreId();
+
+        $this->logger->start('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId));
+        $defaultData = [];
+
+        $transport = new DataObject($defaultData);
+        $this->eventManager->dispatch(
+            'algolia_product_index_before',
+            ['product' => $product, 'custom_data' => $transport]
+        );
+
+        $defaultData = $transport->getData();
+
+        $visibility = $product->getVisibility();
+
+        $visibleInCatalog = $this->visibility->getVisibleInCatalogIds();
+        $visibleInSearch = $this->visibility->getVisibleInSearchIds();
+
+        $urlParams = [
+            '_secure' => $this->configHelper->useSecureUrlsInFrontend($product->getStoreId()),
+            '_nosid' => true,
+        ];
+
+        $customData = [
+            'objectID' => $product->getId(),
+            'name' => $product->getName(),
+            'url' => $product->getUrlModel()->getUrl($product, $urlParams),
+            'visibility_search' => (int)(in_array($visibility, $visibleInSearch)),
+            'visibility_catalog' => (int)(in_array($visibility, $visibleInCatalog)),
+            'type_id' => $product->getTypeId(),
+        ];
+
+        $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
+        $groups = null;
+
+        $customData = $this->addAttribute('description', $defaultData, $customData, $additionalAttributes, $product);
+        $customData = $this->addAttribute('ordered_qty', $defaultData, $customData, $additionalAttributes, $product);
+        $customData = $this->addAttribute('total_ordered', $defaultData, $customData, $additionalAttributes, $product);
+        $customData = $this->addAttribute('rating_summary', $defaultData, $customData, $additionalAttributes, $product);
+        $customData = $this->addCategoryData($customData, $product);
+        $customData = $this->addImageData($customData, $product, $additionalAttributes);
+        $customData = $this->addInStock($defaultData, $customData, $product);
+        $customData = $this->addStockQty($defaultData, $customData, $additionalAttributes, $product);
+        $subProducts = $this->getSubProducts($product);
+        $customData = $this->addAdditionalAttributes($customData, $additionalAttributes, $product, $subProducts);
+        $customData = $this->priceManager->addPriceDataByProductType($customData, $product, $subProducts);
+        $transport = new DataObject($customData);
+        $this->eventManager->dispatch(
+            'algolia_subproducts_index',
+            ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
+        );
+        $customData = $transport->getData();
+        $customData = array_merge($customData, $defaultData);
+        $this->algoliaHelper->castProductObject($customData);
+        $transport = new DataObject($customData);
+        $this->eventManager->dispatch(
+            'algolia_after_create_product_object',
+            ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
+        );
+        $customData = $transport->getData();
+
+        $this->logger->stop('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId));
+
+        return $customData;
+    }
+
+    /**
+     * @param Product $product
+     * @return array|\Magento\Catalog\Api\Data\ProductInterface[]|DataObject[]
+     */
+    protected function getSubProducts(Product $product)
+    {
+        $type = $product->getTypeId();
+
+        if (!in_array($type, ['bundle', 'grouped', 'configurable'], true)) {
+            return [];
+        }
+
+        $storeId = $product->getStoreId();
+        $typeInstance = $product->getTypeInstance();
+
+        if ($typeInstance instanceof Configurable) {
+            $subProducts = $typeInstance->getUsedProducts($product);
+        } elseif ($typeInstance instanceof BundleProductType) {
+            $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product)->getItems();
+        } else { // Grouped product
+            $subProducts = $typeInstance->getAssociatedProducts($product);
+        }
+
+        /**
+         * @var int $index
+         * @var Product $subProduct
+         */
+        foreach ($subProducts as $index => $subProduct) {
+            try {
+                $this->canProductBeReindexed($subProduct, $storeId, true);
+            } catch (ProductReindexingException $e) {
+                unset($subProducts[$index]);
+            }
+        }
+
+        return $subProducts;
+    }
+
+    /**
+     * Returns all parent product IDs, e.g. when simple product is part of configurable or bundle
+     *
+     * @param array $productIds
+     *
+     * @return array
+     */
+    public function getParentProductIds(array $productIds)
+    {
+        $parentIds = [];
+        foreach ($this->getCompositeTypes() as $typeInstance) {
+            $parentIds = array_merge($parentIds, $typeInstance->getParentIdsByChild($productIds));
+        }
+
+        return $parentIds;
+    }
+
+    /**
+     * Returns composite product type instances
+     *
+     * @return AbstractType[]
+     *
+     * @see \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction::_getProductTypeInstances
+     */
+    protected function getCompositeTypes()
+    {
+        if ($this->compositeTypes === null) {
+            $productEmulator = new \Magento\Framework\DataObject();
+            foreach ($this->productType->getCompositeTypes() as $typeId) {
+                $productEmulator->setTypeId($typeId);
+                $this->compositeTypes[$typeId] = $this->productType->factory($productEmulator);
+            }
+        }
+
+        return $this->compositeTypes;
+    }
+
+    /**
+     * @param $attribute
+     * @param $defaultData
+     * @param $customData
+     * @param $additionalAttributes
+     * @param Product $product
+     * @return mixed
+     */
+    protected function addAttribute($attribute, $defaultData, $customData, $additionalAttributes, Product $product)
+    {
+        if (isset($defaultData[$attribute]) === false
+            && $this->isAttributeEnabled($additionalAttributes, $attribute)) {
+            $customData[$attribute] = $product->getData($attribute);
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $customData
+     * @param Product $product
+     * @return mixed
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function addCategoryData($customData, Product $product)
+    {
+        $storeId = $product->getStoreId();
+        $categories = [];
+        $categoriesWithPath = [];
+        $categoryIds = [];
+
+        $_categoryIds = $product->getCategoryIds();
+
+        if (is_array($_categoryIds) && count($_categoryIds) > 0) {
+            $categoryCollection = $this->getAllCategories($_categoryIds, $storeId);
+
+            /** @var Store $store */
+            $store = $this->storeManager->getStore($product->getStoreId());
+            $rootCat = $store->getRootCategoryId();
+
+            foreach ($categoryCollection as $category) {
+                // Check and skip all categories that is not
+                // in the path of the current store.
+                $path = $category->getPath();
+                $pathParts = explode('/', $path);
+                if (isset($pathParts[1]) && $pathParts[1] !== $rootCat) {
+                    continue;
+                }
+
+                $categoryName = $this->categoryHelper->getCategoryName($category->getId(), $storeId);
+                if ($categoryName) {
+                    $categories[] = $categoryName;
+                }
+
+                $category->getUrlInstance()->setStore($product->getStoreId());
+                $path = [];
+
+                foreach ($category->getPathIds() as $treeCategoryId) {
+                    $name = $this->categoryHelper->getCategoryName($treeCategoryId, $storeId);
+                    if ($name) {
+                        $categoryIds[] = $treeCategoryId;
+                        $path[] = $name;
+                    }
+                }
+
+                $categoriesWithPath[] = $path;
+            }
+        }
+
+        foreach ($categoriesWithPath as $result) {
+            for ($i = count($result) - 1; $i > 0; $i--) {
+                $categoriesWithPath[] = array_slice($result, 0, $i);
+            }
+        }
+
+        $categoriesWithPath = array_intersect_key(
+            $categoriesWithPath,
+            array_unique(array_map('serialize', $categoriesWithPath))
+        );
+
+        $hierarchicalCategories = $this->getHierarchicalCategories($categoriesWithPath);
+
+        $customData['categories'] = $hierarchicalCategories;
+        $customData['categories_without_path'] = $categories;
+        $customData['categoryIds'] = array_values(array_unique($categoryIds));
+
+        return $customData;
+    }
+
+    /**
+     * @param $categoriesWithPath
+     * @return array
+     */
+    protected function getHierarchicalCategories($categoriesWithPath)
+    {
+        $hierachivalCategories = [];
+
+        $levelName = 'level';
+
+        foreach ($categoriesWithPath as $category) {
+            $categoryCount = count($category);
+            for ($i = 0; $i < $categoryCount; $i++) {
+                if (isset($hierachivalCategories[$levelName . $i]) === false) {
+                    $hierachivalCategories[$levelName . $i] = [];
+                }
+
+                if ($category[$i] === null) {
+                    continue;
+                }
+
+                $hierachivalCategories[$levelName . $i][] = implode(' /// ', array_slice($category, 0, $i + 1));
+            }
+        }
+
+        foreach ($hierachivalCategories as &$level) {
+            $level = array_values(array_unique($level));
+        }
+
+        return $hierachivalCategories;
+    }
+
+    /**
+     * @param array $customData
+     * @param Product $product
+     * @param $additionalAttributes
+     * @return array
+     */
+    protected function addImageData(array $customData, Product $product, $additionalAttributes)
+    {
+        if (false === isset($customData['thumbnail_url'])) {
+            $customData['thumbnail_url'] = $this->imageHelper
+                ->init($product, 'product_thumbnail_image')
+                ->getUrl();
+        }
+
+        if (false === isset($customData['image_url'])) {
+            $this->imageHelper
+                ->init($product, $this->configHelper->getImageType())
+                ->resize($this->configHelper->getImageWidth(), $this->configHelper->getImageHeight());
+
+            $customData['image_url'] = $this->imageHelper->getUrl();
+
+            if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
+                $product->load($product->getId(), 'media_gallery');
+
+                $customData['media_gallery'] = [];
+
+                $images = $product->getMediaGalleryImages();
+                if ($images) {
+                    foreach ($images as $image) {
+                        $customData['media_gallery'][] = $image->getUrl();
+                    }
+                }
+            }
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $defaultData
+     * @param $customData
+     * @param Product $product
+     * @return mixed
+     */
+    protected function addInStock($defaultData, $customData, Product $product)
+    {
+        if (isset($defaultData['in_stock']) === false) {
+            $stockItem = $this->stockRegistry->getStockItem($product->getId());
+            $customData['in_stock'] = $product->isSaleable() && $stockItem->getIsInStock();
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $defaultData
+     * @param $customData
+     * @param $additionalAttributes
+     * @param Product $product
+     * @return mixed
+     */
+    protected function addStockQty($defaultData, $customData, $additionalAttributes, Product $product)
+    {
+        if (isset($defaultData['stock_qty']) === false
+            && $this->isAttributeEnabled($additionalAttributes, 'stock_qty')) {
+            $customData['stock_qty'] = 0;
+
+            $stockItem = $this->stockRegistry->getStockItem($product->getId());
+            if ($stockItem) {
+                $customData['stock_qty'] = (int)$stockItem->getQty();
+            }
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $customData
+     * @param $additionalAttributes
+     * @param Product $product
+     * @param $subProducts
+     * @return mixed
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    protected function addAdditionalAttributes($customData, $additionalAttributes, Product $product, $subProducts)
+    {
+        foreach ($additionalAttributes as $attribute) {
+            $attributeName = $attribute['attribute'];
+
+            if (isset($customData[$attributeName]) && $attributeName !== 'sku') {
+                continue;
+            }
+
+            /** @var \Magento\Catalog\Model\ResourceModel\Product $resource */
+            $resource = $product->getResource();
+
+            /** @var AttributeResource $attributeResource */
+            $attributeResource = $resource->getAttribute($attributeName);
+            if (!$attributeResource) {
+                continue;
+            }
+
+            $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
+
+            $value = $product->getData($attributeName);
+
+            if ($value !== null) {
+                $customData = $this->addNonNullValue($customData, $value, $product, $attribute, $attributeResource);
+
+                if (!in_array($attributeName, $this->attributesToIndexAsArray, true)) {
+                    continue;
+                }
+            }
+
+            $type = $product->getTypeId();
+            if ($type !== 'configurable' && $type !== 'grouped' && $type !== 'bundle') {
+                continue;
+            }
+
+            $customData = $this->addNullValue($customData, $subProducts, $attribute, $attributeResource);
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $customData
+     * @param $subProducts
+     * @param $attribute
+     * @param AttributeResource $attributeResource
+     * @return mixed
+     */
+    protected function addNullValue($customData, $subProducts, $attribute, AttributeResource $attributeResource)
+    {
+        $attributeName = $attribute['attribute'];
+
+        $values = [];
+        $subProductImages = [];
+
+        if (isset($customData[$attributeName])) {
+            $values[] = $customData[$attributeName];
+        }
+
+        /** @var Product $subProduct */
+        foreach ($subProducts as $subProduct) {
+            $value = $subProduct->getData($attributeName);
+            if ($value) {
+                /** @var string|array $valueText */
+                $valueText = $subProduct->getAttributeText($attributeName);
+
+                $values = array_merge($values, $this->getValues($valueText, $subProduct, $attributeResource));
+                if ($this->configHelper->useAdaptiveImage($attributeResource->getStoreId())) {
+                    $subProductImages = $this->addSubProductImage(
+                        $subProductImages,
+                        $attribute,
+                        $subProduct,
+                        $valueText
+                    );
+                }
+            }
+        }
+
+        if (is_array($values) && count($values) > 0) {
+            $customData[$attributeName] = array_values(array_unique($values));
+        }
+
+        if (count($subProductImages) > 0) {
+            $customData['images_data'] = $subProductImages;
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $valueText
+     * @param Product $subProduct
+     * @param AttributeResource $attributeResource
+     * @return array
+     */
+    protected function getValues($valueText, Product $subProduct, AttributeResource $attributeResource)
+    {
+        $values = [];
+
+        if ($valueText) {
+            if (is_array($valueText)) {
+                foreach ($valueText as $valueText_elt) {
+                    $values[] = $valueText_elt;
+                }
+            } else {
+                $values[] = $valueText;
+            }
+        } else {
+            $values[] = $attributeResource->getFrontend()->getValue($subProduct);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param $subProductImages
+     * @param $attribute
+     * @param $subProduct
+     * @param $valueText
+     * @return mixed
+     */
+    protected function addSubProductImage($subProductImages, $attribute, $subProduct, $valueText)
+    {
+        if (mb_strtolower($attribute['attribute'], 'utf-8') !== 'color') {
+            return $subProductImages;
+        }
+
+        $image = $this->imageHelper
+            ->init($subProduct, $this->configHelper->getImageType())
+            ->resize(
+                $this->configHelper->getImageWidth(),
+                $this->configHelper->getImageHeight()
+            );
+
+        $subImage = $subProduct->getData($image->getType());
+        if (!$subImage || $subImage === 'no_selection') {
+            return $subProductImages;
         }
 
         try {
-            $this->algoliaHelper->copyQueryRules($indexName, $indexNameTmp);
-            $this->logger->log('
-                    Copying query rules to "' . $indexNameTmp . '" to not to erase them with the index move.
-                ');
+            $textValueInLower = mb_strtolower($valueText, 'utf-8');
+            $subProductImages[$textValueInLower] = $image->getUrl();
+        } catch (\Exception $e) {
+            $this->logger->log($e->getMessage());
+            $this->logger->log($e->getTraceAsString());
+        }
+
+        return $subProductImages;
+    }
+
+    /**
+     * @param $customData
+     * @param $value
+     * @param Product $product
+     * @param $attribute
+     * @param AttributeResource $attributeResource
+     * @return mixed
+     */
+    protected function addNonNullValue(
+        $customData,
+        $value,
+        Product $product,
+        $attribute,
+        AttributeResource $attributeResource
+    )
+    {
+        $valueText = null;
+
+        if (!is_array($value) && $attributeResource->usesSource()) {
+            $valueText = $product->getAttributeText($attribute['attribute']);
+        }
+
+        if ($valueText) {
+            $value = $valueText;
+        } else {
+            $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
+            $value = $attributeResource->getFrontend()->getValue($product);
+        }
+
+        if ($value) {
+            $customData[$attribute['attribute']] = $value;
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $storeId
+     * @return array
+     */
+    protected function getSearchableAttributes($storeId = null)
+    {
+        $searchableAttributes = [];
+
+        foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
+            if ($attribute['searchable'] === '1') {
+                if (!isset($attribute['order']) || $attribute['order'] === 'ordered') {
+                    $searchableAttributes[] = $attribute['attribute'];
+                } else {
+                    $searchableAttributes[] = 'unordered(' . $attribute['attribute'] . ')';
+                }
+
+                if ($attribute['attribute'] === 'categories') {
+                    $searchableAttributes[] = (isset($attribute['order']) && $attribute['order'] === 'ordered') ?
+                        'categories_without_path' : 'unordered(categories_without_path)';
+                }
+            }
+        }
+
+        $searchableAttributes = array_values(array_unique($searchableAttributes));
+
+        return $searchableAttributes;
+    }
+
+    /**
+     * @param $storeId
+     * @return array
+     */
+    protected function getCustomRanking($storeId)
+    {
+        $customRanking = [];
+
+        $customRankings = $this->configHelper->getProductCustomRanking($storeId);
+        foreach ($customRankings as $ranking) {
+            $customRanking[] = $ranking['order'] . '(' . $ranking['attribute'] . ')';
+        }
+
+        return $customRanking;
+    }
+
+    /**
+     * @param $storeId
+     * @return array
+     */
+    protected function getUnretrieveableAttributes($storeId = null)
+    {
+        $unretrievableAttributes = [];
+
+        foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
+            if ($attribute['retrievable'] !== '1') {
+                $unretrievableAttributes[] = $attribute['attribute'];
+            }
+        }
+
+        return $unretrievableAttributes;
+    }
+
+    /**
+     * @param $storeId
+     * @return array
+     */
+    protected function getAttributesForFaceting($storeId)
+    {
+        $attributesForFaceting = [];
+
+        $currencies = $this->currencyManager->getConfigAllowCurrencies();
+
+        $facets = $this->configHelper->getFacets($storeId);
+        foreach ($facets as $facet) {
+            if ($facet['attribute'] === 'price') {
+                foreach ($currencies as $currency_code) {
+                    $facet['attribute'] = 'price.' . $currency_code . '.default';
+
+                    if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
+                        foreach ($this->groupCollection as $group) {
+                            $group_id = (int)$group->getData('customer_group_id');
+
+                            $attributesForFaceting[] = 'price.' . $currency_code . '.group_' . $group_id;
+                        }
+                    }
+
+                    $attributesForFaceting[] = $facet['attribute'];
+                }
+            } else {
+                $attribute = $facet['attribute'];
+                if (array_key_exists('searchable', $facet)) {
+                    if ($facet['searchable'] === '1') {
+                        $attribute = 'searchable(' . $attribute . ')';
+                    } elseif ($facet['searchable'] === '3') {
+                        $attribute = 'filterOnly(' . $attribute . ')';
+                    }
+                }
+
+                $attributesForFaceting[] = $attribute;
+            }
+        }
+
+        if ($this->configHelper->replaceCategories($storeId) && !in_array('categories', $attributesForFaceting, true)) {
+            $attributesForFaceting[] = 'categories';
+        }
+
+        // Used for merchandising
+        $attributesForFaceting[] = 'categoryIds';
+
+        return $attributesForFaceting;
+    }
+
+    /**
+     * @param $indexName
+     * @param $replicas
+     * @param $setReplicasTaskId
+     * @return void
+     */
+    protected function deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId)
+    {
+        $indicesToDelete = [];
+
+        $allIndices = $this->algoliaHelper->listIndexes();
+        foreach ($allIndices['items'] as $indexInfo) {
+            if (mb_strpos($indexInfo['name'], $indexName) !== 0 || $indexInfo['name'] === $indexName) {
+                continue;
+            }
+
+            if (mb_strpos($indexInfo['name'], '_tmp') === false && in_array($indexInfo['name'], $replicas) === false) {
+                $indicesToDelete[] = $indexInfo['name'];
+            }
+        }
+
+        if (count($indicesToDelete) > 0) {
+            $this->algoliaHelper->waitLastTask($indexName, $setReplicasTaskId);
+
+            foreach ($indicesToDelete as $indexToDelete) {
+                $this->algoliaHelper->deleteIndex($indexToDelete);
+            }
+        }
+    }
+
+    /**
+     * @param $indexName
+     * @return void
+     * @throws AlgoliaException
+     */
+    protected function setFacetsQueryRules($indexName)
+    {
+        $index = $this->algoliaHelper->getIndex($indexName);
+
+        $this->clearFacetsQueryRules($index);
+
+        $rules = [];
+        $facets = $this->configHelper->getFacets();
+        foreach ($facets as $facet) {
+            if (!array_key_exists('create_rule', $facet) || $facet['create_rule'] !== '1') {
+                continue;
+            }
+
+            $attribute = $facet['attribute'];
+
+            $condition = [
+                'anchoring' => 'contains',
+                'pattern' => '{facet:' . $attribute . '}',
+                'context' => 'magento_filters',
+            ];
+
+            $rules[] = [
+                'objectID' => 'filter_' . $attribute,
+                'description' => 'Filter facet "' . $attribute . '"',
+                'conditions' => [$condition],
+                'consequence' => [
+                    'params' => [
+                        'automaticFacetFilters' => [$attribute],
+                        'query' => [
+                            'remove' => ['{facet:' . $attribute . '}'],
+                        ],
+                    ],
+                ],
+            ];
+        }
+
+        if ($rules) {
+            $this->logger->log('Setting facets query rules to "' . $indexName . '" index: ' . json_encode($rules));
+            $index->saveRules($rules, [
+                'forwardToReplicas' => true,
+            ]);
+        }
+    }
+
+    /**
+     * @param SearchIndex $index
+     * @return void
+     * @throws AlgoliaException
+     */
+    protected function clearFacetsQueryRules(SearchIndex $index)
+    {
+        try {
+            $hitsPerPage = 100;
+            $page = 0;
+            do {
+                $fetchedQueryRules = $index->searchRules('', [
+                    'context' => 'magento_filters',
+                    'page' => $page,
+                    'hitsPerPage' => $hitsPerPage,
+                ]);
+
+                if (!$fetchedQueryRules || !array_key_exists('hits', $fetchedQueryRules)) {
+                    break;
+                }
+
+                foreach ($fetchedQueryRules['hits'] as $hit) {
+                    $index->deleteRule($hit['objectID'], [
+                        'forwardToReplicas' => true,
+                    ]);
+                }
+
+                $page++;
+            } while (($page * $hitsPerPage) < $fetchedQueryRules['nbHits']);
         } catch (AlgoliaException $e) {
             // Fail silently if query rules are disabled on the app
             // If QRs are disabled, nothing will happen and the extension will work as expected
@@ -535,896 +1323,80 @@ function setSettings($indexName, $indexNameTmp, $storeId, $saveToTmpIndicesToo =
             }
         }
     }
-}
 
-/**
- * @param $categoryIds
- * @param $storeId
- * @return array
- * @throws \Magento\Framework\Exception\LocalizedException
- */
-public
-function getAllCategories($categoryIds, $storeId)
-{
-    $filterNotIncludedCategories = $this->configHelper->showCatsNotIncludedInNavigation($storeId);
-    $categories = $this->categoryHelper->getCoreCategories($filterNotIncludedCategories, $storeId);
-
-    $selectedCategories = [];
-    foreach ($categoryIds as $id) {
-        if (isset($categories[$id])) {
-            $selectedCategories[] = $categories[$id];
+    /**
+     * Check if product can be index on Algolia
+     *
+     * @param Product $product
+     * @param int $storeId
+     * @param bool $isChildProduct
+     *
+     * @return bool
+     */
+    public function canProductBeReindexed($product, $storeId, $isChildProduct = false)
+    {
+        if ($product->isDeleted() === true) {
+            throw (new ProductDeletedException())
+                ->withProduct($product)
+                ->withStoreId($storeId);
         }
-    }
 
-    return $selectedCategories;
-}
+        if ($product->getStatus() == Status::STATUS_DISABLED) {
+            throw (new ProductDisabledException())
+                ->withProduct($product)
+                ->withStoreId($storeId);
+        }
 
-/**
- * @param Product $product
- * @return array|mixed|null
- * @throws \Exception
- */
-public
-function getObject(Product $product)
-{
-    $storeId = $product->getStoreId();
+        if ($isChildProduct === false && !in_array($product->getVisibility(), [
+                Visibility::VISIBILITY_BOTH,
+                Visibility::VISIBILITY_IN_SEARCH,
+                Visibility::VISIBILITY_IN_CATALOG,
+            ])) {
+            throw (new ProductNotVisibleException())
+                ->withProduct($product)
+                ->withStoreId($storeId);
+        }
 
-    $this->logger->start('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId));
-    $defaultData = [];
+        $isInStock = true;
+        if (!$this->configHelper->getShowOutOfStock($storeId)
+            || (!$this->configHelper->indexOutOfStockOptions($storeId) && $isChildProduct === true)) {
+            $isInStock = $this->productIsInStock($product, $storeId);
+        }
 
-    $transport = new DataObject($defaultData);
-    $this->eventManager->dispatch(
-        'algolia_product_index_before',
-        ['product' => $product, 'custom_data' => $transport]
-    );
+        if (!$isInStock) {
+            throw (new ProductOutOfStockException())
+                ->withProduct($product)
+                ->withStoreId($storeId);
+        }
 
-    $defaultData = $transport->getData();
-
-    $visibility = $product->getVisibility();
-
-    $visibleInCatalog = $this->visibility->getVisibleInCatalogIds();
-    $visibleInSearch = $this->visibility->getVisibleInSearchIds();
-
-    $urlParams = [
-        '_secure' => $this->configHelper->useSecureUrlsInFrontend($product->getStoreId()),
-        '_nosid' => true,
-    ];
-
-    $customData = [
-        'objectID' => $product->getId(),
-        'name' => $product->getName(),
-        'url' => $product->getUrlModel()->getUrl($product, $urlParams),
-        'visibility_search' => (int)(in_array($visibility, $visibleInSearch)),
-        'visibility_catalog' => (int)(in_array($visibility, $visibleInCatalog)),
-        'type_id' => $product->getTypeId(),
-    ];
-
-    $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
-    $groups = null;
-
-    $customData = $this->addAttribute('description', $defaultData, $customData, $additionalAttributes, $product);
-    $customData = $this->addAttribute('ordered_qty', $defaultData, $customData, $additionalAttributes, $product);
-    $customData = $this->addAttribute('total_ordered', $defaultData, $customData, $additionalAttributes, $product);
-    $customData = $this->addAttribute('rating_summary', $defaultData, $customData, $additionalAttributes, $product);
-    $customData = $this->addCategoryData($customData, $product);
-    $customData = $this->addImageData($customData, $product, $additionalAttributes);
-    $customData = $this->addInStock($defaultData, $customData, $product);
-    $customData = $this->addStockQty($defaultData, $customData, $additionalAttributes, $product);
-    $subProducts = $this->getSubProducts($product);
-    $customData = $this->addAdditionalAttributes($customData, $additionalAttributes, $product, $subProducts);
-    $customData = $this->priceManager->addPriceDataByProductType($customData, $product, $subProducts);
-    $transport = new DataObject($customData);
-    $this->eventManager->dispatch(
-        'algolia_subproducts_index',
-        ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
-    );
-    $customData = $transport->getData();
-    $customData = array_merge($customData, $defaultData);
-    $this->algoliaHelper->castProductObject($customData);
-    $transport = new DataObject($customData);
-    $this->eventManager->dispatch(
-        'algolia_after_create_product_object',
-        ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
-    );
-    $customData = $transport->getData();
-
-    $this->logger->stop('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId));
-
-    return $customData;
-}
-
-/**
- * @param Product $product
- * @return array|\Magento\Catalog\Api\Data\ProductInterface[]|DataObject[]
- */
-protected
-function getSubProducts(Product $product)
-{
-    $type = $product->getTypeId();
-
-    if (!in_array($type, ['bundle', 'grouped', 'configurable'], true)) {
-        return [];
-    }
-
-    $storeId = $product->getStoreId();
-    $typeInstance = $product->getTypeInstance();
-
-    if ($typeInstance instanceof Configurable) {
-        $subProducts = $typeInstance->getUsedProducts($product);
-    } elseif ($typeInstance instanceof BundleProductType) {
-        $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product)->getItems();
-    } else { // Grouped product
-        $subProducts = $typeInstance->getAssociatedProducts($product);
+        return true;
     }
 
     /**
-     * @var int $index
-     * @var Product $subProduct
+     * Returns is product in stock
+     *
+     * @param Product $product
+     * @param int $storeId
+     *
+     * @return bool
      */
-    foreach ($subProducts as $index => $subProduct) {
-        try {
-            $this->canProductBeReindexed($subProduct, $storeId, true);
-        } catch (ProductReindexingException $e) {
-            unset($subProducts[$index]);
-        }
-    }
-
-    return $subProducts;
-}
-
-/**
- * Returns all parent product IDs, e.g. when simple product is part of configurable or bundle
- *
- * @param array $productIds
- *
- * @return array
- */
-public
-function getParentProductIds(array $productIds)
-{
-    $parentIds = [];
-    foreach ($this->getCompositeTypes() as $typeInstance) {
-        $parentIds = array_merge($parentIds, $typeInstance->getParentIdsByChild($productIds));
-    }
-
-    return $parentIds;
-}
-
-/**
- * Returns composite product type instances
- *
- * @return AbstractType[]
- *
- * @see \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction::_getProductTypeInstances
- */
-protected
-function getCompositeTypes()
-{
-    if ($this->compositeTypes === null) {
-        $productEmulator = new \Magento\Framework\DataObject();
-        foreach ($this->productType->getCompositeTypes() as $typeId) {
-            $productEmulator->setTypeId($typeId);
-            $this->compositeTypes[$typeId] = $this->productType->factory($productEmulator);
-        }
-    }
-
-    return $this->compositeTypes;
-}
-
-/**
- * @param $attribute
- * @param $defaultData
- * @param $customData
- * @param $additionalAttributes
- * @param Product $product
- * @return mixed
- */
-protected
-function addAttribute($attribute, $defaultData, $customData, $additionalAttributes, Product $product)
-{
-    if (isset($defaultData[$attribute]) === false
-        && $this->isAttributeEnabled($additionalAttributes, $attribute)) {
-        $customData[$attribute] = $product->getData($attribute);
-    }
-
-    return $customData;
-}
-
-/**
- * @param $customData
- * @param Product $product
- * @return mixed
- * @throws \Magento\Framework\Exception\LocalizedException
- * @throws \Magento\Framework\Exception\NoSuchEntityException
- */
-protected
-function addCategoryData($customData, Product $product)
-{
-    $storeId = $product->getStoreId();
-    $categories = [];
-    $categoriesWithPath = [];
-    $categoryIds = [];
-
-    $_categoryIds = $product->getCategoryIds();
-
-    if (is_array($_categoryIds) && count($_categoryIds) > 0) {
-        $categoryCollection = $this->getAllCategories($_categoryIds, $storeId);
-
-        /** @var Store $store */
-        $store = $this->storeManager->getStore($product->getStoreId());
-        $rootCat = $store->getRootCategoryId();
-
-        foreach ($categoryCollection as $category) {
-            // Check and skip all categories that is not
-            // in the path of the current store.
-            $path = $category->getPath();
-            $pathParts = explode('/', $path);
-            if (isset($pathParts[1]) && $pathParts[1] !== $rootCat) {
-                continue;
-            }
-
-            $categoryName = $this->categoryHelper->getCategoryName($category->getId(), $storeId);
-            if ($categoryName) {
-                $categories[] = $categoryName;
-            }
-
-            $category->getUrlInstance()->setStore($product->getStoreId());
-            $path = [];
-
-            foreach ($category->getPathIds() as $treeCategoryId) {
-                $name = $this->categoryHelper->getCategoryName($treeCategoryId, $storeId);
-                if ($name) {
-                    $categoryIds[] = $treeCategoryId;
-                    $path[] = $name;
-                }
-            }
-
-            $categoriesWithPath[] = $path;
-        }
-    }
-
-    foreach ($categoriesWithPath as $result) {
-        for ($i = count($result) - 1; $i > 0; $i--) {
-            $categoriesWithPath[] = array_slice($result, 0, $i);
-        }
-    }
-
-    $categoriesWithPath = array_intersect_key(
-        $categoriesWithPath,
-        array_unique(array_map('serialize', $categoriesWithPath))
-    );
-
-    $hierarchicalCategories = $this->getHierarchicalCategories($categoriesWithPath);
-
-    $customData['categories'] = $hierarchicalCategories;
-    $customData['categories_without_path'] = $categories;
-    $customData['categoryIds'] = array_values(array_unique($categoryIds));
-
-    return $customData;
-}
-
-/**
- * @param $categoriesWithPath
- * @return array
- */
-protected
-function getHierarchicalCategories($categoriesWithPath)
-{
-    $hierachivalCategories = [];
-
-    $levelName = 'level';
-
-    foreach ($categoriesWithPath as $category) {
-        $categoryCount = count($category);
-        for ($i = 0; $i < $categoryCount; $i++) {
-            if (isset($hierachivalCategories[$levelName . $i]) === false) {
-                $hierachivalCategories[$levelName . $i] = [];
-            }
-
-            if ($category[$i] === null) {
-                continue;
-            }
-
-            $hierachivalCategories[$levelName . $i][] = implode(' /// ', array_slice($category, 0, $i + 1));
-        }
-    }
-
-    foreach ($hierachivalCategories as &$level) {
-        $level = array_values(array_unique($level));
-    }
-
-    return $hierachivalCategories;
-}
-
-/**
- * @param array $customData
- * @param Product $product
- * @param $additionalAttributes
- * @return array
- */
-protected
-function addImageData(array $customData, Product $product, $additionalAttributes)
-{
-    if (false === isset($customData['thumbnail_url'])) {
-        $customData['thumbnail_url'] = $this->imageHelper
-            ->init($product, 'product_thumbnail_image')
-            ->getUrl();
-    }
-
-    if (false === isset($customData['image_url'])) {
-        $this->imageHelper
-            ->init($product, $this->configHelper->getImageType())
-            ->resize($this->configHelper->getImageWidth(), $this->configHelper->getImageHeight());
-
-        $customData['image_url'] = $this->imageHelper->getUrl();
-
-        if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
-            $product->load($product->getId(), 'media_gallery');
-
-            $customData['media_gallery'] = [];
-
-            $images = $product->getMediaGalleryImages();
-            if ($images) {
-                foreach ($images as $image) {
-                    $customData['media_gallery'][] = $image->getUrl();
-                }
-            }
-        }
-    }
-
-    return $customData;
-}
-
-/**
- * @param $defaultData
- * @param $customData
- * @param Product $product
- * @return mixed
- */
-protected
-function addInStock($defaultData, $customData, Product $product)
-{
-    if (isset($defaultData['in_stock']) === false) {
+    public function productIsInStock($product, $storeId)
+    {
         $stockItem = $this->stockRegistry->getStockItem($product->getId());
-        $customData['in_stock'] = $product->isSaleable() && $stockItem->getIsInStock();
+
+        return $product->isSaleable() && $stockItem->getIsInStock();
     }
 
-    return $customData;
-}
-
-/**
- * @param $defaultData
- * @param $customData
- * @param $additionalAttributes
- * @param Product $product
- * @return mixed
- */
-protected
-function addStockQty($defaultData, $customData, $additionalAttributes, Product $product)
-{
-    if (isset($defaultData['stock_qty']) === false
-        && $this->isAttributeEnabled($additionalAttributes, 'stock_qty')) {
-        $customData['stock_qty'] = 0;
-
-        $stockItem = $this->stockRegistry->getStockItem($product->getId());
-        if ($stockItem) {
-            $customData['stock_qty'] = (int)$stockItem->getQty();
+    /**
+     * @param $replica
+     * @return array
+     */
+    protected function handleVirtualReplica($replicas, $indexName)
+    {
+        $virtualReplicaArray = [];
+        foreach ($replicas as $replica) {
+            $virtualReplicaArray[] = 'virtual(' . $replica . ')';
         }
+        return $virtualReplicaArray;
     }
-
-    return $customData;
-}
-
-/**
- * @param $customData
- * @param $additionalAttributes
- * @param Product $product
- * @param $subProducts
- * @return mixed
- * @throws \Magento\Framework\Exception\LocalizedException
- */
-protected
-function addAdditionalAttributes($customData, $additionalAttributes, Product $product, $subProducts)
-{
-    foreach ($additionalAttributes as $attribute) {
-        $attributeName = $attribute['attribute'];
-
-        if (isset($customData[$attributeName]) && $attributeName !== 'sku') {
-            continue;
-        }
-
-        /** @var \Magento\Catalog\Model\ResourceModel\Product $resource */
-        $resource = $product->getResource();
-
-        /** @var AttributeResource $attributeResource */
-        $attributeResource = $resource->getAttribute($attributeName);
-        if (!$attributeResource) {
-            continue;
-        }
-
-        $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
-
-        $value = $product->getData($attributeName);
-
-        if ($value !== null) {
-            $customData = $this->addNonNullValue($customData, $value, $product, $attribute, $attributeResource);
-
-            if (!in_array($attributeName, $this->attributesToIndexAsArray, true)) {
-                continue;
-            }
-        }
-
-        $type = $product->getTypeId();
-        if ($type !== 'configurable' && $type !== 'grouped' && $type !== 'bundle') {
-            continue;
-        }
-
-        $customData = $this->addNullValue($customData, $subProducts, $attribute, $attributeResource);
-    }
-
-    return $customData;
-}
-
-/**
- * @param $customData
- * @param $subProducts
- * @param $attribute
- * @param AttributeResource $attributeResource
- * @return mixed
- */
-protected
-function addNullValue($customData, $subProducts, $attribute, AttributeResource $attributeResource)
-{
-    $attributeName = $attribute['attribute'];
-
-    $values = [];
-    $subProductImages = [];
-
-    if (isset($customData[$attributeName])) {
-        $values[] = $customData[$attributeName];
-    }
-
-    /** @var Product $subProduct */
-    foreach ($subProducts as $subProduct) {
-        $value = $subProduct->getData($attributeName);
-        if ($value) {
-            /** @var string|array $valueText */
-            $valueText = $subProduct->getAttributeText($attributeName);
-
-            $values = array_merge($values, $this->getValues($valueText, $subProduct, $attributeResource));
-            if ($this->configHelper->useAdaptiveImage($attributeResource->getStoreId())) {
-                $subProductImages = $this->addSubProductImage(
-                    $subProductImages,
-                    $attribute,
-                    $subProduct,
-                    $valueText
-                );
-            }
-        }
-    }
-
-    if (is_array($values) && count($values) > 0) {
-        $customData[$attributeName] = array_values(array_unique($values));
-    }
-
-    if (count($subProductImages) > 0) {
-        $customData['images_data'] = $subProductImages;
-    }
-
-    return $customData;
-}
-
-/**
- * @param $valueText
- * @param Product $subProduct
- * @param AttributeResource $attributeResource
- * @return array
- */
-protected
-function getValues($valueText, Product $subProduct, AttributeResource $attributeResource)
-{
-    $values = [];
-
-    if ($valueText) {
-        if (is_array($valueText)) {
-            foreach ($valueText as $valueText_elt) {
-                $values[] = $valueText_elt;
-            }
-        } else {
-            $values[] = $valueText;
-        }
-    } else {
-        $values[] = $attributeResource->getFrontend()->getValue($subProduct);
-    }
-
-    return $values;
-}
-
-/**
- * @param $subProductImages
- * @param $attribute
- * @param $subProduct
- * @param $valueText
- * @return mixed
- */
-protected
-function addSubProductImage($subProductImages, $attribute, $subProduct, $valueText)
-{
-    if (mb_strtolower($attribute['attribute'], 'utf-8') !== 'color') {
-        return $subProductImages;
-    }
-
-    $image = $this->imageHelper
-        ->init($subProduct, $this->configHelper->getImageType())
-        ->resize(
-            $this->configHelper->getImageWidth(),
-            $this->configHelper->getImageHeight()
-        );
-
-    $subImage = $subProduct->getData($image->getType());
-    if (!$subImage || $subImage === 'no_selection') {
-        return $subProductImages;
-    }
-
-    try {
-        $textValueInLower = mb_strtolower($valueText, 'utf-8');
-        $subProductImages[$textValueInLower] = $image->getUrl();
-    } catch (\Exception $e) {
-        $this->logger->log($e->getMessage());
-        $this->logger->log($e->getTraceAsString());
-    }
-
-    return $subProductImages;
-}
-
-/**
- * @param $customData
- * @param $value
- * @param Product $product
- * @param $attribute
- * @param AttributeResource $attributeResource
- * @return mixed
- */
-protected
-function addNonNullValue(
-    $customData,
-    $value,
-    Product $product,
-    $attribute,
-    AttributeResource $attributeResource
-)
-{
-    $valueText = null;
-
-    if (!is_array($value) && $attributeResource->usesSource()) {
-        $valueText = $product->getAttributeText($attribute['attribute']);
-    }
-
-    if ($valueText) {
-        $value = $valueText;
-    } else {
-        $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
-        $value = $attributeResource->getFrontend()->getValue($product);
-    }
-
-    if ($value) {
-        $customData[$attribute['attribute']] = $value;
-    }
-
-    return $customData;
-}
-
-/**
- * @param $storeId
- * @return array
- */
-protected
-function getSearchableAttributes($storeId = null)
-{
-    $searchableAttributes = [];
-
-    foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
-        if ($attribute['searchable'] === '1') {
-            if (!isset($attribute['order']) || $attribute['order'] === 'ordered') {
-                $searchableAttributes[] = $attribute['attribute'];
-            } else {
-                $searchableAttributes[] = 'unordered(' . $attribute['attribute'] . ')';
-            }
-
-            if ($attribute['attribute'] === 'categories') {
-                $searchableAttributes[] = (isset($attribute['order']) && $attribute['order'] === 'ordered') ?
-                    'categories_without_path' : 'unordered(categories_without_path)';
-            }
-        }
-    }
-
-    $searchableAttributes = array_values(array_unique($searchableAttributes));
-
-    return $searchableAttributes;
-}
-
-/**
- * @param $storeId
- * @return array
- */
-protected
-function getCustomRanking($storeId)
-{
-    $customRanking = [];
-
-    $customRankings = $this->configHelper->getProductCustomRanking($storeId);
-    foreach ($customRankings as $ranking) {
-        $customRanking[] = $ranking['order'] . '(' . $ranking['attribute'] . ')';
-    }
-
-    return $customRanking;
-}
-
-/**
- * @param $storeId
- * @return array
- */
-protected
-function getUnretrieveableAttributes($storeId = null)
-{
-    $unretrievableAttributes = [];
-
-    foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
-        if ($attribute['retrievable'] !== '1') {
-            $unretrievableAttributes[] = $attribute['attribute'];
-        }
-    }
-
-    return $unretrievableAttributes;
-}
-
-/**
- * @param $storeId
- * @return array
- */
-protected
-function getAttributesForFaceting($storeId)
-{
-    $attributesForFaceting = [];
-
-    $currencies = $this->currencyManager->getConfigAllowCurrencies();
-
-    $facets = $this->configHelper->getFacets($storeId);
-    foreach ($facets as $facet) {
-        if ($facet['attribute'] === 'price') {
-            foreach ($currencies as $currency_code) {
-                $facet['attribute'] = 'price.' . $currency_code . '.default';
-
-                if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
-                    foreach ($this->groupCollection as $group) {
-                        $group_id = (int)$group->getData('customer_group_id');
-
-                        $attributesForFaceting[] = 'price.' . $currency_code . '.group_' . $group_id;
-                    }
-                }
-
-                $attributesForFaceting[] = $facet['attribute'];
-            }
-        } else {
-            $attribute = $facet['attribute'];
-            if (array_key_exists('searchable', $facet)) {
-                if ($facet['searchable'] === '1') {
-                    $attribute = 'searchable(' . $attribute . ')';
-                } elseif ($facet['searchable'] === '3') {
-                    $attribute = 'filterOnly(' . $attribute . ')';
-                }
-            }
-
-            $attributesForFaceting[] = $attribute;
-        }
-    }
-
-    if ($this->configHelper->replaceCategories($storeId) && !in_array('categories', $attributesForFaceting, true)) {
-        $attributesForFaceting[] = 'categories';
-    }
-
-    // Used for merchandising
-    $attributesForFaceting[] = 'categoryIds';
-
-    return $attributesForFaceting;
-}
-
-/**
- * @param $indexName
- * @param $replicas
- * @param $setReplicasTaskId
- * @return void
- */
-protected
-function deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId)
-{
-    $indicesToDelete = [];
-
-    $allIndices = $this->algoliaHelper->listIndexes();
-    foreach ($allIndices['items'] as $indexInfo) {
-        if (mb_strpos($indexInfo['name'], $indexName) !== 0 || $indexInfo['name'] === $indexName) {
-            continue;
-        }
-
-        if (mb_strpos($indexInfo['name'], '_tmp') === false && in_array($indexInfo['name'], $replicas) === false) {
-            $indicesToDelete[] = $indexInfo['name'];
-        }
-    }
-
-    if (count($indicesToDelete) > 0) {
-        $this->algoliaHelper->waitLastTask($indexName, $setReplicasTaskId);
-
-        foreach ($indicesToDelete as $indexToDelete) {
-            $this->algoliaHelper->deleteIndex($indexToDelete);
-        }
-    }
-}
-
-/**
- * @param $indexName
- * @return void
- * @throws AlgoliaException
- */
-protected
-function setFacetsQueryRules($indexName)
-{
-    $index = $this->algoliaHelper->getIndex($indexName);
-
-    $this->clearFacetsQueryRules($index);
-
-    $rules = [];
-    $facets = $this->configHelper->getFacets();
-    foreach ($facets as $facet) {
-        if (!array_key_exists('create_rule', $facet) || $facet['create_rule'] !== '1') {
-            continue;
-        }
-
-        $attribute = $facet['attribute'];
-
-        $condition = [
-            'anchoring' => 'contains',
-            'pattern' => '{facet:' . $attribute . '}',
-            'context' => 'magento_filters',
-        ];
-
-        $rules[] = [
-            'objectID' => 'filter_' . $attribute,
-            'description' => 'Filter facet "' . $attribute . '"',
-            'conditions' => [$condition],
-            'consequence' => [
-                'params' => [
-                    'automaticFacetFilters' => [$attribute],
-                    'query' => [
-                        'remove' => ['{facet:' . $attribute . '}'],
-                    ],
-                ],
-            ],
-        ];
-    }
-
-    if ($rules) {
-        $this->logger->log('Setting facets query rules to "' . $indexName . '" index: ' . json_encode($rules));
-        $index->saveRules($rules, [
-            'forwardToReplicas' => true,
-        ]);
-    }
-}
-
-/**
- * @param SearchIndex $index
- * @return void
- * @throws AlgoliaException
- */
-protected
-function clearFacetsQueryRules(SearchIndex $index)
-{
-    try {
-        $hitsPerPage = 100;
-        $page = 0;
-        do {
-            $fetchedQueryRules = $index->searchRules('', [
-                'context' => 'magento_filters',
-                'page' => $page,
-                'hitsPerPage' => $hitsPerPage,
-            ]);
-
-            if (!$fetchedQueryRules || !array_key_exists('hits', $fetchedQueryRules)) {
-                break;
-            }
-
-            foreach ($fetchedQueryRules['hits'] as $hit) {
-                $index->deleteRule($hit['objectID'], [
-                    'forwardToReplicas' => true,
-                ]);
-            }
-
-            $page++;
-        } while (($page * $hitsPerPage) < $fetchedQueryRules['nbHits']);
-    } catch (AlgoliaException $e) {
-        // Fail silently if query rules are disabled on the app
-        // If QRs are disabled, nothing will happen and the extension will work as expected
-        if ($e->getMessage() !== 'Query Rules are not enabled on this application') {
-            throw $e;
-        }
-    }
-}
-
-/**
- * Check if product can be index on Algolia
- *
- * @param Product $product
- * @param int $storeId
- * @param bool $isChildProduct
- *
- * @return bool
- */
-public
-function canProductBeReindexed($product, $storeId, $isChildProduct = false)
-{
-    if ($product->isDeleted() === true) {
-        throw (new ProductDeletedException())
-            ->withProduct($product)
-            ->withStoreId($storeId);
-    }
-
-    if ($product->getStatus() == Status::STATUS_DISABLED) {
-        throw (new ProductDisabledException())
-            ->withProduct($product)
-            ->withStoreId($storeId);
-    }
-
-    if ($isChildProduct === false && !in_array($product->getVisibility(), [
-            Visibility::VISIBILITY_BOTH,
-            Visibility::VISIBILITY_IN_SEARCH,
-            Visibility::VISIBILITY_IN_CATALOG,
-        ])) {
-        throw (new ProductNotVisibleException())
-            ->withProduct($product)
-            ->withStoreId($storeId);
-    }
-
-    $isInStock = true;
-    if (!$this->configHelper->getShowOutOfStock($storeId)
-        || (!$this->configHelper->indexOutOfStockOptions($storeId) && $isChildProduct === true)) {
-        $isInStock = $this->productIsInStock($product, $storeId);
-    }
-
-    if (!$isInStock) {
-        throw (new ProductOutOfStockException())
-            ->withProduct($product)
-            ->withStoreId($storeId);
-    }
-
-    return true;
-}
-
-/**
- * Returns is product in stock
- *
- * @param Product $product
- * @param int $storeId
- *
- * @return bool
- */
-public
-function productIsInStock($product, $storeId)
-{
-    $stockItem = $this->stockRegistry->getStockItem($product->getId());
-
-    return $product->isSaleable() && $stockItem->getIsInStock();
-}
-
-/**
- * @param $replica
- * @return array
- */
-protected
-function handleVirtualReplica($replicas, $indexName)
-{
-    $virtualReplicaArray = [];
-    foreach ($replicas as $replica) {
-        $virtualReplicaArray[] = 'virtual(' . $replica . ')';
-    }
-    return $virtualReplicaArray;
-}
 }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -410,12 +410,12 @@ class ProductHelper
         $attributesForFaceting = $this->getAttributesForFaceting($storeId);
 
         $indexSettings = [
-            'searchableAttributes' => $searchableAttributes,
-            'customRanking' => $customRanking,
+            'searchableAttributes'    => $searchableAttributes,
+            'customRanking'           => $customRanking,
             'unretrievableAttributes' => $unretrievableAttributes,
-            'attributesForFaceting' => $attributesForFaceting,
-            'maxValuesPerFacet' => (int)$this->configHelper->getMaxValuesPerFacet($storeId),
-            'removeWordsIfNoResults' => $this->configHelper->getRemoveWordsIfNoResult($storeId),
+            'attributesForFaceting'   => $attributesForFaceting,
+            'maxValuesPerFacet'       => (int)$this->configHelper->getMaxValuesPerFacet($storeId),
+            'removeWordsIfNoResults'  => $this->configHelper->getRemoveWordsIfNoResult($storeId),
         ];
 
         // Additional index settings from event observer
@@ -583,16 +583,16 @@ class ProductHelper
 
         $urlParams = [
             '_secure' => $this->configHelper->useSecureUrlsInFrontend($product->getStoreId()),
-            '_nosid' => true,
+            '_nosid'  => true,
         ];
 
         $customData = [
-            'objectID' => $product->getId(),
-            'name' => $product->getName(),
-            'url' => $product->getUrlModel()->getUrl($product, $urlParams),
-            'visibility_search' => (int)(in_array($visibility, $visibleInSearch)),
+            'objectID'           => $product->getId(),
+            'name'               => $product->getName(),
+            'url'                => $product->getUrlModel()->getUrl($product, $urlParams),
+            'visibility_search'  => (int)(in_array($visibility, $visibleInSearch)),
             'visibility_catalog' => (int)(in_array($visibility, $visibleInCatalog)),
-            'type_id' => $product->getTypeId(),
+            'type_id'            => $product->getTypeId(),
         ];
 
         $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
@@ -612,7 +612,11 @@ class ProductHelper
         $transport = new DataObject($customData);
         $this->eventManager->dispatch(
             'algolia_subproducts_index',
-            ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
+            [
+                'custom_data'   => $transport,
+                'sub_products'  => $subProducts,
+                'productObject' => $product
+            ]
         );
         $customData = $transport->getData();
         $customData = array_merge($customData, $defaultData);
@@ -620,7 +624,11 @@ class ProductHelper
         $transport = new DataObject($customData);
         $this->eventManager->dispatch(
             'algolia_after_create_product_object',
-            ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
+            [
+                'custom_data'   => $transport,
+                'sub_products'  => $subProducts,
+                'productObject' => $product
+            ]
         );
         $customData = $transport->getData();
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -21,6 +21,7 @@ use Magento\Catalog\Model\Product\Type;
 use Magento\Catalog\Model\Product\Type\AbstractType;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeResource;
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\CatalogInventory\Helper\Stock;
@@ -167,23 +168,24 @@ class ProductHelper
      * @param ImageHelper $imageHelper
      */
     public function __construct(
-        Config $eavConfig,
-        ConfigHelper $configHelper,
-        AlgoliaHelper $algoliaHelper,
-        Logger $logger,
-        StoreManagerInterface $storeManager,
-        ManagerInterface $eventManager,
-        Visibility $visibility,
-        Stock $stockHelper,
+        Config                 $eavConfig,
+        ConfigHelper           $configHelper,
+        AlgoliaHelper          $algoliaHelper,
+        Logger                 $logger,
+        StoreManagerInterface  $storeManager,
+        ManagerInterface       $eventManager,
+        Visibility             $visibility,
+        Stock                  $stockHelper,
         StockRegistryInterface $stockRegistry,
-        CurrencyHelper $currencyManager,
-        CategoryHelper $categoryHelper,
-        PriceManager $priceManager,
-        Type $productType,
-        CollectionFactory $productCollectionFactory,
-        GroupCollection $groupCollection,
-        ImageHelper $imageHelper
-    ) {
+        CurrencyHelper         $currencyManager,
+        CategoryHelper         $categoryHelper,
+        PriceManager           $priceManager,
+        Type                   $productType,
+        CollectionFactory      $productCollectionFactory,
+        GroupCollection        $groupCollection,
+        ImageHelper            $imageHelper
+    )
+    {
         $this->eavConfig = $eavConfig;
         $this->configHelper = $configHelper;
         $this->algoliaHelper = $algoliaHelper;
@@ -288,14 +290,15 @@ class ProductHelper
      * @param $productIds
      * @param $onlyVisible
      * @param $includeNotVisibleIndividually
-     * @return \Magento\Catalog\Model\ResourceModel\Product\Collection
+     * @return Collection
      */
     public function getProductCollectionQuery(
         $storeId,
         $productIds = null,
         $onlyVisible = true,
         $includeNotVisibleIndividually = false
-    ) {
+    )
+    {
         $productCollection = $this->productCollectionFactory->create();
         $products = $productCollection
             ->setStoreId($storeId)
@@ -362,12 +365,18 @@ class ProductHelper
     }
 
     /**
+     * Adds key attributes like pricing and visibility to product collection query.
+     * IMPORTANT: The "Product Price" (aka `catalog_product_price`) index must be
+     *            up-to-date in order to properly build this collection.
+     *            Otherwise, the resulting inner join will filter out products
+     *            without a price. These removed products will initiate a `deleteObject`
+     *            operation against the underlying product index in Algolia.
      * @param $products
      * @return void
      */
-    protected function addMandatoryAttributes($products)
+    protected function addMandatoryAttributes(ProductCollection $products) : void
     {
-        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $products */
+        /** @var ProductCollection $products */
         $products->addFinalPrice()
             ->addAttributeToSelect('special_price')
             ->addAttributeToSelect('special_from_date')
@@ -376,935 +385,148 @@ class ProductHelper
             ->addAttributeToSelect('status');
     }
 
-    /**
-     * @param $storeId
-     * @return array
-     */
-    public function getAdditionalAttributes($storeId = null)
-    {
-        return $this->configHelper->getProductAdditionalAttributes($storeId);
+/**
+ * @param $storeId
+ * @return array
+ */
+public
+function getAdditionalAttributes($storeId = null)
+{
+    return $this->configHelper->getProductAdditionalAttributes($storeId);
+}
+
+/**
+ * @param $indexName
+ * @param $indexNameTmp
+ * @param $storeId
+ * @param $saveToTmpIndicesToo
+ * @return void
+ * @throws AlgoliaException
+ */
+public
+function setSettings($indexName, $indexNameTmp, $storeId, $saveToTmpIndicesToo = false)
+{
+    $searchableAttributes = $this->getSearchableAttributes($storeId);
+    $customRanking = $this->getCustomRanking($storeId);
+    $unretrievableAttributes = $this->getUnretrieveableAttributes($storeId);
+    $attributesForFaceting = $this->getAttributesForFaceting($storeId);
+
+    $indexSettings = [
+        'searchableAttributes' => $searchableAttributes,
+        'customRanking' => $customRanking,
+        'unretrievableAttributes' => $unretrievableAttributes,
+        'attributesForFaceting' => $attributesForFaceting,
+        'maxValuesPerFacet' => (int)$this->configHelper->getMaxValuesPerFacet($storeId),
+        'removeWordsIfNoResults' => $this->configHelper->getRemoveWordsIfNoResult($storeId),
+    ];
+
+    // Additional index settings from event observer
+    $transport = new DataObject($indexSettings);
+    // Only for backward compatibility
+    $this->eventManager->dispatch(
+        'algolia_index_settings_prepare',
+        ['store_id' => $storeId, 'index_settings' => $transport]
+    );
+    $this->eventManager->dispatch(
+        'algolia_products_index_before_set_settings',
+        [
+            'store_id' => $storeId,
+            'index_settings' => $transport,
+        ]
+    );
+
+    $indexSettings = $transport->getData();
+
+    $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
+    $this->logger->log('Settings: ' . json_encode($indexSettings));
+    if ($saveToTmpIndicesToo === true) {
+        $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true, $indexName);
+        $this->logger->log('Pushing the same settings to TMP index as well');
     }
 
-    /**
-     * @param $indexName
-     * @param $indexNameTmp
-     * @param $storeId
-     * @param $saveToTmpIndicesToo
-     * @return void
-     * @throws AlgoliaException
+    $this->setFacetsQueryRules($indexName);
+    if ($saveToTmpIndicesToo === true) {
+        $this->setFacetsQueryRules($indexNameTmp);
+    }
+
+    /*
+     * Handle replicas
      */
-    public function setSettings($indexName, $indexNameTmp, $storeId, $saveToTmpIndicesToo = false)
-    {
-        $searchableAttributes = $this->getSearchableAttributes($storeId);
-        $customRanking = $this->getCustomRanking($storeId);
-        $unretrievableAttributes = $this->getUnretrieveableAttributes($storeId);
-        $attributesForFaceting = $this->getAttributesForFaceting($storeId);
+    $sortingIndices = $this->configHelper->getSortingIndices($indexName, $storeId);
 
-        $indexSettings = [
-            'searchableAttributes'    => $searchableAttributes,
-            'customRanking'           => $customRanking,
-            'unretrievableAttributes' => $unretrievableAttributes,
-            'attributesForFaceting'   => $attributesForFaceting,
-            'maxValuesPerFacet'       => (int) $this->configHelper->getMaxValuesPerFacet($storeId),
-            'removeWordsIfNoResults'  => $this->configHelper->getRemoveWordsIfNoResult($storeId),
-        ];
+    $replicas = [];
 
-        // Additional index settings from event observer
-        $transport = new DataObject($indexSettings);
-        // Only for backward compatibility
-        $this->eventManager->dispatch(
-            'algolia_index_settings_prepare',
-            ['store_id' => $storeId, 'index_settings' => $transport]
-        );
-        $this->eventManager->dispatch(
-            'algolia_products_index_before_set_settings',
-            [
-                'store_id'       => $storeId,
-                'index_settings' => $transport,
-            ]
-        );
+    if ($this->configHelper->isInstantEnabled($storeId)) {
+        $replicas = array_values(array_map(function ($sortingIndex) {
+            return $sortingIndex['name'];
+        }, $sortingIndices));
+    }
 
-        $indexSettings = $transport->getData();
+    // Managing Virtual Replica
+    if ($this->configHelper->useVirtualReplica($storeId)) {
+        $replicas = $this->handleVirtualReplica($replicas, $indexName);
+    }
 
-        $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
-        $this->logger->log('Settings: ' . json_encode($indexSettings));
-        if ($saveToTmpIndicesToo === true) {
-            $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true, $indexName);
-            $this->logger->log('Pushing the same settings to TMP index as well');
+    // Merge current replicas with sorting replicas to not delete A/B testing replica indices
+    try {
+        $currentSettings = $this->algoliaHelper->getSettings($indexName);
+        if (array_key_exists('replicas', $currentSettings)) {
+            $replicas = array_values(array_unique(array_merge($replicas, $currentSettings['replicas'])));
         }
-
-        $this->setFacetsQueryRules($indexName);
-        if ($saveToTmpIndicesToo === true) {
-            $this->setFacetsQueryRules($indexNameTmp);
+    } catch (AlgoliaException $e) {
+        if ($e->getMessage() !== 'Index does not exist') {
+            throw $e;
         }
+    }
 
-        /*
-         * Handle replicas
-         */
-        $sortingIndices = $this->configHelper->getSortingIndices($indexName, $storeId);
+    if (count($replicas) > 0) {
+        $this->algoliaHelper->setSettings($indexName, ['replicas' => $replicas]);
+        $this->logger->log('Setting replicas to "' . $indexName . '" index.');
+        $this->logger->log('Replicas: ' . json_encode($replicas));
+        $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
 
-        $replicas = [];
-
-        if ($this->configHelper->isInstantEnabled($storeId)) {
-            $replicas = array_values(array_map(function ($sortingIndex) {
-                return $sortingIndex['name'];
-            }, $sortingIndices));
-        }
-
-        // Managing Virtual Replica
-        if ($this->configHelper->useVirtualReplica($storeId)) {
-            $replicas = $this->handleVirtualReplica($replicas, $indexName);
-        }
-
-        // Merge current replicas with sorting replicas to not delete A/B testing replica indices
-        try {
-            $currentSettings = $this->algoliaHelper->getSettings($indexName);
-            if (array_key_exists('replicas', $currentSettings)) {
-                $replicas = array_values(array_unique(array_merge($replicas, $currentSettings['replicas'])));
-            }
-        } catch (AlgoliaException $e) {
-            if ($e->getMessage() !== 'Index does not exist') {
-                throw $e;
-            }
-        }
-
-        if (count($replicas) > 0) {
-            $this->algoliaHelper->setSettings($indexName, ['replicas' => $replicas]);
-            $this->logger->log('Setting replicas to "' . $indexName . '" index.');
-            $this->logger->log('Replicas: ' . json_encode($replicas));
-            $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
-
-            if (!$this->configHelper->useVirtualReplica($storeId)) {
-                foreach ($sortingIndices as $values) {
-                    $replicaName = $values['name'];
-                    $indexSettings['ranking'] = $values['ranking'];
-                    $this->algoliaHelper->setSettings($replicaName, $indexSettings, false, true);
-                    $this->logger->log('Setting settings to "' . $replicaName . '" replica.');
-                    $this->logger->log('Settings: ' . json_encode($indexSettings));
-                }
-            } else {
-                foreach ($sortingIndices as $values) {
-                    $replicaName = $values['name'];
-                    array_unshift($customRanking,$values['ranking'][0]);
-                    $replicaSetting['customRanking'] = $customRanking;
-                    $this->algoliaHelper->setSettings($replicaName, $replicaSetting, false, false);
-                    $this->logger->log('Setting settings to "' . $replicaName . '" replica.');
-                    $this->logger->log('Settings: ' . json_encode($replicaSetting));
-                }
+        if (!$this->configHelper->useVirtualReplica($storeId)) {
+            foreach ($sortingIndices as $values) {
+                $replicaName = $values['name'];
+                $indexSettings['ranking'] = $values['ranking'];
+                $this->algoliaHelper->setSettings($replicaName, $indexSettings, false, true);
+                $this->logger->log('Setting settings to "' . $replicaName . '" replica.');
+                $this->logger->log('Settings: ' . json_encode($indexSettings));
             }
         } else {
-            $this->algoliaHelper->setSettings($indexName, ['replicas' => []]);
-            $this->logger->log('Removing replicas from "' . $indexName . '" index');
-            $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
+            foreach ($sortingIndices as $values) {
+                $replicaName = $values['name'];
+                array_unshift($customRanking, $values['ranking'][0]);
+                $replicaSetting['customRanking'] = $customRanking;
+                $this->algoliaHelper->setSettings($replicaName, $replicaSetting, false, false);
+                $this->logger->log('Setting settings to "' . $replicaName . '" replica.');
+                $this->logger->log('Settings: ' . json_encode($replicaSetting));
+            }
         }
+    } else {
+        $this->algoliaHelper->setSettings($indexName, ['replicas' => []]);
+        $this->logger->log('Removing replicas from "' . $indexName . '" index');
+        $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
+    }
 
-        // Commented out as it doesn't delete anything now because of merging replica indices earlier
-        // $this->deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId);
+    // Commented out as it doesn't delete anything now because of merging replica indices earlier
+    // $this->deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId);
 
-        if ($saveToTmpIndicesToo === true) {
-            try {
-                $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
-                $this->logger->log('
+    if ($saveToTmpIndicesToo === true) {
+        try {
+            $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
+            $this->logger->log('
                     Copying synonyms from production index to TMP one to not erase them with the index move.
                 ');
-            } catch (AlgoliaException $e) {
-                $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
-            }
+        } catch (AlgoliaException $e) {
+            $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
+        }
 
-            try {
-                $this->algoliaHelper->copyQueryRules($indexName, $indexNameTmp);
-                $this->logger->log('
+        try {
+            $this->algoliaHelper->copyQueryRules($indexName, $indexNameTmp);
+            $this->logger->log('
                     Copying query rules to "' . $indexNameTmp . '" to not to erase them with the index move.
                 ');
-            } catch (AlgoliaException $e) {
-                // Fail silently if query rules are disabled on the app
-                // If QRs are disabled, nothing will happen and the extension will work as expected
-                if ($e->getMessage() !== 'Query Rules are not enabled on this application') {
-                    throw $e;
-                }
-            }
-        }
-    }
-
-    /**
-     * @param $categoryIds
-     * @param $storeId
-     * @return array
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    public function getAllCategories($categoryIds, $storeId)
-    {
-        $filterNotIncludedCategories = $this->configHelper->showCatsNotIncludedInNavigation($storeId);
-        $categories = $this->categoryHelper->getCoreCategories($filterNotIncludedCategories, $storeId);
-
-        $selectedCategories = [];
-        foreach ($categoryIds as $id) {
-            if (isset($categories[$id])) {
-                $selectedCategories[] = $categories[$id];
-            }
-        }
-
-        return $selectedCategories;
-    }
-
-    /**
-     * @param Product $product
-     * @return array|mixed|null
-     * @throws \Exception
-     */
-    public function getObject(Product $product)
-    {
-        $storeId = $product->getStoreId();
-
-        $this->logger->start('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId));
-        $defaultData = [];
-
-        $transport = new DataObject($defaultData);
-        $this->eventManager->dispatch(
-            'algolia_product_index_before',
-            ['product' => $product, 'custom_data' => $transport]
-        );
-
-        $defaultData = $transport->getData();
-
-        $visibility = $product->getVisibility();
-
-        $visibleInCatalog = $this->visibility->getVisibleInCatalogIds();
-        $visibleInSearch = $this->visibility->getVisibleInSearchIds();
-
-        $urlParams = [
-            '_secure' => $this->configHelper->useSecureUrlsInFrontend($product->getStoreId()),
-            '_nosid' => true,
-        ];
-
-        $customData = [
-            'objectID'           => $product->getId(),
-            'name'               => $product->getName(),
-            'url'                => $product->getUrlModel()->getUrl($product, $urlParams),
-            'visibility_search'  => (int) (in_array($visibility, $visibleInSearch)),
-            'visibility_catalog' => (int) (in_array($visibility, $visibleInCatalog)),
-            'type_id'            => $product->getTypeId(),
-        ];
-
-        $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
-        $groups = null;
-
-        $customData = $this->addAttribute('description', $defaultData, $customData, $additionalAttributes, $product);
-        $customData = $this->addAttribute('ordered_qty', $defaultData, $customData, $additionalAttributes, $product);
-        $customData = $this->addAttribute('total_ordered', $defaultData, $customData, $additionalAttributes, $product);
-        $customData = $this->addAttribute('rating_summary', $defaultData, $customData, $additionalAttributes, $product);
-        $customData = $this->addCategoryData($customData, $product);
-        $customData = $this->addImageData($customData, $product, $additionalAttributes);
-        $customData = $this->addInStock($defaultData, $customData, $product);
-        $customData = $this->addStockQty($defaultData, $customData, $additionalAttributes, $product);
-        $subProducts = $this->getSubProducts($product);
-        $customData = $this->addAdditionalAttributes($customData, $additionalAttributes, $product, $subProducts);
-        $customData = $this->priceManager->addPriceDataByProductType($customData, $product, $subProducts);
-        $transport = new DataObject($customData);
-        $this->eventManager->dispatch(
-            'algolia_subproducts_index',
-            ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
-        );
-        $customData = $transport->getData();
-        $customData = array_merge($customData, $defaultData);
-        $this->algoliaHelper->castProductObject($customData);
-        $transport = new DataObject($customData);
-        $this->eventManager->dispatch(
-            'algolia_after_create_product_object',
-            ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
-        );
-        $customData = $transport->getData();
-
-        $this->logger->stop('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId));
-
-        return $customData;
-    }
-
-    /**
-     * @param Product $product
-     * @return array|\Magento\Catalog\Api\Data\ProductInterface[]|DataObject[]
-     */
-    protected function getSubProducts(Product $product)
-    {
-        $type = $product->getTypeId();
-
-        if (!in_array($type, ['bundle', 'grouped', 'configurable'], true)) {
-            return [];
-        }
-
-        $storeId = $product->getStoreId();
-        $typeInstance = $product->getTypeInstance();
-
-        if ($typeInstance instanceof Configurable) {
-            $subProducts = $typeInstance->getUsedProducts($product);
-        } elseif ($typeInstance instanceof BundleProductType) {
-            $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product)->getItems();
-        } else { // Grouped product
-            $subProducts = $typeInstance->getAssociatedProducts($product);
-        }
-
-        /**
-         * @var int $index
-         * @var Product $subProduct
-         */
-        foreach ($subProducts as $index => $subProduct) {
-            try {
-                $this->canProductBeReindexed($subProduct, $storeId, true);
-            } catch (ProductReindexingException $e) {
-                unset($subProducts[$index]);
-            }
-        }
-
-        return $subProducts;
-    }
-
-    /**
-     * Returns all parent product IDs, e.g. when simple product is part of configurable or bundle
-     *
-     * @param array $productIds
-     *
-     * @return array
-     */
-    public function getParentProductIds(array $productIds)
-    {
-        $parentIds = [];
-        foreach ($this->getCompositeTypes() as $typeInstance) {
-            $parentIds = array_merge($parentIds, $typeInstance->getParentIdsByChild($productIds));
-        }
-
-        return $parentIds;
-    }
-
-    /**
-     * Returns composite product type instances
-     *
-     * @return AbstractType[]
-     *
-     * @see \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction::_getProductTypeInstances
-     */
-    protected function getCompositeTypes()
-    {
-        if ($this->compositeTypes === null) {
-            $productEmulator = new \Magento\Framework\DataObject();
-            foreach ($this->productType->getCompositeTypes() as $typeId) {
-                $productEmulator->setTypeId($typeId);
-                $this->compositeTypes[$typeId] = $this->productType->factory($productEmulator);
-            }
-        }
-
-        return $this->compositeTypes;
-    }
-
-    /**
-     * @param $attribute
-     * @param $defaultData
-     * @param $customData
-     * @param $additionalAttributes
-     * @param Product $product
-     * @return mixed
-     */
-    protected function addAttribute($attribute, $defaultData, $customData, $additionalAttributes, Product $product)
-    {
-        if (isset($defaultData[$attribute]) === false
-            && $this->isAttributeEnabled($additionalAttributes, $attribute)) {
-            $customData[$attribute] = $product->getData($attribute);
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $customData
-     * @param Product $product
-     * @return mixed
-     * @throws \Magento\Framework\Exception\LocalizedException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     */
-    protected function addCategoryData($customData, Product $product)
-    {
-        $storeId = $product->getStoreId();
-        $categories = [];
-        $categoriesWithPath = [];
-        $categoryIds = [];
-
-        $_categoryIds = $product->getCategoryIds();
-
-        if (is_array($_categoryIds) && count($_categoryIds) > 0) {
-            $categoryCollection = $this->getAllCategories($_categoryIds, $storeId);
-
-            /** @var Store $store */
-            $store = $this->storeManager->getStore($product->getStoreId());
-            $rootCat = $store->getRootCategoryId();
-
-            foreach ($categoryCollection as $category) {
-                // Check and skip all categories that is not
-                // in the path of the current store.
-                $path = $category->getPath();
-                $pathParts = explode('/', $path);
-                if (isset($pathParts[1]) && $pathParts[1] !== $rootCat) {
-                    continue;
-                }
-
-                $categoryName = $this->categoryHelper->getCategoryName($category->getId(), $storeId);
-                if ($categoryName) {
-                    $categories[] = $categoryName;
-                }
-
-                $category->getUrlInstance()->setStore($product->getStoreId());
-                $path = [];
-
-                foreach ($category->getPathIds() as $treeCategoryId) {
-                    $name = $this->categoryHelper->getCategoryName($treeCategoryId, $storeId);
-                    if ($name) {
-                        $categoryIds[] = $treeCategoryId;
-                        $path[] = $name;
-                    }
-                }
-
-                $categoriesWithPath[] = $path;
-            }
-        }
-
-        foreach ($categoriesWithPath as $result) {
-            for ($i = count($result) - 1; $i > 0; $i--) {
-                $categoriesWithPath[] = array_slice($result, 0, $i);
-            }
-        }
-
-        $categoriesWithPath = array_intersect_key(
-            $categoriesWithPath,
-            array_unique(array_map('serialize', $categoriesWithPath))
-        );
-
-        $hierarchicalCategories = $this->getHierarchicalCategories($categoriesWithPath);
-
-        $customData['categories'] = $hierarchicalCategories;
-        $customData['categories_without_path'] = $categories;
-        $customData['categoryIds'] = array_values(array_unique($categoryIds));
-
-        return $customData;
-    }
-
-    /**
-     * @param $categoriesWithPath
-     * @return array
-     */
-    protected function getHierarchicalCategories($categoriesWithPath)
-    {
-        $hierachivalCategories = [];
-
-        $levelName = 'level';
-
-        foreach ($categoriesWithPath as $category) {
-            $categoryCount = count($category);
-            for ($i = 0; $i < $categoryCount; $i++) {
-                if (isset($hierachivalCategories[$levelName . $i]) === false) {
-                    $hierachivalCategories[$levelName . $i] = [];
-                }
-
-                if ($category[$i] === null) {
-                    continue;
-                }
-
-                $hierachivalCategories[$levelName . $i][] = implode(' /// ', array_slice($category, 0, $i + 1));
-            }
-        }
-
-        foreach ($hierachivalCategories as &$level) {
-            $level = array_values(array_unique($level));
-        }
-
-        return $hierachivalCategories;
-    }
-
-    /**
-     * @param array $customData
-     * @param Product $product
-     * @param $additionalAttributes
-     * @return array
-     */
-    protected function addImageData(array $customData, Product $product, $additionalAttributes)
-    {
-        if (false === isset($customData['thumbnail_url'])) {
-            $customData['thumbnail_url'] = $this->imageHelper
-                ->init($product, 'product_thumbnail_image')
-                ->getUrl();
-        }
-
-        if (false === isset($customData['image_url'])) {
-            $this->imageHelper
-                ->init($product, $this->configHelper->getImageType())
-                ->resize($this->configHelper->getImageWidth(), $this->configHelper->getImageHeight());
-
-            $customData['image_url'] = $this->imageHelper->getUrl();
-
-            if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
-                $product->load($product->getId(), 'media_gallery');
-
-                $customData['media_gallery'] = [];
-
-                $images = $product->getMediaGalleryImages();
-                if ($images) {
-                    foreach ($images as $image) {
-                        $customData['media_gallery'][] = $image->getUrl();
-                    }
-                }
-            }
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $defaultData
-     * @param $customData
-     * @param Product $product
-     * @return mixed
-     */
-    protected function addInStock($defaultData, $customData, Product $product)
-    {
-        if (isset($defaultData['in_stock']) === false) {
-            $stockItem = $this->stockRegistry->getStockItem($product->getId());
-            $customData['in_stock'] = $product->isSaleable() && $stockItem->getIsInStock();
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $defaultData
-     * @param $customData
-     * @param $additionalAttributes
-     * @param Product $product
-     * @return mixed
-     */
-    protected function addStockQty($defaultData, $customData, $additionalAttributes, Product $product)
-    {
-        if (isset($defaultData['stock_qty']) === false
-            && $this->isAttributeEnabled($additionalAttributes, 'stock_qty')) {
-            $customData['stock_qty'] = 0;
-
-            $stockItem = $this->stockRegistry->getStockItem($product->getId());
-            if ($stockItem) {
-                $customData['stock_qty'] = (int) $stockItem->getQty();
-            }
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $customData
-     * @param $additionalAttributes
-     * @param Product $product
-     * @param $subProducts
-     * @return mixed
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    protected function addAdditionalAttributes($customData, $additionalAttributes, Product $product, $subProducts)
-    {
-        foreach ($additionalAttributes as $attribute) {
-            $attributeName = $attribute['attribute'];
-
-            if (isset($customData[$attributeName]) && $attributeName !== 'sku') {
-                continue;
-            }
-
-            /** @var \Magento\Catalog\Model\ResourceModel\Product $resource */
-            $resource = $product->getResource();
-
-            /** @var AttributeResource $attributeResource */
-            $attributeResource = $resource->getAttribute($attributeName);
-            if (!$attributeResource) {
-                continue;
-            }
-
-            $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
-
-            $value = $product->getData($attributeName);
-
-            if ($value !== null) {
-                $customData = $this->addNonNullValue($customData, $value, $product, $attribute, $attributeResource);
-
-                if (!in_array($attributeName, $this->attributesToIndexAsArray, true)) {
-                    continue;
-                }
-            }
-
-            $type = $product->getTypeId();
-            if ($type !== 'configurable' && $type !== 'grouped' && $type !== 'bundle') {
-                continue;
-            }
-
-            $customData = $this->addNullValue($customData, $subProducts, $attribute, $attributeResource);
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $customData
-     * @param $subProducts
-     * @param $attribute
-     * @param AttributeResource $attributeResource
-     * @return mixed
-     */
-    protected function addNullValue($customData, $subProducts, $attribute, AttributeResource $attributeResource)
-    {
-        $attributeName = $attribute['attribute'];
-
-        $values = [];
-        $subProductImages = [];
-
-        if (isset($customData[$attributeName])) {
-            $values[] = $customData[$attributeName];
-        }
-
-        /** @var Product $subProduct */
-        foreach ($subProducts as $subProduct) {
-            $value = $subProduct->getData($attributeName);
-            if ($value) {
-                /** @var string|array $valueText */
-                $valueText = $subProduct->getAttributeText($attributeName);
-
-                $values = array_merge($values, $this->getValues($valueText, $subProduct, $attributeResource));
-                if ($this->configHelper->useAdaptiveImage($attributeResource->getStoreId())) {
-                    $subProductImages = $this->addSubProductImage(
-                        $subProductImages,
-                        $attribute,
-                        $subProduct,
-                        $valueText
-                    );
-                }
-            }
-        }
-
-        if (is_array($values) && count($values) > 0) {
-            $customData[$attributeName] = array_values(array_unique($values));
-        }
-
-        if (count($subProductImages) > 0) {
-            $customData['images_data'] = $subProductImages;
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $valueText
-     * @param Product $subProduct
-     * @param AttributeResource $attributeResource
-     * @return array
-     */
-    protected function getValues($valueText, Product $subProduct, AttributeResource $attributeResource)
-    {
-        $values = [];
-
-        if ($valueText) {
-            if (is_array($valueText)) {
-                foreach ($valueText as $valueText_elt) {
-                    $values[] = $valueText_elt;
-                }
-            } else {
-                $values[] = $valueText;
-            }
-        } else {
-            $values[] = $attributeResource->getFrontend()->getValue($subProduct);
-        }
-
-        return $values;
-    }
-
-    /**
-     * @param $subProductImages
-     * @param $attribute
-     * @param $subProduct
-     * @param $valueText
-     * @return mixed
-     */
-    protected function addSubProductImage($subProductImages, $attribute, $subProduct, $valueText)
-    {
-        if (mb_strtolower($attribute['attribute'], 'utf-8') !== 'color') {
-            return $subProductImages;
-        }
-
-        $image = $this->imageHelper
-            ->init($subProduct, $this->configHelper->getImageType())
-            ->resize(
-                $this->configHelper->getImageWidth(),
-                $this->configHelper->getImageHeight()
-            );
-
-        $subImage = $subProduct->getData($image->getType());
-        if (!$subImage || $subImage === 'no_selection') {
-            return $subProductImages;
-        }
-
-        try {
-            $textValueInLower = mb_strtolower($valueText, 'utf-8');
-            $subProductImages[$textValueInLower] = $image->getUrl();
-        } catch (\Exception $e) {
-            $this->logger->log($e->getMessage());
-            $this->logger->log($e->getTraceAsString());
-        }
-
-        return $subProductImages;
-    }
-
-    /**
-     * @param $customData
-     * @param $value
-     * @param Product $product
-     * @param $attribute
-     * @param AttributeResource $attributeResource
-     * @return mixed
-     */
-    protected function addNonNullValue(
-        $customData,
-        $value,
-        Product $product,
-        $attribute,
-        AttributeResource $attributeResource
-    ) {
-        $valueText = null;
-
-        if (!is_array($value) && $attributeResource->usesSource()) {
-            $valueText = $product->getAttributeText($attribute['attribute']);
-        }
-
-        if ($valueText) {
-            $value = $valueText;
-        } else {
-            $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
-            $value = $attributeResource->getFrontend()->getValue($product);
-        }
-
-        if ($value) {
-            $customData[$attribute['attribute']] = $value;
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    protected function getSearchableAttributes($storeId = null)
-    {
-        $searchableAttributes = [];
-
-        foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
-            if ($attribute['searchable'] === '1') {
-                if (!isset($attribute['order']) || $attribute['order'] === 'ordered') {
-                    $searchableAttributes[] = $attribute['attribute'];
-                } else {
-                    $searchableAttributes[] = 'unordered(' . $attribute['attribute'] . ')';
-                }
-
-                if ($attribute['attribute'] === 'categories') {
-                    $searchableAttributes[] = (isset($attribute['order']) && $attribute['order'] === 'ordered') ?
-                        'categories_without_path' : 'unordered(categories_without_path)';
-                }
-            }
-        }
-
-        $searchableAttributes = array_values(array_unique($searchableAttributes));
-
-        return $searchableAttributes;
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    protected function getCustomRanking($storeId)
-    {
-        $customRanking = [];
-
-        $customRankings = $this->configHelper->getProductCustomRanking($storeId);
-        foreach ($customRankings as $ranking) {
-            $customRanking[] = $ranking['order'] . '(' . $ranking['attribute'] . ')';
-        }
-
-        return $customRanking;
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    protected function getUnretrieveableAttributes($storeId = null)
-    {
-        $unretrievableAttributes = [];
-
-        foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
-            if ($attribute['retrievable'] !== '1') {
-                $unretrievableAttributes[] = $attribute['attribute'];
-            }
-        }
-
-        return $unretrievableAttributes;
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    protected function getAttributesForFaceting($storeId)
-    {
-        $attributesForFaceting = [];
-
-        $currencies = $this->currencyManager->getConfigAllowCurrencies();
-
-        $facets = $this->configHelper->getFacets($storeId);
-        foreach ($facets as $facet) {
-            if ($facet['attribute'] === 'price') {
-                foreach ($currencies as $currency_code) {
-                    $facet['attribute'] = 'price.' . $currency_code . '.default';
-
-                    if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
-                        foreach ($this->groupCollection as $group) {
-                            $group_id = (int) $group->getData('customer_group_id');
-
-                            $attributesForFaceting[] = 'price.' . $currency_code . '.group_' . $group_id;
-                        }
-                    }
-
-                    $attributesForFaceting[] = $facet['attribute'];
-                }
-            } else {
-                $attribute = $facet['attribute'];
-                if (array_key_exists('searchable', $facet)) {
-                    if ($facet['searchable'] === '1') {
-                        $attribute = 'searchable(' . $attribute . ')';
-                    } elseif ($facet['searchable'] === '3') {
-                        $attribute = 'filterOnly(' . $attribute . ')';
-                    }
-                }
-
-                $attributesForFaceting[] = $attribute;
-            }
-        }
-
-        if ($this->configHelper->replaceCategories($storeId) && !in_array('categories', $attributesForFaceting, true)) {
-            $attributesForFaceting[] = 'categories';
-        }
-
-        // Used for merchandising
-        $attributesForFaceting[] = 'categoryIds';
-
-        return $attributesForFaceting;
-    }
-
-    /**
-     * @param $indexName
-     * @param $replicas
-     * @param $setReplicasTaskId
-     * @return void
-     */
-    protected function deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId)
-    {
-        $indicesToDelete = [];
-
-        $allIndices = $this->algoliaHelper->listIndexes();
-        foreach ($allIndices['items'] as $indexInfo) {
-            if (mb_strpos($indexInfo['name'], $indexName) !== 0 || $indexInfo['name'] === $indexName) {
-                continue;
-            }
-
-            if (mb_strpos($indexInfo['name'], '_tmp') === false && in_array($indexInfo['name'], $replicas) === false) {
-                $indicesToDelete[] = $indexInfo['name'];
-            }
-        }
-
-        if (count($indicesToDelete) > 0) {
-            $this->algoliaHelper->waitLastTask($indexName, $setReplicasTaskId);
-
-            foreach ($indicesToDelete as $indexToDelete) {
-                $this->algoliaHelper->deleteIndex($indexToDelete);
-            }
-        }
-    }
-
-    /**
-     * @param $indexName
-     * @return void
-     * @throws AlgoliaException
-     */
-    protected function setFacetsQueryRules($indexName)
-    {
-        $index = $this->algoliaHelper->getIndex($indexName);
-
-        $this->clearFacetsQueryRules($index);
-
-        $rules = [];
-        $facets = $this->configHelper->getFacets();
-        foreach ($facets as $facet) {
-            if (!array_key_exists('create_rule', $facet) || $facet['create_rule'] !== '1') {
-                continue;
-            }
-
-            $attribute = $facet['attribute'];
-
-            $condition = [
-                'anchoring' => 'contains',
-                'pattern' => '{facet:' . $attribute . '}',
-                'context' => 'magento_filters',
-            ];
-
-            $rules[] = [
-                'objectID' => 'filter_' . $attribute,
-                'description' => 'Filter facet "' . $attribute . '"',
-                'conditions' => [$condition],
-                'consequence' => [
-                    'params' => [
-                        'automaticFacetFilters' => [$attribute],
-                        'query' => [
-                            'remove' => ['{facet:' . $attribute . '}'],
-                        ],
-                    ],
-                ],
-            ];
-        }
-
-        if ($rules) {
-            $this->logger->log('Setting facets query rules to "' . $indexName . '" index: ' . json_encode($rules));
-            $index->saveRules($rules, [
-                'forwardToReplicas' => true,
-            ]);
-        }
-    }
-
-    /**
-     * @param SearchIndex $index
-     * @return void
-     * @throws AlgoliaException
-     */
-    protected function clearFacetsQueryRules(SearchIndex $index)
-    {
-        try {
-            $hitsPerPage = 100;
-            $page = 0;
-            do {
-                $fetchedQueryRules = $index->searchRules('', [
-                    'context' => 'magento_filters',
-                    'page' => $page,
-                    'hitsPerPage' => $hitsPerPage,
-                ]);
-
-                if (!$fetchedQueryRules || !array_key_exists('hits', $fetchedQueryRules)) {
-                    break;
-                }
-
-                foreach ($fetchedQueryRules['hits'] as $hit) {
-                    $index->deleteRule($hit['objectID'], [
-                        'forwardToReplicas' => true,
-                    ]);
-                }
-
-                $page++;
-            } while (($page * $hitsPerPage) < $fetchedQueryRules['nbHits']);
         } catch (AlgoliaException $e) {
             // Fail silently if query rules are disabled on the app
             // If QRs are disabled, nothing will happen and the extension will work as expected
@@ -1313,79 +535,896 @@ class ProductHelper
             }
         }
     }
+}
+
+/**
+ * @param $categoryIds
+ * @param $storeId
+ * @return array
+ * @throws \Magento\Framework\Exception\LocalizedException
+ */
+public
+function getAllCategories($categoryIds, $storeId)
+{
+    $filterNotIncludedCategories = $this->configHelper->showCatsNotIncludedInNavigation($storeId);
+    $categories = $this->categoryHelper->getCoreCategories($filterNotIncludedCategories, $storeId);
+
+    $selectedCategories = [];
+    foreach ($categoryIds as $id) {
+        if (isset($categories[$id])) {
+            $selectedCategories[] = $categories[$id];
+        }
+    }
+
+    return $selectedCategories;
+}
+
+/**
+ * @param Product $product
+ * @return array|mixed|null
+ * @throws \Exception
+ */
+public
+function getObject(Product $product)
+{
+    $storeId = $product->getStoreId();
+
+    $this->logger->start('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId));
+    $defaultData = [];
+
+    $transport = new DataObject($defaultData);
+    $this->eventManager->dispatch(
+        'algolia_product_index_before',
+        ['product' => $product, 'custom_data' => $transport]
+    );
+
+    $defaultData = $transport->getData();
+
+    $visibility = $product->getVisibility();
+
+    $visibleInCatalog = $this->visibility->getVisibleInCatalogIds();
+    $visibleInSearch = $this->visibility->getVisibleInSearchIds();
+
+    $urlParams = [
+        '_secure' => $this->configHelper->useSecureUrlsInFrontend($product->getStoreId()),
+        '_nosid' => true,
+    ];
+
+    $customData = [
+        'objectID' => $product->getId(),
+        'name' => $product->getName(),
+        'url' => $product->getUrlModel()->getUrl($product, $urlParams),
+        'visibility_search' => (int)(in_array($visibility, $visibleInSearch)),
+        'visibility_catalog' => (int)(in_array($visibility, $visibleInCatalog)),
+        'type_id' => $product->getTypeId(),
+    ];
+
+    $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
+    $groups = null;
+
+    $customData = $this->addAttribute('description', $defaultData, $customData, $additionalAttributes, $product);
+    $customData = $this->addAttribute('ordered_qty', $defaultData, $customData, $additionalAttributes, $product);
+    $customData = $this->addAttribute('total_ordered', $defaultData, $customData, $additionalAttributes, $product);
+    $customData = $this->addAttribute('rating_summary', $defaultData, $customData, $additionalAttributes, $product);
+    $customData = $this->addCategoryData($customData, $product);
+    $customData = $this->addImageData($customData, $product, $additionalAttributes);
+    $customData = $this->addInStock($defaultData, $customData, $product);
+    $customData = $this->addStockQty($defaultData, $customData, $additionalAttributes, $product);
+    $subProducts = $this->getSubProducts($product);
+    $customData = $this->addAdditionalAttributes($customData, $additionalAttributes, $product, $subProducts);
+    $customData = $this->priceManager->addPriceDataByProductType($customData, $product, $subProducts);
+    $transport = new DataObject($customData);
+    $this->eventManager->dispatch(
+        'algolia_subproducts_index',
+        ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
+    );
+    $customData = $transport->getData();
+    $customData = array_merge($customData, $defaultData);
+    $this->algoliaHelper->castProductObject($customData);
+    $transport = new DataObject($customData);
+    $this->eventManager->dispatch(
+        'algolia_after_create_product_object',
+        ['custom_data' => $transport, 'sub_products' => $subProducts, 'productObject' => $product]
+    );
+    $customData = $transport->getData();
+
+    $this->logger->stop('CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId));
+
+    return $customData;
+}
+
+/**
+ * @param Product $product
+ * @return array|\Magento\Catalog\Api\Data\ProductInterface[]|DataObject[]
+ */
+protected
+function getSubProducts(Product $product)
+{
+    $type = $product->getTypeId();
+
+    if (!in_array($type, ['bundle', 'grouped', 'configurable'], true)) {
+        return [];
+    }
+
+    $storeId = $product->getStoreId();
+    $typeInstance = $product->getTypeInstance();
+
+    if ($typeInstance instanceof Configurable) {
+        $subProducts = $typeInstance->getUsedProducts($product);
+    } elseif ($typeInstance instanceof BundleProductType) {
+        $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product)->getItems();
+    } else { // Grouped product
+        $subProducts = $typeInstance->getAssociatedProducts($product);
+    }
 
     /**
-     * Check if product can be index on Algolia
-     *
-     * @param Product $product
-     * @param int $storeId
-     * @param bool $isChildProduct
-     *
-     * @return bool
+     * @var int $index
+     * @var Product $subProduct
      */
-    public function canProductBeReindexed($product, $storeId, $isChildProduct = false)
-    {
-        if ($product->isDeleted() === true) {
-            throw (new ProductDeletedException())
-                ->withProduct($product)
-                ->withStoreId($storeId);
+    foreach ($subProducts as $index => $subProduct) {
+        try {
+            $this->canProductBeReindexed($subProduct, $storeId, true);
+        } catch (ProductReindexingException $e) {
+            unset($subProducts[$index]);
+        }
+    }
+
+    return $subProducts;
+}
+
+/**
+ * Returns all parent product IDs, e.g. when simple product is part of configurable or bundle
+ *
+ * @param array $productIds
+ *
+ * @return array
+ */
+public
+function getParentProductIds(array $productIds)
+{
+    $parentIds = [];
+    foreach ($this->getCompositeTypes() as $typeInstance) {
+        $parentIds = array_merge($parentIds, $typeInstance->getParentIdsByChild($productIds));
+    }
+
+    return $parentIds;
+}
+
+/**
+ * Returns composite product type instances
+ *
+ * @return AbstractType[]
+ *
+ * @see \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction::_getProductTypeInstances
+ */
+protected
+function getCompositeTypes()
+{
+    if ($this->compositeTypes === null) {
+        $productEmulator = new \Magento\Framework\DataObject();
+        foreach ($this->productType->getCompositeTypes() as $typeId) {
+            $productEmulator->setTypeId($typeId);
+            $this->compositeTypes[$typeId] = $this->productType->factory($productEmulator);
+        }
+    }
+
+    return $this->compositeTypes;
+}
+
+/**
+ * @param $attribute
+ * @param $defaultData
+ * @param $customData
+ * @param $additionalAttributes
+ * @param Product $product
+ * @return mixed
+ */
+protected
+function addAttribute($attribute, $defaultData, $customData, $additionalAttributes, Product $product)
+{
+    if (isset($defaultData[$attribute]) === false
+        && $this->isAttributeEnabled($additionalAttributes, $attribute)) {
+        $customData[$attribute] = $product->getData($attribute);
+    }
+
+    return $customData;
+}
+
+/**
+ * @param $customData
+ * @param Product $product
+ * @return mixed
+ * @throws \Magento\Framework\Exception\LocalizedException
+ * @throws \Magento\Framework\Exception\NoSuchEntityException
+ */
+protected
+function addCategoryData($customData, Product $product)
+{
+    $storeId = $product->getStoreId();
+    $categories = [];
+    $categoriesWithPath = [];
+    $categoryIds = [];
+
+    $_categoryIds = $product->getCategoryIds();
+
+    if (is_array($_categoryIds) && count($_categoryIds) > 0) {
+        $categoryCollection = $this->getAllCategories($_categoryIds, $storeId);
+
+        /** @var Store $store */
+        $store = $this->storeManager->getStore($product->getStoreId());
+        $rootCat = $store->getRootCategoryId();
+
+        foreach ($categoryCollection as $category) {
+            // Check and skip all categories that is not
+            // in the path of the current store.
+            $path = $category->getPath();
+            $pathParts = explode('/', $path);
+            if (isset($pathParts[1]) && $pathParts[1] !== $rootCat) {
+                continue;
+            }
+
+            $categoryName = $this->categoryHelper->getCategoryName($category->getId(), $storeId);
+            if ($categoryName) {
+                $categories[] = $categoryName;
+            }
+
+            $category->getUrlInstance()->setStore($product->getStoreId());
+            $path = [];
+
+            foreach ($category->getPathIds() as $treeCategoryId) {
+                $name = $this->categoryHelper->getCategoryName($treeCategoryId, $storeId);
+                if ($name) {
+                    $categoryIds[] = $treeCategoryId;
+                    $path[] = $name;
+                }
+            }
+
+            $categoriesWithPath[] = $path;
+        }
+    }
+
+    foreach ($categoriesWithPath as $result) {
+        for ($i = count($result) - 1; $i > 0; $i--) {
+            $categoriesWithPath[] = array_slice($result, 0, $i);
+        }
+    }
+
+    $categoriesWithPath = array_intersect_key(
+        $categoriesWithPath,
+        array_unique(array_map('serialize', $categoriesWithPath))
+    );
+
+    $hierarchicalCategories = $this->getHierarchicalCategories($categoriesWithPath);
+
+    $customData['categories'] = $hierarchicalCategories;
+    $customData['categories_without_path'] = $categories;
+    $customData['categoryIds'] = array_values(array_unique($categoryIds));
+
+    return $customData;
+}
+
+/**
+ * @param $categoriesWithPath
+ * @return array
+ */
+protected
+function getHierarchicalCategories($categoriesWithPath)
+{
+    $hierachivalCategories = [];
+
+    $levelName = 'level';
+
+    foreach ($categoriesWithPath as $category) {
+        $categoryCount = count($category);
+        for ($i = 0; $i < $categoryCount; $i++) {
+            if (isset($hierachivalCategories[$levelName . $i]) === false) {
+                $hierachivalCategories[$levelName . $i] = [];
+            }
+
+            if ($category[$i] === null) {
+                continue;
+            }
+
+            $hierachivalCategories[$levelName . $i][] = implode(' /// ', array_slice($category, 0, $i + 1));
+        }
+    }
+
+    foreach ($hierachivalCategories as &$level) {
+        $level = array_values(array_unique($level));
+    }
+
+    return $hierachivalCategories;
+}
+
+/**
+ * @param array $customData
+ * @param Product $product
+ * @param $additionalAttributes
+ * @return array
+ */
+protected
+function addImageData(array $customData, Product $product, $additionalAttributes)
+{
+    if (false === isset($customData['thumbnail_url'])) {
+        $customData['thumbnail_url'] = $this->imageHelper
+            ->init($product, 'product_thumbnail_image')
+            ->getUrl();
+    }
+
+    if (false === isset($customData['image_url'])) {
+        $this->imageHelper
+            ->init($product, $this->configHelper->getImageType())
+            ->resize($this->configHelper->getImageWidth(), $this->configHelper->getImageHeight());
+
+        $customData['image_url'] = $this->imageHelper->getUrl();
+
+        if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
+            $product->load($product->getId(), 'media_gallery');
+
+            $customData['media_gallery'] = [];
+
+            $images = $product->getMediaGalleryImages();
+            if ($images) {
+                foreach ($images as $image) {
+                    $customData['media_gallery'][] = $image->getUrl();
+                }
+            }
+        }
+    }
+
+    return $customData;
+}
+
+/**
+ * @param $defaultData
+ * @param $customData
+ * @param Product $product
+ * @return mixed
+ */
+protected
+function addInStock($defaultData, $customData, Product $product)
+{
+    if (isset($defaultData['in_stock']) === false) {
+        $stockItem = $this->stockRegistry->getStockItem($product->getId());
+        $customData['in_stock'] = $product->isSaleable() && $stockItem->getIsInStock();
+    }
+
+    return $customData;
+}
+
+/**
+ * @param $defaultData
+ * @param $customData
+ * @param $additionalAttributes
+ * @param Product $product
+ * @return mixed
+ */
+protected
+function addStockQty($defaultData, $customData, $additionalAttributes, Product $product)
+{
+    if (isset($defaultData['stock_qty']) === false
+        && $this->isAttributeEnabled($additionalAttributes, 'stock_qty')) {
+        $customData['stock_qty'] = 0;
+
+        $stockItem = $this->stockRegistry->getStockItem($product->getId());
+        if ($stockItem) {
+            $customData['stock_qty'] = (int)$stockItem->getQty();
+        }
+    }
+
+    return $customData;
+}
+
+/**
+ * @param $customData
+ * @param $additionalAttributes
+ * @param Product $product
+ * @param $subProducts
+ * @return mixed
+ * @throws \Magento\Framework\Exception\LocalizedException
+ */
+protected
+function addAdditionalAttributes($customData, $additionalAttributes, Product $product, $subProducts)
+{
+    foreach ($additionalAttributes as $attribute) {
+        $attributeName = $attribute['attribute'];
+
+        if (isset($customData[$attributeName]) && $attributeName !== 'sku') {
+            continue;
         }
 
-        if ($product->getStatus() == Status::STATUS_DISABLED) {
-            throw (new ProductDisabledException())
-                ->withProduct($product)
-                ->withStoreId($storeId);
+        /** @var \Magento\Catalog\Model\ResourceModel\Product $resource */
+        $resource = $product->getResource();
+
+        /** @var AttributeResource $attributeResource */
+        $attributeResource = $resource->getAttribute($attributeName);
+        if (!$attributeResource) {
+            continue;
         }
 
-        if ($isChildProduct === false && !in_array($product->getVisibility(), [
+        $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
+
+        $value = $product->getData($attributeName);
+
+        if ($value !== null) {
+            $customData = $this->addNonNullValue($customData, $value, $product, $attribute, $attributeResource);
+
+            if (!in_array($attributeName, $this->attributesToIndexAsArray, true)) {
+                continue;
+            }
+        }
+
+        $type = $product->getTypeId();
+        if ($type !== 'configurable' && $type !== 'grouped' && $type !== 'bundle') {
+            continue;
+        }
+
+        $customData = $this->addNullValue($customData, $subProducts, $attribute, $attributeResource);
+    }
+
+    return $customData;
+}
+
+/**
+ * @param $customData
+ * @param $subProducts
+ * @param $attribute
+ * @param AttributeResource $attributeResource
+ * @return mixed
+ */
+protected
+function addNullValue($customData, $subProducts, $attribute, AttributeResource $attributeResource)
+{
+    $attributeName = $attribute['attribute'];
+
+    $values = [];
+    $subProductImages = [];
+
+    if (isset($customData[$attributeName])) {
+        $values[] = $customData[$attributeName];
+    }
+
+    /** @var Product $subProduct */
+    foreach ($subProducts as $subProduct) {
+        $value = $subProduct->getData($attributeName);
+        if ($value) {
+            /** @var string|array $valueText */
+            $valueText = $subProduct->getAttributeText($attributeName);
+
+            $values = array_merge($values, $this->getValues($valueText, $subProduct, $attributeResource));
+            if ($this->configHelper->useAdaptiveImage($attributeResource->getStoreId())) {
+                $subProductImages = $this->addSubProductImage(
+                    $subProductImages,
+                    $attribute,
+                    $subProduct,
+                    $valueText
+                );
+            }
+        }
+    }
+
+    if (is_array($values) && count($values) > 0) {
+        $customData[$attributeName] = array_values(array_unique($values));
+    }
+
+    if (count($subProductImages) > 0) {
+        $customData['images_data'] = $subProductImages;
+    }
+
+    return $customData;
+}
+
+/**
+ * @param $valueText
+ * @param Product $subProduct
+ * @param AttributeResource $attributeResource
+ * @return array
+ */
+protected
+function getValues($valueText, Product $subProduct, AttributeResource $attributeResource)
+{
+    $values = [];
+
+    if ($valueText) {
+        if (is_array($valueText)) {
+            foreach ($valueText as $valueText_elt) {
+                $values[] = $valueText_elt;
+            }
+        } else {
+            $values[] = $valueText;
+        }
+    } else {
+        $values[] = $attributeResource->getFrontend()->getValue($subProduct);
+    }
+
+    return $values;
+}
+
+/**
+ * @param $subProductImages
+ * @param $attribute
+ * @param $subProduct
+ * @param $valueText
+ * @return mixed
+ */
+protected
+function addSubProductImage($subProductImages, $attribute, $subProduct, $valueText)
+{
+    if (mb_strtolower($attribute['attribute'], 'utf-8') !== 'color') {
+        return $subProductImages;
+    }
+
+    $image = $this->imageHelper
+        ->init($subProduct, $this->configHelper->getImageType())
+        ->resize(
+            $this->configHelper->getImageWidth(),
+            $this->configHelper->getImageHeight()
+        );
+
+    $subImage = $subProduct->getData($image->getType());
+    if (!$subImage || $subImage === 'no_selection') {
+        return $subProductImages;
+    }
+
+    try {
+        $textValueInLower = mb_strtolower($valueText, 'utf-8');
+        $subProductImages[$textValueInLower] = $image->getUrl();
+    } catch (\Exception $e) {
+        $this->logger->log($e->getMessage());
+        $this->logger->log($e->getTraceAsString());
+    }
+
+    return $subProductImages;
+}
+
+/**
+ * @param $customData
+ * @param $value
+ * @param Product $product
+ * @param $attribute
+ * @param AttributeResource $attributeResource
+ * @return mixed
+ */
+protected
+function addNonNullValue(
+    $customData,
+    $value,
+    Product $product,
+    $attribute,
+    AttributeResource $attributeResource
+)
+{
+    $valueText = null;
+
+    if (!is_array($value) && $attributeResource->usesSource()) {
+        $valueText = $product->getAttributeText($attribute['attribute']);
+    }
+
+    if ($valueText) {
+        $value = $valueText;
+    } else {
+        $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
+        $value = $attributeResource->getFrontend()->getValue($product);
+    }
+
+    if ($value) {
+        $customData[$attribute['attribute']] = $value;
+    }
+
+    return $customData;
+}
+
+/**
+ * @param $storeId
+ * @return array
+ */
+protected
+function getSearchableAttributes($storeId = null)
+{
+    $searchableAttributes = [];
+
+    foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
+        if ($attribute['searchable'] === '1') {
+            if (!isset($attribute['order']) || $attribute['order'] === 'ordered') {
+                $searchableAttributes[] = $attribute['attribute'];
+            } else {
+                $searchableAttributes[] = 'unordered(' . $attribute['attribute'] . ')';
+            }
+
+            if ($attribute['attribute'] === 'categories') {
+                $searchableAttributes[] = (isset($attribute['order']) && $attribute['order'] === 'ordered') ?
+                    'categories_without_path' : 'unordered(categories_without_path)';
+            }
+        }
+    }
+
+    $searchableAttributes = array_values(array_unique($searchableAttributes));
+
+    return $searchableAttributes;
+}
+
+/**
+ * @param $storeId
+ * @return array
+ */
+protected
+function getCustomRanking($storeId)
+{
+    $customRanking = [];
+
+    $customRankings = $this->configHelper->getProductCustomRanking($storeId);
+    foreach ($customRankings as $ranking) {
+        $customRanking[] = $ranking['order'] . '(' . $ranking['attribute'] . ')';
+    }
+
+    return $customRanking;
+}
+
+/**
+ * @param $storeId
+ * @return array
+ */
+protected
+function getUnretrieveableAttributes($storeId = null)
+{
+    $unretrievableAttributes = [];
+
+    foreach ($this->getAdditionalAttributes($storeId) as $attribute) {
+        if ($attribute['retrievable'] !== '1') {
+            $unretrievableAttributes[] = $attribute['attribute'];
+        }
+    }
+
+    return $unretrievableAttributes;
+}
+
+/**
+ * @param $storeId
+ * @return array
+ */
+protected
+function getAttributesForFaceting($storeId)
+{
+    $attributesForFaceting = [];
+
+    $currencies = $this->currencyManager->getConfigAllowCurrencies();
+
+    $facets = $this->configHelper->getFacets($storeId);
+    foreach ($facets as $facet) {
+        if ($facet['attribute'] === 'price') {
+            foreach ($currencies as $currency_code) {
+                $facet['attribute'] = 'price.' . $currency_code . '.default';
+
+                if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
+                    foreach ($this->groupCollection as $group) {
+                        $group_id = (int)$group->getData('customer_group_id');
+
+                        $attributesForFaceting[] = 'price.' . $currency_code . '.group_' . $group_id;
+                    }
+                }
+
+                $attributesForFaceting[] = $facet['attribute'];
+            }
+        } else {
+            $attribute = $facet['attribute'];
+            if (array_key_exists('searchable', $facet)) {
+                if ($facet['searchable'] === '1') {
+                    $attribute = 'searchable(' . $attribute . ')';
+                } elseif ($facet['searchable'] === '3') {
+                    $attribute = 'filterOnly(' . $attribute . ')';
+                }
+            }
+
+            $attributesForFaceting[] = $attribute;
+        }
+    }
+
+    if ($this->configHelper->replaceCategories($storeId) && !in_array('categories', $attributesForFaceting, true)) {
+        $attributesForFaceting[] = 'categories';
+    }
+
+    // Used for merchandising
+    $attributesForFaceting[] = 'categoryIds';
+
+    return $attributesForFaceting;
+}
+
+/**
+ * @param $indexName
+ * @param $replicas
+ * @param $setReplicasTaskId
+ * @return void
+ */
+protected
+function deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId)
+{
+    $indicesToDelete = [];
+
+    $allIndices = $this->algoliaHelper->listIndexes();
+    foreach ($allIndices['items'] as $indexInfo) {
+        if (mb_strpos($indexInfo['name'], $indexName) !== 0 || $indexInfo['name'] === $indexName) {
+            continue;
+        }
+
+        if (mb_strpos($indexInfo['name'], '_tmp') === false && in_array($indexInfo['name'], $replicas) === false) {
+            $indicesToDelete[] = $indexInfo['name'];
+        }
+    }
+
+    if (count($indicesToDelete) > 0) {
+        $this->algoliaHelper->waitLastTask($indexName, $setReplicasTaskId);
+
+        foreach ($indicesToDelete as $indexToDelete) {
+            $this->algoliaHelper->deleteIndex($indexToDelete);
+        }
+    }
+}
+
+/**
+ * @param $indexName
+ * @return void
+ * @throws AlgoliaException
+ */
+protected
+function setFacetsQueryRules($indexName)
+{
+    $index = $this->algoliaHelper->getIndex($indexName);
+
+    $this->clearFacetsQueryRules($index);
+
+    $rules = [];
+    $facets = $this->configHelper->getFacets();
+    foreach ($facets as $facet) {
+        if (!array_key_exists('create_rule', $facet) || $facet['create_rule'] !== '1') {
+            continue;
+        }
+
+        $attribute = $facet['attribute'];
+
+        $condition = [
+            'anchoring' => 'contains',
+            'pattern' => '{facet:' . $attribute . '}',
+            'context' => 'magento_filters',
+        ];
+
+        $rules[] = [
+            'objectID' => 'filter_' . $attribute,
+            'description' => 'Filter facet "' . $attribute . '"',
+            'conditions' => [$condition],
+            'consequence' => [
+                'params' => [
+                    'automaticFacetFilters' => [$attribute],
+                    'query' => [
+                        'remove' => ['{facet:' . $attribute . '}'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    if ($rules) {
+        $this->logger->log('Setting facets query rules to "' . $indexName . '" index: ' . json_encode($rules));
+        $index->saveRules($rules, [
+            'forwardToReplicas' => true,
+        ]);
+    }
+}
+
+/**
+ * @param SearchIndex $index
+ * @return void
+ * @throws AlgoliaException
+ */
+protected
+function clearFacetsQueryRules(SearchIndex $index)
+{
+    try {
+        $hitsPerPage = 100;
+        $page = 0;
+        do {
+            $fetchedQueryRules = $index->searchRules('', [
+                'context' => 'magento_filters',
+                'page' => $page,
+                'hitsPerPage' => $hitsPerPage,
+            ]);
+
+            if (!$fetchedQueryRules || !array_key_exists('hits', $fetchedQueryRules)) {
+                break;
+            }
+
+            foreach ($fetchedQueryRules['hits'] as $hit) {
+                $index->deleteRule($hit['objectID'], [
+                    'forwardToReplicas' => true,
+                ]);
+            }
+
+            $page++;
+        } while (($page * $hitsPerPage) < $fetchedQueryRules['nbHits']);
+    } catch (AlgoliaException $e) {
+        // Fail silently if query rules are disabled on the app
+        // If QRs are disabled, nothing will happen and the extension will work as expected
+        if ($e->getMessage() !== 'Query Rules are not enabled on this application') {
+            throw $e;
+        }
+    }
+}
+
+/**
+ * Check if product can be index on Algolia
+ *
+ * @param Product $product
+ * @param int $storeId
+ * @param bool $isChildProduct
+ *
+ * @return bool
+ */
+public
+function canProductBeReindexed($product, $storeId, $isChildProduct = false)
+{
+    if ($product->isDeleted() === true) {
+        throw (new ProductDeletedException())
+            ->withProduct($product)
+            ->withStoreId($storeId);
+    }
+
+    if ($product->getStatus() == Status::STATUS_DISABLED) {
+        throw (new ProductDisabledException())
+            ->withProduct($product)
+            ->withStoreId($storeId);
+    }
+
+    if ($isChildProduct === false && !in_array($product->getVisibility(), [
             Visibility::VISIBILITY_BOTH,
             Visibility::VISIBILITY_IN_SEARCH,
             Visibility::VISIBILITY_IN_CATALOG,
         ])) {
-            throw (new ProductNotVisibleException())
-                ->withProduct($product)
-                ->withStoreId($storeId);
-        }
-
-        $isInStock = true;
-        if (!$this->configHelper->getShowOutOfStock($storeId)
-            || (!$this->configHelper->indexOutOfStockOptions($storeId) && $isChildProduct === true)) {
-            $isInStock = $this->productIsInStock($product, $storeId);
-        }
-
-        if (!$isInStock) {
-            throw (new ProductOutOfStockException())
-                ->withProduct($product)
-                ->withStoreId($storeId);
-        }
-
-        return true;
+        throw (new ProductNotVisibleException())
+            ->withProduct($product)
+            ->withStoreId($storeId);
     }
 
-    /**
-     * Returns is product in stock
-     *
-     * @param Product $product
-     * @param int $storeId
-     *
-     * @return bool
-     */
-    public function productIsInStock($product, $storeId)
-    {
-        $stockItem = $this->stockRegistry->getStockItem($product->getId());
-
-        return $product->isSaleable() && $stockItem->getIsInStock();
+    $isInStock = true;
+    if (!$this->configHelper->getShowOutOfStock($storeId)
+        || (!$this->configHelper->indexOutOfStockOptions($storeId) && $isChildProduct === true)) {
+        $isInStock = $this->productIsInStock($product, $storeId);
     }
 
-    /**
-     * @param $replica
-     * @return array
-     */
-    protected function handleVirtualReplica($replicas, $indexName) {
-        $virtualReplicaArray = [];
-        foreach ($replicas as $replica) {
-            $virtualReplicaArray[] = 'virtual('.$replica.')';
-        }
-        return $virtualReplicaArray;
+    if (!$isInStock) {
+        throw (new ProductOutOfStockException())
+            ->withProduct($product)
+            ->withStoreId($storeId);
     }
+
+    return true;
+}
+
+/**
+ * Returns is product in stock
+ *
+ * @param Product $product
+ * @param int $storeId
+ *
+ * @return bool
+ */
+public
+function productIsInStock($product, $storeId)
+{
+    $stockItem = $this->stockRegistry->getStockItem($product->getId());
+
+    return $product->isSaleable() && $stockItem->getIsInStock();
+}
+
+/**
+ * @param $replica
+ * @return array
+ */
+protected
+function handleVirtualReplica($replicas, $indexName)
+{
+    $virtualReplicaArray = [];
+    foreach ($replicas as $replica) {
+        $virtualReplicaArray[] = 'virtual(' . $replica . ')';
+    }
+    return $virtualReplicaArray;
+}
 }

--- a/etc/indexer.xml
+++ b/etc/indexer.xml
@@ -5,6 +5,9 @@
         <description translate="true">
             Rebuild products index.
         </description>
+        <dependencies>
+            <indexer id="catalog_product_price" />
+        </dependencies>
     </indexer>
     <indexer id="algolia_categories" view_id="algolia_categories" class="Algolia\AlgoliaSearch\Model\Indexer\Category">
         <title translate="true">Algolia Search Categories</title>


### PR DESCRIPTION
A dependency exists in `\Algolia\AlgoliaSearch\Helper\Entity\ProductHelper::getProductCollectionQuery` on the “Product Price” indexer (aka `catalog_product_price`) which performs a join on the underlying `catalog_product_index_price` table. 

Frequent catalog updates can create a detached state between this indexer and our `algolia_products` indexer. This affects both deltas and full reindexes - but is even more problematic for full indexes which can produce `_tmp` indices that are missing key products from a customer catalog. 

This PR aims to address this dependency when pushing data to Algolia to ensure that the pricing records are in place. 

Two items of note:

1. Assumes that the `catalog_product_price` index is in an invalid state before attempting the dependency reindex. To derive this at runtime would be non-performant.
2. The requirement for pricing records to be present when building collections of products mirrors Magento's core functionality. 