### PR TITLE
Feature/mage 744 - debouncing autocomplete search requests

### DIFF
--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -164,7 +164,9 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
                 'nbOfCategoriesSuggestions' => $config->getNumberOfCategoriesSuggestions(),
                 'nbOfQueriesSuggestions' => $config->getNumberOfQueriesSuggestions(),
                 'isDebugEnabled' => $config->isAutocompleteDebugEnabled(),
-                'isNavigatorEnabled' => $config->isAutocompleteNavigatorEnabled()
+                'isNavigatorEnabled' => $config->isAutocompleteNavigatorEnabled(),
+                'debounceMilliseconds' => $config->getAutocompleteDebounceMilliseconds(),
+                'minimumCharacters' => $config->getAutocompleteMinimumCharacterLength()
             ],
             'landingPage' => [
                 'query' => $this->getLandingPageQuery(),

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -45,7 +45,7 @@ class ConfigHelper
     public const MIN_NUMBER_OF_RESULTS = 'algoliasearch_autocomplete/autocomplete/min_number_of_results';
     public const RENDER_TEMPLATE_DIRECTIVES = 'algoliasearch_autocomplete/autocomplete/render_template_directives';
     public const AUTOCOMPLETE_MENU_DEBUG = 'algoliasearch_autocomplete/autocomplete/debug';
-    public const AUTOCOMPLETE_DEBOUNCE_MILLIS = 'algoliasearch_autocomplete/autocomplete/debounce_millis';
+    public const AUTOCOMPLETE_DEBOUNCE_MILLISEC = 'algoliasearch_autocomplete/autocomplete/debounce_millisec';
     public const AUTOCOMPLETE_MINIMUM_CHAR_LENGTH = 'algoliasearch_autocomplete/autocomplete/minimum_char_length';
 
     public const PRODUCT_ATTRIBUTES = 'algoliasearch_products/products/product_additional_attributes';
@@ -938,7 +938,7 @@ class ConfigHelper
     public function getAutocompleteDebounceMilliseconds($storeId = null): int
     {
         return (int) $this->configInterface->getValue(
-            self::AUTOCOMPLETE_DEBOUNCE_MILLIS,
+            self::AUTOCOMPLETE_DEBOUNCE_MILLISEC,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -45,6 +45,8 @@ class ConfigHelper
     public const MIN_NUMBER_OF_RESULTS = 'algoliasearch_autocomplete/autocomplete/min_number_of_results';
     public const RENDER_TEMPLATE_DIRECTIVES = 'algoliasearch_autocomplete/autocomplete/render_template_directives';
     public const AUTOCOMPLETE_MENU_DEBUG = 'algoliasearch_autocomplete/autocomplete/debug';
+    public const AUTOCOMPLETE_DEBOUNCE_MILLIS = 'algoliasearch_autocomplete/autocomplete/debounce_millis';
+    public const AUTOCOMPLETE_MINIMUM_CHAR_LENGTH = 'algoliasearch_autocomplete/autocomplete/minimum_char_length';
 
     public const PRODUCT_ATTRIBUTES = 'algoliasearch_products/products/product_additional_attributes';
     public const PRODUCT_CUSTOM_RANKING = 'algoliasearch_products/products/custom_ranking_product_attributes';
@@ -931,6 +933,24 @@ class ConfigHelper
     public function isAutocompleteDebugEnabled($storeId = null)
     {
         return $this->configInterface->isSetFlag(self::AUTOCOMPLETE_MENU_DEBUG, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function getAutocompleteDebounceMilliseconds($storeId = null): int
+    {
+        return (int) $this->configInterface->getValue(
+            self::AUTOCOMPLETE_DEBOUNCE_MILLIS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    public function getAutocompleteMinimumCharacterLength($storeId = null): int
+    {
+        return (int) $this->configInterface->getValue(
+            self::AUTOCOMPLETE_MINIMUM_CHAR_LENGTH,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -243,6 +243,30 @@
                         <field id="is_popup_enabled">1</field>
                     </depends>
                 </field>
+                <field id="debounce_millis" translate="label comment" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <validate>validate-digits</validate>
+                    <label>Debounce requests</label>
+                    <comment>
+                        <![CDATA[
+                            The minimal time (in milliseconds) that should elapse as users type their search query before a request is sent to the Algolia Search API. Default value is 300.
+                        ]]>
+                    </comment>
+                    <depends>
+                        <field id="is_popup_enabled">1</field>
+                    </depends>
+                </field>
+                <field id="minimum_char_length" translate="label comment" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <validate>validate-digits</validate>
+                    <label>Minimum query length</label>
+                    <comment>
+                        <![CDATA[
+                            The minimal number of characters required for a search term before a request is sent to the Algolia Search API. If set to 0 then results will be fetched on first keystroke. Default value is 0.
+                        ]]>
+                    </comment>
+                    <depends>
+                        <field id="is_popup_enabled">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
         <section id="algoliasearch_instant" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -243,7 +243,7 @@
                         <field id="is_popup_enabled">1</field>
                     </depends>
                 </field>
-                <field id="debounce_millis" translate="label comment" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="debounce_millisec" translate="label comment" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
                     <validate>validate-digits</validate>
                     <label>Debounce requests</label>
                     <comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,7 +12,7 @@
                 <sections><![CDATA[{"_1600351750374_374":{"name":"pages","label":"Pages","hitsPerPage":"2"}}]]></sections>
                 <excluded_pages><![CDATA[{"_1600351757831_831":{"attribute":"no-route"}}]]></excluded_pages>
                 <navigator>1</navigator>
-                <debounce_millis>300</debounce_millis>
+                <debounce_millisec>300</debounce_millisec>
                 <minimum_char_length>0</minimum_char_length>
             </autocomplete>
         </algoliasearch_autocomplete>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,6 +12,8 @@
                 <sections><![CDATA[{"_1600351750374_374":{"name":"pages","label":"Pages","hitsPerPage":"2"}}]]></sections>
                 <excluded_pages><![CDATA[{"_1600351757831_831":{"attribute":"no-route"}}]]></excluded_pages>
                 <navigator>1</navigator>
+                <debounce_millis>300</debounce_millis>
+                <minimum_char_length>0</minimum_char_length>
             </autocomplete>
         </algoliasearch_autocomplete>
         <algoliasearch_instant>

--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -15,6 +15,7 @@ define(
     function ($, algoliaBundle, pagesHtml, categoriesHtml, productsHtml, suggestionsHtml, additionalHtml) {
 
         const DEFAULT_HITS_PER_SECTION = 2;
+        const DEBOUNCE_MS = 300;
 
         // global state
         let suggestionSection = false;
@@ -382,7 +383,22 @@ define(
                     };
                 },
             });
-        }
+        };
+
+        const debouncePromise = (fn, time) => {
+            let timerId = undefined;
+
+            return function debounced(...args) {
+                if (timerId) {
+                    clearTimeout(timerId);
+                }
+
+                return new Promise((resolve) => {
+                    timerId = setTimeout(() => resolve(fn(...args)), time);
+                });
+            };
+        };
+        const debounced = debouncePromise((items) => Promise.resolve(items), DEBOUNCE_MS);
 
         /**
          * Load suggestions, products and categories as configured
@@ -438,7 +454,7 @@ define(
                 }
             },
             getSources() {
-                return autocompleteConfig;
+                return debounced(autocompleteConfig);
             },
         };
 

--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -16,6 +16,7 @@ define(
 
         const DEFAULT_HITS_PER_SECTION = 2;
         const DEBOUNCE_MS = 300;
+        const MIN_SEARCH_LENGTH_CHARS = 3;
 
         // global state
         let suggestionSection = false;
@@ -349,8 +350,8 @@ define(
                 transformSource({source}) {
                     return {
                         ...source,
-                        getItems() {
-                          const items = source.getItems();
+                        getItems({ query }) {
+                          const items = filterMinChars(query, source.getItems());
                           const oldTransform = items.transformResponse;
                           items.transformResponse = arg => {
                               const hits = oldTransform ? oldTransform(arg) : arg.hits;
@@ -384,6 +385,12 @@ define(
                 },
             });
         };
+
+        const filterMinChars = (query, result) => {
+            return (query.length >= MIN_SEARCH_LENGTH_CHARS)
+                ? result
+                : [];
+        }
 
         const debouncePromise = (fn, time) => {
             let timerId = undefined;
@@ -453,9 +460,12 @@ define(
                     window.location.href = algoliaConfig.resultPageUrl + `?q=${data.state.query}`;
                 }
             },
-            getSources() {
-                return debounced(autocompleteConfig);
+            getSources({query}) {
+              return filterMinChars(query, debounced(autocompleteConfig));
             },
+            shouldPanelOpen({ state }) {
+                return state.query.length >= MIN_SEARCH_LENGTH_CHARS;
+            }
         };
 
         if (isMobile() === true) {

--- a/view/frontend/web/autocomplete.js
+++ b/view/frontend/web/autocomplete.js
@@ -15,8 +15,8 @@ define(
     function ($, algoliaBundle, pagesHtml, categoriesHtml, productsHtml, suggestionsHtml, additionalHtml) {
 
         const DEFAULT_HITS_PER_SECTION = 2;
-        const DEBOUNCE_MS = 300;
-        const MIN_SEARCH_LENGTH_CHARS = 3;
+        const DEBOUNCE_MS = algoliaConfig.autocomplete.debounceMilliseconds;
+        const MIN_SEARCH_LENGTH_CHARS = algoliaConfig.autocomplete.minimumCharacters;
 
         // global state
         let suggestionSection = false;

--- a/view/frontend/web/internals/autocomplete.css
+++ b/view/frontend/web/internals/autocomplete.css
@@ -503,6 +503,13 @@ html {
     background: #fff;
     display: none;
 }
+
+#algoliaAutocomplete .aa-LoadingIndicator {
+    position: absolute;
+    top: 20%;
+    right: 10px;
+}
+
 .aa-Panel li.aa-Item{
     list-style-type: none;
 }


### PR DESCRIPTION
Provides an implementation for debouncing requests (configurable by milliseconds) as well as setting a minimal length for search terms before submission to the Algolia API.

Sample Autocomplete configuration:
<img width="1081" alt="2023-09-07_23-31-50" src="https://github.com/algolia/algoliasearch-magento-2/assets/986313/515d6e74-6939-4c42-ac01-1831b0e4d730">
