### PR TITLE
Feature/mage 837 - virtual replica validator

### DIFF
--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -31,4 +31,13 @@ interface ReplicaManagerInterface
      * @throws NoSuchEntityException
      */
     public function handleReplicas(string $primaryIndexName, int $storeId, array $primaryIndexSettings): void;
+
+
+    /**
+     * For standard Magento front end (e.g. Luma) replicas will likely only be needed if InstantSearch is enabled
+     * Headless implementations may wish to override this behavior via plugin
+     * @param int $storeId
+     * @return bool
+     */
+    public function isReplicaSyncEnabled(int $storeId): bool;
 }

--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -9,11 +9,13 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 interface ReplicaManagerInterface
 {
-    public const REPLICA_TRANSFORM_MODE_STANDARD = 1;
-    public const REPLICA_TRANSFORM_MODE_VIRTUAL = 2;
-    public const REPLICA_TRANSFORM_MODE_ACTUAL = 3;
+    public const SORT_ATTRIBUTE_PRICE = 'price';
 
+    public const SORT_KEY_ATTRIBUTE_NAME = 'attribute';
     public const SORT_KEY_VIRTUAL_REPLICA = 'virtualReplica';
+    // https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/in-depth/replicas/#what-are-virtual-replicas
+    public const MAX_VIRTUAL_REPLICA_LIMIT = 20;
+
 
     /**
      * Configure replicas in Algolia based on the sorting configuration in Magento

--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -9,6 +9,12 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 interface ReplicaManagerInterface
 {
+    public const REPLICA_TRANSFORM_MODE_STANDARD = 1;
+    public const REPLICA_TRANSFORM_MODE_VIRTUAL = 2;
+    public const REPLICA_TRANSFORM_MODE_ACTUAL = 3;
+
+    public const SORT_KEY_VIRTUAL_REPLICA = 'virtualReplica';
+
     /**
      * Configure replicas in Algolia based on the sorting configuration in Magento
      *

--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -13,7 +13,6 @@ interface ReplicaManagerInterface
 
     public const SORT_KEY_ATTRIBUTE_NAME = 'attribute';
     public const SORT_KEY_VIRTUAL_REPLICA = 'virtualReplica';
-    // https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/in-depth/replicas/#what-are-virtual-replicas
     public const MAX_VIRTUAL_REPLICA_LIMIT = 20;
 
 
@@ -40,4 +39,12 @@ interface ReplicaManagerInterface
      * @return bool
      */
     public function isReplicaSyncEnabled(int $storeId): bool;
+
+    /**
+     * Return the number of virtual replicas permitted per index
+     * @link https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/in-depth/replicas/#differences
+     *
+     * @return int
+     */
+    public function getMaxVirtualReplicasPerIndex() : int;
 }

--- a/Exception/ReplicaLimitExceededException.php
+++ b/Exception/ReplicaLimitExceededException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Exception;
+
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+
+class ReplicaLimitExceededException extends AlgoliaException
+{
+    protected int $replicaCount = 0;
+
+    public function withReplicaCount(int $replicaCount): ReplicaLimitExceededException
+    {
+        $this->replicaCount = $replicaCount;
+        return $this;
+    }
+
+    public function getReplicaCount(): int {
+        return $this->replicaCount;
+    }
+
+}

--- a/Exception/ReplicaLimitExceededException.php
+++ b/Exception/ReplicaLimitExceededException.php
@@ -2,9 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Exception;
 
-use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Magento\Framework\Exception\LocalizedException;
 
