### PR TITLE
Update ProductHelper.php to prevent false in facets

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1237,7 +1237,7 @@ class ProductHelper
             $value = $attributeResource->getFrontend()->getValue($product);
         }
 
-        if ($value !== null) {
+        if ($value !== null && $value !== false) {
             $customData[$attribute['attribute']] = $value;
         }
 


### PR DESCRIPTION
We had a report from a customer that their facets show false as a value because there is no check if the product attribute  value is false before passing it on to be potentially added to the attributes of a product. Adding their suggestion which should resolve the issue.

**Summary**

This change modifies the check to make sure that the attribute value is not false before passing it to the $customerData object

**Result**
