### PR TITLE
MAGE-909: algoliaLastUpdateAtCET time changed to UTC timestamp

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -590,6 +590,8 @@ class AlgoliaHelper extends AbstractHelper
         $modifiedIds = [];
         foreach ($objects as $key => &$object) {
             $object['algoliaLastUpdateAtCET'] = $currentCET;
+            // Convert created_at to UTC timestamp
+            $object['created_at'] = strtotime($object['created_at']);
 
             $previousObject = $object;
 

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -585,8 +585,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     protected function prepareRecords(array &$objects, string $indexName): void
     {
-        $currentCET = new \DateTime('now', new \DateTimeZone('Europe/Paris'));
-        $currentCET = $currentCET->format('Y-m-d H:i:s');
+        $currentCET = strtotime('now');
 
         $modifiedIds = [];
         foreach ($objects as $key => &$object) {


### PR DESCRIPTION
**Summary**

algoliaLastUpdateAtCET time changed to UTC timestamp 
<img width="1238" alt="Screenshot 2024-07-02 at 3 28 49 PM" src="https://github.com/algolia/algoliasearch-magento-2/assets/167926401/7a93c02e-10c5-4d61-9552-e956308d92ab">
