### PR TITLE
Generic CSS Selectors Need to be more specific

### DIFF
--- a/view/frontend/web/internals/recommend.css
+++ b/view/frontend/web/internals/recommend.css
@@ -1,4 +1,4 @@
-.product-img {
+.recommend-item .product-img {
     width: 180px;
 }
 .auc-Recommend-list {
@@ -6,7 +6,7 @@
     justify-content: space-evenly;
     list-style: none;
 }
-.product-name {
+.recommend-item .product-name {
     height: 50px;
     width: 110px;
     margin: 0 auto;
@@ -50,12 +50,12 @@
     flex-wrap: wrap;
     justify-content: flex-start;
 }
-.product-details .action.primary, .action-primary{
+.product-details .recommend-item .action.primary, .action-primary{
     background: #f4f4f4;
     border: 1px solid #f4f4f4;
     color: #666666;
 }
-.product-details .action.primary:hover, .action-primary:hover {
+.product-details .recommend-item .action.primary:hover, .action-primary:hover {
     border-color: #1979c3;
     background: #1979c3;
     color: #FFFFFF;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

CSS selectors in `recommend.css` are too generic and can cause negative effects to other uses of the CSS classes on the page that are not related to Algolia.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

Based on the DOM structure in `vendor/algolia/algoliasearch-magento-2/view/frontend/web/internals/template/recommend/products.js` this CSS will create the same result for the Algolia implementation but will not affect other uses across a Magento site.

In my case, I was using the MageDellight SubscribeNow Pro module.  When viewing the customers subscriptions in their account this CSS was breaking the layout of the pages.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->