### PR TITLE
MAGE-947: restrict recommend CSS to algolia managed blocks

### DIFF
--- a/view/frontend/templates/recommend/cart/recommend_items.phtml
+++ b/view/frontend/templates/recommend/cart/recommend_items.phtml
@@ -5,9 +5,11 @@ $recommendConfig = $viewModel->getAlgoliaRecommendConfiguration();
 if (!empty($recommendConfig['enabledRelatedInCart']) || !empty($recommendConfig['enabledFBTInCart']) || !empty($recommendConfig['isTrendItemsEnabledInCartPage'])):
     $cartItems = $viewModel->getAllCartItems();
     ?>
-    <div id="frequentlyBoughtTogether" class="recommend-component"></div>
-    <div id="relatedProducts" class="recommend-component"></div>
-    <div id="trendItems" class="trendsItem recommend-component"></div>
+    <div id="algoliaRecommend">
+        <div id="frequentlyBoughtTogether" class="recommend-component"></div>
+        <div id="relatedProducts" class="recommend-component"></div>
+        <div id="trendItems" class="trendsItem recommend-component"></div>
+    </div>
     <script type="text/x-magento-init">
         {
             "*": {

--- a/view/frontend/templates/recommend/products.phtml
+++ b/view/frontend/templates/recommend/products.phtml
@@ -5,9 +5,11 @@ $recommendConfig =  $viewModel->getAlgoliaRecommendConfiguration();
 
 if (!empty($recommendConfig['enabledFBT']) || !empty($recommendConfig['enabledRelated']) || !empty($recommendConfig['isTrendItemsEnabledInPDP'])):
     $product = $viewModel->getProduct(); ?>
-    <div id="frequentlyBoughtTogether" class="recommend-component"></div>
-    <div id="relatedProducts" class="recommend-component"></div>
-    <div id="trendItems" class="trendsItem recommend-component"></div>
+    <div id="algoliaRecommend">
+        <div id="frequentlyBoughtTogether" class="recommend-component"></div>
+        <div id="relatedProducts" class="recommend-component"></div>
+        <div id="trendItems" class="trendsItem recommend-component"></div>
+    </div>
     <script type="text/x-magento-init">
         {
             "*": {

--- a/view/frontend/templates/recommend/widget/trends-item.phtml
+++ b/view/frontend/templates/recommend/widget/trends-item.phtml
@@ -3,7 +3,9 @@
 $isEnabled = $block->isTrendingItemEnabled();
 if ($isEnabled):
     $trendConstainer =  'trendItems' . $block->generateUniqueToken(); ?>
-    <div id="<?= $trendConstainer ?>" class="trendsItem recommend-component"></div>
+    <div id="algoliaRecommend">
+        <div id="<?= $trendConstainer ?>" class="trendsItem recommend-component"></div>
+    </div>
     <script type="text/x-magento-init">
         {
             "*": {

--- a/view/frontend/web/internals/recommend.css
+++ b/view/frontend/web/internals/recommend.css
@@ -11,7 +11,7 @@
     width: 110px;
     margin: 0 auto;
 }
-.recommend-component {
+#algoliaRecommend .recommend-component {
     margin-bottom: 80px;
 }
 #relatedProducts .auc-Recommend-list, #frequentlyBoughtTogether .auc-Recommend-list, .trendsItem  .auc-Recommend-list{

--- a/view/frontend/web/internals/recommend.css
+++ b/view/frontend/web/internals/recommend.css
@@ -1,12 +1,12 @@
-.recommend-item .product-img {
+#algoliaRecommend .recommend-item .product-img {
     width: 180px;
 }
-.auc-Recommend-list {
+#algoliaRecommend .auc-Recommend-list {
     display: flex;
     justify-content: space-evenly;
     list-style: none;
 }
-.recommend-item .product-name {
+#algoliaRecommend .recommend-item .product-name {
     height: 50px;
     width: 110px;
     margin: 0 auto;
@@ -14,20 +14,29 @@
 #algoliaRecommend .recommend-component {
     margin-bottom: 80px;
 }
-#relatedProducts .auc-Recommend-list, #frequentlyBoughtTogether .auc-Recommend-list, .trendsItem  .auc-Recommend-list{
+#algoliaRecommend #relatedProducts .auc-Recommend-list,
+#algoliaRecommend #frequentlyBoughtTogether .auc-Recommend-list,
+#algoliaRecommend .trendsItem  .auc-Recommend-list {
     flex-wrap: wrap;
     justify-content: flex-start;
 }
-#relatedProducts li, #frequentlyBoughtTogether li, .trendsItem li {
+#algoliaRecommend #relatedProducts li,
+#algoliaRecommend #frequentlyBoughtTogether li,
+#algoliaRecommend .trendsItem li {
     display: flex;
     justify-content: center;
     width: 16.66666667%;
 }
-#relatedProducts li a, #frequentlyBoughtTogether li a, .trendsItem li a {
+#algoliaRecommend #relatedProducts li a,
+#algoliaRecommend #frequentlyBoughtTogether li a,
+#algoliaRecommend .trendsItem li a {
     color: inherit;
     display: block;
 }
-#relatedProducts .product-name, #frequentlyBoughtTogether .product-name, #trendItems .product-name, .trendsItem .product-name{
+#algoliaRecommend #relatedProducts .product-name,
+#algoliaRecommend #frequentlyBoughtTogether .product-name,
+#algoliaRecommend #trendItems .product-name,
+#algoliaRecommend .trendsItem .product-name{
     text-align: center;
     width: 150px;
     text-overflow: ellipsis;
@@ -40,37 +49,45 @@
     -webkit-box-orient: vertical;
     display: -webkit-box;
 }
-#trendItems a, #trendItems a:hover, .trendsItem a, .trendsItem a:hover{
+#algoliaRecommend #trendItems a,
+#algoliaRecommend #trendItems a:hover,
+#algoliaRecommend .trendsItem a,
+#algoliaRecommend .trendsItem a:hover{
     color:#333;
 }
