### PR TITLE
MAGE-2 Class CSS name conflict from other modules fix

### DIFF
--- a/view/frontend/web/internals/recommend.css
+++ b/view/frontend/web/internals/recommend.css
@@ -11,7 +11,7 @@
     width: 110px;
     margin: 0 auto;
 }
-.recommend-component {
+#algoliaAutocomplete .recommend-component {
     margin-bottom: 80px;
 }
 #relatedProducts .auc-Recommend-list, #frequentlyBoughtTogether .auc-Recommend-list, .trendsItem  .auc-Recommend-list{


### PR DESCRIPTION
Some name of CSS class have very common name that can conflict with other class from other modules. I think we should be using more specific selector for it.

```
#{some id} .recommend-component {
    margin-bottom: 80px;
}
```