### PR TITLE
MAGE-653 Use labels with refinementList 

### DIFF
--- a/view/frontend/templates/instant/facet.phtml
+++ b/view/frontend/templates/instant/facet.phtml
@@ -1,7 +1,7 @@
 <script type="text/template" id="refinements-lists-item-template">
     <label class="{{cssClasses.label}} {{#isRefined}}checked{{/isRefined}}">
         <input class="{{cssClasses.checkbox}}" {{#isRefined}}checked{{/isRefined}} type="checkbox" value="{{value}}" />
-        {{value}}
+        {{label}}
         <span class="{{cssClasses.count}}">{{count}}</span>
     </label>
 </script>


### PR DESCRIPTION
Use labels with `refinementList` to avoid presentation of JavaScript escaped values