### PR TITLE
MAGE-3 Checking on exists element fix

### DIFF
--- a/view/frontend/web/internals/common.js
+++ b/view/frontend/web/internals/common.js
@@ -624,7 +624,7 @@ define(['jquery', 'algoliaBundle'], function ($, algoliaBundle) {
             var input = $(this).closest('#algolia-searchbox').find('input');
 
             input.val('');
-            input.get(0).dispatchEvent(new Event('input'));
+            input.length ?  input.get(0)?.dispatchEvent(new Event('input')) : null
 
             handleInputCrossAutocomplete(input);
         });


### PR DESCRIPTION
When we have a dynamically element  #algolia-search-box, we will get error when this element doesn't exists in DOM on the moment when we try to get him, this fix check it.


view/frontend/web/internals/common.js
```
 var input = $(this).closest('#algolia-searchbox').find('input');

            input.val('');
            **input.length ?  input.get(0)?.dispatchEvent(new Event('input')) : null**

            handleInputCrossAutocomplete(input);
```