### PR TITLE
Bugfix/mage 889 - Autocomplete highlight robustness

### DIFF
--- a/view/frontend/web/internals/template/autocomplete/categories.js
+++ b/view/frontend/web/internals/template/autocomplete/categories.js
@@ -15,12 +15,24 @@ define([], function () {
                             data-position="${item.position}"
                             data-index="${item.__autocomplete_indexName}"
                             data-queryId="${item.__autocomplete_queryID}">
-                ${components.Highlight({ hit: item, attribute: 'path' })} (${item.product_count})
+                ${this.safeHighlight(components, item, "path")} (${item.product_count})
             </a>`;
         },
 
         getFooterHtml: function () {
             return "";
         },
+
+        safeHighlight: function(components, hit, attribute) {
+            const highlightResult = hit._highlightResult[attribute];
+
+            if (!highlightResult) return '';
+
+            try {
+                return components.Highlight({ hit, attribute });
+            } catch (e) {
+                return '';
+            }
+        }
     };
 });

--- a/view/frontend/web/internals/template/autocomplete/pages.js
+++ b/view/frontend/web/internals/template/autocomplete/pages.js
@@ -16,9 +16,9 @@ define([], function () {
                            data-index="${item.__autocomplete_indexName}"
                            data-queryId="${item.__autocomplete_queryID}">
                 <div class="info-without-thumb">
-                    ${components.Highlight({hit: item, attribute: 'name'})}
+                    ${this.safeHighlight(components, item, "name")}
                     <div class="details">
-                        ${components.Highlight({hit: item, attribute: 'content'})}
+                        ${this.safeHighlight(components, item, "content")}
                     </div>
                 </div>
                 <div class="algolia-clearfix"></div>
@@ -27,6 +27,19 @@ define([], function () {
 
         getFooterHtml: function () {
             return "";
+        },
+
+        safeHighlight: function(components, hit, attribute) {
+            const highlightResult = hit._highlightResult[attribute];
+
+            if (!highlightResult) return '';
+
+            try {
+                return components.Highlight({ hit, attribute });
+            } catch (e) {
+                return '';
+            }
         }
+
     };
 });

--- a/view/frontend/web/internals/template/autocomplete/products.js
+++ b/view/frontend/web/internals/template/autocomplete/products.js
@@ -104,6 +104,7 @@ define([], function () {
             `;
         },
 
+        // TODO: Refactor to external lib
         safeHighlight: function(components, hit, attribute, strict = true) {
             const highlightResult = hit._highlightResult[attribute];
 

--- a/view/frontend/web/internals/template/autocomplete/products.js
+++ b/view/frontend/web/internals/template/autocomplete/products.js
@@ -22,7 +22,7 @@ define([], function () {
                            data-queryId="${item.__autocomplete_queryID}">
                 <div class="thumb"><img src="${item.thumbnail_url || ''}" alt="${item.name || ''}"/></div>
                 <div class="info">
-                    ${components.Highlight({hit: item, attribute: 'name'})}
+                    ${this.safeHighlight(components, item, "name")}
                     <div class="algoliasearch-autocomplete-category">
                         ${this.getColorHtml(item, components, html)}
                         ${this.getCategoriesHtml(item, components, html)}
@@ -43,16 +43,20 @@ define([], function () {
         // Helper methods //
         ////////////////////
 
-        getColorHtml: (item, components, html) => {
-            if (item._highlightResult.color == undefined || item._highlightResult.color.value == "") return "";
-
-            return html`<span class="color">color: ${components.Highlight({ hit: item, attribute: "color" })}</span>`;
+        getColorHtml: function(item, components, html) {
+            const highlight = this.safeHighlight(components, item, "color");
+            
+            return highlight 
+                ? html`<span class="color">color: ${highlight}</span>`
+                : "";
         },
 
-        getCategoriesHtml: (item, components, html) => {
-            if (item.categories_without_path == undefined || item.categories_without_path.length == 0) return "";
+        getCategoriesHtml: function(item, components, html) {
+            const highlight = this.safeHighlight(components, item, "categories_without_path", false);
 
-            return html`<span>in ${components.Highlight({ hit: item, attribute: "categories_without_path",})}</span>`;
+            return highlight 
+                ? html`<span>in ${highlight}</span>`
+                : "";
         },
 
         getOriginalPriceHtml: (item, html, priceGroup) => {
@@ -98,6 +102,29 @@ define([], function () {
             return html`${algoliaConfig.translations.seeIn} <span><a href="${resultDetails.allDepartmentsUrl}">${algoliaConfig.translations.allDepartments}</a></span> (${resultDetails.nbHits})
                 ${this.getFooterSearchCategoryLinks(html, resultDetails)}
             `;
+        },
+
+        safeHighlight: function(components, hit, attribute, strict = true) {
+            const highlightResult = hit._highlightResult[attribute];
+
+            if (!highlightResult) return '';
+
+            if (strict
+                &&
+                (
+                    (Array.isArray(highlightResult)) && !highlightResult.find(hit => hit.matchLevel !== 'none')
+                    ||
+                    highlightResult.value === ''
+                )
+            ) {
+                return '';
+            }
+
+            try {
+                return components.Highlight({ hit, attribute });
+            } catch (e) {
+                return '';
+            }
         }
 
     };


### PR DESCRIPTION
**Summary**

There are certain index object attributes that the "out-of-the-box" integration expects to sync to Algolia to drive the default user experience. However, in the event that a customization is made, these configurations may be missing and additional checks are necessary. 

In this case, highlighting of attributes could fail if not found in either the `searchableAttributes` or `attributesToHighlight` configuration.

e.g.
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/471d38a8-aa7d-4d7d-8371-35e8a19b0c9f)

Rather than be opinionated about which fields to include (by enforcing these values via code) this update allows graceful degradation. Further updates can be made through customization of the underlying JavaScript templates.

**Result**

The following screenshots demonstrate successful handling of the categories attribute...

With configuration:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/4ddb01f3-6652-428b-8c5c-5f7b8dc971e9)

Without configuration:
<img width="930" alt="image" src="https://github.com/algolia/algoliasearch-magento-2/assets/986313/ab4cdf52-1b66-4855-a4e8-43bcc5b2c353">
