### PR TITLE
Feature/mage 935 - handle toggle virtual / standard replica on individual attributes

### DIFF
--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -12,7 +12,7 @@ interface ReplicaManagerInterface
     /**
      * Configure replicas in Algolia based on the sorting configuration in Magento
      *
-     * @param string $indexName Could be tmp (legacy impl)
+     * @param string $primaryIndexName Could be tmp (legacy impl)
      * @param int $storeId
      * @param array<string, mixed> $primaryIndexSettings
      * @return void
@@ -22,5 +22,5 @@ interface ReplicaManagerInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function handleReplicas(string $indexName, int $storeId, array $primaryIndexSettings): void;
+    public function handleReplicas(string $primaryIndexName, int $storeId, array $primaryIndexSettings): void;
 }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -363,22 +363,22 @@ class ProductHelper
 
         $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
         $this->logger->log('Settings: ' . json_encode($indexSettings));
-        if ($saveToTmpIndicesToo === true) {
+        if ($saveToTmpIndicesToo) {
             $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true, $indexName);
             $this->logger->log('Pushing the same settings to TMP index as well');
         }
 
         $this->setFacetsQueryRules($indexName);
-        if ($saveToTmpIndicesToo === true) {
+        if ($saveToTmpIndicesToo) {
             $this->setFacetsQueryRules($indexNameTmp);
         }
 
-        /*
-         * Handle replicas
-         */
         $this->replicaManager->handleReplicas($indexName, $storeId, $indexSettings);
+        if ($saveToTmpIndicesToo) {
+            $this->replicaManager->handleReplicas($indexNameTmp, $storeId, $indexSettings);
+        }
 
-        if ($saveToTmpIndicesToo === true) {
+        if ($saveToTmpIndicesToo) {
             try {
                 $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
                 $this->algoliaHelper->waitLastTask();

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -78,10 +78,12 @@ class IndicesConfigurator
     /**
      * @param int $storeId
      * @param bool $useTmpIndex
-     *
+     * @return void
      * @throws AlgoliaException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function saveConfigurationToAlgolia($storeId, $useTmpIndex = false)
+    public function saveConfigurationToAlgolia(int $storeId, bool $useTmpIndex = false): void
     {
         $logEventName = 'Save configuration to Algolia for store: ' . $this->logger->getStoreName($storeId);
         $this->logger->start($logEventName);
@@ -210,10 +212,12 @@ class IndicesConfigurator
     /**
      * @param int $storeId
      * @param bool $useTmpIndex
-     *
+     * @return void
      * @throws AlgoliaException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    protected function setProductsSettings($storeId, $useTmpIndex)
+    protected function setProductsSettings(int $storeId, bool $useTmpIndex): void
     {
         $this->logger->start('Pushing settings for products indices.');
 

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -204,7 +204,7 @@ class ReplicaManager implements ReplicaManagerInterface
     /**
      * @param $primaryIndexName
      * @param int $storeId
-     * @return string[] Replicas added by this operation
+     * @return string[] Replicas added or modified by this operation
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @throws AlgoliaException
@@ -219,9 +219,9 @@ class ReplicaManager implements ReplicaManagerInterface
         $newMagentoReplicaIndices = $this->getBareIndexNamesFromReplicaSetting($newMagentoReplicasSetting);
 
         $replicasToDelete = array_diff($oldMagentoReplicaIndices, $newMagentoReplicaIndices);
-        $replicasToUpdate = array_diff($newMagentoReplicasSetting, $oldMagentoReplicasSetting);
-        $replicasToUpdate = $this->getBareIndexNamesFromReplicaSetting($replicasToUpdate);
         $replicasToAdd = array_diff($newMagentoReplicaIndices, $oldMagentoReplicaIndices);
+        $replicasToRank = $this->getBareIndexNamesFromReplicaSetting(array_diff($newMagentoReplicasSetting, $oldMagentoReplicasSetting));
+        $replicasToUpdate = array_diff($replicasToRank, $replicasToAdd);
 
         $this->algoliaHelper->setSettings(
             $indexName,
@@ -241,7 +241,8 @@ class ReplicaManager implements ReplicaManagerInterface
             );
         }
 
-        return $replicasToUpdate;
+        // include both added and updated replica indices
+        return $replicasToRank;
     }
 
     /**


### PR DESCRIPTION
This PR aims to ensure that replica changes propagate for all sorting attribute changes - including:
- changing virtual vs standard (update)
- changing sort direction (add + delete)
- updating ranking (relevant sort vs exhaustive sort)
- housekeeping to ensure that out of date replica indices are properly deleted

A new approach is taken to evaluating the change state between Algolia and Magento - relying on an opinionated prefix comparison vs comparing the old sorts that were previously used via backend model + ReplicaState. This is considerably less complex and requires less tracking of earlier states in Magento. It also allows sync state repair in the event of a failed operation on the Magento side of things where that change set could be lost. 