### PR TITLE
Fixed mb_convert_encoding() function deprecated issue in php8.2

### DIFF
--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -196,7 +196,14 @@ class PageHelper
         if ($completeRemoveTags && $completeRemoveTags !== [] && $s) {
             $dom = new \DOMDocument();
             libxml_use_internal_errors(true);
-            $dom->loadHTML(mb_convert_encoding($s, 'HTML-ENTITIES', 'UTF-8'));
+            $encodedStr = mb_encode_numericentity(
+                htmlspecialchars_decode(
+                    htmlentities($s, ENT_NOQUOTES, 'UTF-8', false)
+                    ,ENT_NOQUOTES
+                ), [0x80, 0x10FFFF, 0, ~0],
+                'UTF-8'
+            );
+            $dom->loadHTML($encodedStr);
             libxml_use_internal_errors(false);
 
             $toRemove = [];

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -196,13 +196,7 @@ class PageHelper
         if ($completeRemoveTags && $completeRemoveTags !== [] && $s) {
             $dom = new \DOMDocument();
             libxml_use_internal_errors(true);
-            $encodedStr = mb_encode_numericentity(
-                htmlspecialchars_decode(
-                    htmlentities($s, ENT_NOQUOTES, 'UTF-8', false)
-                    ,ENT_NOQUOTES
-                ), [0x80, 0x10FFFF, 0, ~0],
-                'UTF-8'
-            );
+            $encodedStr = mb_encode_numericentity($s, [0x80, 0x10fffff, 0, ~0]);
             $dom->loadHTML($encodedStr);
             libxml_use_internal_errors(false);
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->