### PR TITLE
MAGE-851: fix inline scripts

### DIFF
--- a/view/frontend/templates/internals/configuration.phtml
+++ b/view/frontend/templates/internals/configuration.phtml
@@ -1,20 +1,18 @@
 <?php
 
 /** @var \Algolia\AlgoliaSearch\Block\Configuration $block */
+/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 $configuration = $block->getConfiguration();
 
 ?>
-<script>
-    <?php
-    if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true) :
-        $css = '<style type="text/css">' . $configuration['instant']['selector'] . ' {display:none}</style>';
-    ?>
-	// Hide the instant-search selector ASAP to remove flickering. Will be re-displayed later with JS.
-	document.write('<?php /* @noEscape */ echo $css; ?>');
-    <?php
-    endif;
-    ?>
 
-	window.algoliaConfig = <?php /* @noEscape */ echo json_encode($configuration); ?>;
-</script>
+<?php
+if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true)  {
+    $css = /* @noEscape */ $secureRenderer->renderTag('style', [],  $configuration['instant']['selector'] . ' {display:none}', false);
+    /* @noEscape */ echo $secureRenderer->renderTag('script', [], 'document.write(\'' . $css . '\');' , false);
+}
+?>
+
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], "window.algoliaConfig = " . json_encode($configuration) . ';' , false); ?>
+

--- a/view/frontend/templates/layer/view.phtml
+++ b/view/frontend/templates/layer/view.phtml
@@ -1,3 +1,7 @@
+<?php
+/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+?>
+
 <?php if ($block->canShowBlock()) : ?>
     <div class="block filter algolia-filter-list" id="layered-filter-block" data-mage-init='{"collapsible":{"openedState": "active", "collapsible": true, "active": false, "collateral": { "openedState": "filter-active", "element": "body" } }}'>
         <?php $filtered = count($block->getLayer()->getState()->getFilters()) ?>
@@ -30,13 +34,15 @@
             <?php if ($wrapOptions) : ?>
                 </div>
             <?php else : ?>
-                <script>
-                    require([
-                        'jquery'
-                    ], function ($) {
-                        $('#layered-filter-block').addClass('filter-no-options');
-                    });
-                </script>
+                <?php $scriptString = <<<script
+                require([
+                    'jquery'
+                ], function ($) {
+                    $('#layered-filter-block').addClass('filter-no-options');
+                });
+    script;
+                ?>
+                <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false); ?>
             <?php endif; ?>
         </div>
     </div>


### PR DESCRIPTION
Following the [Magento recommendations](https://developer.adobe.com/commerce/php/development/security/content-security-policies/#whitelist-an-inline-script-or-style) for the latest releases, we now use a secured renderer to render the `algoliaConfig` object and other inline scripts. 