-.auc-Recommend-item .product-details {
+#algoliaRecommend .auc-Recommend-item .product-details {
     text-align: center;
 }
-#trendItems .auc-Recommend-list{
+#algoliaRecommend #trendItems .auc-Recommend-list{
     flex-wrap: wrap;
     justify-content: flex-start;
 }
-.product-details .recommend-item .action.primary, .action-primary{
+#algoliaRecommend .product-details .recommend-item .action.primary,
+#algoliaRecommend .action-primary{
     background: #f4f4f4;
     border: 1px solid #f4f4f4;
     color: #666666;
 }
-.product-details .recommend-item .action.primary:hover, .action-primary:hover {
+#algoliaRecommend .product-details .recommend-item .action.primary:hover,
+#algoliaRecommend .action-primary:hover {
     border-color: #1979c3;
     background: #1979c3;
     color: #FFFFFF;
 }
 @media (min-width: 768px) and (max-width: 1023px) {
-    #relatedProducts li, #frequentlyBoughtTogether li, #trendItems li {
+    #algoliaRecommend #relatedProducts li,
+    #algoliaRecommend #frequentlyBoughtTogether li,
+    #algoliaRecommend #trendItems li {
         width: 33.33333333%;
     }
 }
 @media (max-width: 767px) {
-    #relatedProducts li, #frequentlyBoughtTogether li, #trendItems li {
+    #algoliaRecommend #relatedProducts li,
+    #algoliaRecommend #frequentlyBoughtTogether li,
+    #algoliaRecommend #trendItems li {
         width: 50%;
     }
 }
-h3.auc-Recommend-title {
-    padding: 20p;
+#algoliaRecommend h3.auc-Recommend-title {
     padding-bottom: 20px;
 }


### PR DESCRIPTION
This PR ports the change suggested by @sgeleon here: https://github.com/algolia/algoliasearch-magento-2/pull/1514

- Added a #algoliaRecommend block which acts as a parent for each recommend block
- Applied CSS on the recommend blocks, taking into account the newly created parent block