### PR TITLE
Feature/mage 839 Store scoped replica state management

### DIFF
--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -12,7 +12,7 @@ interface ReplicaManagerInterface
     /**
      * Configure replicas in Algolia based on the sorting configuration in Magento
      *
-     * @param string $indexName Could be tmp (legacy impl)
+     * @param string $primaryIndexName Could be tmp (legacy impl)
      * @param int $storeId
      * @param array<string, mixed> $primaryIndexSettings
      * @return void
@@ -22,5 +22,5 @@ interface ReplicaManagerInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function handleReplicas(string $indexName, int $storeId, array $primaryIndexSettings): void;
+    public function handleReplicas(string $primaryIndexName, int $storeId, array $primaryIndexSettings): void;
 }

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Helper;
 
+use Algolia\AlgoliaSearch\Model\Product\ReplicaManager;
 use Magento;
 use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
 use Magento\Directory\Model\Currency as DirCurrency;
@@ -1166,7 +1167,7 @@ class ConfigHelper
                 $attrsToReturn[] = $attr;
             }
         }
-        
+
         if ($useCache) {
             $this->_sortingIndices[$storeId] = $attrsToReturn;
         }
@@ -1868,7 +1869,7 @@ class ConfigHelper
         return (bool) count(array_filter(
             $this->getSorting($storeId),
             function ($sort) {
-                return $sort['virtualReplica'];
+                return $sort[ReplicaManager::SORT_KEY_VIRTUAL_REPLICA];
             }
         ));
     }

--- a/Helper/Configuration/ConfigChecker.php
+++ b/Helper/Configuration/ConfigChecker.php
@@ -16,11 +16,32 @@ class ConfigChecker
         protected WebsiteRepositoryInterface $websiteRepository
     ) {}
 
-    public function isSettingAppliedForScopeAndCode(string $path, string $scope, string $code): bool
+    /**
+     * Is a scoped value different from the default?
+     * @param string $path
+     * @param string $scope
+     * @param mixed $code
+     * @return bool
+     */
+    public function isSettingAppliedForScopeAndCode(string $path, string $scope, mixed $code): bool
     {
         $value = $this->scopeConfig->getValue($path, $scope, $code);
         $defaultValue = $this->scopeConfig->getValue($path);
         return ($value !== $defaultValue);
+    }
+
+    /**
+     * Does a store config override the website config?
+     * @param string $path
+     * @param mixed $websiteId
+     * @param int $storeId
+     * @return bool
+     */
+    protected function isStoreSettingOverridingWebsite(string $path, mixed $websiteId, int $storeId): bool
+    {
+        $storeValue = $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORES, $storeId);
+        $websiteValue = $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_WEBSITES, $websiteId);
+        return ($storeValue !== $websiteValue);
     }
 
     /**
@@ -94,9 +115,9 @@ class ConfigChecker
             case ScopeInterface::SCOPE_WEBSITES:
                 $website = $this->websiteRepository->getById($scopeId);
                 foreach ($website->getStores() as $store) {
-                    if (!$this->isSettingAppliedForScopeAndCode(
+                    if (!$this->isStoreSettingOverridingWebsite(
                         $path,
-                        ScopeInterface::SCOPE_STORES,
+                        $website->getId(),
                         $store->getId()
                     )) {
                         $storeIds[] = $store->getId();

--- a/Helper/Configuration/ConfigChecker.php
+++ b/Helper/Configuration/ConfigChecker.php
@@ -37,7 +37,7 @@ class ConfigChecker
         /** @var \Magento\Store\Api\Data\WebsiteInterface $website */
         foreach ($this->storeManager->getWebsites() as $website) {
             if ($this->isSettingAppliedForScopeAndCode(
-                ConfigHelper::CC_CONVERSION_ANALYTICS_MODE,
+                $path,
                 ScopeInterface::SCOPE_WEBSITES,
                 $website->getId()
             )) {
@@ -48,7 +48,7 @@ class ConfigChecker
         /** @var \Magento\Store\Api\Data\StoreInterface $store */
         foreach ($this->storeManager->getStores() as $store) {
             if ($this->isSettingAppliedForScopeAndCode(
-                ConfigHelper::CC_CONVERSION_ANALYTICS_MODE,
+                $path,
                 ScopeInterface::SCOPE_STORES,
                 $store->getId()
             )) {

--- a/Helper/Configuration/ConfigChecker.php
+++ b/Helper/Configuration/ConfigChecker.php
@@ -2,7 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Configuration;
 
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -34,7 +33,6 @@ class ConfigChecker
      */
     public function checkAndApplyAllScopes(string $path, callable $callback, bool $includeDefault = true) {
         // First update all the possible scoped configurations
-        /** @var \Magento\Store\Api\Data\WebsiteInterface $website */
         foreach ($this->storeManager->getWebsites() as $website) {
             if ($this->isSettingAppliedForScopeAndCode(
                 $path,
@@ -45,7 +43,6 @@ class ConfigChecker
             }
         }
 
-        /** @var \Magento\Store\Api\Data\StoreInterface $store */
         foreach ($this->storeManager->getStores() as $store) {
             if ($this->isSettingAppliedForScopeAndCode(
                 $path,

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -363,22 +363,22 @@ class ProductHelper
 
         $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
         $this->logger->log('Settings: ' . json_encode($indexSettings));
-        if ($saveToTmpIndicesToo === true) {
+        if ($saveToTmpIndicesToo) {
             $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true, $indexName);
             $this->logger->log('Pushing the same settings to TMP index as well');
         }
 
         $this->setFacetsQueryRules($indexName);
-        if ($saveToTmpIndicesToo === true) {
+        if ($saveToTmpIndicesToo) {
             $this->setFacetsQueryRules($indexNameTmp);
         }
 
-        /*
-         * Handle replicas
-         */
         $this->replicaManager->handleReplicas($indexName, $storeId, $indexSettings);
+        if ($saveToTmpIndicesToo) {
+            $this->replicaManager->handleReplicas($indexNameTmp, $storeId, $indexSettings);
+        }
 
-        if ($saveToTmpIndicesToo === true) {
+        if ($saveToTmpIndicesToo) {
             try {
                 $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
                 $this->algoliaHelper->waitLastTask();

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -15,6 +15,7 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
 use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
 use Algolia\AlgoliaSearch\Helper\Logger;
+use Algolia\AlgoliaSearch\Model\Product\ReplicaManager;
 use Magento\Bundle\Model\Product\Type as BundleProductType;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -1425,7 +1426,7 @@ class ProductHelper
         return array_map(
             function($sort) {
                 $replica = $sort['name'];
-                return !! $sort['virtualReplica']
+                return !! $sort[ReplicaManager::SORT_KEY_VIRTUAL_REPLICA]
                     ? "virtual($replica)"
                     : $replica;
             },

--- a/Model/Backend/EnableCustomerGroups.php
+++ b/Model/Backend/EnableCustomerGroups.php
@@ -2,9 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Model\Backend;
 
-use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
-use Algolia\AlgoliaSearch\Helper\Data;
-use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Helper\Configuration\ConfigChecker;
+use Algolia\AlgoliaSearch\Registry\ReplicaState;
 use Magento\Framework\App\Cache\TypeListInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Value;
@@ -13,33 +12,19 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
-use Magento\Store\Model\StoreManagerInterface;
 
 class EnableCustomerGroups extends Value
 {
-    /**
-     * @param Context $context
-     * @param Registry $registry
-     * @param ScopeConfigInterface $config
-     * @param TypeListInterface $cacheTypeList
-     * @param StoreManagerInterface $storeManager
-     * @param Data $helper
-     * @param ProductHelper $productHelper
-     * @param AbstractResource|null $resource
-     * @param AbstractDb|null $resourceCollection
-     * @param array $data
-     */
     public function __construct(
-        Context                         $context,
-        Registry                        $registry,
-        ScopeConfigInterface            $config,
-        TypeListInterface               $cacheTypeList,
-        protected StoreManagerInterface $storeManager,
-        protected Data                  $helper,
-        protected ProductHelper         $productHelper,
-        AbstractResource                $resource = null,
-        AbstractDb                      $resourceCollection = null,
-        array                           $data = []
+        Context                 $context,
+        Registry                $registry,
+        ScopeConfigInterface    $config,
+        TypeListInterface       $cacheTypeList,
+        protected ReplicaState  $replicaState,
+        protected ConfigChecker $configChecker,
+        AbstractResource        $resource = null,
+        AbstractDb              $resourceCollection = null,
+        array                   $data = []
     )
     {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
@@ -47,27 +32,23 @@ class EnableCustomerGroups extends Value
 
     /**
      * @return $this
-     * @throws AlgoliaException
      * @throws NoSuchEntityException
      */
-    public function afterSave(): \Magento\Framework\App\Config\Value
+    public function afterSave(): Value
     {
-        // TODO: Determine if this action should be performed in the event of customer group pricing enablement
-        /*
-        if ($this->isValueChanged()) {
-            try {
-                $storeIds = array_keys($this->storeManager->getStores());
-                foreach ($storeIds as $storeId) {
-                    $indexName = $this->helper->getIndexName($this->productHelper->getIndexNameSuffix(), $storeId);
-                    $this->productHelper->handlingReplica($indexName, $storeId);
-                }
-            } catch (AlgoliaException $e) {
-                if ($e->getCode() !== 404) {
-                    throw $e;
-                }
-            }
+        $storeIds = $this->configChecker->getAffectedStoreIds(
+            $this->getPath(),
+            $this->getScope(),
+            $this->getScopeId()
+        );
+
+        foreach ($storeIds as $storeId) {
+            $this->replicaState->setChangeState(
+                $this->isValueChanged()
+                    ? ReplicaState::REPLICA_STATE_CHANGED
+                    : ReplicaState::REPLICA_STATE_UNCHANGED,
+                $storeId);
         }
-        */
 
         return parent::afterSave();
     }

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -78,10 +78,12 @@ class IndicesConfigurator
     /**
      * @param int $storeId
      * @param bool $useTmpIndex
-     *
+     * @return void
      * @throws AlgoliaException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function saveConfigurationToAlgolia($storeId, $useTmpIndex = false)
+    public function saveConfigurationToAlgolia(int $storeId, bool $useTmpIndex = false): void
     {
         $logEventName = 'Save configuration to Algolia for store: ' . $this->logger->getStoreName($storeId);
         $this->logger->start($logEventName);
@@ -210,10 +212,12 @@ class IndicesConfigurator
     /**
      * @param int $storeId
      * @param bool $useTmpIndex
-     *
+     * @return void
      * @throws AlgoliaException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    protected function setProductsSettings($storeId, $useTmpIndex)
+    protected function setProductsSettings(int $storeId, bool $useTmpIndex): void
     {
         $this->logger->start('Pushing settings for products indices.');
 

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -77,13 +77,25 @@ class ReplicaManager implements ReplicaManagerInterface
         }
     }
 
-    protected function getReplicaConfigurationFromAlgolia($primaryIndexName, bool $refreshCache = false)
+    /**
+     * @param $primaryIndexName
+     * @param bool $refreshCache
+     * @return array<string, mixed>
+     * @throws LocalizedException
+     */
+    protected function getReplicaConfigurationFromAlgolia($primaryIndexName, bool $refreshCache = false): array
     {
         if ($refreshCache || !isset($this->_algoliaReplicaConfig[$primaryIndexName])) {
-            $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName);
-            $this->_algoliaReplicaConfig[$primaryIndexName] = array_key_exists('replicas', $currentSettings)
-                ? $currentSettings['replicas']
-                : [];
+            try {
+                $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName);
+                $this->_algoliaReplicaConfig[$primaryIndexName] = array_key_exists('replicas', $currentSettings)
+                    ? $currentSettings['replicas']
+                    : [];
+            } catch (\Exception $e) {
+                $msg = "Unable to retrieve replica settings for $primaryIndexName: " . $e->getMessage();
+                $this->logger->error($msg);
+                throw new LocalizedException(__($msg));
+            }
         }
         return $this->_algoliaReplicaConfig[$primaryIndexName];
     }
@@ -103,6 +115,7 @@ class ReplicaManager implements ReplicaManagerInterface
      *
      * @param string $primaryIndexName
      * @return string[]
+     * @throws LocalizedException
      */
     protected function getMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName): array
     {
@@ -130,6 +143,7 @@ class ReplicaManager implements ReplicaManagerInterface
     /**
      * @param string $primaryIndexName
      * @return array
+     * @throws LocalizedException
      */
     protected function getNonMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName): array
     {

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -37,6 +37,8 @@ class ReplicaManager implements ReplicaManagerInterface
     public const REPLICA_TRANSFORM_MODE_VIRTUAL = 2;
     public const REPLICA_TRANSFORM_MODE_ACTUAL = 3;
 
+    public const SORT_KEY_VIRTUAL_REPLICA = 'virtualReplica';
+
     protected const _DEBUG = true;
 
     protected array $_algoliaReplicaConfig = [];
@@ -151,8 +153,8 @@ class ReplicaManager implements ReplicaManagerInterface
                 $replica = $sort['name'];
                 if (
                     $mode === self::REPLICA_TRANSFORM_MODE_VIRTUAL
-                    || array_key_exists('virtualReplica', $sort)
-                    && $sort['virtualReplica']
+                    || array_key_exists(self::SORT_KEY_VIRTUAL_REPLICA, $sort)
+                    && $sort[self::SORT_KEY_VIRTUAL_REPLICA]
                     && $mode === self::REPLICA_TRANSFORM_MODE_ACTUAL
                 ) {
                     $replica = "virtual($replica)";
@@ -300,7 +302,8 @@ class ReplicaManager implements ReplicaManagerInterface
         foreach ($replicaDetails as $replica) {
             $replicaName = $replica['name'];
             // Virtual replicas - relevant sort
-            if ($replica['virtualReplica']) {
+            if (array_key_exists(self::SORT_KEY_VIRTUAL_REPLICA, $replica)
+                && $replica[self::SORT_KEY_VIRTUAL_REPLICA]) {
                 $customRanking = array_key_exists('customRanking', $primaryIndexSettings)
                     ? $primaryIndexSettings['customRanking']
                     : [];

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -204,7 +204,7 @@ class ReplicaManager implements ReplicaManagerInterface
     /**
      * @param $primaryIndexName
      * @param int $storeId
-     * @return string[] Replicas added by this operation
+     * @return string[] Replicas added or modified by this operation
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @throws AlgoliaException
@@ -219,9 +219,9 @@ class ReplicaManager implements ReplicaManagerInterface
         $newMagentoReplicaIndices = $this->getBareIndexNamesFromReplicaSetting($newMagentoReplicasSetting);
 
         $replicasToDelete = array_diff($oldMagentoReplicaIndices, $newMagentoReplicaIndices);
-        $replicasToUpdate = array_diff($newMagentoReplicasSetting, $oldMagentoReplicasSetting);
-        $replicasToUpdate = $this->getBareIndexNamesFromReplicaSetting($replicasToUpdate);
         $replicasToAdd = array_diff($newMagentoReplicaIndices, $oldMagentoReplicaIndices);
+        $replicasToRank = $this->getBareIndexNamesFromReplicaSetting(array_diff($newMagentoReplicasSetting, $oldMagentoReplicasSetting));
+        $replicasToUpdate = array_diff($replicasToRank, $replicasToAdd);
 
         $this->algoliaHelper->setSettings(
             $indexName,
@@ -241,7 +241,8 @@ class ReplicaManager implements ReplicaManagerInterface
             );
         }
 
-        return $replicasToUpdate;
+        // include both added and updated replica indices
+        return $replicasToRank;
     }
 
     /**

--- a/Model/Source/Sorts.php
+++ b/Model/Source/Sorts.php
@@ -2,6 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Model\Source;
 
+use Algolia\AlgoliaSearch\Model\Product\ReplicaManager;
+
 /**
  * Algolia custom sort order field
  */
@@ -33,7 +35,7 @@ class Sorts extends AbstractTable
             'sortLabel' => [
                 'label' => 'Label',
             ],
-            'virtualReplica' => [
+            ReplicaManager::SORT_KEY_VIRTUAL_REPLICA => [
                 'label' => 'Enable Virtual Replica?',
                 'values' => ['0' => __('No'), '1' => __('Yes')],
             ],

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -440,20 +440,6 @@
             <group id="instant_sorts" translate="label" type="text" sortOrder="10" showInDefault="1"
                    showInWebsite="1" showInStore="1">
                 <label>Sorting</label>
-
-                <!--                <field id="use_virtual_replica" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">-->
-                <!--                    <label>Use Virtual Replica</label>-->
-                <!--                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>-->
-                <!--                    <backend_model>Algolia\AlgoliaSearch\Model\Backend\Replica</backend_model>-->
-                <!--                    <comment>-->
-                <!--                        <![CDATA[-->
-                <!--                            Virtual Replica is only available on Premium plans <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/?client=php#switching-to-virtual-replica">documentation</a>-->
-                <!--                        ]]>-->
-                <!--                    </comment>-->
-                <!--                    <depends>-->
-                <!--                        <field id="is_instant_enabled">1</field>-->
-                <!--                    </depends>-->
-                <!--                </field>-->
                 <field id="sorts" translate="label comment" type="text" sortOrder="20" showInDefault="1"
                        showInWebsite="1" showInStore="1">
                     <label>Sorts</label>


### PR DESCRIPTION
This PR introduces store scoped state management for replicas allowing highly selective changes to be persisted to Algolia minimizing the number of build operations on each store's respective index. 

All replica configuration persistence to Algolia is funneled through the new `ReplicaManager` class while backend models are used to track exactly what was changed for which affected stores via the `ReplicaState` singleton and the `ConfigChecker` utility class. 

Currently the `SaveSettings` observer iterates over all stores by default but replicas will not persist unless a change actually occurs for a given store. Changes to the default scope should not impact overridden websites or stores. Changes to a website should be localized to the associated store indices only (unless explicitly overridden by individual store configurations). A future refactor could make the `SaveSettings` observer more precise but the `ReplicaManager` handles its state management independently regardless.

If the `IndicesConfigurator` is triggered independently of `ReplicaState` management (e.g. via the indexing queue etc.) things will fall back to an "unknown" state which then uses direct comparison against the Algolia configuration to determine whether a change needs to be applied to the index. Hopefully this is flexible enough for a variety of scenarios. 

