### PR TITLE
Removed polyfill.io from csp_whitelist, was forgotten in MAGE-822

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -2,11 +2,6 @@
 <csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
     <policies>
-        <policy id="script-src">
-            <values>
-                <value id="polyfill" type="host">polyfill.io</value>
-            </values>
-        </policy>
         <policy id="connect-src">
             <values>
                 <value id="algolia-api" type="host">*.algolia.net</value>


### PR DESCRIPTION
Hi guys

I think in https://github.com/algolia/algoliasearch-magento-2/pull/1474, it was forgotten to also remove the polyfill.io domain name from the `csp_whitelist.xml` file.
This is only a minor cleanup.

This was brought to my attention after searching our codebases for such references, after reading https://sansec.io/research/polyfill-supply-chain-attack