### PR TITLE
MAGE-894: Looking similar admin config added

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -826,6 +826,69 @@
                         </comment>
                     </field>
                 </group>
+                <group id="looking_similar" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Looking Similar</label>
+                    <field id="is_looking_similar_enabled_on_pdp" translate="label comment" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Enable on PDP</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <comment>
+                            <![CDATA[
+                                Do you want Looking Similar Items to display inside a product detail page after main product info?
+                            ]]>
+                        </comment>
+                    </field>
+                    <field id="is_looking_similar_enabled_on_cart_page" translate="label comment" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Enable on Cart Page</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <comment>
+                            <![CDATA[
+                                Do you want Looking Similar Items to display inside a cart page after cart item info?
+                            ]]>
+                        </comment>
+                    </field>
+                    <field id="is_looking_similar_enabled" translate="label comment" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Enable Looking Similar Widgets</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    </field>
+                    <field id="title" translate="label comment" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <validate>required-entry</validate>
+                        <label>Title</label>
+                    </field>
+                    <field id="facet_name" translate="label comment" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Facet Name</label>
+                        <comment>
+                            <![CDATA[
+                                Please Input Valid facet attribute name EX:- color,size etc.
+                            ]]>
+                        </comment>
+                    </field>
+                    <field id="facet_value" translate="label comment" type="text" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Facet Value</label>
+                        <comment>
+                            <![CDATA[
+                                Please Enter Valid Facet Value.
+                            ]]>
+                        </comment>
+                    </field>
+                    <field id="num_of_products" translate="label comment" type="text" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Number of products to display</label>
+                        <validate>required-entry validate-digits validate-greater-than-zero</validate>
+                        <comment>
+                            <![CDATA[
+                                How many Looking Similar Products do you want to display? Default value is 6.
+                            ]]>
+                        </comment>
+                    </field>
+                    <field id="is_addtocart_enabled" translate="label comment" type="select" sortOrder="8" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Enable Add To Cart Button</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <comment>
+                            <![CDATA[
+                            Do you want to display an "Add To Cart" button in Looking Similar Items?
+                            ]]>
+                        </comment>
+                    </field>
+                </group>
             </group>
         </section>
         <section id="algoliasearch_images" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -854,22 +854,6 @@
                         <validate>required-entry</validate>
                         <label>Title</label>
                     </field>
-                    <field id="facet_name" translate="label comment" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
-                        <label>Facet Name</label>
-                        <comment>
-                            <![CDATA[
-                                Please Input Valid facet attribute name EX:- color,size etc.
-                            ]]>
-                        </comment>
-                    </field>
-                    <field id="facet_value" translate="label comment" type="text" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
-                        <label>Facet Value</label>
-                        <comment>
-                            <![CDATA[
-                                Please Enter Valid Facet Value.
-                            ]]>
-                        </comment>
-                    </field>
                     <field id="num_of_products" translate="label comment" type="text" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Number of products to display</label>
                         <validate>required-entry validate-digits validate-greater-than-zero</validate>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -76,6 +76,10 @@
                     <title>Trending items</title>
                     <num_of_trending_items>6</num_of_trending_items>
                 </trends_item>
+                <looking_similar>
+                    <title>Looking Similar</title>
+                    <num_of_products>6</num_of_products>
+                </looking_similar>
             </recommend>
         </algoliasearch_recommend>
         <algoliasearch_advanced>


### PR DESCRIPTION
Admin config added for looking similar feature
<img width="1267" alt="Screenshot 2024-05-31 at 8 10 49 AM" src="https://github.com/algolia/algoliasearch-magento-2/assets/167926401/49948210-61f6-4484-bf47-160076cc5680">
