### PR TITLE
Bugfix/mage 666 - conditional Autocomplete lib loading

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -27,7 +27,6 @@ var config = {
         'rangeSlider'     : 'Algolia_AlgoliaSearch/navigation/range-slider-widget',
     },
     deps  : [
-        'algoliaAutocomplete',
         'algoliaInstantSearch',
         'algoliaInsights'
     ],

--- a/view/frontend/templates/autocomplete.phtml
+++ b/view/frontend/templates/autocomplete.phtml
@@ -7,5 +7,12 @@ $catalogSearchHelper = $blockInstance->getCatalogSearchHelper();
 
 // Render form with autocomplete input
 if ($config->isAutoCompleteEnabled()) : ?>
+    <script type="text/x-magento-init">
+        {
+            "*": {
+                "algoliaAutocomplete": {}
+            }
+        }
+    </script>
     <div id="algoliaAutocomplete" class="block block-search algolia-search-block algolia-search-input"></div>
 <?php endif;?>


### PR DESCRIPTION
This PR is intended to address the bugs resulting from globally loading the Autocomplete library in non-applicable contexts - particularly checkout where the same global navigational elements do not exist. 