-class ReplicaLimitExceededException extends AlgoliaException
+class ReplicaLimitExceededException extends LocalizedException
 {
     protected int $replicaCount = 0;
 

--- a/Exception/TooManyCustomerGroupsAsReplicasException.php
+++ b/Exception/TooManyCustomerGroupsAsReplicasException.php
@@ -2,8 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Exception;
 
-use Algolia\AlgoliaSearch\Exception\ReplicaLimitExceededException;
-
 class TooManyCustomerGroupsAsReplicasException extends ReplicaLimitExceededException
 {
     protected int $priceSortReplicaCount = 0;

--- a/Exception/TooManyCustomerGroupsAsReplicasException.php
+++ b/Exception/TooManyCustomerGroupsAsReplicasException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Exception;
+
+use Algolia\AlgoliaSearch\Exception\ReplicaLimitExceededException;
+
+class TooManyCustomerGroupsAsReplicasException extends ReplicaLimitExceededException
+{
+    protected int $priceSortReplicaCount = 0;
+
+    public function withPriceSortReplicaCount(int $priceSortReplicaCount): TooManyCustomerGroupsAsReplicasException
+    {
+        $this->priceSortReplicaCount = $priceSortReplicaCount;
+        return $this;
+    }
+
+    public function getPriceSortReplicaCount(): int
+    {
+        return $this->priceSortReplicaCount;
+    }
+}

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -443,6 +443,10 @@ class ConfigHelper
         return [];
     }
 
+    protected function serialize(array $value): string {
+        return $this->serializer->serialize($value);
+    }
+
     /**
      * @param $value
      * @return array|bool|float|int|mixed|string|null
@@ -1116,6 +1120,22 @@ class ConfigHelper
             self::SORTING_INDICES,
             ScopeInterface::SCOPE_STORE,
             $storeId
+        );
+    }
+
+    /**
+     * @param array $sorting
+     * @param string|null $scope
+     * @param int|null $scopeId
+     * @return void
+     */
+    public function setSorting(array $sorting, ?string $scope = null, ?int $scopeId = null): void
+    {
+        $this->configWriter->save(
+            self::SORTING_INDICES,
+            $this->serialize($sorting),
+            $scope,
+            $scopeId
         );
     }
 

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -2,8 +2,10 @@
 
 namespace Algolia\AlgoliaSearch\Helper;
 
-use Algolia\AlgoliaSearch\Model\Product\ReplicaManager;
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
 use Magento;
+use Magento\Cookie\Helper\Cookie as CookieHelper;
+use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
 use Magento\Directory\Model\Currency as DirCurrency;
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -13,9 +15,6 @@ use Magento\Framework\Locale\Currency;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
-use Magento\Cookie\Helper\Cookie as CookieHelper;
-
 
 class ConfigHelper
 {
@@ -1869,7 +1868,7 @@ class ConfigHelper
         return (bool) count(array_filter(
             $this->getSorting($storeId),
             function ($sort) {
-                return $sort[ReplicaManager::SORT_KEY_VIRTUAL_REPLICA];
+                return $sort[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA];
             }
         ));
     }

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -148,66 +148,6 @@ class ConfigHelper
     public const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/queue/archive_clear_limit';
 
     /**
-     * @var Magento\Framework\App\Config\ScopeConfigInterface
-     */
-    protected $configInterface;
-
-    /**
-     * @var Currency
-     */
-    protected $currency;
-
-    /**
-     * @var StoreManagerInterface
-     */
-    protected $storeManager;
-
-    /**
-     * @var DirCurrency
-     */
-    protected $dirCurrency;
-
-    /**
-     * @var DirectoryList
-     */
-    protected $directoryList;
-
-    /**
-     * @var Magento\Framework\Module\ResourceInterface
-     */
-    protected $moduleResource;
-
-    /**
-     * @var Magento\Framework\App\ProductMetadataInterface
-     */
-    protected $productMetadata;
-
-    /**
-     * @var Magento\Framework\Event\ManagerInterface
-     */
-    protected $eventManager;
-
-    /**
-     * @var SerializerInterface
-     */
-    protected $serializer;
-
-    /**
-     * @var GroupCollection
-     */
-    protected $groupCollection;
-
-    /**
-     * @var GroupExcludedWebsiteRepositoryInterface
-     */
-    protected $groupExcludedWebsiteRepository;
-
-    /**
-     * @var CookieHelper
-     */
-    protected $cookieHelper;
-
-    /**
      * @var array<int,<array<string, mixed>>>
      */
     protected array $_sortingIndices = [];
@@ -228,32 +168,21 @@ class ConfigHelper
 
      */
     public function __construct(
-        Magento\Framework\App\Config\ScopeConfigInterface $configInterface,
-        StoreManagerInterface                             $storeManager,
-        Currency                                          $currency,
-        DirCurrency                                       $dirCurrency,
-        DirectoryList                                     $directoryList,
-        Magento\Framework\Module\ResourceInterface        $moduleResource,
-        Magento\Framework\App\ProductMetadataInterface    $productMetadata,
-        Magento\Framework\Event\ManagerInterface          $eventManager,
-        SerializerInterface                               $serializer,
-        GroupCollection                                   $groupCollection,
-        GroupExcludedWebsiteRepositoryInterface           $groupExcludedWebsiteRepository,
-        CookieHelper                                      $cookieHelper
-    ) {
-        $this->configInterface = $configInterface;
-        $this->currency = $currency;
-        $this->storeManager = $storeManager;
-        $this->dirCurrency = $dirCurrency;
-        $this->directoryList = $directoryList;
-        $this->moduleResource = $moduleResource;
-        $this->productMetadata = $productMetadata;
-        $this->eventManager = $eventManager;
-        $this->serializer = $serializer;
-        $this->groupCollection = $groupCollection;
-        $this->groupExcludedWebsiteRepository = $groupExcludedWebsiteRepository;
-        $this->cookieHelper = $cookieHelper;
-    }
+        protected Magento\Framework\App\Config\ScopeConfigInterface    $configInterface,
+        protected Magento\Framework\App\Config\Storage\WriterInterface $configWriter,
+        protected StoreManagerInterface                                $storeManager,
+        protected Currency                                             $currency,
+        protected DirCurrency                                          $dirCurrency,
+        protected DirectoryList                                        $directoryList,
+        protected Magento\Framework\Module\ResourceInterface           $moduleResource,
+        protected Magento\Framework\App\ProductMetadataInterface       $productMetadata,
+        protected Magento\Framework\Event\ManagerInterface             $eventManager,
+        protected SerializerInterface                                  $serializer,
+        protected GroupCollection                                      $groupCollection,
+        protected GroupExcludedWebsiteRepositoryInterface              $groupExcludedWebsiteRepository,
+        protected CookieHelper                                         $cookieHelper
+    )
+    {}
 
 
     /**

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1103,20 +1103,20 @@ class ConfigHelper
 
     /***
      * @param $storeId
-     * @return array|bool|float|int|mixed|string|null
+     * @return array<string,<array<string, mixed>>>
      */
