### PR TITLE
MAGE-851: add PHP 8.3 compatibility to composer and README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Algolia Search & Discovery extension for Magento 2
 ![Latest version](https://img.shields.io/badge/latest-3.13.3-green)
 ![Magento 2](https://img.shields.io/badge/Magento-2.4.x-orange)
 
-![PHP](https://img.shields.io/badge/PHP-8.2%2C8.1%2C7.4-blue)
+![PHP](https://img.shields.io/badge/PHP-8.1%2C8.2%2C8.3-blue)
 
 [![CircleCI](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/master.svg?style=svg)](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/master)
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": ["MIT"],
   "version": "3.14.0-beta.1",
   "require": {
-    "php": "~8.1|~8.2",
+    "php": "~8.1|~8.2|~8.3",
     "magento/framework": "~102.0|~103.0",
     "algolia/algoliasearch-client-php": "^4.0@alpha",
     "guzzlehttp/guzzle": "^6.3.3|^7.3.0",


### PR DESCRIPTION
As Magento 2.4.7 now supports PHP 8.3, add this version to our own composer file.