### PR TITLE
MAGE-879: decompoundedAttributes removed from merging settings

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -289,7 +289,7 @@ class AlgoliaHelper extends AbstractHelper
         } catch (\Exception $e) {
         }
 
-        $removes = ['slaves', 'replicas'];
+        $removes = ['slaves', 'replicas', 'decompoundedAttributes'];
 
         if (isset($settings['attributesToIndex'])) {
             $settings['searchableAttributes'] = $settings['attributesToIndex'];


### PR DESCRIPTION
Based on my limited knowledge, decompoundedAttributes setting is specific to Algolia dashboard. It should not be part of the merged settings. So I added in the remove list.

Now config saves without any error
<img width="1327" alt="Screenshot 2024-05-15 at 12 59 41 PM" src="https://github.com/algolia/algoliasearch-magento-2/assets/167926401/459091b8-4cfd-4902-9f0b-c76ad8c4027f">
