### PR TITLE
Bugfix/mage 796 - banner fix

### DIFF
--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -299,18 +299,6 @@ define(
                                         return item;
                                     });
                             },
-
-                            /*
-                             * queryRuleCustomData
-                             * The queryRuleCustomData widget displays custom data from Query Rules.
-                             * Docs: https://www.algolia.com/doc/api-reference/widgets/query-rule-custom-data/js/
-                             **/
-                            queryRuleCustomData: {
-                                container: '#algolia-banner',
-                                templates: {
-                                    default: '{{#items}} {{#banner}} {{{banner}}} {{/banner}} {{/items}}',
-                                }
-                            }
                         },
 
                         /*
@@ -340,6 +328,18 @@ define(
                                     item.label = attribute.label;
                                     return item;
                                 })
+                            }
+                        },
+
+                        /*
+                        * queryRuleCustomData
+                        * The queryRuleCustomData widget displays custom data from Query Rules.
+                        * Docs: https://www.algolia.com/doc/api-reference/widgets/query-rule-custom-data/js/
+                        **/
+                        queryRuleCustomData: {
+                            container: '#algolia-banner',
+                            templates: {
+                                    default: '{{#items}} {{#banner}} {{{banner}}} {{/banner}} {{/items}}',
                             }
                         }
                     };


### PR DESCRIPTION
An earlier merge conflict resolution incorrectly nested certain widgets. This PR restores custom banner functionality via the extension's Magento merchandising feature. 