-    public function getSorting($storeId = null)
+    public function getSorting($storeId = null): array
     {
         return $this->unserialize($this->getRawSortingValue($storeId));
     }
 
     /**
-     * @param $storeId
-     * @return mixed
+     * @param int|null $storeId
+     * @return string
      */
-    public function getRawSortingValue($storeId = null)
+    public function getRawSortingValue(?int $storeId = null): string
     {
-        return $this->configInterface->getValue(
+        return (string) $this->configInterface->getValue(
             self::SORTING_INDICES,
             ScopeInterface::SCOPE_STORE,
             $storeId
@@ -1155,7 +1155,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isCustomerGroupsEnabled($storeId = null)
+    public function isCustomerGroupsEnabled($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::CUSTOMER_GROUPS_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
     }

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1160,6 +1160,16 @@ class ConfigHelper
         return $this->configInterface->isSetFlag(self::CUSTOMER_GROUPS_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
+    public function setCustomerGroupsEnabled(bool $val, ?string $scope = null, ?int $scopeId = null): void
+    {
+        $this->configWriter->save(
+            self::CUSTOMER_GROUPS_ENABLE,
+            $val ? '1' : '0',
+            $scope,
+            $scopeId
+        );
+    }
+
     /**
      * @param $storeId
      * @return bool

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1016,6 +1016,7 @@ class ConfigHelper
     /**
      * Augment sorting configuration with corresponding replica indices, ranking,
      * and (as needed) customer group pricing
+     * TODO: MAGE-941 Remove the $originalIndexName param - this should never be needed as tmp indices cannot have attached replicas
      *
      * @param string $originalIndexName
      * @param ?int $storeId

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -146,10 +146,6 @@ class ConfigHelper
     public const ENHANCED_QUEUE_ARCHIVE = 'algoliasearch_advanced/queue/enhanced_archive';
     public const NUMBER_OF_ELEMENT_BY_PAGE = 'algoliasearch_advanced/queue/number_of_element_by_page';
     public const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/queue/archive_clear_limit';
-    // https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/in-depth/replicas/#what-are-virtual-replicas
-    public const MAX_VIRTUAL_REPLICA_LIMIT = 20;
-
-    public const SORT_ATTRIBUTE_PRICE = 'price';
 
     /**
      * @var Magento\Framework\App\Config\ScopeConfigInterface
@@ -1125,7 +1121,7 @@ class ConfigHelper
             $indexName = false;
             $sortAttribute = false;
             // Group pricing
-            if ($this->isCustomerGroupsEnabled($storeId) && $attr['attribute'] === self::SORT_ATTRIBUTE_PRICE) {
+            if ($this->isCustomerGroupsEnabled($storeId) && $attr[ReplicaManagerInterface::SORT_KEY_ATTRIBUTE_NAME] === ReplicaManagerInterface::SORT_ATTRIBUTE_PRICE) {
                 $websiteId = (int) $this->storeManager->getStore($storeId)->getWebsiteId();
                 $groupCollection = $this->groupCollection;
                 if (!is_null($currentCustomerGroupId)) {
@@ -1139,7 +1135,7 @@ class ConfigHelper
                     }
                 }
             // Regular pricing
-            } elseif ($attr['attribute'] === self::SORT_ATTRIBUTE_PRICE) {
+            } elseif ($attr[ReplicaManagerInterface::SORT_KEY_ATTRIBUTE_NAME] === ReplicaManagerInterface::SORT_ATTRIBUTE_PRICE) {
                 $indexName = $originalIndexName . '_' . $attr['attribute'] . '_' . 'default' . '_' . $attr['sort'];
                 $sortAttribute = $attr['attribute'] . '.' . $currency . '.' . 'default';
             // All other sort attributes
@@ -1158,7 +1154,7 @@ class ConfigHelper
         $attrsToReturn = [];
 
         foreach ($attrs as $attr) {
-            if ($attr['attribute'] == self::SORT_ATTRIBUTE_PRICE
+            if ($attr[ReplicaManagerInterface::SORT_KEY_ATTRIBUTE_NAME] == ReplicaManagerInterface::SORT_ATTRIBUTE_PRICE
                 && count($attributesToAdd)
                 && isset($attributesToAdd[$attr['sort']])) {
                 $attrsToReturn = array_merge($attrsToReturn, $attributesToAdd[$attr['sort']]);

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1028,16 +1028,14 @@ class ConfigHelper
         $attrName = $origAttr['attribute'];
         $sortDir = $origAttr['sort'];
         $groupIndexNameSuffix = 'group_' . $customerGroupId;
-        $groupIndexName =
-            $originalIndexName . '_' . $attrName . '_' . $groupIndexNameSuffix . '_' . $sortDir;
-        $groupSortAttribute = $attrName . '.' . $currency . '.' . $groupIndexNameSuffix;
-        $newAttr = [
-            'attribute' => $attrName,
-            'name'      => $groupIndexName,
-            'sort'      => $sortDir,
-            'sortLabel' => $origAttr['sortLabel']
-        ];
+        $groupIndexName = $originalIndexName . '_' . $attrName . '_' . $groupIndexNameSuffix . '_' . $sortDir;
 
+        $newAttr = array_merge(
+            $origAttr,
+            ['name' => $groupIndexName]
+        );
+
+        $groupSortAttribute = $attrName . '.' . $currency . '.' . $groupIndexNameSuffix;
         $newAttr['ranking'] = $this->getSortAttributingRankingSetting($groupSortAttribute, $sortDir);
         return $this->decorateSortAttribute($newAttr);
     }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -373,6 +373,7 @@ class ProductHelper
         }
 
         $this->replicaManager->handleReplicas($indexName, $storeId, $indexSettings);
+        // TODO: Reevaluate whether we need to pre-bake the temp index replicas
         if ($saveToTmpIndicesToo) {
             $this->replicaManager->handleReplicas($indexNameTmp, $storeId, $indexSettings);
         }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -214,7 +214,6 @@ class ProductHelper
      * @param $productIds
      * @param $onlyVisible
      * @param $includeNotVisibleIndividually
-     * @return Collection
      */
     public function getProductCollectionQuery(
         $storeId,
@@ -599,20 +598,6 @@ class ProductHelper
         }
 
         return $customData;
-    }
-
-    protected function getCategoryPaths($product, $category)
-    {
-        $category->getUrlInstance()->setStore($product->getStoreId());
-        $path = [];
-
-        foreach ($category->getPathIds() as $treeCategoryId) {
-            $name = $this->categoryHelper->getCategoryName($treeCategoryId, $storeId);
-            if ($name) {
-                $categoryIds[] = $treeCategoryId;
-                $path[] = $name;
-            }
-        }
     }
 
     /**
@@ -1437,7 +1422,7 @@ class ProductHelper
      * Moving to ReplicaManager class
      * @param string $indexName
      * @param int $storeId
-     * @param bool $sortingAttribute
+     * @param array|bool $sortingAttribute
      * @return void
      * @throws AlgoliaException
      * @throws ExceededRetriesException

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -373,18 +373,14 @@ class ProductHelper
         }
 
         $this->replicaManager->handleReplicas($indexName, $storeId, $indexSettings);
-        // TODO: Reevaluate whether we need to pre-bake the temp index replicas
-        if ($saveToTmpIndicesToo) {
-            $this->replicaManager->handleReplicas($indexNameTmp, $storeId, $indexSettings);
-        }
 
         if ($saveToTmpIndicesToo) {
             try {
                 $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
                 $this->algoliaHelper->waitLastTask();
                 $this->logger->log('
-                    Copying synonyms from production index to "' . $indexNameTmp . '" to not erase them with the index move.
-                ');
+                        Copying synonyms from production index to "' . $indexNameTmp . '" to not erase them with the index move.
+                    ');
             } catch (AlgoliaException $e) {
                 $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
             }
@@ -393,8 +389,8 @@ class ProductHelper
                 $this->algoliaHelper->copyQueryRules($indexName, $indexNameTmp);
                 $this->algoliaHelper->waitLastTask();
                 $this->logger->log('
-                    Copying query rules from production index to "' . $indexNameTmp . '" to not erase them with the index move.
-                ');
+                        Copying query rules from production index to "' . $indexNameTmp . '" to not erase them with the index move.
+                    ');
             } catch (AlgoliaException $e) {
                 if ($e->getCode() !== 404) {
                     throw $e;

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -15,7 +15,6 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
 use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
 use Algolia\AlgoliaSearch\Helper\Logger;
-use Algolia\AlgoliaSearch\Model\Product\ReplicaManager;
 use Magento\Bundle\Model\Product\Type as BundleProductType;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -1426,7 +1425,7 @@ class ProductHelper
         return array_map(
             function($sort) {
                 $replica = $sort['name'];
-                return !! $sort[ReplicaManager::SORT_KEY_VIRTUAL_REPLICA]
+                return !! $sort[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA]
                     ? "virtual($replica)"
                     : $replica;
             },

--- a/Model/Backend/EnableCustomerGroups.php
+++ b/Model/Backend/EnableCustomerGroups.php
@@ -36,6 +36,9 @@ class EnableCustomerGroups extends Value
      */
     public function afterSave(): Value
     {
+        $this->replicaState->setAppliedScope($this->getScope(), $this->getScopeId());
+        $this->replicaState->setCustomerGroupsEnabled((bool) $this->getValue());
+
         $storeIds = $this->configChecker->getAffectedStoreIds(
             $this->getPath(),
             $this->getScope(),

--- a/Model/Backend/Sorts.php
+++ b/Model/Backend/Sorts.php
@@ -48,6 +48,10 @@ class Sorts extends ArraySerialized
      */
     public function afterSave(): \Magento\Framework\App\Config\Value
     {
+        // Save context of the admin operation for possible state reversion
+        $this->replicaState->setParentScope($this->getScope());
+        $this->replicaState->setParentScopeId($this->getScopeId());
+
         $storeIds = $this->configChecker->getAffectedStoreIds(
             $this->getPath(),
             $this->getScope(),

--- a/Model/Backend/Sorts.php
+++ b/Model/Backend/Sorts.php
@@ -48,9 +48,7 @@ class Sorts extends ArraySerialized
      */
     public function afterSave(): \Magento\Framework\App\Config\Value
     {
-        // Save context of the admin operation for possible state reversion
-        $this->replicaState->setParentScope($this->getScope());
-        $this->replicaState->setParentScopeId($this->getScopeId());
+        $this->replicaState->setAppliedScope($this->getScope(), $this->getScopeId());
 
         $storeIds = $this->configChecker->getAffectedStoreIds(
             $this->getPath(),

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -370,4 +370,12 @@ class ReplicaManager implements ReplicaManagerInterface
     {
         return $this->configHelper->isInstantEnabled($storeId);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMaxVirtualReplicasPerIndex() : int
+    {
+        return self::MAX_VIRTUAL_REPLICA_LIMIT;
+    }
 }

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -275,14 +275,15 @@ class ReplicaManager implements ReplicaManagerInterface
         $sortingIndices = $this->configHelper->getSortingIndices($primaryIndexName, $storeId);
         $validator = $this->validatorFactory->create();
         if (!$validator->isReplicaConfigurationValid($sortingIndices)) {
+            $postfix = "Please note that there can be no more than " . $this->getMaxVirtualReplicasPerIndex() . " virtual replicas per index. Reverting to previous configuration.";
             // TODO: Implement revert settings via ReplicaState
             if ($validator->isTooManyCustomerGroups()) {
-                throw (new TooManyCustomerGroupsAsReplicasException("You have too many customer groups to enable virtual replicas on the pricing sort."))
+                throw (new TooManyCustomerGroupsAsReplicasException(__("You have too many customer groups to enable virtual replicas on the pricing sort. $postfix")))
                     ->withReplicaCount($validator->getReplicaCount())
                     ->withPriceSortReplicaCount($validator->getPriceSortReplicaCount());
             }
             else {
-                throw (new ReplicaLimitExceededException("Replica limit exceeded."))
+                throw (new ReplicaLimitExceededException(__("Replica limit exceeded. $postfix")))
                     ->withReplicaCount($validator->getReplicaCount());
             }
         }

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -280,12 +280,12 @@ class ReplicaManager implements ReplicaManagerInterface
                 $postfix .= ' Reverting to previous configuration.';
             }
             if ($validator->isTooManyCustomerGroups()) {
-                throw (new TooManyCustomerGroupsAsReplicasException(__("You have too many customer groups to enable virtual replicas on the pricing sort. $postfix")))
+                throw (new TooManyCustomerGroupsAsReplicasException(__("You have too many customer groups to enable virtual replicas on the pricing sort for store $storeId. $postfix")))
                     ->withReplicaCount($validator->getReplicaCount())
                     ->withPriceSortReplicaCount($validator->getPriceSortReplicaCount());
             }
             else {
-                throw (new ReplicaLimitExceededException(__("Replica limit exceeded. $postfix")))
+                throw (new ReplicaLimitExceededException(__("Replica limit exceeded for store ID $storeId. $postfix")))
                     ->withReplicaCount($validator->getReplicaCount());
             }
         }

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -303,6 +303,14 @@ class ReplicaManager implements ReplicaManagerInterface
             return true;
         }
 
+        if ($this->replicaState->wereCustomerGroupsEnabled()) {
+            $this->configHelper->setCustomerGroupsEnabled(
+                false,
+                $this->replicaState->getParentScope(),
+                $this->replicaState->getParentScopeId());
+            return true;
+        }
+
         return false;
     }
 

--- a/Model/Product/ReplicaManager.php
+++ b/Model/Product/ReplicaManager.php
@@ -210,8 +210,7 @@ class ReplicaManager implements ReplicaManagerInterface
      */
     public function handleReplicas(string $primaryIndexName, int $storeId, array $primaryIndexSettings): void
     {
-        // TODO: InstantSearch enablement should not be a hard requirement (i.e. headless implementations may still need replicas) - add an override for this
-        if ($this->configHelper->isInstantEnabled($storeId)
+        if ($this->isReplicaSyncEnabled($storeId)
             && $this->hasReplicaConfigurationChanged($primaryIndexName, $storeId)
             && $this->isReplicaConfigurationValid($primaryIndexName, $storeId)) {
             $addedReplicas = $this->setReplicasOnPrimaryIndex($primaryIndexName, $storeId);
@@ -362,5 +361,13 @@ class ReplicaManager implements ReplicaManagerInterface
                 );
             }
         }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isReplicaSyncEnabled(int $storeId): bool
+    {
+        return $this->configHelper->isInstantEnabled($storeId);
     }
 }

--- a/Model/Source/Sorts.php
+++ b/Model/Source/Sorts.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Model\Source;
 
-use Algolia\AlgoliaSearch\Model\Product\ReplicaManager;
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
 
 /**
  * Algolia custom sort order field
@@ -35,7 +35,7 @@ class Sorts extends AbstractTable
             'sortLabel' => [
                 'label' => 'Label',
             ],
-            ReplicaManager::SORT_KEY_VIRTUAL_REPLICA => [
+            ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA => [
                 'label' => 'Enable Virtual Replica?',
                 'values' => ['0' => __('No'), '1' => __('Yes')],
             ],

--- a/Registry/ReplicaState.php
+++ b/Registry/ReplicaState.php
@@ -13,7 +13,28 @@ class ReplicaState
     private array $_scopeConfigurationOld = [];
 
     private array $_scopeConfigurationNew = [];
-    
+
+    private ?string $_parentScope = null;
+    private ?int $_parentScopeId = null;
+
+    public function getParentScope(): ?string
+    {
+        return $this->_parentScope;
+    }
+
+    public function setParentScope(string $scope) {
+        $this->_parentScope = $scope;
+    }
+
+    public function getParentScopeId(): ?int
+    {
+        return $this->_parentScopeId;
+    }
+
+    public function setParentScopeId(int $scopeId) {
+        $this->_parentScopeId = $scopeId;
+    }
+
     public function getOriginalSortConfiguration(int $storeId): array
     {
         return $this->_scopeConfigurationOld[$storeId] ?? [];

--- a/Registry/ReplicaState.php
+++ b/Registry/ReplicaState.php
@@ -17,22 +17,32 @@ class ReplicaState
     private ?string $_parentScope = null;
     private ?int $_parentScopeId = null;
 
+    private bool $_customerGroupsEnabled = false;
+
+    /**
+     * Save context of the original admin operation
+     * This is considered the "parent" scope.
+     * This is different from the affected store IDs for the applied/parent scope
+     * Retaining this is necessary for potential state reversion on error because while changes are persisted
+     * to Algolia indices for each store, the idea of default / website scope is a Magento only concept.
+     *
+     * @param string $scope
+     * @param int $scopeId
+     * @return void
+     */
+    public function setAppliedScope(string $scope, int $scopeId): void {
+        $this->_parentScope = $scope;
+        $this->_parentScopeId = $scopeId;
+    }
+
     public function getParentScope(): ?string
     {
         return $this->_parentScope;
     }
 
-    public function setParentScope(string $scope) {
-        $this->_parentScope = $scope;
-    }
-
     public function getParentScopeId(): ?int
     {
         return $this->_parentScopeId;
-    }
-
-    public function setParentScopeId(int $scopeId) {
-        $this->_parentScopeId = $scopeId;
     }
 
     public function getOriginalSortConfiguration(int $storeId): array
@@ -55,7 +65,8 @@ class ReplicaState
         $this->_scopeConfigurationNew[$storeId] = $updatedSortConfiguration;
     }
 
-    protected function hasConfigDataToCompare(int $storeId) {
+    protected function hasConfigDataToCompare(int $storeId): bool
+    {
         return isset($this->_scopeConfigurationOld[$storeId])
             && isset($this->_scopeConfigurationNew[$storeId]);
     }
@@ -77,6 +88,16 @@ class ReplicaState
             $state = self::REPLICA_STATE_UNKNOWN;
         }
         $this->_scopeState[$storeId] = $state;
+    }
+
+    public function wereCustomerGroupsEnabled(): bool
+    {
+        return $this->_customerGroupsEnabled;
+    }
+
+    public function setCustomerGroupsEnabled(bool $customerGroupsEnabled): void
+    {
+        $this->_customerGroupsEnabled = $customerGroupsEnabled;
     }
 
 }

--- a/Validator/VirtualReplicaValidator.php
+++ b/Validator/VirtualReplicaValidator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Validator;
+
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+
+class VirtualReplicaValidator
+{
+    protected int $replicaCount = 0;
+    protected int $priceSortReplicaCount = 0;
+    protected bool $replicaLimitExceeded = false;
+    protected bool $tooManyCustomerGroups = false;
+
+    public function isReplicaConfigurationValid(array $replicas): bool
+    {
+        foreach ($replicas as $replica) {
+            // TODO: Implement replica limit override
+            if (!empty($replica[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA])) {
+                $this->replicaCount++;
+                if ($replica[ReplicaManagerInterface::SORT_KEY_ATTRIBUTE_NAME] == ReplicaManagerInterface::SORT_ATTRIBUTE_PRICE) {
+                    $this->priceSortReplicaCount++;
+                }
+            }
+
+            if ($this->replicaCount > ReplicaManagerInterface::MAX_VIRTUAL_REPLICA_LIMIT) {
+                $this->replicaLimitExceeded = true;
+                $this->tooManyCustomerGroups = $this->priceSortReplicaCount > ReplicaManagerInterface::MAX_VIRTUAL_REPLICA_LIMIT;
+            }
+        }
+        return !$this->replicaLimitExceeded;
+    }
+
+    public function isTooManyCustomerGroups(): bool
+    {
+        return $this->tooManyCustomerGroups;
+    }
+
+    public function getReplicaCount(): int
+    {
+        return $this->replicaCount;
+    }
+
+    public function getPriceSortReplicaCount(): int
+    {
+        return $this->priceSortReplicaCount;
+    }
+}

--- a/Validator/VirtualReplicaValidator.php
+++ b/Validator/VirtualReplicaValidator.php
@@ -11,10 +11,15 @@ class VirtualReplicaValidator
     protected bool $replicaLimitExceeded = false;
     protected bool $tooManyCustomerGroups = false;
 
+    public function __construct(
+        protected ReplicaManagerInterface $replicaManager
+    )
+    {}
+
     public function isReplicaConfigurationValid(array $replicas): bool
     {
         foreach ($replicas as $replica) {
-            // TODO: Implement replica limit override
+            $maxReplicas = $this->replicaManager->getMaxVirtualReplicasPerIndex();
             if (!empty($replica[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA])) {
                 $this->replicaCount++;
                 if ($replica[ReplicaManagerInterface::SORT_KEY_ATTRIBUTE_NAME] == ReplicaManagerInterface::SORT_ATTRIBUTE_PRICE) {
@@ -22,9 +27,9 @@ class VirtualReplicaValidator
                 }
             }
 
-            if ($this->replicaCount > ReplicaManagerInterface::MAX_VIRTUAL_REPLICA_LIMIT) {
+            if ($this->replicaCount > $maxReplicas) {
                 $this->replicaLimitExceeded = true;
-                $this->tooManyCustomerGroups = $this->priceSortReplicaCount > ReplicaManagerInterface::MAX_VIRTUAL_REPLICA_LIMIT;
+                $this->tooManyCustomerGroups = $this->priceSortReplicaCount > $maxReplicas;
             }
         }
         return !$this->replicaLimitExceeded;


### PR DESCRIPTION
This PR aims to do the following:
- Introduce validation across replica operations (including admin and indexing) to ensure that granular sorting configurations do not create an undesirable virtual replica scenario.
- Clearly communicate to the end user what the cause of the replica error was, including calling out scenarios where customer group pricing is preventing the activation of virtual replicas.
- Automatically roll back any configuration changes made in the admin that will result in an invalid configuration and lead to an Algolia / Magento configuration mismatch.
- Link both customer group pricing enablement and sorting in the admin to the same underlying replica state so both can be validated independently.
- Maintain awareness of _applied_ scope in Magento and _affected_ stores in Algolia.
- Communicate which store is responsible for any encountered replica errors in case it must be remedied outside of the current scope. 

Standard replica limit exceeded error:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/4ce3b133-f99a-4556-badf-f69c02d00843)

Customer group limit exceeded error:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/f2e03246-5a58-423b-af3f-665cfabc21cf)

Enablement of customer group pricing error:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/984e1f61-4535-4c34-b538-ddf517aff30b)

Indexing error:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/b58ffef9-3dc8-4c6a-8739-9663c00a679b)
