### PR TITLE
Feature/mage 827 - PHP connector v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 vendor/
 .php_cs.cache
 .vscode
+.idea

--- a/Controller/Adminhtml/Landingpage/Delete.php
+++ b/Controller/Adminhtml/Landingpage/Delete.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Landingpage;
 
+use Algolia\AlgoliaSearch\Model\LandingPage;
 use Magento\Framework\Controller\ResultFactory;
 
 class Delete extends AbstractAction
@@ -15,7 +16,7 @@ class Delete extends AbstractAction
         $landingPageId = $this->getRequest()->getParam('id');
         if ($landingPageId) {
             try {
-                /** @var \Algolia\AlgoliaSearch\Model\LandingPage $landingPage */
+                /** @var LandingPage $landingPage */
                 $landingPage = $this->landingPageFactory->create();
                 $landingPage->getResource()->load($landingPage, $landingPageId);
                 $landingPage->getResource()->delete($landingPage);
@@ -35,7 +36,12 @@ class Delete extends AbstractAction
         return $resultRedirect->setPath('*/*/');
     }
 
-    private function deleteQueryRules($landingPage)
+    /**
+     * @param LandingPage $landingPage
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function deleteQueryRules(LandingPage $landingPage): void
     {
         $stores = [];
         if ($landingPage->getStoreId() == 0) {

--- a/Controller/Adminhtml/Landingpage/Duplicate.php
+++ b/Controller/Adminhtml/Landingpage/Duplicate.php
@@ -2,6 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Landingpage;
 
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Model\LandingPage;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
 
@@ -20,7 +22,7 @@ class Duplicate extends AbstractAction
             return $resultRedirect->setPath('*/*/');
         }
 
-        /** @var \Algolia\AlgoliaSearch\Model\LandingPage $landingPage */
+        /** @var LandingPage $landingPage */
         $landingPage = $this->landingPageFactory->create();
         $landingPage->getResource()->load($landingPage, $landingPageId);
 
@@ -53,9 +55,13 @@ class Duplicate extends AbstractAction
         return $resultRedirect->setPath('*/*/');
     }
 
-    private function duplicateLandingPage($landingPage)
+    /**
+     * @param LandingPage $landingPage
+     * @return LandingPage
+     */
+    private function duplicateLandingPage(LandingPage $landingPage): LandingPage
     {
-        /** @var \Algolia\AlgoliaSearch\Model\LandingPage $newLandingPage */
+        /** @var LandingPage $newLandingPage */
         $newLandingPage = $this->landingPageFactory->create();
         $newLandingPage->setData($landingPage->getData());
         $newLandingPage->setId(null);
@@ -65,7 +71,13 @@ class Duplicate extends AbstractAction
         return $newLandingPage;
     }
 
-    private function copyQueryRules($landingPageFromId, $landingPageToId)
+    /**
+     * @param int $landingPageFromId
+     * @param int $landingPageToId
+     * @return void
+     * @throws AlgoliaException|\Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function copyQueryRules(int $landingPageFromId, int $landingPageToId): void
     {
         $stores = [];
         if ($landingPageFromId) {

--- a/Controller/Adminhtml/Landingpage/Save.php
+++ b/Controller/Adminhtml/Landingpage/Save.php
@@ -154,11 +154,12 @@ class Save extends AbstractAction
     }
 
     /**
-     * @param $landingPageId
-     * @param $data
+     * @param int $landingPageId
+     * @param array<string, mixed> $data
      * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    protected function manageQueryRules($landingPageId, $data)
+    protected function manageQueryRules(int $landingPageId, array $data): void
     {
         $positions = json_decode($data['algolia_merchandising_positions'], true);
         $stores = [];

--- a/Controller/Adminhtml/Query/Delete.php
+++ b/Controller/Adminhtml/Query/Delete.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Query;
 
+use Algolia\AlgoliaSearch\Model\Query;
 use Magento\Framework\Controller\ResultFactory;
 
 class Delete extends AbstractAction
@@ -15,7 +16,7 @@ class Delete extends AbstractAction
         $queryId = $this->getRequest()->getParam('id');
         if ($queryId) {
             try {
-                /** @var \Algolia\AlgoliaSearch\Model\Query $query */
+                /** @var Query $query */
                 $query = $this->queryFactory->create();
                 $query->getResource()->load($query, $queryId);
                 $query->getResource()->delete($query);
@@ -35,7 +36,12 @@ class Delete extends AbstractAction
         return $resultRedirect->setPath('*/*/');
     }
 
-    private function deleteQueryRules($query)
+    /**
+     * @param Query $query
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function deleteQueryRules(Query $query): void
     {
         $stores = [];
         if ($query->getStoreId() == 0) {

--- a/Controller/Adminhtml/Query/Save.php
+++ b/Controller/Adminhtml/Query/Save.php
@@ -149,7 +149,13 @@ class Save extends AbstractAction
         return $resultRedirect->setPath('*/*/');
     }
 
