### PR TITLE
Removed unnecessary opening tag for DataSize field in job view

### DIFF
--- a/view/adminhtml/templates/job/view.phtml
+++ b/view/adminhtml/templates/job/view.phtml
@@ -85,7 +85,7 @@ $job = $block->getCurrentJob();
                 </div>
             </div>
             <div class="admin__field">
-                <label class="admin__field-label"><span><<?php echo $block->escapeHtml(__('Data Size')); ?></span></label>
+                <label class="admin__field-label"><span><?php echo $block->escapeHtml(__('Data Size')); ?></span></label>
                 <div class="admin__field-control">
                     <div class="admin__field admin__field-option">
                         <?php echo $block->escapeHtml($job->getDataSize()); ?>


### PR DESCRIPTION
**Summary**

Job view had a unnecessary opening tag, it breaks the page: "Data Size" label was not displayed.

**Result**

Job's "Data Size" label is displayed.