### PR TITLE
The index in Algolia after full reindex has less records than expected

### DIFF
--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -392,8 +392,6 @@ class Queue
             $fullReindexJobs = $this->fetchJobs($fullReindexJobsLimit, true);
             $fullReindexJobsCount = count($fullReindexJobs);
 
-            $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($fullReindexJobs));
-
             $realtimeJobsLimit = (int) $maxJobs - $fullReindexJobsCount;
 
             $realtimeJobs = $this->fetchJobs($realtimeJobsLimit, false);
@@ -403,6 +401,7 @@ class Queue
 
             if ($jobsCount > 0 && $jobsCount < $maxJobs) {
                 $restLimit = $maxJobs - $jobsCount;
+                $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($fullReindexJobs));
 
                 $restFullReindexJobs = $this->fetchJobs($restLimit, true, $lastFullReindexJobId);
 

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -401,7 +401,12 @@ class Queue
 
             if ($jobsCount > 0 && $jobsCount < $maxJobs) {
                 $restLimit = $maxJobs - $jobsCount;
-                $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($fullReindexJobs));
+
+                if (count($fullReindexJobs)) {
+                    $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($fullReindexJobs));
+                } else {
+                    $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($jobs));
+                }
 
                 $restFullReindexJobs = $this->fetchJobs($restLimit, true, $lastFullReindexJobId);
 

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -402,7 +402,7 @@ class Queue
             if ($jobsCount > 0 && $jobsCount < $maxJobs) {
                 $restLimit = $maxJobs - $jobsCount;
 
-                if (count($fullReindexJobs)) {
+                if ($fullReindexJobsCount > 0) {
                     $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($fullReindexJobs));
                 } else {
                     $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($jobs));

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -392,6 +392,8 @@ class Queue
             $fullReindexJobs = $this->fetchJobs($fullReindexJobsLimit, true);
             $fullReindexJobsCount = count($fullReindexJobs);
 
+            $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($fullReindexJobs));
+
             $realtimeJobsLimit = (int) $maxJobs - $fullReindexJobsCount;
 
             $realtimeJobs = $this->fetchJobs($realtimeJobsLimit, false);
@@ -401,7 +403,6 @@ class Queue
 
             if ($jobsCount > 0 && $jobsCount < $maxJobs) {
                 $restLimit = $maxJobs - $jobsCount;
-                $lastFullReindexJobId = max($this->getJobsIdsFromMergedJobs($jobs));
 
                 $restFullReindexJobs = $this->fetchJobs($restLimit, true, $lastFullReindexJobId);
 


### PR DESCRIPTION
**Summary**

If a queue has jobs from a full reindex, then some realtime jobs, and then another full reindex jobs, at the end the resulted index has less records.

**Details**

The issue is related to the way how jobs are loaded from the queue in \Algolia\AlgoliaSearch\Model\Queue::getJobs() method.

The jobs loaded from the queue to be processed by QueueRunner indexer consist of three parts:
- "full reindex" jobs - 33% of "max number of jobs per run"
- "realtime" jobs (from 33% up to 100%)
- rest are "full reindex" jobs (up to 100%).


The current logic of loading jobs from the queue is the following:
- step 1. loading 30% of "max number of jobs per run" of "full reindex" jobs (those with "is_full_reindex" = 1)
- step 2. loading "realtime" jobs (those with "is_full_reindex" = 0) - up to "max number of jobs per run"
- step 3. get the max job ID of these jobs above ("max ID of full reindex and realtime jobs", $lastFullReindexJobId in the code)
- step 4. if the number of jobs still less than "max number of jobs per run", then load "full reindex" jobs with IDs AFTER "max ID of full reindex and realtime jobs"

**Steps to reproduce the bug**
1. Full reindex (#<span></span>1) is performed, so the corresponding "full reindex" jobs are added to the queue.
2. Then some entities are updated, so some "realtime" jobs are added to the queue.
3. Another full reindex (#<span></span>2) is performed, so the corresponding "full reindex" jobs are added to the queue.

In this case $lastFullReindexJobId calculated in step 3 will point to "full reindex" jobs from reindex #<span></span>2.
So, jobs added for full reindex #<span></span>2 will be used in reindex #<span></span>1, processed and deleted from the queue.
Full reindex #<span></span>2 will not include these jobs any more.

When full reindex #<span></span>2 finishes, the index in Algolia will miss these records.
With default page number=300 it is missing 300 records for each job added initially for reindex #<span></span>2, but processed and deleted while processing jobs of reindex #<span></span>1.

See the attached screenshot with loaded jobs: "pid" field is filled for loaded jobs:
- from full reindex #<span></span>1, 
- realtime job,  
- jobs from full reindex #<span></span>2.
 

![algolia](https://github.com/algolia/algoliasearch-magento-2/assets/475660/ce9ff4ad-3bab-40d2-8f2f-36cdf707ef6e)


**Result**

With the fix applied the jobs from full reindex #<span></span>1 will be processed without loading jobs from full reindex #<span></span>2.
The index after full reindex #<span></span>2 will have all records.
