### PR TITLE
Bugfix/mage 773 improved category anchor

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -475,7 +475,7 @@ define(
                                         separator         : algoliaConfig.instant.categorySeparator,
                                         templates         : templates,
                                         showParentLevel   : true,
-                                        limit             : algoliaConfig.maxValuesPerFacet,
+                                        limit             : 999, // arbitrarily high number - as premature truncate of results can prevent preselection for large category lists
                                         sortBy            : ['name:asc'],
                                         transformItems(items) {
                                             return (algoliaConfig.isCategoryPage)

--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -446,40 +446,25 @@ define(
                      * Custom widgets can be added to this object like [attribute]: function(facet, templates)
                      * Function must return an array [<widget name>: string, <widget options>: object]
                      **/
-                    var customAttributeFacet = {
+                    const customAttributeFacet = {
                             categories: function (facet, templates) {
-                                    var hierarchical_levels = [];
-                                    for (var l = 0; l < 10; l++) {
+                                    const hierarchical_levels = [];
+                                    for (let l = 0; l < 10; l++) {
                                             hierarchical_levels.push('categories.level' + l.toString());
                                     }
 
-
-                                    //return array of items starting from root based on category
-                                    const findRoot = (items) => {
-                                        const root = items.find(element => algoliaConfig.request.path.startsWith(element.value));
-
-                                        if (!root) {
-                                            return items;
-                                        }
-                                        if (!root.data) {
-                                            return [];
-                                        }
-
-                                        return findRoot(root.data);
-
-                                    };
-
-                                    var hierarchicalMenuParams = {
+                                    const hierarchicalMenuParams = {
                                         container         : facet.wrapper.appendChild(createISWidgetContainer(facet.attribute)),
                                         attributes        : hierarchical_levels,
                                         separator         : algoliaConfig.instant.categorySeparator,
                                         templates         : templates,
                                         showParentLevel   : true,
-                                        limit             : 999, // arbitrarily high number - as premature truncate of results can prevent preselection for large category lists
+                                        limit             : algoliaConfig.maxValuesPerFacet,
+                                        rootPath          : algoliaConfig.request.path,
                                         sortBy            : ['name:asc'],
                                         transformItems(items) {
                                             return (algoliaConfig.isCategoryPage)
-                                                ? findRoot(items).map(
+                                                ? items.map(
                                                     item => {
                                                         return {
                                                             ...item,

--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -405,7 +405,7 @@ define(['jquery', 'algoliaBundle'], function ($, algoliaBundle) {
                             if (algoliaConfig.isLandingPage &&
                                 typeof uiStateProductIndex['hierarchicalMenu']['categories.level0'] === 'undefined' &&
                                 'categories.level0' in landingPageConfig) {
-                                uiStateProductIndex['hierarchicalMenu']['categories.level0'] = landingPageConfig['categories.level0'].split(' /// ');
+                                uiStateProductIndex['hierarchicalMenu']['categories.level0'] = landingPageConfig['categories.level0'].split(algoliaConfig.instant.categorySeparator);
                             }
                         }
                         if (currentFacet.attribute == 'categories' && algoliaConfig.isCategoryPage) {


### PR DESCRIPTION
It was observed that manually anchoring the `hiearchicalMenu` widget via `transformItems` fails when the number of categories exceeds the [limit defined](https://www.algolia.com/doc/api-reference/widgets/hierarchical-menu/js/#widget-param-limit). 

The result is an inexplicable category menu that does not appear to match the data on browse (in this case the category menu should not appear at all because "Jackets" is at the deepest level):
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/08f35d11-d7b6-436e-8811-ea1b710afb4d)

A simpler approach is available via the core InstantSearch API - which has been tested to work with `algoliaConfig.request.path` for both browse and search operations.