### PR TITLE
MAGE-949: Drop Magento 2.3 compatibility (3.14.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "version": "3.14.0-beta.1",
   "require": {
     "php": "~8.1|~8.2|~8.3",
-    "magento/framework": "~102.0|~103.0",
+    "magento/framework": "~103.0",
     "algolia/algoliasearch-client-php": "^4.0@alpha",
     "guzzlehttp/guzzle": "^6.3.3|^7.3.0",
     "ext-json": "*",


### PR DESCRIPTION
As suggested here https://github.com/algolia/algoliasearch-magento-2/pull/1541#issuecomment-2190947847 by @hostep , we drop support for Magento 2.3 for upcoming branch 3.14 of the extension.

(A fix will be applied to the branch 3.13 ASAP to check if the Secure Renderer is available or not in our blocks)