### PR TITLE
Bugfix/mage 792 - categoryPageId serialization fix

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -773,9 +773,11 @@ class ProductHelper
      */
     protected function dedupePaths($paths): array
     {
-        return array_intersect_key(
-            $paths,
-            array_unique(array_map('serialize', $paths))
+        return array_values(
+            array_intersect_key(
+                $paths,
+                array_unique(array_map('serialize', $paths))
+            )
         );
     }
 


### PR DESCRIPTION
This provides a critical fix for serialization of arrays that have been deduplicated leaving gaps in the key sequence. `json_encode` will serialize an array as a JSON object when the array keys are not consecutive. 

Because the scenario does not happen for every product only certain objects in the Algolia index may manifest this behavior. This can create a problem for Algolia features such as visual merchandising which require a scalar array to function as a category page ID and not an object and mixed data types can result in the index. 

Further details will be supplied in the corresponding Jira ticket. 