### PR TITLE
Fix issue with promotion class being added to all products in autocom…

### DIFF
--- a/view/frontend/web/internals/template/autocomplete/products.js
+++ b/view/frontend/web/internals/template/autocomplete/products.js
@@ -73,7 +73,7 @@ define([], function () {
             const priceGroup =  algoliaConfig.priceGroup || 'default';
 
             return html `<div className="algoliasearch-autocomplete-price">
-                <span className="after_special ${algoliaConfig.origFormatedVar != null ? 'promotion' : ''}">
+                <span className="after_special ${item['price'][algoliaConfig.currencyCode][priceGroup + '_original_formated'] != null ? 'promotion' : ''}">
                     ${item['price'][algoliaConfig.currencyCode][priceGroup + '_formated']}
                 </span>
                 ${this.getOriginalPriceHtml(item, html, priceGroup)}


### PR DESCRIPTION
**Summary**

Fix promotion class being added to all products in autocomplete dropdown.

**Result**

Search for a product using search autocomplete. The price for the product item in the auto complete dropdown will have the "promotion" class on it regardless of promotion state.

After fix only products on promotion will have the "promotion" class.