-    private function manageQueryRules($queryId, $data)
+    /**
+     * @param int $queryId
+     * @param array<string, mixed> $data
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function manageQueryRules(int $queryId, array $data): void
     {
         $positions = json_decode($data['algolia_merchandising_positions'], true);
         $stores = [];

--- a/Helper/AdapterHelper.php
+++ b/Helper/AdapterHelper.php
@@ -45,6 +45,7 @@ class AdapterHelper
      * Get search result from Algolia
      *
      * @return array
+     * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
      */
     public function getDocumentsFromAlgolia()
     {

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -576,7 +576,7 @@ class AlgoliaHelper extends AbstractHelper
         $currentCET = $currentCET->format('Y-m-d H:i:s');
 
         $modifiedIds = [];
-        foreach ($objects as $key => $object) {
+        foreach ($objects as $key => &$object) {
             $object['algoliaLastUpdateAtCET'] = $currentCET;
 
             $previousObject = $object;

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -2,12 +2,12 @@
 
 namespace Algolia\AlgoliaSearch\Helper;
 
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Configuration\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Response\AbstractResponse;
 use Algolia\AlgoliaSearch\Response\BatchIndexingResponse;
 use Algolia\AlgoliaSearch\Response\MultiResponse;
-use Algolia\AlgoliaSearch\Configuration\SearchConfig;
-use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 use Algolia\AlgoliaSearch\Support\Helpers;
 use Magento\Framework\App\Helper\AbstractHelper;
@@ -70,10 +70,12 @@ class AlgoliaHelper extends AbstractHelper
             $this->config->getNonCastableAttributes()
         );
 
-        AlgoliaAgent::addAlgoliaAgent('Magento2 integration', 'desktop', $this->config->getExtensionVersion());
-        AlgoliaAgent::addAlgoliaAgent('PHP', 'desktop', phpversion());
-        AlgoliaAgent::addAlgoliaAgent('Magento', 'desktop', $this->config->getMagentoVersion());
-        AlgoliaAgent::addAlgoliaAgent('Edition', 'desktop', $this->config->getMagentoEdition());
+        $clientName = $this->client->getClientConfig()->getClientName();
+
+        AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento2 integration', $this->config->getExtensionVersion());
+        AlgoliaAgent::addAlgoliaAgent($clientName, 'PHP', phpversion());
+        AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento', $this->config->getMagentoVersion());
+        AlgoliaAgent::addAlgoliaAgent($clientName, 'Edition', $this->config->getMagentoEdition());
     }
 
     /**

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -157,16 +157,28 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param $indexName
-     * @param $objectIds
-     * @return mixed
+     * @param string $indexName
+     * @param array $objectIds
+     * @return array<string, mixed>
      * @throws AlgoliaException
      */
-    public function getObjects($indexName, $objectIds)
+    public function getObjects(string $indexName, array $objectIds): array
     {
         $this->checkClient(__FUNCTION__);
 
-        return $this->client->getObject($indexName, $objectIds);
+        $requests = array_values(
+            array_map(
+                function($id) use ($indexName) {
+                    return [
+                        'indexName' => $indexName,
+                        'objectID' => $id
+                    ];
+                },
+                $objectIds
+            )
+        );
+
+        return $this->client->getObjects([ 'requests' => $requests ]);
     }
 
     /**

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -149,26 +149,31 @@ class AlgoliaHelper extends AbstractHelper
      * @param $indexName
      * @param $q
      * @param $params
-     * @return mixed|null
+     * @return array<string, mixed>
      * @throws AlgoliaException
+     * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
      */
-    public function query(sring $indexName, string $q, $params)
+    public function query(string $indexName, string $q, array $params): array
     {
         $this->checkClient(__FUNCTION__);
 
-        if (isset($params['disjunctiveFacets'])) {
-            return $this->searchWithDisjunctiveFaceting($indexName, $q, $params);
-        }
-        $searchResults = $this->client->search([
-            'requests' => [
-                [
-                    self::ALGOLIA_API_INDEX_NAME => $indexName,
-                    'query'     => $q
-                ],
-            ],
-        ], $params);
+        // TODO: Revisit - not compatible with PHP v4
+        // if (isset($params['disjunctiveFacets'])) {
+        //    return $this->searchWithDisjunctiveFaceting($indexName, $q, $params);
+        //}
 
-        return $searchResults;
+        $params = array_merge(
+            [
+                self::ALGOLIA_API_INDEX_NAME => $indexName,
+                'query' => $q
+            ],
+            $params
+        );
+
+        // TODO: Validate return value for integration tests
+        return $this->client->search([
+            'requests' => [ $params ]
+        ]);
     }
 
     /**
@@ -459,7 +464,7 @@ class AlgoliaHelper extends AbstractHelper
      * @throws AlgoliaException
      * @deprecated Managing synonyms from Magento is no longer supported. Use the Algolia dashboard instead.
      */
-    public function setSynonyms($indexName, $synonyms)
+    public function setSynonyms($indexName, $synonyms): void
     {
         throw new AlgoliaException("This method is no longer supported for PHP client v4!");
     }
@@ -511,7 +516,7 @@ class AlgoliaHelper extends AbstractHelper
      * @return void
      * @throws AlgoliaException
      */
-    protected function checkClient($methodName)
+    protected function checkClient($methodName): void
     {
         if (isset($this->client)) {
             return;
@@ -527,10 +532,10 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param $indexName
+     * @param string $indexName
      * @return void
      */
-    public function clearIndex($indexName)
+    public function clearIndex(string $indexName): void
     {
         $res = $this->client->clearObjects($indexName);
 
@@ -618,7 +623,7 @@ class AlgoliaHelper extends AbstractHelper
     /**
      * @return int
      */
-    protected function getMaxRecordSize()
+    protected function getMaxRecordSize(): int
     {
         if (!$this->maxRecordSize) {
             $this->maxRecordSize = $this->config->getMaxRecordSizeLimit();
@@ -779,15 +784,15 @@ class AlgoliaHelper extends AbstractHelper
     /**
      * @return string
      */
-    public function getLastIndexName()
+    public function getLastIndexName(): string
     {
         return self::$lastUsedIndexName;
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getLastTaskId()
+    public function getLastTaskId(): int
     {
         return self::$lastTaskId;
     }
@@ -797,7 +802,7 @@ class AlgoliaHelper extends AbstractHelper
      *
      * @return int
      */
-    protected function calculateObjectSize($object)
+    protected function calculateObjectSize($object): int
     {
         return mb_strlen(json_encode($object));
     }
@@ -807,9 +812,14 @@ class AlgoliaHelper extends AbstractHelper
      * @param $q
      * @param $params
      * @return mixed|null
+     * @throws AlgoliaException
+     * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
      */
     protected function searchWithDisjunctiveFaceting($indexName, $q, $params)
     {
+        throw new AlgoliaException("This function is not currently supported on PHP connector v4");
+
+        // TODO: Revisit this implementation for backend render
         if (! is_array($params['disjunctiveFacets']) || count($params['disjunctiveFacets']) <= 0) {
             throw new \InvalidArgumentException('disjunctiveFacets needs to be an non empty array');
         }
@@ -832,7 +842,7 @@ class AlgoliaHelper extends AbstractHelper
         }
 
         // Merge facets and disjunctiveFacets for the hits query
-        $facets = isset($params['facets']) ? $params['facets'] : [];
+        $facets = $params['facets'] ?? [];
         $facets = array_merge($facets, $params['disjunctiveFacets']);
         unset($params['disjunctiveFacets']);
 

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -27,6 +27,10 @@ class AlgoliaHelper extends AbstractHelper
      * @var string
      */
     public const ALGOLIA_API_INDEX_NAME = 'indexName';
+    /**
+     * @var string
+     */
+    public const ALGOLIA_API_TASK_ID = 'taskID';
 
     protected SearchClient $client;
 
@@ -283,7 +287,7 @@ class AlgoliaHelper extends AbstractHelper
                 'destination' => $indexName
             ]
         );
-        $this->client->waitForTask($indexName, $response['taskID']);
+        $this->client->waitForTask($indexName, $response[self::ALGOLIA_API_TASK_ID]);
 
         self::setLastOperationInfo($indexName, $response);
     }
@@ -411,7 +415,7 @@ class AlgoliaHelper extends AbstractHelper
     protected static function setLastOperationInfo(string $indexName, array $response): void
     {
         self::$lastUsedIndexName = $indexName;
-        self::$lastTaskId = $response['taskID'] ?? null;
+        self::$lastTaskId = $response[self::ALGOLIA_API_TASK_ID] ?? null;
     }
 
     /**
@@ -538,7 +542,7 @@ class AlgoliaHelper extends AbstractHelper
                 'destination' => $toIndexName
             ]
         );
-        $this->client->waitForTask($toIndexName, $response['taskID']);
+        $this->client->waitForTask($toIndexName, $response[self::ALGOLIA_API_TASK_ID]);
 
         self::setLastOperationInfo($toIndexName, $response);
     }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -113,16 +113,14 @@ class AlgoliaHelper extends AbstractHelper
 
     /**
      * @param $name
-     * @return SearchIndex
      * @throws AlgoliaException
+     *
+     * @deprecated This method has been completely removed from the Algolia PHP connector version 4 and should not be used.
      */
     public function getIndex($name)
     {
-        $this->checkClient(__FUNCTION__);
-
-        return $this->client->initIndex($name);
+        throw new AlgoliaException("This method is no longer supported for PHP client v4!");
     }
-
 
     /**
      * @return mixed

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -431,26 +431,31 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param $rule
-     * @param $indexName
-     * @param $forwardToReplicas
+     * @param array<string, mixed> $rule
+     * @param string $indexName
+     * @param bool $forwardToReplicas
      * @return void
      */
-    public function saveRule($rule, $indexName, $forwardToReplicas = false)
+    public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false): void
     {
-        $res = $this->client->saveRule($indexName, $rule, $forwardToReplicas);
+        $res = $this->client->saveRule(
+            $indexName,
+            $rule[AlgoliaHelper::ALGOLIA_API_OBJECT_ID],
+            $rule,
+            $forwardToReplicas
+        );
 
         self::setLastOperationInfo($indexName, $res);
     }
 
 
     /**
-     * @param $indexName
-     * @param $objectID
-     * @param $forwardToReplicas
+     * @param string $indexName
+     * @param string $objectID
+     * @param bool $forwardToReplicas
      * @return void
      */
-    public function deleteRule($indexName, $objectID, $forwardToReplicas = false)
+    public function deleteRule(string $indexName, string $objectID, bool $forwardToReplicas = false): void
     {
         $res = $this->client->deleteRule($indexName, $objectID, $forwardToReplicas);
 

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -381,16 +381,30 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
+     * Legacy function signature to add objects to Algolia
      * @param array $objects
      * @param string $indexName
      * @return void
      * @throws \Exception
+     * @deprecated Do not use. This method has been replaced by saveObjects and may be removed in the future.
      */
-    public function addObjects(array $objects, string $indexName): void
+    public function addObjects(array $objects, string $indexName): void {
+        $this->saveObjects($indexName, $objects, $this->config->isPartialUpdateEnabled());
+    }
+
+    /**
+     * Save objects to index (upserts records)
+     * @param string $indexName
+     * @param array $objects
+     * @param bool $isPartialUpdate
+     * @return void
+     * @throws \Exception
+     */
+    public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false): void
     {
         $this->prepareRecords($objects, $indexName);
 
-        $action = $this->config->isPartialUpdateEnabled() ? 'partialUpdateObject' : 'addObject';
+        $action = $isPartialUpdate ? 'partialUpdateObject' : 'addObject';
 
         $requests = array_values(
             array_map(
@@ -600,7 +614,7 @@ class AlgoliaHelper extends AbstractHelper
      * @return void
      * @throws \Exception
      */
-    protected function prepareRecords(array $objects, string $indexName)
+    protected function prepareRecords(array $objects, string $indexName): void
     {
         $currentCET = new \DateTime('now', new \DateTimeZone('Europe/Paris'));
         $currentCET = $currentCET->format('Y-m-d H:i:s');

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -346,17 +346,19 @@ class AlgoliaHelper extends AbstractHelper
 
         $action = $this->config->isPartialUpdateEnabled() ? 'partialUpdateObject' : 'addObject';
 
-        $requests = array_map(
-            function ($object) use ($action) {
-                return [
-                    'action' => $action,
-                    'body' => $object
-                ];
-            },
-            $objects
+        $requests = array_values(
+            array_map(
+                function ($object) use ($action) {
+                    return [
+                        'action' => $action,
+                        'body'   => $object
+                    ];
+                },
+                $objects
+            )
         );
 
-        $response = $this->client->batch($indexName, $requests);
+        $response = $this->client->batch($indexName, [ 'requests' => $requests ] );
 
         self::setLastOperationInfo($indexName, $response);
 

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -222,19 +222,31 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param $ids
-     * @param $indexName
+     * @param array $ids
+     * @param string $indexName
      * @return void
      * @throws AlgoliaException
      */
-    public function deleteObjects($ids, $indexName)
+    public function deleteObjects(array $ids, string $indexName): void
     {
         $this->checkClient(__FUNCTION__);
-        foreach ($ids as $id){
-            $res = $this->client->deleteObject($id);
-            self::setLastOperationInfo($indexName, $res);
-        }
-        /*Need to implement function for delete by Query for bulk*/
+        $requests = array_values(
+            array_map(
+                function ($id) {
+                    return [
+                        'action' => 'deleteObject',
+                        'body'   => [
+                            'objectID' => $id
+                        ]
+                    ];
+                },
+                $ids
+            )
+        );
+
+        $response = $this->client->batch($indexName, [ 'requests' => $requests ] );
+
+        self::setLastOperationInfo($indexName, $response);
     }
 
     /**

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -538,17 +538,19 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param $fromIndexName
-     * @param $toIndexName
+     * @param string $fromIndexName
+     * @param string $toIndexName
      *
+     * @throws \Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException
      */
-    public function copyQueryRules($fromIndexName, $toIndexName)
+    public function copyQueryRules(string $fromIndexName, string $toIndexName): void
     {
         $response = $this->client->operationIndex(
             $fromIndexName,
             [
                 'operation' => 'copy',
-                'destination' => $toIndexName
+                'destination' => $toIndexName,
+                'scope' => ['rules']
             ]
         );
         $this->client->waitForTask($toIndexName, $response[self::ALGOLIA_API_TASK_ID]);

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -32,6 +32,11 @@ class AlgoliaHelper extends AbstractHelper
      */
     public const ALGOLIA_API_TASK_ID = 'taskID';
 
+    /** @var int This value should be configured based on system/full_page_cache/ttl
+     *           (which is by default 86400) and/or the configuration block TTL
+     */
+    protected const ALGOLIA_API_SECURED_KEY_TIMEOUT_SECONDS = 60 * 60 * 24; // TODO: Implement as config
+
     protected SearchClient $client;
 
     protected ConfigHelper $config;
@@ -304,19 +309,9 @@ class AlgoliaHelper extends AbstractHelper
             $params['tagFilters'] = '';
         }
 
-        return $this->generateSecuredApiKey($key, $params);
-    }
+        $params['validUntil'] = time() + self::ALGOLIA_API_SECURED_KEY_TIMEOUT_SECONDS;
 
-    public function  generateSecuredApiKey($key, $params)
-    {
-        $validUntil = time() + (3600 * 25);
-
-        $urlEncodedRestrictions = Helpers::buildQuery([
-            'validUntil' => $validUntil,
-        ]);
-
-        $content = hash_hmac('sha256', $urlEncodedRestrictions, $key).$urlEncodedRestrictions;
-        return base64_encode($content);
+        return $this->client->generateSecuredApiKey($key, $params);
     }
 
     /**

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -48,9 +48,9 @@ class AlgoliaHelper extends AbstractHelper
     /** @var string[] */
     protected array $nonCastableAttributes = ['sku', 'name', 'description', 'query'];
 
-    protected static string $lastUsedIndexName;
+    protected static ?string $lastUsedIndexName;
 
-    protected static string $lastTaskId;
+    protected static ?int $lastTaskId;
 
     /**
      * @param Context $context
@@ -240,7 +240,7 @@ class AlgoliaHelper extends AbstractHelper
     public function deleteIndex(string $indexName): void
     {
         $this->checkClient(__FUNCTION__);
-        $res = $this->client->clearObjects($indexName);
+        $res = $this->client->deleteIndex($indexName);
 
         self::setLastOperationInfo($indexName, $res);
     }
@@ -593,18 +593,27 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param $lastUsedIndexName
-     * @param $lastTaskId
+     * @param string|null $lastUsedIndexName
+     * @param int|null $lastTaskId
      * @return void
-     * @throws AlgoliaException
+     * @throws \Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException|AlgoliaException
      */
-    public function waitLastTask($lastUsedIndexName = null, $lastTaskId = null)
+    public function waitLastTask(string $lastUsedIndexName = null, int $lastTaskId = null): void
     {
+        $this->checkClient(__FUNCTION__);
+
+        if ($lastUsedIndexName === null && isset(self::$lastUsedIndexName)) {
+            $lastUsedIndexName = self::$lastUsedIndexName;
+        }
+
+        if ($lastTaskId === null && isset(self::$lastTaskId)) {
+            $lastTaskId = self::$lastTaskId;
+        }
+
         if (!$lastUsedIndexName || !$lastTaskId) {
             return;
         }
 
-        $this->checkClient(__FUNCTION__);
         $this->client->waitForTask($lastUsedIndexName, $lastTaskId);
     }
 

--- a/Helper/AnalyticsHelper.php
+++ b/Helper/AnalyticsHelper.php
@@ -417,13 +417,9 @@ class AnalyticsHelper
 
             $this->setupAnalyticsClient();
 
-            $requestOptions = new RequestOptionsFactory($this->analyticsConfig);
-            $requestOptions = $requestOptions->create([]);
-
-            $requestOptions->addQueryParameters($params);
-
             $response = $this->analyticsClient->customGet($path, $params);
         } catch (\Exception $e) {
+            // TODO: Revisit this error handling code to provide better feedback to front end with PHP connect v4 API
             $this->errors[] = $e->getMessage() . ': ' . $path;
             $this->logger->log($e->getMessage());
 

--- a/Helper/AnalyticsHelper.php
+++ b/Helper/AnalyticsHelper.php
@@ -2,8 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Helper;
 
-use Algolia\AlgoliaSearch\AnalyticsClient;
-use Algolia\AlgoliaSearch\Config\AnalyticsConfig;
+use Algolia\AlgoliaSearch\Api\AnalyticsClient;
+use Algolia\AlgoliaSearch\Configuration\AnalyticsConfig;
 use Algolia\AlgoliaSearch\DataProvider\Analytics\IndexEntityDataProvider;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptionsFactory;
 
@@ -103,11 +103,11 @@ class AnalyticsHelper
     /**
      * @param $storeId
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function getAnalyticsIndices($storeId)
+    public function getAnalyticsIndices(int $storeId): array
     {
-        return $sections = [
+        return [
             'products' => $this->entityHelper->getIndexNameByEntity('products', $storeId),
             'categories' => $this->entityHelper->getIndexNameByEntity('categories', $storeId),
             'pages' => $this->entityHelper->getIndexNameByEntity('pages', $storeId),
@@ -119,23 +119,31 @@ class AnalyticsHelper
      *
      * @param array $params
      *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    public function getTopSearches(array $params)
+    public function getTopSearches(array $params): array
     {
-        return $this->fetch(self::ANALYTICS_SEARCH_PATH, $params);
+        return $this->safeFetch(self::ANALYTICS_SEARCH_PATH, $params);
     }
 
-    public function getCountOfSearches(array $params)
+    /**
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getCountOfSearches(array $params): array
     {
-        if (!$this->searches) {
-            $this->searches = $this->fetch(self::ANALYTICS_SEARCH_PATH . '/count', $params);
+        if (!isset($this->searches)) {
+            $this->searches = $this->safeFetch(self::ANALYTICS_SEARCH_PATH . '/count', $params);
         }
 
         return $this->searches;
     }
 
-    public function getTotalCountOfSearches(array $params)
+    /**
+     * @param array $params
+     * @return int
+     */
+    public function getTotalCountOfSearches(array $params): int
     {
         $searches = $this->getCountOfSearches($params);
 
@@ -149,15 +157,23 @@ class AnalyticsHelper
         return $searches && isset($searches['dates']) ? $searches['dates'] : [];
     }
 
-    public function getTopSearchesNoResults(array $params)
+    /**
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getTopSearchesNoResults(array $params): array
     {
-        return $this->fetch(self::ANALYTICS_SEARCH_PATH . '/noResults', $params);
+        return $this->safeFetch(self::ANALYTICS_SEARCH_PATH . '/noResults', $params);
     }
 
-    public function getRateOfNoResults(array $params)
+    /**
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getRateOfNoResults(array $params): array
     {
-        if (!$this->rateOfNoResults) {
-            $this->rateOfNoResults = $this->fetch(self::ANALYTICS_SEARCH_PATH . '/noResultRate', $params);
+        if (!isset($this->rateOfNoResults)) {
+            $this->rateOfNoResults = $this->safeFetch(self::ANALYTICS_SEARCH_PATH . '/noResultRate', $params);
         }
 
         return $this->rateOfNoResults;
@@ -182,16 +198,21 @@ class AnalyticsHelper
      *
      * @param array $params
      *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    public function getTopHits(array $params)
+    public function getTopHits(array $params): array
     {
-        return $this->fetch(self::ANALYTICS_HITS_PATH, $params);
+        return $this->safeFetch(self::ANALYTICS_HITS_PATH, $params);
     }
 
-    public function getTopHitsForSearch($search, array $params)
+    /**
+     * @param $search
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getTopHitsForSearch($search, array $params): array
     {
-        return $this->fetch(self::ANALYTICS_HITS_PATH . '?search=' . urlencode($search), $params);
+        return $this->safeFetch(self::ANALYTICS_HITS_PATH . '?search=' . urlencode($search), $params);
     }
 
     /**
@@ -199,18 +220,22 @@ class AnalyticsHelper
      *
      * @param array $params
      *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    public function getUsers(array $params)
+    public function getUsers(array $params): array
     {
-        if (!$this->users) {
-            $this->users = $this->fetch('/2/users/count', $params);
+        if (!isset($this->users)) {
+            $this->users = $this->safeFetch('/2/users/count', $params);
         }
 
         return $this->users;
     }
 
-    public function getTotalUsersCount(array $params)
+    /**
+     * @param array $params
+     * @return int
+     */
+    public function getTotalUsersCount(array $params): int
     {
         $users = $this->getUsers($params);
 
@@ -229,32 +254,53 @@ class AnalyticsHelper
      *
      * @param array $params
      *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    public function getTopFilterAttributes(array $params)
+    public function getTopFilterAttributes(array $params): array
     {
-        return $this->fetch(self::ANALYTICS_FILTER_PATH, $params);
+        return $this->safeFetch(self::ANALYTICS_FILTER_PATH, $params);
     }
 
-    public function getTopFiltersForANoResultsSearch($search, array $params)
+    /**
+     * @param string $search
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getTopFiltersForANoResultsSearch(string $search, array $params): array
     {
-        return $this->fetch(self::ANALYTICS_FILTER_PATH . '/noResults?search=' . urlencode($search), $params);
+        return $this->safeFetch(self::ANALYTICS_FILTER_PATH . '/noResults?search=' . urlencode($search), $params);
     }
 
-    public function getTopFiltersForASearch($search, array $params)
+    /**
+     * @param string $search
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getTopFiltersForASearch(string $search, array $params): array
     {
-        return $this->fetch(self::ANALYTICS_FILTER_PATH . '?search=' . urlencode($search), $params);
+        return $this->safeFetch(self::ANALYTICS_FILTER_PATH . '?search=' . urlencode($search), $params);
     }
 
-    public function getTopFiltersForAttributesAndSearch(array $attributes, $search, array $params)
+    /**
+     * @param array $attributes
+     * @param string $search
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getTopFiltersForAttributesAndSearch(array $attributes, string $search, array $params): array
     {
-        return $this->fetch(self::ANALYTICS_FILTER_PATH . '/' . implode(',', $attributes)
+        return $this->safeFetch(self::ANALYTICS_FILTER_PATH . '/' . implode(',', $attributes)
             . '?search=' . urlencode($search), $params);
     }
 
-    public function getTopFiltersForAttribute($attribute, array $params)
+    /**
+     * @param string $attribute
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getTopFiltersForAttribute(string $attribute, array $params): array
     {
-        return $this->fetch(self::ANALYTICS_FILTER_PATH . '/' . $attribute, $params);
+        return $this->safeFetch(self::ANALYTICS_FILTER_PATH . '/' . $attribute, $params);
     }
 
     /**
@@ -262,12 +308,16 @@ class AnalyticsHelper
      *
      * @param array $params
      *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    public function getAverageClickPosition(array $params)
+    public function getAverageClickPosition(array $params): array
     {
-        if (!$this->clickPositions) {
-            $this->clickPositions = $this->fetch(self::ANALYTICS_CLICKS_PATH . '/averageClickPosition', $params);
+        if (!isset($this->clickPositions)) {
+            $this->clickPositions = $this->safeFetch(
+                self::ANALYTICS_CLICKS_PATH . '/averageClickPosition',
+                $params,
+                array_fill_keys(['average', 'clickCount'], null)
+            );
         }
 
         return $this->clickPositions;
@@ -280,10 +330,18 @@ class AnalyticsHelper
         return $click && isset($click['dates']) ? $click['dates'] : [];
     }
 
-    public function getClickThroughRate(array $params)
+    /**
+     * @param array $params
+     * @return array<string,mixed>
+     */
+    public function getClickThroughRate(array $params): array
     {
-        if (!$this->clickThroughs) {
-            $this->clickThroughs = $this->fetch(self::ANALYTICS_CLICKS_PATH . '/clickThroughRate', $params);
+        if (!isset($this->clickThroughs)) {
+            $this->clickThroughs = $this->safeFetch(
+                self::ANALYTICS_CLICKS_PATH . '/clickThroughRate',
+                $params,
+                array_fill_keys(['rate', 'trackedSearchCount'], null)
+            );
         }
 
         return $this->clickThroughs;
@@ -296,10 +354,18 @@ class AnalyticsHelper
         return $click && isset($click['dates']) ? $click['dates'] : [];
     }
 
-    public function getConversionRate(array $params)
+    /**
+     * @param array $params
+     * @return array<string, mixed>
+     */
+    public function getConversionRate(array $params): array
     {
-        if (!$this->conversions) {
-            $this->conversions = $this->fetch('/2/conversions/conversionRate', $params);
+        if (!isset($this->conversions)) {
+            $this->conversions = $this->safeFetch(
+                '/2/conversions/conversionRate',
+                $params,
+                array_fill_keys(['rate', 'trackedSearchCount'], null)
+            );
         }
 
         return $this->conversions;
@@ -332,9 +398,9 @@ class AnalyticsHelper
      * @param string $path
      * @param array $params
      *
-     * @return mixed
+     * @return array<string, mixed>|false
      */
-    private function fetch($path, array $params)
+    private function fetch(string $path, array $params): array|false
     {
         $response = false;
         if ($this->fetchError) {
@@ -356,7 +422,7 @@ class AnalyticsHelper
 
             $requestOptions->addQueryParameters($params);
 
-            $response = $this->analyticsClient->custom('GET', $path, $requestOptions);
+            $response = $this->analyticsClient->customGet($path, $params);
         } catch (\Exception $e) {
             $this->errors[] = $e->getMessage() . ': ' . $path;
             $this->logger->log($e->getMessage());
@@ -365,6 +431,18 @@ class AnalyticsHelper
         }
 
         return $response;
+    }
+
+    /**
+     * A failed request can return false - this provides a way to specify a default
+     * @param string $path
+     * @param array $params
+     * @param array $default Optional default - if not supplied will return an empty array on failed request
+     * @return array<string, mixed>
+     */
+    protected function safeFetch(string $path, array $params, array $default = []): array {
+        $value = $this->fetch($path, $params);
+        return $value !== false ? $value : $default;
     }
 
     public function getErrors()

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1420,7 +1420,7 @@ class ConfigHelper
             }
         }
         $attributes = array_merge($attributes, [
-            'objectID',
+            AlgoliaHelper::ALGOLIA_API_OBJECT_ID,
             'name',
             'url',
             'visibility_search',

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1187,10 +1187,10 @@ class ConfigHelper
     }
 
     /**
-     * @param $storeId
-     * @return mixed
+     * @param int|null $storeId
+     * @return string
      */
-    public function getIndexPrefix($storeId = null)
+    public function getIndexPrefix(int $storeId = null): string
     {
         return $this->configInterface->getValue(self::INDEX_PREFIX, ScopeInterface::SCOPE_STORE, $storeId);
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -180,7 +180,7 @@ class Data
 
         $params = [
             'hitsPerPage'            => $numberOfResults, // retrieve all the hits (hard limit is 1000)
-            'attributesToRetrieve'   => 'objectID',
+            'attributesToRetrieve'   => AlgoliaHelper::ALGOLIA_API_OBJECT_ID,
             'attributesToHighlight'  => '',
             'attributesToSnippet'    => '',
             'numericFilters'         => ['visibility_search=1'],
@@ -199,7 +199,7 @@ class Data
         $data = [];
 
         foreach ($answer['hits'] as $i => $hit) {
-            $productId = $hit['objectID'];
+            $productId = $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID];
 
             if ($productId) {
                 $data[$productId] = [
@@ -847,8 +847,8 @@ class Data
         foreach (array_chunk($idsToRemove, 1000) as $chunk) {
             $objects = $this->algoliaHelper->getObjects($indexName, $chunk);
             foreach ($objects['results'] as $object) {
-                if (isset($object['objectID'])) {
-                    $toRealRemove[] = $object['objectID'];
+                if (isset($object[AlgoliaHelper::ALGOLIA_API_OBJECT_ID])) {
+                    $toRealRemove[] = $object[AlgoliaHelper::ALGOLIA_API_OBJECT_ID];
                 }
             }
         }
@@ -902,10 +902,10 @@ class Data
         $counter = 0;
         $browseOptions = [
             'query'                => '',
-            'attributesToRetrieve' => ['objectID'],
+            'attributesToRetrieve' => [AlgoliaHelper::ALGOLIA_API_OBJECT_ID],
         ];
         foreach ($client->browseObjects($indexName, $browseOptions) as $hit) {
-            $objectIds[] = $hit['objectID'];
+            $objectIds[] = $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID];
             $counter++;
             if ($counter === 1000) {
                 $this->deleteInactiveIds($storeId, $objectIds, $indexName);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -215,6 +215,16 @@ class Data
     }
 
     /**
+     * @param array $objects
+     * @param string $indexName
+     * @return void
+     * @throws \Exception
+     */
+    protected function saveObjects(array $objects, string $indexName): void {
+        $this->algoliaHelper->saveObjects($indexName, $objects, $this->configHelper->isPartialUpdateEnabled());
+    }
+
+    /**
      * @param $storeId
      * @return void
      * @throws \Algolia\AlgoliaSearch\Exceptions\AlgoliaException
@@ -239,7 +249,7 @@ class Data
             $attributeValues = $this->additionalSectionHelper->getAttributeValues($storeId, $section);
 
             foreach (array_chunk($attributeValues, 100) as $chunk) {
-                $this->algoliaHelper->addObjects($chunk, $indexName . '_tmp');
+                $this->saveObjects($chunk, $indexName . '_tmp');
             }
 
             $this->algoliaHelper->copyQueryRules($indexName, $indexName . '_tmp');
@@ -283,7 +293,7 @@ class Data
 
             foreach (array_chunk($pagesToIndex, 100) as $chunk) {
                 try {
-                    $this->algoliaHelper->addObjects($chunk, $toIndexName);
+                    $this->saveObjects($chunk, $toIndexName);
                 } catch (\Exception $e) {
                     $this->logger->log($e->getMessage());
                     continue;
@@ -523,7 +533,7 @@ class Data
             }
         }
         if (count($indexData) > 0) {
-            $this->algoliaHelper->addObjects($indexData, $indexName);
+            $this->saveObjects($indexData, $indexName);
         }
 
         unset($indexData);
@@ -543,7 +553,7 @@ class Data
         $indexData = $this->getCategoryRecords($storeId, $collection, $categoryIds);
         if (!empty($indexData['toIndex'])) {
             $this->logger->start('ADD/UPDATE TO ALGOLIA');
-            $this->algoliaHelper->addObjects($indexData['toIndex'], $indexName);
+            $this->saveObjects($indexData['toIndex'], $indexName);
             $this->logger->log('Product IDs: ' . implode(', ', array_keys($indexData['toIndex'])));
             $this->logger->stop('ADD/UPDATE TO ALGOLIA');
         }
@@ -764,7 +774,7 @@ class Data
         $indexData = $this->getProductsRecords($storeId, $collection, $productIds);
         if (!empty($indexData['toIndex'])) {
             $this->logger->start('ADD/UPDATE TO ALGOLIA');
-            $this->algoliaHelper->addObjects($indexData['toIndex'], $indexName);
+            $this->saveObjects($indexData['toIndex'], $indexName);
             $this->logger->log('Product IDs: ' . implode(', ', array_keys($indexData['toIndex'])));
             $this->logger->stop('ADD/UPDATE TO ALGOLIA');
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Helper;
 
 use Algolia\AlgoliaSearch\Exception\CategoryReindexingException;
 use Algolia\AlgoliaSearch\Exception\ProductReindexingException;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\Entity\AdditionalSectionHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\PageHelper;
@@ -159,10 +160,11 @@ class Data
      * @param int $storeId
      * @param array|null $searchParams
      * @param string|null $targetedIndex
+     * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
      *
      * @return array
      */
-    public function getSearchResult($query, $storeId, $searchParams = null, $targetedIndex = null)
+    public function getSearchResult($query, $storeId, $searchParams = null, $targetedIndex = null): array
     {
         $indexName = $targetedIndex !== null ?
             $targetedIndex :
@@ -227,7 +229,7 @@ class Data
     /**
      * @param $storeId
      * @return void
-     * @throws \Algolia\AlgoliaSearch\Exceptions\AlgoliaException
+     * @throws AlgoliaException
      */
     public function rebuildStoreAdditionalSectionsIndex($storeId)
     {
@@ -263,7 +265,7 @@ class Data
      * @param $storeId
      * @param array|null $pageIds
      * @return void
-     * @throws \Algolia\AlgoliaSearch\Exceptions\AlgoliaException
+     * @throws AlgoliaException
      */
     public function rebuildStorePageIndex($storeId, array $pageIds = null)
     {
@@ -903,8 +905,9 @@ class Data
      * @param $storeId
      * @return void
      * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws AlgoliaException
      */
-    public function deleteInactiveProducts($storeId)
+    public function deleteInactiveProducts($storeId): void
     {
         $indexName = $this->getIndexName($this->productHelper->getIndexNameSuffix(), $storeId);
         $client = $this->algoliaHelper->getClient();
@@ -974,8 +977,9 @@ class Data
      * @param $objectIds
      * @param $indexName
      * @return void
+     * @throws AlgoliaException
      */
-    protected function deleteInactiveIds($storeId, $objectIds, $indexName)
+    protected function deleteInactiveIds($storeId, $objectIds, $indexName): void
     {
         $collection = $this->productHelper->getProductCollectionQuery($storeId, $objectIds);
         $dbIds = $collection->getAllIds();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -932,23 +932,23 @@ class Data
     }
 
     /**
-     * @param $indexSuffix
-     * @param $storeId
-     * @param $tmp
+     * @param string $indexSuffix
+     * @param int|null $storeId
+     * @param bool $tmp
      * @return string
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getIndexName($indexSuffix, $storeId = null, $tmp = false)
+    public function getIndexName(string $indexSuffix, int $storeId = null, bool $tmp = false): string
     {
         return $this->getBaseIndexName($storeId) . $indexSuffix . ($tmp ? '_tmp' : '');
     }
 
     /**
-     * @param $storeId
+     * @param int|null $storeId
      * @return string
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getBaseIndexName($storeId = null)
+    public function getBaseIndexName(int $storeId = null): string
     {
         return $this->configHelper->getIndexPrefix($storeId) . $this->storeManager->getStore($storeId)->getCode();
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -260,7 +260,7 @@ class Data
         if ($this->isIndexingEnabled($storeId) === false) {
             return;
         }
-        
+
         if (!$this->configHelper->isPagesIndexEnabled($storeId)) {
             $this->logger->log('Pages Indexing is not enabled for the store.');
             return;
@@ -522,10 +522,10 @@ class Data
                 array_push($indexData, $suggestionObject);
             }
         }
-
         if (count($indexData) > 0) {
             $this->algoliaHelper->addObjects($indexData, $indexName);
         }
+
         unset($indexData);
         $collection->walk('clearInstance');
         $collection->clear();
@@ -897,14 +897,14 @@ class Data
     public function deleteInactiveProducts($storeId)
     {
         $indexName = $this->getIndexName($this->productHelper->getIndexNameSuffix(), $storeId);
-        $index = $this->algoliaHelper->getIndex($indexName);
+        $client = $this->algoliaHelper->getClient();
         $objectIds = [];
         $counter = 0;
         $browseOptions = [
             'query'                => '',
             'attributesToRetrieve' => ['objectID'],
         ];
-        foreach ($index->browseObjects($browseOptions) as $hit) {
+        foreach ($client->browseObjects($indexName, $browseOptions) as $hit) {
             $objectIds[] = $hit['objectID'];
             $counter++;
             if ($counter === 1000) {

--- a/Helper/Entity/AdditionalSectionHelper.php
+++ b/Helper/Entity/AdditionalSectionHelper.php
@@ -91,8 +91,8 @@ class AdditionalSectionHelper
 
         $values = array_map(function ($value) use ($section, $storeId) {
             $record = [
-                'objectID' => $value,
-                'value'    => $value,
+                AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $value,
+                'value'                              => $value,
             ];
 
             $transport = new DataObject($record);

--- a/Helper/Entity/AdditionalSectionHelper.php
+++ b/Helper/Entity/AdditionalSectionHelper.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Eav\Model\Config;
 use Magento\Framework\DataObject;

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Helper\Entity;
 
 use Algolia\AlgoliaSearch\Exception\CategoryEmptyException;
 use Algolia\AlgoliaSearch\Exception\CategoryNotActiveException;
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Image;
 use Magento\Catalog\Model\Category;

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -307,15 +307,15 @@ class CategoryHelper
         }
 
         $data = [
-            'objectID' => $category->getId(),
-            'name' => $category->getName(),
-            'path' => $path,
-            'level' => $category->getLevel(),
-            'url' => $this->getUrl($category),
-            'include_in_menu' => $category->getIncludeInMenu(),
-            '_tags' => ['category'],
-            'popularity' => 1,
-            'product_count' => $category->getProductCount(),
+            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $category->getId(),
+            'name'                               => $category->getName(),
+            'path'                               => $path,
+            'level'                              => $category->getLevel(),
+            'url'                                => $this->getUrl($category),
+            'include_in_menu'                    => $category->getIncludeInMenu(),
+            '_tags'                              => ['category'],
+            'popularity'                         => 1,
+            'product_count'                      => $category->getProductCount(),
         ];
 
         if (!empty($imageUrl)) {

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -131,7 +131,7 @@ class PageHelper
                 $content = $this->filterProvider->getPageFilter()->filter($content);
             }
 
-            $pageObject['objectID'] = $page->getId();
+            $pageObject[AlgoliaHelper::ALGOLIA_API_OBJECT_ID] = $page->getId();
             $pageObject['url'] = $frontendUrlBuilder->getUrl(
                 null,
                 [

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Cms\Model\Page;
 use Magento\Cms\Model\ResourceModel\Page\CollectionFactory as PageCollectionFactory;

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -215,7 +215,7 @@ class ProductHelper
     /**
      * @return string
      */
-    public function getIndexNameSuffix()
+    public function getIndexNameSuffix(): string
     {
         return '_products';
     }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -591,12 +591,12 @@ class ProductHelper
         ];
 
         $customData = [
-            'objectID'           => $product->getId(),
-            'name'               => $product->getName(),
-            'url'                => $product->getUrlModel()->getUrl($product, $urlParams),
-            'visibility_search'  => (int)(in_array($visibility, $visibleInSearch)),
-            'visibility_catalog' => (int)(in_array($visibility, $visibleInCatalog)),
-            'type_id'            => $product->getTypeId(),
+            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $product->getId(),
+            'name'                               => $product->getName(),
+            'url'                                => $product->getUrlModel()->getUrl($product, $urlParams),
+            'visibility_search'                  => (int) (in_array($visibility, $visibleInSearch)),
+            'visibility_catalog'                 => (int) (in_array($visibility, $visibleInCatalog)),
+            'type_id'                            => $product->getTypeId(),
         ];
 
         $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
@@ -1421,7 +1421,7 @@ class ProductHelper
             ];
 
             $rules[] = [
-                'objectID' => 'filter_' . $attribute,
+                AlgoliaHelper::ALGOLIA_API_OBJECT_ID => 'filter_' . $attribute,
                 'description' => 'Filter facet "' . $attribute . '"',
                 'conditions' => [$condition],
                 'consequence' => [
@@ -1465,7 +1465,7 @@ class ProductHelper
                 }
 
                 foreach ($fetchedQueryRules['hits'] as $hit) {
-                    $client->deleteRule($indexName, $hit['objectID'], true);
+                    $client->deleteRule($indexName, $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID], true);
                 }
 
                 $page++;

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -13,7 +13,6 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
 use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
 use Algolia\AlgoliaSearch\Helper\Logger;
-use Algolia\AlgoliaSearch\SearchIndex;
 use Magento\Bundle\Model\Product\Type as BundleProductType;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -26,6 +25,7 @@ use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\CatalogInventory\Helper\Stock;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
 use Magento\Directory\Model\Currency as CurrencyHelper;
 use Magento\Eav\Model\Config;
@@ -33,7 +33,6 @@ use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
 
 class ProductHelper
 {

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1365,12 +1365,14 @@ class ProductHelper
     }
 
     /**
-     * @param $indexName
-     * @param $replicas
-     * @param $setReplicasTaskId
+     * @param string $indexName
+     * @param array $replicas
+     * @param int $setReplicasTaskId
      * @return void
+     * @throws AlgoliaException
+     * @throws \Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException
      */
-    protected function deleteUnusedReplicas($indexName, $replicas, $setReplicasTaskId)
+    protected function deleteUnusedReplicas(string $indexName, array $replicas, int $setReplicasTaskId): void
     {
         $indicesToDelete = [];
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -403,14 +403,16 @@ class ProductHelper
     }
 
     /**
-     * @param $indexName
-     * @param $indexNameTmp
-     * @param $storeId
-     * @param $saveToTmpIndicesToo
+     * @param string $indexName
+     * @param string $indexNameTmp
+     * @param int $storeId
+     * @param bool $saveToTmpIndicesToo
      * @return void
      * @throws AlgoliaException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function setSettings($indexName, $indexNameTmp, $storeId, $saveToTmpIndicesToo = false)
+    public function setSettings(string $indexName, string $indexNameTmp, int $storeId, bool $saveToTmpIndicesToo = false): void
     {
         $searchableAttributes = $this->getSearchableAttributes($storeId);
         $customRanking = $this->getCustomRanking($storeId);
@@ -519,8 +521,9 @@ class ProductHelper
         if ($saveToTmpIndicesToo === true) {
             try {
                 $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
+                $this->algoliaHelper->waitLastTask();
                 $this->logger->log('
-                    Copying synonyms from production index to TMP one to not erase them with the index move.
+                    Copying synonyms from production index to "' . $indexNameTmp . '" to not erase them with the index move.
                 ');
             } catch (AlgoliaException $e) {
                 $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
@@ -528,8 +531,9 @@ class ProductHelper
 
             try {
                 $this->algoliaHelper->copyQueryRules($indexName, $indexNameTmp);
+                $this->algoliaHelper->waitLastTask();
                 $this->logger->log('
-                    Copying query rules to "' . $indexNameTmp . '" to not to erase them with the index move.
+                    Copying query rules from production index to "' . $indexNameTmp . '" to not erase them with the index move.
                 ');
             } catch (AlgoliaException $e) {
                 if ($e->getCode() !== 404) {

--- a/Helper/Entity/SuggestionHelper.php
+++ b/Helper/Entity/SuggestionHelper.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Framework\App\Cache\Type\Config as ConfigCache;
 use Magento\Framework\DataObject;

--- a/Helper/Entity/SuggestionHelper.php
+++ b/Helper/Entity/SuggestionHelper.php
@@ -100,11 +100,11 @@ class SuggestionHelper
     public function getObject(Query $suggestion)
     {
         $suggestionObject = [
-            'objectID'          => $suggestion->getData('query_id'),
-            'query'             => $suggestion->getData('query_text'),
-            'number_of_results' => (int) $suggestion->getData('num_results'),
-            'popularity'        => (int) $suggestion->getData('popularity'),
-            'updated_at'        => (int) strtotime($suggestion->getData('updated_at')),
+            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $suggestion->getData('query_id'),
+            'query'                              => $suggestion->getData('query_text'),
+            'number_of_results'                  => (int) $suggestion->getData('num_results'),
+            'popularity'                         => (int) $suggestion->getData('popularity'),
+            'updated_at'                         => (int) strtotime($suggestion->getData('updated_at')),
         ];
 
         $transport = new DataObject($suggestionObject);

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -42,7 +42,7 @@ class MerchandisingHelper
         ];
 
         $rule = [
-            'objectID' => $this->getQueryRuleId($entityId, $entityType),
+            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $this->getQueryRuleId($entityId, $entityType),
             'description' => 'MagentoGeneratedQueryRule',
             'consequence' => [
                 'filterPromotes' => true,
@@ -93,7 +93,7 @@ class MerchandisingHelper
 
         foreach ($positions as $objectID => $position) {
             $transformedPositions[] = [
-                'objectID' => (string) $objectID,
+                AlgoliaHelper::ALGOLIA_API_OBJECT_ID => (string) $objectID,
                 'position' => $position,
             ];
         }
@@ -134,7 +134,7 @@ class MerchandisingHelper
                     unset($hit['_highlightResult']);
 
                     $newContext = $this->getQueryRuleId($entityIdTo, $entityType);
-                    $hit['objectID'] = $newContext;
+                    $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID] = $newContext;
                     if (isset($hit['condition']['context']) && $hit['condition']['context'] == $context) {
                         $hit['condition']['context'] = $newContext;
                     }

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -121,7 +121,7 @@ class MerchandisingHelper
             $page = 0;
             do {
                 $fetchedQueryRules = $client->searchRules($productsIndexName, [
-                    'context' => 'magento_filters',
+                    'context' => $context,
                     'page' => $page,
                     'hitsPerPage' => $hitsPerPage,
                 ]);

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -26,7 +26,22 @@ class MerchandisingHelper
         $this->algoliaHelper = $algoliaHelper;
     }
 
-    public function saveQueryRule($storeId, $entityId, $rawPositions, $entityType, $query = null, $banner = null)
+    /**
+     * @param int $storeId
+     * @param int $entityId
+     * @param array $rawPositions
+     * @param string $entityType
+     * @param string|null $query
+     * @param string|null $banner
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function saveQueryRule(int    $storeId,
+                                  int    $entityId,
+                                  array  $rawPositions,
+                                  string $entityType,
+                                  string $query = null,
+                                  string $banner = null): void
     {
         if ($this->coreHelper->isIndexingEnabled($storeId) === false) {
             return;
@@ -73,7 +88,14 @@ class MerchandisingHelper
         $this->algoliaHelper->saveRule($rule, $productsIndexName);
     }
 
-    public function deleteQueryRule($storeId, $entityId, $entityType)
+    /**
+     * @param int $storeId
+     * @param int $entityId
+     * @param string $entityType
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function deleteQueryRule(int $storeId, int $entityId, string $entityType): void
     {
         if ($this->coreHelper->isIndexingEnabled($storeId) === false) {
             return;
@@ -102,14 +124,14 @@ class MerchandisingHelper
     }
 
     /**
-     * @param $storeId
+     * @param int $storeId
      * @param $entityIdFrom
      * @param $entityIdTo
      * @param $entityType
      *
-     * @throws AlgoliaException
+     * @throws AlgoliaException|\Magento\Framework\Exception\NoSuchEntityException
      */
-    public function copyQueryRules($storeId, $entityIdFrom, $entityIdTo, $entityType)
+    public function copyQueryRules(int $storeId, $entityIdFrom, $entityIdTo, $entityType): void
     {
         $productsIndexName = $this->coreHelper->getIndexName($this->productHelper->getIndexNameSuffix(), $storeId);
         $client = $this->algoliaHelper->getClient();
@@ -163,7 +185,12 @@ class MerchandisingHelper
         }
     }
 
-    private function getQueryRuleId($entityId, $entityType)
+    /**
+     * @param int $entityId
+     * @param string $entityType
+     * @return string
+     */
+    private function getQueryRuleId(int $entityId, string $entityType): string
     {
         return 'magento-' . $entityType . '-' . $entityId;
     }

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -109,7 +109,11 @@ class MerchandisingHelper
         $this->algoliaHelper->deleteRule($productsIndexName, $ruleId);
     }
 
-    private function transformPositions($positions)
+    /**
+     * @param array $positions
+     * @return array
+     */
+    private function transformPositions(array $positions): array
     {
         $transformedPositions = [];
 
@@ -125,13 +129,13 @@ class MerchandisingHelper
 
     /**
      * @param int $storeId
-     * @param $entityIdFrom
-     * @param $entityIdTo
-     * @param $entityType
-     *
+     * @param int $entityIdFrom
+     * @param int $entityIdTo
+     * @param string $entityType
+     * @return void
      * @throws AlgoliaException|\Magento\Framework\Exception\NoSuchEntityException
      */
-    public function copyQueryRules(int $storeId, $entityIdFrom, $entityIdTo, $entityType): void
+    public function copyQueryRules(int $storeId, int $entityIdFrom, int $entityIdTo, string $entityType): void
     {
         $productsIndexName = $this->coreHelper->getIndexName($this->productHelper->getIndexNameSuffix(), $storeId);
         $client = $this->algoliaHelper->getClient();

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -112,7 +112,7 @@ class MerchandisingHelper
     public function copyQueryRules($storeId, $entityIdFrom, $entityIdTo, $entityType)
     {
         $productsIndexName = $this->coreHelper->getIndexName($this->productHelper->getIndexNameSuffix(), $storeId);
-        $productIndex = $this->algoliaHelper->getIndex($productsIndexName);
+        $client = $this->algoliaHelper->getClient();
         $context = $this->getQueryRuleId($entityIdFrom, $entityType);
         $queryRulesToSet = [];
 
@@ -120,8 +120,8 @@ class MerchandisingHelper
             $hitsPerPage = 100;
             $page = 0;
             do {
-                $fetchedQueryRules = $productIndex->searchRules('', [
-                    'context' => $context,
+                $fetchedQueryRules = $client->searchRules($productsIndexName, [
+                    'context' => 'magento_filters',
                     'page' => $page,
                     'hitsPerPage' => $hitsPerPage,
                 ]);
@@ -154,10 +154,7 @@ class MerchandisingHelper
             } while (($page * $hitsPerPage) < $fetchedQueryRules['nbHits']);
 
             if (!empty($queryRulesToSet)) {
-                $productIndex->saveRules($queryRulesToSet, [
-                    'forwardToReplicas'  => false,
-                    'clearExistingRules' => false,
-                ]);
+                $client->saveRules($productsIndexName, $queryRulesToSet, false, false);
             }
         } catch (AlgoliaException $e) {
             if ($e->getCode() !== 404) {

--- a/Model/IndexMover.php
+++ b/Model/IndexMover.php
@@ -35,9 +35,10 @@ class IndexMover
     /**
      * @param string $tmpIndexName
      * @param string $indexName
-     * @param int    $storeId
+     * @param int $storeId
+     * @throws AlgoliaException
      */
-    public function moveIndex($tmpIndexName, $indexName, $storeId)
+    public function moveIndex(string $tmpIndexName, string $indexName, int $storeId): void
     {
         if ($this->baseHelper->isIndexingEnabled($storeId) === false) {
             return;
@@ -49,11 +50,11 @@ class IndexMover
     /**
      * @param string $tmpIndexName
      * @param string $indexName
-     * @param int    $storeId
+     * @param int $storeId
      *
      * @throws AlgoliaException
      */
-    public function moveIndexWithSetSettings($tmpIndexName, $indexName, $storeId)
+    public function moveIndexWithSetSettings(string $tmpIndexName, string $indexName, int $storeId): void
     {
         if ($this->baseHelper->isIndexingEnabled($storeId) === false) {
             return;

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "version": "3.13.2",
   "require": {
     "magento/framework": "~102.0|~103.0",
-    "algolia/algoliasearch-client-php": "3.3.2",
+    "algolia/algoliasearch-client-php": "^4.0@alpha",
     "guzzlehttp/guzzle": "^6.3.3|^7.3.0",
     "ext-json": "*",
     "ext-PDO": "*",

--- a/view/frontend/web/instantsearch.js
+++ b/view/frontend/web/instantsearch.js
@@ -663,7 +663,6 @@ define(
                         search.on('render', () => {
                             const cartForms = document.querySelectorAll('[data-role="tocart-form"]');
                             cartForms.forEach((form, i) => {
-                                const ts = Date.now();
                                 form.addEventListener('submit', e => {
                                     const url = `${algoliaConfig.request.url}${window.location.search}`;
                                     e.target.elements[algoliaConfig.instant.addToCartParams.redirectUrlParam].value = AlgoliaBase64.mageEncode(url);


### PR DESCRIPTION
This PR updates to Algolia PHP API client version 4 alpha. 

Some key changes include:

* New API namespacing
* New `AlgoliaAgent`
* `batch` API calls for both partial / full object updates and deletions
* Applied constants such as case sensitive `objectID`
* `getObjects` signature change
* `safeFetch` added to handle inconsistent return types in `AnalyticsHelper`
*  Wait tasks cleanup
* Fix secured API key call and adding `validUntil` to prevent long lived keys
* Reworked `copyRules` / `copySynonyms` to leverage core API 
* Fixed facet query rules for admin settings save

Caveats:

* `AnalyticsClient` v4 alpha is not yet generating proper endpoint paths. Current prefixing is incorrect per our [API documentation](https://www.algolia.com/doc/rest-api/analytics/#quick-reference-1). 