### PR TITLE
MAGE-934: release 3.13.4 version upgrade commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGE LOG
 
+## 3.13.4
+
+### Bug Fixes
+- Fixed XSS vulnerability issue in InstantSearch search box
+- Fixed Algolia merchandising product listing issue
+- Fixed lock timeout issue on indexing queue integration test
+- Community fix added - job queue dropping jobs from sandwiched full reindexes
+
+
 ## 3.13.3
 
 ### Updates

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Algolia Search & Discovery extension for Magento 2
 ==================================================
 
-![Latest version](https://img.shields.io/badge/latest-3.13.3-green)
+![Latest version](https://img.shields.io/badge/latest-3.13.4-green)
 ![Magento 2](https://img.shields.io/badge/Magento-2.4.x-orange)
 
 ![PHP](https://img.shields.io/badge/PHP-8.2%2C8.1%2C7.4-blue)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.13.3",
+  "version": "3.13.4",
   "require": {
     "magento/framework": "~102.0|~103.0",
     "algolia/algoliasearch-client-php": "3.3.2",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.13.3">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.13.4">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
**Summary**

Release Notes:

Bug Fix:
Fixed XSS vulnerability issue in InstantSearch search box
Fixed Algolia merchandising product listing issue
Fixed lock timeout issue on indexing queue integration test
Community fix added - job queue dropping jobs from sandwiched full reindexes

