### PR TITLE
Bugfix/mage 633 autocomplete click position

### DIFF
--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -345,6 +345,20 @@ define(
                 transformSource({source}) {
                     return {
                         ...source,
+                        getItems() {
+                          const items = source.getItems();
+                          const oldTransform = items.transformResponse;
+                          items.transformResponse = arg => {
+                              const hits = oldTransform ? oldTransform(arg) : arg.hits;
+                              return hits.map((hit, i) => {
+                                  return {
+                                      ...hit,
+                                      position: i + 1
+                                  }
+                              });
+                          };
+                          return items;
+                        },
                         getItemUrl({item}) {
                             return getNavigatorUrl(algoliaConfig.resultPageUrl + `?q=${item.query}`);
                         },

--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -188,10 +188,11 @@ define(
                 const resDetail = results[0];
 
                 return hits.map(res => {
-                    return res.map(hit => {
+                    return res.map((hit, i) => {
                         return {
                             ...hit,
-                            query: resDetail.query
+                            query: resDetail.query,
+                            position: i + 1
                         }
                     })
                 });
@@ -267,14 +268,14 @@ define(
                     };
                 source.transformResponse = ({results, hits}) => {
                     const resDetail = results[0];
-
                     return hits.map(res => {
-                        return res.map(hit => {
+                        return res.map((hit, i) => {
                             return {
                                 ...hit,
                                 nbHits:        resDetail.nbHits,
                                 allCategories: resDetail.facets['categories.level0'],
-                                query:         resDetail.query
+                                query:         resDetail.query,
+                                position:      i + 1
                             }
                         })
                     });

--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -340,7 +340,10 @@ define(
                 searchClient,
                 indexName: `${algoliaConfig.indexName}_suggestions`,
                 getSearchParams() {
-                    return { hitsPerPage: algoliaConfig.autocomplete.nbOfQueriesSuggestions };
+                    return {
+                        hitsPerPage: algoliaConfig.autocomplete.nbOfQueriesSuggestions,
+                        clickAnalytics: true
+                    };
                 },
                 transformSource({source}) {
                     return {

--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -509,11 +509,13 @@ define(
                 const $this = $(this);
                 if ($this.data('clicked')) return;
 
-                let objectId = $this.attr('data-objectId');
-                let indexName = $this.attr('data-index');
-                let queryId = $this.attr('data-queryId');
-                let eventData = algoliaInsights.buildEventData(
-                    'Clicked', objectId, indexName, 1, queryId
+                const objectId = $this.attr('data-objectId');
+                const indexName = $this.attr('data-index');
+                const queryId = $this.attr('data-queryId');
+                const position = $this.attr('data-position');
+
+                const eventData = algoliaInsights.buildEventData(
+                    'Clicked', objectId, indexName, position, queryId
                 );
                 algoliaInsights.trackClick(eventData);
                 $this.attr('data-clicked', true);

--- a/view/frontend/web/internals/template/autocomplete/additional-section.js
+++ b/view/frontend/web/internals/template/autocomplete/additional-section.js
@@ -9,8 +9,12 @@ define([], function () {
         },
 
         getItemHtml: function ({item, components, html, section}) {
-            return html`<a class="aa-ItemLink" href="${algoliaConfig.resultPageUrl}?q=${encodeURIComponent(item.query)}&${section.name}=${encodeURIComponent(item.value)}"
-                data-objectId=${item.objectID} data-index=${item.__autocomplete_indexName} data-queryId=${item.__autocomplete_queryID}>
+            return html`<a class="aa-ItemLink"
+                           href="${algoliaConfig.resultPageUrl}?q=${encodeURIComponent(item.query)}&${section.name}=${encodeURIComponent(item.value)}"
+                           data-objectId="${item.objectID}"
+                           data-position="${item.position}"
+                           data-index="${item.__autocomplete_indexName}"
+                           data-queryId="${item.__autocomplete_queryID}">
                 ${components.Highlight({ hit: item, attribute: 'value' })}
             </a>`;
 

--- a/view/frontend/web/internals/template/autocomplete/categories.js
+++ b/view/frontend/web/internals/template/autocomplete/categories.js
@@ -9,8 +9,12 @@ define([], function () {
         },
 
         getItemHtml: function ({item, components, html}) {
-            return html `<a class="algoliasearch-autocomplete-hit" href="${item.url}"
-                data-objectId=${item.objectID} data-index=${item.__autocomplete_indexName} data-queryId=${item.__autocomplete_queryID}>
+            return html `<a class="algoliasearch-autocomplete-hit"
+                            href="${item.url}"
+                            data-objectId="${item.objectID}"
+                            data-position="${item.position}"
+                            data-index="${item.__autocomplete_indexName}"
+                            data-queryId="${item.__autocomplete_queryID}">
                 ${components.Highlight({ hit: item, attribute: 'path' })} (${item.product_count})
             </a>`;
         },

--- a/view/frontend/web/internals/template/autocomplete/pages.js
+++ b/view/frontend/web/internals/template/autocomplete/pages.js
@@ -9,8 +9,12 @@ define([], function () {
         },
 
         getItemHtml: function ({item, components, html}) {
-            return html`<a class="algoliasearch-autocomplete-hit" href="${item.url}"
-                data-objectId=${item.objectID} data-index=${item.__autocomplete_indexName} data-queryId=${item.__autocomplete_queryID}>
+            return html`<a class="algoliasearch-autocomplete-hit"
+                           href="${item.url}"
+                           data-objectId="${item.objectID}"
+                           data-position="${item.position}"
+                           data-index="${item.__autocomplete_indexName}"
+                           data-queryId="${item.__autocomplete_queryID}">
                 <div class="info-without-thumb">
                     ${components.Highlight({hit: item, attribute: 'name'})}
                     <div class="details">

--- a/view/frontend/web/internals/template/autocomplete/products.js
+++ b/view/frontend/web/internals/template/autocomplete/products.js
@@ -14,8 +14,12 @@ define([], function () {
         },
 
         getItemHtml: function ({item, components, html}) {
-            return html`<a class="algoliasearch-autocomplete-hit" href="${item.__autocomplete_queryID != null ? item.urlForInsights : item.url}"
-                data-objectId=${item.objectID} data-index=${item.__autocomplete_indexName} data-queryId=${item.__autocomplete_queryID}>
+            return html`<a class="algoliasearch-autocomplete-hit"
+                           href="${item.__autocomplete_queryID != null ? item.urlForInsights : item.url}"
+                           data-objectId="${item.objectID}"
+                           data-position="${item.position}"
+                           data-index="${item.__autocomplete_indexName}"
+                           data-queryId="${item.__autocomplete_queryID}">
                 <div class="thumb"><img src="${item.thumbnail_url || ''}" alt="${item.name || ''}"/></div>
                 <div class="info">
                     ${components.Highlight({hit: item, attribute: 'name'})}

--- a/view/frontend/web/internals/template/autocomplete/suggestions.js
+++ b/view/frontend/web/internals/template/autocomplete/suggestions.js
@@ -13,8 +13,12 @@ define([], function () {
                 ? components.Highlight({ hit: item, attribute: "query" })
                 : item.query;
 
-            return html`<a class="aa-ItemLink algolia-suggestions" href="${algoliaConfig.resultPageUrl}?q=${encodeURIComponent(item.query)}"
-                data-objectId=${item.objectID} data-index=${item.__autocomplete_indexName} data-queryId=${item.__autocomplete_queryID}>
+            return html`<a class="aa-ItemLink algolia-suggestions"
+                           href="${algoliaConfig.resultPageUrl}?q=${encodeURIComponent(item.query)}"
+                           data-objectId="${item.objectID}"
+                           data-position="${item.position}"
+                           data-index="${item.__autocomplete_indexName}"
+                           data-queryId="${item.__autocomplete_queryID}">
                 <svg xmlns="http://www.w3.org/2000/svg"
                      class="algolia-glass-suggestion magnifying-glass"
                      width="24"

--- a/view/frontend/web/internals/template/autocomplete/suggestions.js
+++ b/view/frontend/web/internals/template/autocomplete/suggestions.js
@@ -13,7 +13,7 @@ define([], function () {
                 ? components.Highlight({ hit: item, attribute: "query" })
                 : item.query;
 
-            return html`<a class="aa-ItemLink algolia-suggestions"
+            return html`<a class="aa-ItemLink algolia-suggestions algoliasearch-autocomplete-hit"
                            href="${algoliaConfig.resultPageUrl}?q=${encodeURIComponent(item.query)}"
                            data-objectId="${item.objectID}"
                            data-position="${item.position}"


### PR DESCRIPTION
Includes:

- Fix click position calculation by index
- Applies transformResponse for all sources: default, product, suggestions plugin
- Adds params / selector for suggestions plugin to properly track clicks on underlying index

NOTE: Suggestions plugin has an existing transformResponse callback that this approach wraps rather than replaces. 