### PR TITLE
Feature/mage 731

### DIFF
--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -10,6 +10,7 @@ use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\SuggestionHelper;
 use Algolia\AlgoliaSearch\Helper\LandingPageHelper;
+use Algolia\AlgoliaSearch\Registry\CurrentCategory;
 use Magento\Catalog\Model\Product;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Customer\Model\Context as CustomerContext;
@@ -97,6 +98,9 @@ class Algolia extends Template implements CollectionDataSourceInterface
      */
     protected $date;
 
+    /** @var CurrentCategory  */
+    protected CurrentCategory $currentCategory;
+
     protected $priceKey;
 
     /**
@@ -139,6 +143,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
         PersonalizationHelper $personalizationHelper,
         CheckoutSession $checkoutSession,
         DateTime $date,
+        CurrentCategory $currentCategory,
         array $data = []
     ) {
         $this->config = $config;
@@ -158,6 +163,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
         $this->personalizationHelper = $personalizationHelper;
         $this->checkoutSession = $checkoutSession;
         $this->date = $date;
+        $this->currentCategory = $currentCategory;
 
         parent::__construct($context, $data);
     }
@@ -255,7 +261,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
 
     public function getCurrentCategory()
     {
-        return $this->registry->registry('current_category');
+        return $this->currentCategory->get();
     }
 
     /** @return Product */

--- a/Observer/RegisterCurrentCategoryObserver.php
+++ b/Observer/RegisterCurrentCategoryObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Observer;
+
+use Algolia\AlgoliaSearch\Registry\CurrentCategory;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class RegisterCurrentCategoryObserver implements ObserverInterface
+{
+    /** @var CurrentCategory  */
+    private CurrentCategory $currentCategory;
+
+    public function __construct(CurrentCategory $currentCategory) {
+        $this->currentCategory = $currentCategory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var CategoryInterface */
+        $category = $observer->getEvent()->getData('category');
+        $this->currentCategory->set($category);
+    }
+}

--- a/Registry/CurrentCategory.php
+++ b/Registry/CurrentCategory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Registry;
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Api\Data\CategoryInterfaceFactory;
+
+class CurrentCategory
+{
+    private CategoryInterface $category;
+    private CategoryRepositoryInterface $categoryRepository;
+    private CategoryInterfaceFactory $categoryFactory;
+
+    public function __construct(
+        CategoryRepositoryInterface $categoryRepository,
+        CategoryInterfaceFactory $categoryFactory
+    )
+    {
+        $this->categoryRepository = $categoryRepository;
+        $this->categoryFactory = $categoryFactory;
+    }
+
+    public function set(CategoryInterface $category): void {
+        $this->category = $category;
+    }
+
+    public function get(): CategoryInterface {
+        return $this->category ?? $this->categoryFactory->create();
+    }
+}

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -23,4 +23,9 @@
     <event name="checkout_onepage_controller_success_action">
         <observer name="algoliasearch_insights_place_order_event" instance="Algolia\AlgoliaSearch\Observer\Insights\CheckoutOnepageControllerSuccessAction" />
     </event>
+
+    <!-- Registry -->
+    <event name="catalog_controller_category_init_after">
+        <observer name="algoliasearch_current_category" instance="Algolia\AlgoliaSearch\Observer\RegisterCurrentCategoryObserver"/>
+    </event>
 </config>


### PR DESCRIPTION
Use of the registry is deprecated. This is a drop-in replacement that provides the added benefit of exposing `\Magento\Catalog\Api\Data\CategoryInterface` which allows plugins on the repository interface rather than direct access to underlying `\Magento\Catalog\Model\Category`.

We should do the same for products following the similar pattern on event `catalog_controller_product_init_after`. 