### PR TITLE
MAGE-863 Add extension version notice

### DIFF
--- a/Helper/Configuration/NoticeHelper.php
+++ b/Helper/Configuration/NoticeHelper.php
@@ -44,7 +44,7 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
         'getClickAnalyticsNotice',
         'getPersonalizationNotice',
         'getRecommendNotice',
-	'getCookieConfigurationNotice',
+        'getCookieConfigurationNotice',
     ];
 
     /** @var array[] */
@@ -157,23 +157,33 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
         ];
     }
 
-    protected function getVersionNotice()
+    protected function getVersionNotice(): void
     {
+        $currentVersion = $this->configHelper->getExtensionVersion();
         $newVersion = $this->getNewVersionNotification();
-        if ($newVersion === null) {
+        if (!$currentVersion && !$newVersion) {
             return;
         }
 
-        $noticeTitle = 'Algolia Extension update';
-        $noticeContent = 'You are using old version of Algolia extension. Latest version of the extension is v <b>' . $newVersion['version'] . '</b><br />
+        $notice = [
+            'selector' => '.entry-edit',
+            'method' => 'before'
+        ];
+
+        if ($newVersion) {
+            $noticeTitle = 'Algolia extension update';
+            $noticeContent = 'You are using an old version of Algolia extension. Latest version of the extension is v <b>' . $newVersion['version'] . '</b><br />
 							It is highly recommended to update your version to avoid any unexpected issues and to get new features.<br />
 							See details on our <a target="_blank" href="' . $newVersion['url'] . '">Github repository</a>.';
+            $notice['message'] = $this->formatNotice($noticeTitle, $noticeContent);
+        }
+        else {
+            $noticeTitle = 'Algolia extension version';
+            $noticeContent = "You are using version <strong>$currentVersion</strong> of the Algolia Magento integration.";
+            $notice['message'] = $this->formatNotice($noticeTitle, $noticeContent, 'icon-bulb');
+        }
 
-        $this->notices[] = [
-            'selector' => '.entry-edit',
-            'method' => 'before',
-            'message' => $this->formatNotice($noticeTitle, $noticeContent),
-        ];
+        $this->notices[] = $notice;
     }
 
     protected function getClickAnalyticsNotice()
@@ -208,7 +218,7 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
             'message' => $noticeContent,
         ];
     }
-	
+
    protected function getCookieConfigurationNotice()
    {
         $noticeContent = '';

--- a/view/adminhtml/web/js/config.js
+++ b/view/adminhtml/web/js/config.js
@@ -38,7 +38,7 @@ require(
 			pageWarning += '</div>';
 
 			var pageWarningSynonyms = '<div class="algolia_dashboard_warning algolia_dashboard_warning_page">';
-			pageWarningSynonyms += '<p>Configurations related to Synonyms have been deprecated from the Magento dashboard. We advise you to configure synonyms from the Algolia dashboard.</p>';
+			pageWarningSynonyms += '<p>Configurations related to Synonyms have been removed from the Magento dashboard. We advise you to configure synonyms from the Algolia dashboard.</p>';
 			pageWarningSynonyms += '</div>';
 
 			for (var i=0; i < pageIds.length; i++) {


### PR DESCRIPTION
Adds the following general notice to Magento admin pages to make it easier for customers to find their extension version:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/6acc02df-0e08-460d-be6e-f8b2ce8cd8ad)
