### PR TITLE
PHP8.2 compatibility

### DIFF
--- a/ViewModel/Recommend/Cart.php
+++ b/ViewModel/Recommend/Cart.php
@@ -13,6 +13,11 @@ use Magento\Store\Model\StoreManagerInterface;
 class Cart implements ArgumentInterface
 {
     /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+    
+    /**
      * @var Session
      */
     protected $checkoutSession;


### PR DESCRIPTION
**Summary**

Fix following error on PHP8.2

```
1 exception(s):
Exception #0 (Exception): Deprecated Functionality: Creation of dynamic property Algolia\AlgoliaSearch\ViewModel\Recommend\Cart::$storeManager is deprecated in /var/www/project/magento/vendor/algolia/algoliasearch-magento-2/ViewModel/Recommend/Cart.php on line 42
```

**Result**

Add the storeManager property