### PR TITLE
[BUG] Fix for syntax error in construct

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
@@ -92,7 +92,7 @@ abstract class ProductWithoutChildren
         Rule $rule,
         ProductFactory $productloader,
         ScopedProductTierPriceManagementInterface $productTierPrice,
-        Logger $logger,
+        Logger $logger
     ) {
         $this->configHelper = $configHelper;
         $this->customerGroupCollectionFactory = $customerGroupCollectionFactory;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
The comma on the last item in the constructor is not allowed prior to PHP 8.0 and it's causing syntax issues. Check this for more information: https://php.watch/versions/8.0/trailing-comma-parameter-use-list

![CleanShot 2024-02-22 at 12 45 54](https://github.com/algolia/algoliasearch-magento-2/assets/108009780/0797208f-dbf4-4103-a7b1-549728a8bb69)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
This PR fixes the syntax error in the construct and make it backward-compatible.
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->