### PR TITLE
MAGE-714 Handle ampersand and other special chars

### DIFF
--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -434,7 +434,7 @@ define(
             detachedMediaQuery: 'none',
             onSubmit(data) {
                 if (data.state.query && data.state.query !== null && data.state.query !== "") {
-                    window.location.href = algoliaConfig.resultPageUrl + `?q=${data.state.query}`;
+                    window.location.href = algoliaConfig.resultPageUrl + `?q=${encodeURIComponent(data.state.query)}`;
                 }
             },
             getSources() {


### PR DESCRIPTION
Previously we were not properly escaping special characters on the Autocomplete submit handler. This PR aims to remedy that. 

<img width="1436" alt="2023-08-11_16-41-34" src="https://github.com/algolia/algoliasearch-magento-2/assets/986313/f6e25f21-b67c-46ee-b211-30f397420dca">