### PR TITLE
Fixed missing category data for products if show_cats_not_included_in_navigation is enabled

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -536,7 +536,7 @@ class ProductHelper
      */
     public function getAllCategories($categoryIds, $storeId)
     {
-        $filterNotIncludedCategories = $this->configHelper->showCatsNotIncludedInNavigation($storeId);
+        $filterNotIncludedCategories = !$this->configHelper->showCatsNotIncludedInNavigation($storeId);
         $categories = $this->categoryHelper->getCoreCategories($filterNotIncludedCategories, $storeId);
 
         $selectedCategories = [];


### PR DESCRIPTION
**Summary**

In version 3.9.1, a fix was added for some storeview-related indexing issue. In this fix, it seems a bug fix was introduced, by removing the "!" in front of the `showCatsNotIncludedInNavigation` call:
https://github.com/algolia/algoliasearch-magento-2/commit/f1e3bb44def70f63ba203c1a252dde2811050c20#diff-c138874a1ad098fc3873ea690f53c7236c03b48cb63348e1049e11cc2392a2afL450-R451

As a result of this change, the `$filterNotIncludedCategories` variable in the `\Algolia\AlgoliaSearch\Helper\Entity\ProductHelper::getAllCategories` method is now `true` if the config "Show categories not included in navigation" is set to "Yes", and `false` if set to "No", instead of the other way around. That means that if the config is set to "Yes", which means categories that are not in the menu _should_ be shown/indexed, the `getCoreCategories` method actually _filters_ those categories from the result. Because of this, the `categories` field for products (in Algolia) is missing categories that are not included in the menu, if this config field is set to "Yes".

How we were able to reproduce this issue ourselves:
- Set the "Show categories not included in navigation" config field to "Yes".
- Set "Include in Menu" to false for a category.
- Index at least one product from that category from Magento to Algolia.
- The `categories` field in Algolia now _does not_ include this category. It does, however, include categories that _are_ included in the menu.

**Result**

This PR reverts this, most likely unintended, change, to make sure the config field is properly used in the product indexing process. After this fix, the reproduction path above did result in all categories that the product was in, both included and not included in the menu, being added to the `categories` field for the product in Algolia after indexing the product.
