### PR TITLE
Fixes clear refinements button from not showing

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -301,35 +301,6 @@ define(
                             },
 
                             /*
-                             * clearRefinements
-                             * Widget displays a button that lets the user clean every refinement applied to the search. You can control which attributes are impacted by the button with the options.
-                             * Docs: https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/
-                             **/
-                            clearRefinements: {
-                                container         : '#clear-refinements',
-                                templates         : {
-                                    resetLabel: algoliaConfig.translations.clearAll,
-                                },
-                                includedAttributes: attributes.map(function (attribute) {
-                                    if (!(algoliaConfig.isCategoryPage && attribute.name.indexOf('categories') > -1)) {
-                                        return attribute.name;
-                                    }
-                                }),
-                                cssClasses        : {
-                                    button: ['action', 'primary']
-                                },
-                                transformItems    : function (items) {
-                                    return items.map(function (item) {
-                                        var attribute = attributes.filter(function (_attribute) {
-                                            return item.attribute === _attribute.name
-                                        })[0];
-                                        if (!attribute) return item;
-                                        item.label = attribute.label;
-                                        return item;
-                                    })
-                                }
-                            },
-                            /*
                              * queryRuleCustomData
                              * The queryRuleCustomData widget displays custom data from Query Rules.
                              * Docs: https://www.algolia.com/doc/api-reference/widgets/query-rule-custom-data/js/
@@ -339,6 +310,36 @@ define(
                                 templates: {
                                     default: '{{#items}} {{#banner}} {{{banner}}} {{/banner}} {{/items}}',
                                 }
+                            }
+                        },
+
+                        /*
+                        * clearRefinements
+                        * Widget displays a button that lets the user clean every refinement applied to the search. You can control which attributes are impacted by the button with the options.
+                        * Docs: https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/
+                        **/
+                        clearRefinements: {
+                            container         : '#clear-refinements',
+                            templates         : {
+                                resetLabel: algoliaConfig.translations.clearAll,
+                            },
+                            includedAttributes: attributes.map(function (attribute) {
+                                if (!(algoliaConfig.isCategoryPage && attribute.name.indexOf('categories') > -1)) {
+                                    return attribute.name;
+                                }
+                            }),
+                            cssClasses        : {
+                                button: ['action', 'primary']
+                            },
+                            transformItems    : function (items) {
+                                return items.map(function (item) {
+                                    var attribute = attributes.filter(function (_attribute) {
+                                        return item.attribute === _attribute.name
+                                    })[0];
+                                    if (!attribute) return item;
+                                    item.label = attribute.label;
+                                    return item;
+                                })
                             }
                         }
                     };


### PR DESCRIPTION
Re-nests `clearRefinements` method from allWidgetConfiguration.currentRefinements.clearRefinements > allWidgetConfiguration.clearRefinements


**Summary**

`clearRefinements` method in _view/frontend/web/instandsearch.js_ has been nested under `currentRefinements` from 3.10.7. This caused button to not show. 

Nothing shows when overriding template e.g. 

`allWidgetConfiguration.currentRefinements.clearRefinements.templates = {
    resetLabel: '<span class="ais-ClearRefinements-button__icon">✕</span> <span class="cs-aftersearch-nav-state__text">Clear all filters</span>',
};`

**Result**

Button now works as before and template can be overridden using: 

`allWidgetConfiguration.clearRefinements.templates = {
    resetLabel: '<span class="ais-ClearRefinements-button__icon">✕</span> <span class="cs-aftersearch-nav-state__text">Clear all filters</span>',
};`