### PR TITLE
MAGE-949: SecureHtmlRenderer fallback for Magento2.3

### DIFF
--- a/view/frontend/templates/internals/configuration.phtml
+++ b/view/frontend/templates/internals/configuration.phtml
@@ -1,18 +1,31 @@
 <?php
 
 /** @var \Algolia\AlgoliaSearch\Block\Configuration $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 $configuration = $block->getConfiguration();
 
-?>
+if (class_exists('\Magento\Framework\View\Helper\SecureHtmlRenderer')) : ?>
+    <?php
+        /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+        if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true)  {
+            $css = /* @noEscape */ $secureRenderer->renderTag('style', [],  $configuration['instant']['selector'] . ' {display:none}', false);
+            /* @noEscape */ echo $secureRenderer->renderTag('script', [], 'document.write(\'' . $css . '\');' , false);
+        }
+    ?>
 
-<?php
-if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true)  {
-    $css = /* @noEscape */ $secureRenderer->renderTag('style', [],  $configuration['instant']['selector'] . ' {display:none}', false);
-    /* @noEscape */ echo $secureRenderer->renderTag('script', [], 'document.write(\'' . $css . '\');' , false);
-}
-?>
+    <?= /* @noEscape */ $secureRenderer->renderTag('script', [], "window.algoliaConfig = " . json_encode($configuration) . ';' , false); ?>
+<?php else: ?>
+    <script>
+        <?php
+        if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true) :
+        $css = '<style type="text/css">' . $configuration['instant']['selector'] . ' {display:none}</style>';
+        ?>
+        // Hide the instant-search selector ASAP to remove flickering. Will be re-displayed later with JS.
+        document.write('<?php /* @noEscape */ echo $css; ?>');
+        <?php
+        endif;
+        ?>
 
-<?= /* @noEscape */ $secureRenderer->renderTag('script', [], "window.algoliaConfig = " . json_encode($configuration) . ';' , false); ?>
-
+        window.algoliaConfig = <?php /* @noEscape */ echo json_encode($configuration); ?>;
+    </script>
+<?php endif; ?>

--- a/view/frontend/templates/layer/view.phtml
+++ b/view/frontend/templates/layer/view.phtml
@@ -1,7 +1,3 @@
-<?php
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-
 <?php if ($block->canShowBlock()) : ?>
     <div class="block filter algolia-filter-list" id="layered-filter-block" data-mage-init='{"collapsible":{"openedState": "active", "collapsible": true, "active": false, "collateral": { "openedState": "filter-active", "element": "body" } }}'>
         <?php $filtered = count($block->getLayer()->getState()->getFilters()) ?>
@@ -34,15 +30,25 @@
             <?php if ($wrapOptions) : ?>
                 </div>
             <?php else : ?>
-                <?php $scriptString = <<<script
-                require([
-                    'jquery'
-                ], function ($) {
-                    $('#layered-filter-block').addClass('filter-no-options');
-                });
-    script;
-                ?>
-                <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false); ?>
+                <?php if (class_exists('\Magento\Framework\View\Helper\SecureHtmlRenderer')) : ?>
+                    <?php
+                    /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+                    $scriptString = "require([
+                            'jquery'
+                        ], function ($) {
+                            $('#layered-filter-block').addClass('filter-no-options');
+                        });";
+
+                    /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false); ?>
+                <?php else : ?>
+                    <script>
+                        require([
+                            'jquery'
+                        ], function ($) {
+                            $('#layered-filter-block').addClass('filter-no-options');
+                        });
+                    </script>
+                <?php endif; ?>
             <?php endif; ?>
         </div>
     </div>


### PR DESCRIPTION
Following the previous PR : https://github.com/algolia/algoliasearch-magento-2/pull/1541#issuecomment-2190947847 , we now add a fallback for Magento 2.3 (where the SecureHtmlRenderer doesn't exists) as suggested by @hostep .

This PR also contains the removal of heredoc which is also not supported by Magento 2.3.x .