### PR TITLE
Feature/mage 938 - Replica CLI utilities 

### DIFF
--- a/Api/Console/ReplicaDeleteCommandInterface.php
+++ b/Api/Console/ReplicaDeleteCommandInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api\Console;
+
+interface ReplicaDeleteCommandInterface
+{
+    public function deleteReplicas(array $storeIds = [], bool $unused = false): void;
+    public function deleteReplicasForStore(int $storeId, bool $unused = false): void;
+    public function deleteReplicasForAllStores(bool $unused = false): void;
+}

--- a/Api/Console/ReplicaSyncCommandInterface.php
+++ b/Api/Console/ReplicaSyncCommandInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api\Console;
+
+interface ReplicaSyncCommandInterface
+{
+    public function syncReplicas(array $storeIds = []): void;
+    public function syncReplicasForStore(int $storeId): void;
+    public function syncReplicasForAllStores(): void;
+}

--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -28,6 +28,15 @@ interface ReplicaManagerInterface
      */
     public function syncReplicasToAlgolia(int $storeId, array $primaryIndexSettings): void;
 
+    /**
+     * Delete the replica indices on a store index
+     * @param int $storeId
+     * @param bool $unused Defaults to false - if true identifies any straggler indices and deletes those, otherwise deletes the replicas it knows aobut
+     * @return void
+     *
+     * @throws LocalizedException
+     * @throws AlgoliaException
+     */
     public function deleteReplicasFromAlgolia(int $storeId, bool $unused = false): void;
 
     /**

--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -25,7 +25,6 @@ interface ReplicaManagerInterface
      * @throws AlgoliaException
      * @throws ExceededRetriesException
      * @throws LocalizedException
-     * @throws NoSuchEntityException
      */
     public function syncReplicasToAlgolia(int $storeId, array $primaryIndexSettings): void;
 
@@ -46,4 +45,14 @@ interface ReplicaManagerInterface
      * @return int
      */
     public function getMaxVirtualReplicasPerIndex() : int;
+
+    /**
+     * For a given store return replicas that do not appear to be managed by Magento
+     * @param int $storeId
+     * @return string[]
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     * @throws AlgoliaException
+     */
+    public function getUnusedReplicaIndices(int $storeId): array;
 }

--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -29,6 +29,8 @@ interface ReplicaManagerInterface
      */
     public function syncReplicasToAlgolia(int $storeId, array $primaryIndexSettings): void;
 
+    public function deleteReplicasFromAlgolia(int $storeId, bool $unusedOnly = false): void;
+
     /**
      * For standard Magento front end (e.g. Luma) replicas will likely only be needed if InstantSearch is enabled
      * Headless implementations may wish to override this behavior via plugin

--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -29,7 +29,7 @@ interface ReplicaManagerInterface
      */
     public function syncReplicasToAlgolia(int $storeId, array $primaryIndexSettings): void;
 
-    public function deleteReplicasFromAlgolia(int $storeId, bool $unusedOnly = false): void;
+    public function deleteReplicasFromAlgolia(int $storeId, bool $unused = false): void;
 
     /**
      * For standard Magento front end (e.g. Luma) replicas will likely only be needed if InstantSearch is enabled

--- a/Console/Command/AbstractReplicaCommand.php
+++ b/Console/Command/AbstractReplicaCommand.php
@@ -7,6 +7,7 @@ use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 
 abstract class AbstractReplicaCommand extends Command
 {
@@ -63,6 +64,11 @@ abstract class AbstractReplicaCommand extends Command
         } catch (LocalizedException) {
             // Area code is already set - nothing to do
         }
+    }
+
+    protected function getStoreIds(InputInterface $input): array
+    {
+        return (array) $input->getArgument(self::STORE_ARGUMENT);
     }
 
 }

--- a/Console/Command/AbstractReplicaCommand.php
+++ b/Console/Command/AbstractReplicaCommand.php
@@ -8,10 +8,14 @@ use Magento\Framework\Exception\LocalizedException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractReplicaCommand extends Command
 {
     protected const STORE_ARGUMENT = 'store';
+
+    protected ?OutputInterface $output = null;
+    protected ?InputInterface $input = null;
 
     public function __construct(
         protected State $state,

--- a/Console/Command/AbstractReplicaCommand.php
+++ b/Console/Command/AbstractReplicaCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Command;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+
+abstract class AbstractReplicaCommand extends Command
+{
+    protected const STORE_ARGUMENT = 'store';
+
+    public function __construct(
+        protected State $state,
+        ?string         $name = null
+    )
+    {
+        parent::__construct($name);
+    }
+
+    abstract protected function getReplicaCommandName(): string;
+
+    abstract protected function getCommandDescription(): string;
+
+    abstract protected function getStoreArgumentDescription(): string;
+
+    abstract protected function getAdditionalDefinition(): array;
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure(): void
+    {
+        $definition = [$this->getStoreArgumentDefinition()];
+        $definition = array_merge($definition, $this->getAdditionalDefinition());
+
+        $this->setName($this->getCommandName())
+            ->setDescription($this->getCommandDescription())
+            ->setDefinition($definition);
+
+        parent::configure();
+    }
+
+    protected function getStoreArgumentDefinition(): InputArgument {
+        return new InputArgument(
+            self::STORE_ARGUMENT,
+            InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+            $this->getStoreArgumentDescription()
+        );
+    }
+
+    public function getCommandName(): string
+    {
+        return 'algolia:replicas:' . $this->getReplicaCommandName();
+    }
+
+    protected function setAreaCode(): void
+    {
+        try {
+            $this->state->setAreaCode(Area::AREA_CRONTAB);
+        } catch (LocalizedException) {
+            // Area code is already set - nothing to do
+        }
+    }
+
+}

--- a/Console/Command/ReplicaCommand.php
+++ b/Console/Command/ReplicaCommand.php
@@ -2,16 +2,28 @@
 
 namespace Algolia\AlgoliaSearch\Console\Command;
 
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
 use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ReplicaCommand extends Command
 {
     const STORE_ARGUMENT = 'store';
+
+    /**
+     * @param ReplicaManagerInterface $replicaManager
+     * @param string|null $name
+     */
+    public function __construct(
+        protected ReplicaManagerInterface $replicaManager,
+        ?string $name = null
+    )
+    {
+        parent::__construct($name);
+    }
 
     /**
      * @inheritDoc
@@ -30,13 +42,15 @@ class ReplicaCommand extends Command
     /** @inheritDoc */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $name = $input->getArgument(self::STORE_ARGUMENT);
+        $storeIds = $input->getArgument(self::STORE_ARGUMENT);
 
-        if ($name) {
-            $output->writeln('<info>Syncing store ' . $name . '!</info>');
+        if ($storeIds) {
+            $output->writeln('<info>Syncing store ' . $storeIds . '!</info>');
         } else {
             $output->writeln('<info>Syncing all stores</info>');
         }
+
+//        $this->replicaManager->syncReplicasToAlgolia();
 
         return Cli::RETURN_SUCCESS;
     }

--- a/Console/Command/ReplicaCommand.php
+++ b/Console/Command/ReplicaCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Command;
+
+use Magento\Framework\Console\Cli;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReplicaCommand extends Command
+{
+    const STORE_ARGUMENT = 'store';
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure(): void
+    {
+        $this->setName('algolia:replicas:sync')
+            ->setDescription('Sync configured sorting attributes in Magento to Algolia replica indices')
+            ->setDefinition([
+                new InputArgument(self::STORE_ARGUMENT, InputArgument::OPTIONAL, 'ID for store to be synced with Algolia (optional), if not specified all stores will be synced'),
+            ]);
+
+        parent::configure();
+    }
+
+    /** @inheritDoc */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $name = $input->getArgument(self::STORE_ARGUMENT);
+
+        if ($name) {
+            $output->writeln('<info>Syncing store ' . $name . '!</info>');
+        } else {
+            $output->writeln('<info>Syncing all stores</info>');
+        }
+
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/Console/Command/ReplicaCommand.php
+++ b/Console/Command/ReplicaCommand.php
@@ -3,7 +3,15 @@
 namespace Algolia\AlgoliaSearch\Console\Command;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -11,15 +19,25 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ReplicaCommand extends Command
 {
-    const STORE_ARGUMENT = 'store';
+    protected const STORE_ARGUMENT = 'store';
+
+    protected ?OutputInterface $output = null;
+
+    /** @var string[] */
+    protected array $_storeNames = [];
 
     /**
+     * @param ProductHelper $productHelper
      * @param ReplicaManagerInterface $replicaManager
+     * @param StoreManagerInterface $storeManager
      * @param string|null $name
      */
     public function __construct(
+        protected State                   $state,
+        protected ProductHelper           $productHelper,
         protected ReplicaManagerInterface $replicaManager,
-        ?string $name = null
+        protected StoreManagerInterface   $storeManager,
+        ?string                           $name = null
     )
     {
         parent::__construct($name);
@@ -33,25 +51,105 @@ class ReplicaCommand extends Command
         $this->setName('algolia:replicas:sync')
             ->setDescription('Sync configured sorting attributes in Magento to Algolia replica indices')
             ->setDefinition([
-                new InputArgument(self::STORE_ARGUMENT, InputArgument::OPTIONAL, 'ID for store to be synced with Algolia (optional), if not specified all stores will be synced'),
+                new InputArgument(
+                    self::STORE_ARGUMENT,
+                    InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+                    'ID(s) for store to be synced with Algolia (optional), if not specified all stores will be synced'
+                )
             ]);
 
         parent::configure();
     }
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $storeIds = $input->getArgument(self::STORE_ARGUMENT);
+        $storeIds = (array) $input->getArgument(self::STORE_ARGUMENT);
 
+        $msg = 'Syncing replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
         if ($storeIds) {
-            $output->writeln('<info>Syncing store ' . $storeIds . '!</info>');
+            /** @var string[] $storeNames */
+            $storeNames = array_map(
+                function($storeId) {
+                    return $this->getStoreName($storeId);
+                },
+                $storeIds
+            );
+            $output->writeln("<info>$msg: " . join(", ", $storeNames) . '</info>');
         } else {
-            $output->writeln('<info>Syncing all stores</info>');
+            $output->writeln("<info>$msg</info>");
         }
 
-//        $this->replicaManager->syncReplicasToAlgolia();
+        $this->output = $output;
+        $this->state->setAreaCode(Area::AREA_ADMINHTML);
+        $this->syncReplicas($storeIds);
 
         return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     */
+    protected function getStoreName(int $storeId): string
+    {
+        if (!isset($this->_storeNames[$storeId])) {
+            $this->_storeNames[$storeId] = $this->storeManager->getStore($storeId)->getName();
+        }
+        return $this->_storeNames[$storeId];
+    }
+
+    /**
+     * @param int[] $storeIds
+     * @return void
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    protected function syncReplicas(array $storeIds = []): void
+    {
+        if (count($storeIds)) {
+            foreach ($storeIds as $storeId) {
+                $this->syncReplicasForStore($storeId);
+            }
+        } else {
+          $this->syncReplicasForAllStores();
+        }
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws ExceededRetriesException
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     */
+    protected function syncReplicasForStore(int $storeId): void
+    {
+        $this->output->writeln('<info>Syncing ' . $this->getStoreName($storeId) . '...</info>');
+        $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws ExceededRetriesException
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     */
+    protected function syncReplicasForAllStores(): void
+    {
+        $storeIds = array_keys($this->storeManager->getStores());
+        foreach ($storeIds as $storeId) {
+            $this->syncReplicasForStore($storeId);
+        }
+
     }
 }

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class ReplicaDeleteCommand extends AbstractReplicaCommand
 {
-    protected const STORE_ARGUMENT = 'store';
-
     protected const UNUSED_OPTION = 'unused';
     protected const UNUSED_OPTION_SHORTCUT = 'u';
 
@@ -70,7 +68,7 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand
         $this->output = $output;
         $this->input = $input;
 
-        $storeIds = (array) $input->getArgument(self::STORE_ARGUMENT);
+        $storeIds = $this->getStoreIds($input);
         $unused = $input->getOption(self::UNUSED_OPTION);
 
         $msg = 'Deleting' . ($unused ? ' unused ' : ' ') . 'replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -3,9 +3,12 @@
 namespace Algolia\AlgoliaSearch\Console\Command;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -62,7 +65,7 @@ class ReplicaDeleteCommand extends Command
     {
         $this->output = $output;
         $this->input = $input;
-        
+
         $storeIds = (array) $input->getArgument(self::STORE_ARGUMENT);
         $unused = $input->getOption(self::UNUSED_OPTION);
 
@@ -136,6 +139,11 @@ class ReplicaDeleteCommand extends Command
         return true;
     }
 
+    /**
+     * @throws NoSuchEntityException
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     */
     protected function deleteReplicas(array $storeIds = [], bool $unused = false): void
     {
         if (count($storeIds)) {
@@ -147,12 +155,22 @@ class ReplicaDeleteCommand extends Command
         }
     }
 
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     * @throws AlgoliaException
+     */
     protected function deleteReplicasForStore(int $storeId, bool $unused = false): void
     {
         $this->output->writeln('<info>Deleting' . ($unused ? ' unused ': ' ') . 'replicas for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
         $this->replicaManager->deleteReplicasFromAlgolia($storeId, $unused);
     }
 
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     * @throws AlgoliaException
+     */
     protected function deleteReplicasForAllStores(bool $unused = false): void
     {
         $storeIds = array_keys($this->storeManager->getStores());

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -61,8 +61,9 @@ class ReplicaDeleteCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $storeIds = (array) $input->getArgument(self::STORE_ARGUMENT);
+        $unused = $input->getOption(self::UNUSED_OPTION);
 
-        $msg = 'Deleting replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
+        $msg = 'Deleting' . ($unused ? ' unused ': ' ') . 'replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
         if ($storeIds) {
             $output->writeln("<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>');
         } else {
@@ -72,34 +73,34 @@ class ReplicaDeleteCommand extends Command
         $this->output = $output;
 //        $this->state->setAreaCode(Area::AREA_ADMINHTML);
 
-        $this->deleteReplicas($storeIds);
+        $this->deleteReplicas($storeIds, $unused);
 
         return Cli::RETURN_SUCCESS;
     }
 
 
-    protected function deleteReplicas(array $storeIds = [], bool $unusedOnly = false): void
+    protected function deleteReplicas(array $storeIds = [], bool $unused = false): void
     {
         if (count($storeIds)) {
             foreach ($storeIds as $storeId) {
-                $this->deleteReplicasForStore($storeId);
+                $this->deleteReplicasForStore($storeId, $unused);
             }
         } else {
-            $this->deleteReplicasForAllStores();
+            $this->deleteReplicasForAllStores($unused);
         }
     }
 
-    protected function deleteReplicasForStore(int $storeId): void
+    protected function deleteReplicasForStore(int $storeId, bool $unused = false): void
     {
-        $this->output->writeln('<info>Deleting replicas for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
-        $this->replicaManager->deleteReplicasFromAlgolia($storeId);
+        $this->output->writeln('<info>Deleting' . ($unused ? ' unused ': ' ') . 'replicas for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
+        $this->replicaManager->deleteReplicasFromAlgolia($storeId, $unused);
     }
 
-    protected function deleteReplicasForAllStores(): void
+    protected function deleteReplicasForAllStores(bool $unused = false): void
     {
         $storeIds = array_keys($this->storeManager->getStores());
         foreach ($storeIds as $storeId) {
-            $this->deleteReplicasForStore($storeId);
+            $this->deleteReplicasForStore($storeId, $unused);
         }
     }
 }

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -3,9 +3,8 @@
 namespace Algolia\AlgoliaSearch\Console\Command;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
-use Magento\Framework\App\Area;
-use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
 use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -13,6 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class ReplicaDeleteCommand extends Command
 {
@@ -22,9 +22,9 @@ class ReplicaDeleteCommand extends Command
     protected const UNUSED_OPTION_SHORTCUT = 'u';
 
     protected ?OutputInterface $output = null;
+    protected ?InputInterface $input = null;
 
     public function __construct(
-        protected State                   $state,
         protected ReplicaManagerInterface $replicaManager,
         protected StoreManagerInterface   $storeManager,
         protected StoreNameFetcher        $storeNameFetcher,
@@ -71,13 +71,69 @@ class ReplicaDeleteCommand extends Command
         }
 
         $this->output = $output;
-//        $this->state->setAreaCode(Area::AREA_ADMINHTML);
+        $this->input = $input;
 
-        $this->deleteReplicas($storeIds, $unused);
+        if ($unused) {
+            $unusedReplicas = $this->getUnusedReplicas($storeIds);
+            if (!$unusedReplicas) {
+                $output->writeln('<comment>No unused replicas found.</comment>');
+                return Cli::RETURN_SUCCESS;
+            }
+            if (!$this->confirmDeleteUnused($unusedReplicas)) {
+                return Cli::RETURN_SUCCESS;
+            }
+        }
+
+        try {
+            $this->deleteReplicas($storeIds, $unused);
+        } catch (BadRequestException $e) {
+            $this->output->writeln("<error>Error encountered while attempting to delete replica: {$e->getMessage()}</error>");
+            $this->output->writeln('<comment>It is likely that the Magento integration does not manage the index. You should review your application configuration in Algolia.</comment>');
+            return CLI::RETURN_FAILURE;
+        }
 
         return Cli::RETURN_SUCCESS;
     }
 
+    protected function getUnusedReplicas(array $storeIds): array
+    {
+        return array_reduce(
+            $storeIds,
+            function($allUnused, $storeId) {
+                $unused = [];
+                try {
+                    $unused = $this->replicaManager->getUnusedReplicaIndices($storeId);
+                } catch (\Exception $e) {
+                    $this->output->writeln("<error>Unable to retrieve unused replicas for $storeId: {$e->getMessage()}</error>");
+                }
+                return array_unique(array_merge($allUnused, $unused));
+            },
+            []
+        );
+    }
+
+    /**
+     * Deleting unused replica indices is potentially risky, especially if they have enabled query suggestions on their index
+     * Verify with the end user first!
+     *
+     * @param array $unusedReplicas
+     * @return bool
+     */
+    protected function confirmDeleteUnused(array $unusedReplicas): bool
+    {
+        $this->output->writeln('<info>The following replicas appear to be unused and will be deleted:</info>');
+        foreach ($unusedReplicas as $unusedReplica) {
+            $this->output->writeln('<info> - ' . $unusedReplica . '</info>');
+        }
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('<question>Do you want to proceed? (y/n)</question> ', false);
+
+        if (!$helper->ask($this->input, $this->output, $question)) {
+            $this->output->writeln('<comment>Operation cancelled.</comment>');
+            return false;
+        }
+        return true;
+    }
 
     protected function deleteReplicas(array $storeIds = [], bool $unused = false): void
     {

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -6,18 +6,17 @@ use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class ReplicaDeleteCommand extends Command
+class ReplicaDeleteCommand extends AbstractReplicaCommand
 {
     protected const STORE_ARGUMENT = 'store';
 
@@ -31,35 +30,40 @@ class ReplicaDeleteCommand extends Command
         protected ReplicaManagerInterface $replicaManager,
         protected StoreManagerInterface   $storeManager,
         protected StoreNameFetcher        $storeNameFetcher,
+        protected State                   $state,
         ?string                           $name = null
     )
     {
-        parent::__construct($name);
+        parent::__construct($state, $name);
     }
 
-    /**
-     * @inheritDoc
-     */
-    protected function configure(): void
+    protected function getReplicaCommandName(): string
     {
-        $this->setName('algolia:replicas:delete')
-            ->setDescription('Delete associated replica indices in Algolia')
-            ->setDefinition([
-                new InputArgument(
-                    self::STORE_ARGUMENT,
-                    InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-                    'ID(s) for store(s) to delete replicas in Algolia (optional), if not specified, replicas for all stores will be deleted'
-                ),
-                new InputOption(
-                    self::UNUSED_OPTION,
-                    '-' . self::UNUSED_OPTION_SHORTCUT,
-                    InputOption::VALUE_NONE,
-                    'Delete unused replicas only'
-                )
-            ]);
-
-        parent::configure();
+        return 'delete';
     }
+
+    protected function getCommandDescription(): string
+    {
+        return 'Delete associated replica indices in Algolia';
+    }
+
+    protected function getStoreArgumentDescription(): string
+    {
+        return 'ID(s) for store(s) to delete replicas in Algolia (optional), if not specified, replicas for all stores will be deleted';
+    }
+
+    protected function getAdditionalDefinition(): array
+    {
+        return [
+            new InputOption(
+                self::UNUSED_OPTION,
+                '-' . self::UNUSED_OPTION_SHORTCUT,
+                InputOption::VALUE_NONE,
+                'Delete unused replicas only'
+            )
+        ];
+    }
+
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -69,7 +73,7 @@ class ReplicaDeleteCommand extends Command
         $storeIds = (array) $input->getArgument(self::STORE_ARGUMENT);
         $unused = $input->getOption(self::UNUSED_OPTION);
 
-        $msg = 'Deleting' . ($unused ? ' unused ': ' ') . 'replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
+        $msg = 'Deleting' . ($unused ? ' unused ' : ' ') . 'replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
         if ($storeIds) {
             $output->writeln("<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>');
         } else {
@@ -103,7 +107,7 @@ class ReplicaDeleteCommand extends Command
     {
         return array_reduce(
             $storeIds,
-            function($allUnused, $storeId) {
+            function ($allUnused, $storeId) {
                 $unused = [];
                 try {
                     $unused = $this->replicaManager->getUnusedReplicaIndices($storeId);
@@ -162,7 +166,7 @@ class ReplicaDeleteCommand extends Command
      */
     protected function deleteReplicasForStore(int $storeId, bool $unused = false): void
     {
-        $this->output->writeln('<info>Deleting' . ($unused ? ' unused ': ' ') . 'replicas for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
+        $this->output->writeln('<info>Deleting' . ($unused ? ' unused ' : ' ') . 'replicas for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
         $this->replicaManager->deleteReplicasFromAlgolia($storeId, $unused);
     }
 

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -2,27 +2,25 @@
 
 namespace Algolia\AlgoliaSearch\Console\Command;
 
+use Algolia\AlgoliaSearch\Api\Console\ReplicaDeleteCommandInterface;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
-use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Console\Traits\ReplicaDeleteCommandTrait;
 use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class ReplicaDeleteCommand extends AbstractReplicaCommand
+class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDeleteCommandInterface
 {
+    use ReplicaDeleteCommandTrait;
+
     protected const UNUSED_OPTION = 'unused';
     protected const UNUSED_OPTION_SHORTCUT = 'u';
-
-    protected ?OutputInterface $output = null;
-    protected ?InputInterface $input = null;
 
     public function __construct(
         protected ReplicaManagerInterface $replicaManager,
@@ -61,7 +59,6 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand
             )
         ];
     }
-
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -141,43 +138,4 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand
         return true;
     }
 
-    /**
-     * @throws NoSuchEntityException
-     * @throws AlgoliaException
-     * @throws LocalizedException
-     */
-    protected function deleteReplicas(array $storeIds = [], bool $unused = false): void
-    {
-        if (count($storeIds)) {
-            foreach ($storeIds as $storeId) {
-                $this->deleteReplicasForStore($storeId, $unused);
-            }
-        } else {
-            $this->deleteReplicasForAllStores($unused);
-        }
-    }
-
-    /**
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
-     * @throws AlgoliaException
-     */
-    protected function deleteReplicasForStore(int $storeId, bool $unused = false): void
-    {
-        $this->output->writeln('<info>Deleting' . ($unused ? ' unused ' : ' ') . 'replicas for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
-        $this->replicaManager->deleteReplicasFromAlgolia($storeId, $unused);
-    }
-
-    /**
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
-     * @throws AlgoliaException
-     */
-    protected function deleteReplicasForAllStores(bool $unused = false): void
-    {
-        $storeIds = array_keys($this->storeManager->getStores());
-        foreach ($storeIds as $storeId) {
-            $this->deleteReplicasForStore($storeId, $unused);
-        }
-    }
 }

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -60,6 +60,9 @@ class ReplicaDeleteCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->output = $output;
+        $this->input = $input;
+        
         $storeIds = (array) $input->getArgument(self::STORE_ARGUMENT);
         $unused = $input->getOption(self::UNUSED_OPTION);
 
@@ -70,8 +73,6 @@ class ReplicaDeleteCommand extends Command
             $output->writeln("<info>$msg</info>");
         }
 
-        $this->output = $output;
-        $this->input = $input;
 
         if ($unused) {
             $unusedReplicas = $this->getUnusedReplicas($storeIds);

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -75,7 +75,6 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
             $output->writeln("<info>$msg</info>");
         }
 
-
         if ($unused) {
             $unusedReplicas = $this->getUnusedReplicas($storeIds);
             if (!$unusedReplicas) {
@@ -85,6 +84,8 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
             if (!$this->confirmDeleteUnused($unusedReplicas)) {
                 return Cli::RETURN_SUCCESS;
             }
+        } else if (!$this->confirmDelete()) {
+            return Cli::RETURN_SUCCESS;
         }
 
         try {
@@ -98,6 +99,10 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
         return Cli::RETURN_SUCCESS;
     }
 
+    /**
+     * @param int[] $storeIds
+     * @return string[]
+     */
     protected function getUnusedReplicas(array $storeIds): array
     {
         return array_reduce(
@@ -119,7 +124,7 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
      * Deleting unused replica indices is potentially risky, especially if they have enabled query suggestions on their index
      * Verify with the end user first!
      *
-     * @param array $unusedReplicas
+     * @param string[] $unusedReplicas
      * @return bool
      */
     protected function confirmDeleteUnused(array $unusedReplicas): bool
@@ -135,6 +140,20 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
             $this->output->writeln('<comment>Operation cancelled.</comment>');
             return false;
         }
+        return true;
+    }
+
+
+    protected function confirmDelete(): bool
+    {
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('<question>Are you sure wish to proceed? (y/n)</question> ', false);
+        if (!$helper->ask($this->input, $this->output, $question)) {
+            $this->output->writeln('<comment>Operation cancelled.</comment>');
+            return false;
+        }
+
+        $this->output->writeln('<comment>Please note that you can restore these deleted replicas by running "algolia:replicas:sync".</comment>');
         return true;
     }
 

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Command;
+
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Framework\Console\Cli;
+use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReplicaDeleteCommand extends Command
+{
+    protected const STORE_ARGUMENT = 'store';
+
+    protected const UNUSED_OPTION = 'unused';
+    protected const UNUSED_OPTION_SHORTCUT = 'u';
+
+    protected ?OutputInterface $output = null;
+
+    public function __construct(
+        protected State                   $state,
+        protected ReplicaManagerInterface $replicaManager,
+        protected StoreManagerInterface   $storeManager,
+        protected StoreNameFetcher        $storeNameFetcher,
+        ?string                           $name = null
+    )
+    {
+        parent::__construct($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure(): void
+    {
+        $this->setName('algolia:replicas:delete')
+            ->setDescription('Delete associated replica indices in Algolia')
+            ->setDefinition([
+                new InputArgument(
+                    self::STORE_ARGUMENT,
+                    InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+                    'ID(s) for store(s) to delete replicas in Algolia (optional), if not specified, replicas for all stores will be deleted'
+                ),
+                new InputOption(
+                    self::UNUSED_OPTION,
+                    '-' . self::UNUSED_OPTION_SHORTCUT,
+                    InputOption::VALUE_NONE,
+                    'Delete unused replicas only'
+                )
+            ]);
+
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $storeIds = (array) $input->getArgument(self::STORE_ARGUMENT);
+
+        $msg = 'Deleting replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
+        if ($storeIds) {
+            $output->writeln("<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>');
+        } else {
+            $output->writeln("<info>$msg</info>");
+        }
+
+        $this->output = $output;
+//        $this->state->setAreaCode(Area::AREA_ADMINHTML);
+
+        $this->deleteReplicas($storeIds);
+
+        return Cli::RETURN_SUCCESS;
+    }
+
+
+    protected function deleteReplicas(array $storeIds = [], bool $unusedOnly = false): void
+    {
+        if (count($storeIds)) {
+            foreach ($storeIds as $storeId) {
+                $this->deleteReplicasForStore($storeId);
+            }
+        } else {
+            $this->deleteReplicasForAllStores();
+        }
+    }
+
+    protected function deleteReplicasForStore(int $storeId): void
+    {
+        $this->output->writeln('<info>Deleting replicas for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
+        $this->replicaManager->deleteReplicasFromAlgolia($storeId);
+    }
+
+    protected function deleteReplicasForAllStores(): void
+    {
+        $storeIds = array_keys($this->storeManager->getStores());
+        foreach ($storeIds as $storeId) {
+            $this->deleteReplicasForStore($storeId);
+        }
+    }
+}

--- a/Console/Command/ReplicaRebuildCommand.php
+++ b/Console/Command/ReplicaRebuildCommand.php
@@ -2,25 +2,88 @@
 
 namespace Algolia\AlgoliaSearch\Console\Command;
 
-class ReplicaRebuildCommand extends AbstractReplicaCommand
+use Algolia\AlgoliaSearch\Api\Console\ReplicaDeleteCommandInterface;
+use Algolia\AlgoliaSearch\Api\Console\ReplicaSyncCommandInterface;
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Console\Traits\ReplicaDeleteCommandTrait;
+use Algolia\AlgoliaSearch\Console\Traits\ReplicaSyncCommandTrait;
+use Algolia\AlgoliaSearch\Exception\ReplicaLimitExceededException;
+use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
+use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Magento\Framework\App\State;
+use Magento\Framework\Console\Cli;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReplicaRebuildCommand
+    extends AbstractReplicaCommand
+    implements ReplicaSyncCommandInterface, ReplicaDeleteCommandInterface
 {
+    use ReplicaSyncCommandTrait;
+    use ReplicaDeleteCommandTrait;
+
+    public function __construct(
+        protected ReplicaManagerInterface $replicaManager,
+        protected StoreNameFetcher        $storeNameFetcher,
+        protected ProductHelper           $productHelper,
+        State                             $state,
+        ?string                           $name = null
+    )
+    {
+        parent::__construct($state, $name);
+    }
+
     protected function getReplicaCommandName(): string
     {
         return 'rebuild';
     }
 
-    protected function getCommandDescription(): string {
+    protected function getCommandDescription(): string
+    {
         return 'Rebuild replica configuration for Magento sorting attributes';
     }
 
     protected function getStoreArgumentDescription(): string
     {
-       return 'ID(s) for store(s) to rebuild replicas';
+        return 'ID(s) for store(s) to rebuild replicas (optional), if not specified all store replicas will be rebuilt';
     }
 
     protected function getAdditionalDefinition(): array
     {
-       return [];
+        return [];
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->output = $output;
+        $this->setAreaCode();
+
+        $storeIds = $this->getStoreIds($input);
+
+        $msg = 'Rebuilding replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
+        if ($storeIds) {
+            $output->writeln("<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>');
+        } else {
+            $output->writeln("<info>$msg</info>");
+        }
+
+        $this->deleteReplicas($storeIds);
+        try {
+            $this->syncReplicas($storeIds);
+        } catch (ReplicaLimitExceededException $e) {
+            $this->output->writeln('<error>' . $e->getMessage() . '</error>');
+            $this->output->writeln('<comment>Reduce the number of sorting attributes that have enabled virtual replicas and try again.</comment>');
+            return CLI::RETURN_FAILURE;
+        } catch (BadRequestException $e) {
+            $this->output->writeln('<error>' . $e->getMessage() . '</error>');
+            if ($storeIds) {
+                $this->output->writeln('<comment>Your Algolia application may contain cris-crossed replicas. Try running "algolia:replicas:rebuild" for all stores to correct this.');
+            }
+            return CLI::RETURN_FAILURE;
+        }
+
+        return Cli::RETURN_SUCCESS;
     }
 
 }

--- a/Console/Command/ReplicaRebuildCommand.php
+++ b/Console/Command/ReplicaRebuildCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Command;
+
+class ReplicaRebuildCommand extends AbstractReplicaCommand
+{
+    protected function getReplicaCommandName(): string
+    {
+        return 'rebuild';
+    }
+
+    protected function getCommandDescription(): string {
+        return 'Rebuild replica configuration for Magento sorting attributes';
+    }
+
+    protected function getStoreArgumentDescription(): string
+    {
+       return 'ID(s) for store(s) to rebuild replicas';
+    }
+
+    protected function getAdditionalDefinition(): array
+    {
+       return [];
+    }
+
+}

--- a/Console/Command/ReplicaRebuildCommand.php
+++ b/Console/Command/ReplicaRebuildCommand.php
@@ -41,7 +41,7 @@ class ReplicaRebuildCommand
 
     protected function getCommandDescription(): string
     {
-        return 'Rebuild replica configuration for Magento sorting attributes';
+        return "Delete and rebuild replica configuration for Magento sorting attributes (only run this operation if errors are encountered during regular sync)";
     }
 
     protected function getStoreArgumentDescription(): string

--- a/Console/Command/ReplicaSyncCommand.php
+++ b/Console/Command/ReplicaSyncCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ReplicaCommand extends Command
+class ReplicaSyncCommand extends Command
 {
     protected const STORE_ARGUMENT = 'store';
 
@@ -55,7 +55,7 @@ class ReplicaCommand extends Command
                 new InputArgument(
                     self::STORE_ARGUMENT,
                     InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-                    'ID(s) for store to be synced with Algolia (optional), if not specified all stores will be synced'
+                    'ID(s) for store(s) to be synced with Algolia (optional), if not specified all stores will be synced'
                 )
             ]);
 
@@ -78,14 +78,7 @@ class ReplicaCommand extends Command
 
         $msg = 'Syncing replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
         if ($storeIds) {
-            /** @var string[] $storeNames */
-            $storeNames = array_map(
-                function($storeId) {
-                    return $this->storeNameFetcher->getStoreName($storeId);
-                },
-                $storeIds
-            );
-            $output->writeln("<info>$msg: " . join(", ", $storeNames) . '</info>');
+            $output->writeln("<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>');
         } else {
             $output->writeln("<info>$msg</info>");
         }
@@ -156,6 +149,5 @@ class ReplicaCommand extends Command
         foreach ($storeIds as $storeId) {
             $this->syncReplicasForStore($storeId);
         }
-
     }
 }

--- a/Console/Command/ReplicaSyncCommand.php
+++ b/Console/Command/ReplicaSyncCommand.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Console\Command;
 
+use Algolia\AlgoliaSearch\Api\Console\ReplicaSyncCommandInterface;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
 use Algolia\AlgoliaSearch\Exception\ReplicaLimitExceededException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
@@ -16,11 +17,11 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Algolia\AlgoliaSearch\Console\Traits\ReplicaSyncCommandTrait;
 
-class ReplicaSyncCommand extends AbstractReplicaCommand
+class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCommandInterface
 {
-
-    protected ?OutputInterface $output = null;
+    use ReplicaSyncCommandTrait;
 
     public function __construct(
 
@@ -94,53 +95,4 @@ class ReplicaSyncCommand extends AbstractReplicaCommand
         return Cli::RETURN_SUCCESS;
     }
 
-    /**
-     * @param int[] $storeIds
-     * @return void
-     * @throws AlgoliaException
-     * @throws ExceededRetriesException
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    protected function syncReplicas(array $storeIds = []): void
-    {
-        if (count($storeIds)) {
-            foreach ($storeIds as $storeId) {
-                $this->syncReplicasForStore($storeId);
-            }
-        } else {
-            $this->syncReplicasForAllStores();
-        }
-    }
-
-    /**
-     * @throws NoSuchEntityException
-     * @throws ExceededRetriesException
-     * @throws AlgoliaException
-     * @throws LocalizedException
-     */
-    protected function syncReplicasForStore(int $storeId): void
-    {
-        $this->output->writeln('<info>Syncing ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
-        try {
-            $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
-        } catch (BadRequestException $e) {
-            $this->output->writeln('<error>Failed syncing replicas for store "' . $this->storeNameFetcher->getStoreName($storeId) . '": ' . $e->getMessage() . '</error>');
-            throw $e;
-        }
-    }
-
-    /**
-     * @throws NoSuchEntityException
-     * @throws ExceededRetriesException
-     * @throws AlgoliaException
-     * @throws LocalizedException
-     */
-    protected function syncReplicasForAllStores(): void
-    {
-        $storeIds = array_keys($this->storeManager->getStores());
-        foreach ($storeIds as $storeId) {
-            $this->syncReplicasForStore($storeId);
-        }
-    }
 }

--- a/Console/Command/ReplicaSyncCommand.php
+++ b/Console/Command/ReplicaSyncCommand.php
@@ -70,7 +70,7 @@ class ReplicaSyncCommand extends AbstractReplicaCommand
         $this->output = $output;
         $this->setAreaCode();
 
-        $storeIds = (array) $input->getArgument(self::STORE_ARGUMENT);
+        $storeIds = $this->getStoreIds($input);
 
         $msg = 'Syncing replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
         if ($storeIds) {
@@ -78,7 +78,6 @@ class ReplicaSyncCommand extends AbstractReplicaCommand
         } else {
             $output->writeln("<info>$msg</info>");
         }
-
 
         try {
             $this->syncReplicas($storeIds);

--- a/Console/Traits/ReplicaDeleteCommandTrait.php
+++ b/Console/Traits/ReplicaDeleteCommandTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Traits;
+
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+trait ReplicaDeleteCommandTrait
+{
+    /**
+     * @throws NoSuchEntityException
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     */
+    public function deleteReplicas(array $storeIds = [], bool $unused = false): void
+    {
+        if (count($storeIds)) {
+            foreach ($storeIds as $storeId) {
+                $this->deleteReplicasForStore($storeId, $unused);
+            }
+        } else {
+            $this->deleteReplicasForAllStores($unused);
+        }
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     * @throws AlgoliaException
+     */
+    public function deleteReplicasForStore(int $storeId, bool $unused = false): void
+    {
+        $this->output->writeln('<info>Deleting' . ($unused ? ' unused ' : ' ') . 'replicas for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
+        $this->replicaManager->deleteReplicasFromAlgolia($storeId, $unused);
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     * @throws AlgoliaException
+     */
+    public function deleteReplicasForAllStores(bool $unused = false): void
+    {
+        $storeIds = array_keys($this->storeManager->getStores());
+        foreach ($storeIds as $storeId) {
+            $this->deleteReplicasForStore($storeId, $unused);
+        }
+    }
+}

--- a/Console/Traits/ReplicaSyncCommandTrait.php
+++ b/Console/Traits/ReplicaSyncCommandTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Traits;
+
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+trait ReplicaSyncCommandTrait
+{
+
+    /**
+     * @param int[] $storeIds
+     * @return void
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function syncReplicas(array $storeIds = []): void
+    {
+        if (count($storeIds)) {
+            foreach ($storeIds as $storeId) {
+                $this->syncReplicasForStore($storeId);
+            }
+        } else {
+            $this->syncReplicasForAllStores();
+        }
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws ExceededRetriesException
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     */
+    public function syncReplicasForStore(int $storeId): void
+    {
+        $this->output->writeln('<info>Syncing ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
+        try {
+            $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
+        } catch (BadRequestException $e) {
+            $this->output->writeln('<error>Failed syncing replicas for store "' . $this->storeNameFetcher->getStoreName($storeId) . '": ' . $e->getMessage() . '</error>');
+            throw $e;
+        }
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws ExceededRetriesException
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     */
+    public function syncReplicasForAllStores(): void
+    {
+        $storeIds = array_keys($this->storeManager->getStores());
+        foreach ($storeIds as $storeId) {
+            $this->syncReplicasForStore($storeId);
+        }
+    }
+}

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -297,16 +297,12 @@ class ProductHelper extends AbstractEntityHelper
     }
 
     /**
-     * @param string $indexName
-     * @param string $indexNameTmp
-     * @param int $storeId
-     * @param bool $saveToTmpIndicesToo
-     * @return void
-     * @throws AlgoliaException
+     * @param int|null $storeId
+     * @return array<string, mixed>
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function setSettings(string $indexName, string $indexNameTmp, int $storeId, bool $saveToTmpIndicesToo = false): void
+    public function getIndexSettings(?int $storeId = null): array
     {
         $searchableAttributes = $this->getSearchableAttributes($storeId);
         $customRanking = $this->getCustomRanking($storeId);
@@ -338,6 +334,23 @@ class ProductHelper extends AbstractEntityHelper
         );
 
         $indexSettings = $transport->getData();
+
+        return $indexSettings;
+    }
+
+    /**
+     * @param string $indexName
+     * @param string $indexNameTmp
+     * @param int $storeId
+     * @param bool $saveToTmpIndicesToo
+     * @return void
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function setSettings(string $indexName, string $indexNameTmp, int $storeId, bool $saveToTmpIndicesToo = false): void
+    {
+        $indexSettings = $this->getIndexSettings($storeId);
 
         $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
         $this->logger->log('Settings: ' . json_encode($indexSettings));

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -17,6 +17,7 @@ use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
 use Algolia\AlgoliaSearch\Helper\Logger;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Bundle\Model\Product\Type as BundleProductType;
+use Magento\Catalog\Api\Data\ProductInterfaceFactory;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Type;
@@ -108,7 +109,8 @@ class ProductHelper extends AbstractEntityHelper
         protected GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository,
         protected ImageHelper                             $imageHelper,
         protected IndexNameFetcher                        $indexNameFetcher,
-        protected ReplicaManagerInterface                 $replicaManager
+        protected ReplicaManagerInterface                 $replicaManager,
+        protected ProductInterfaceFactory                 $productFactory
     )
     {
         parent::__construct($indexNameFetcher);
@@ -545,7 +547,7 @@ class ProductHelper extends AbstractEntityHelper
     protected function getCompositeTypes(): array
     {
         if ($this->compositeTypes === null) {
-            $productEmulator = new DataObject();
+            $productEmulator = $this->productFactory->create();
             foreach ($this->productType->getCompositeTypes() as $typeId) {
                 $productEmulator->setTypeId($typeId);
                 $this->compositeTypes[$typeId] = $this->productType->factory($productEmulator);

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1203,38 +1203,6 @@ class ProductHelper extends AbstractEntityHelper
     }
 
     /**
-     * @param string $indexName
-     * @param array $replicas
-     * @param int $setReplicasTaskId
-     * @return void
-     * @throws AlgoliaException
-     * @throws ExceededRetriesException
-     */
-    protected function deleteUnusedReplicas(string $indexName, array $replicas, int $setReplicasTaskId): void
-    {
-        $indicesToDelete = [];
-
-        $allIndices = $this->algoliaHelper->listIndexes();
-        foreach ($allIndices['items'] as $indexInfo) {
-            if (mb_strpos($indexInfo['name'], $indexName) !== 0 || $indexInfo['name'] === $indexName) {
-                continue;
-            }
-
-            if (mb_strpos($indexInfo['name'], IndexNameFetcher::INDEX_TEMP_SUFFIX) === false && in_array($indexInfo['name'], $replicas) === false) {
-                $indicesToDelete[] = $indexInfo['name'];
-            }
-        }
-
-        if (count($indicesToDelete) > 0) {
-            $this->algoliaHelper->waitLastTask($indexName, $setReplicasTaskId);
-
-            foreach ($indicesToDelete as $indexToDelete) {
-                $this->algoliaHelper->deleteIndex($indexToDelete);
-            }
-        }
-    }
-
-    /**
      * @param $indexName
      * @return void
      * @throws AlgoliaException

--- a/Service/IndexNameFetcher.php
+++ b/Service/IndexNameFetcher.php
@@ -18,6 +18,8 @@ class IndexNameFetcher
     /** @var string */
     public const INDEX_TEMP_SUFFIX = '_tmp';
 
+    public const INDEX_QUERY_SUGGESTIONS_SUFFIX = '_query_suggestions';
+
     /**
      * @param string $indexSuffix
      * @param int|null $storeId
@@ -51,6 +53,19 @@ class IndexNameFetcher
     public function isTempIndex($indexName): bool
     {
         return str_ends_with($indexName, self::INDEX_TEMP_SUFFIX);
+    }
+
+    /**
+     * This is the default index name format for query suggestions but it can be overridden
+     * This is a temporary workaround for delete index operations
+     * TODO: Revisit this approach when a QuerySuggestionsClient is implemented in algoliasearch-client-php
+     *
+     * @param $indexName
+     * @return bool
+     */
+    public function isQuerySuggestionsIndex($indexName): bool
+    {
+        return str_ends_with($indexName, self::INDEX_QUERY_SUGGESTIONS_SUFFIX);
     }
 
 }

--- a/Service/IndexNameFetcher.php
+++ b/Service/IndexNameFetcher.php
@@ -48,4 +48,9 @@ class IndexNameFetcher
         return $this->getIndexName(ProductHelper::INDEX_NAME_SUFFIX, $storeId, $tmp);
     }
 
+    public function isTempIndex($indexName): bool
+    {
+        return str_ends_with($indexName, self::INDEX_TEMP_SUFFIX);
+    }
+
 }

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -436,6 +436,10 @@ class ReplicaManager implements ReplicaManagerInterface
         }
 
         $this->deleteIndices($replicasToDelete);
+
+        if ($unused) {
+            $this->clearUnusedReplicaIndicesCache($storeId);
+        }
     }
 
     /**
@@ -472,6 +476,15 @@ class ReplicaManager implements ReplicaManagerInterface
 
 
         return $this->_unusedReplicaIndices[$storeId];
+    }
+
+    protected function clearUnusedReplicaIndicesCache(?int $storeId = null): void
+    {
+        if (is_null($storeId)) {
+            $this->_unusedReplicaIndices = [];
+        } else {
+            unset($this->_unusedReplicaIndices[$storeId]);
+        }
     }
 
     /**

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -302,6 +302,12 @@ class ReplicaManager implements ReplicaManagerInterface
         return true;
     }
 
+    /**
+     * In the event of an invalid replica configuration, this provides the means to revert the
+     * configuration settings to the previous state (provided the ReplicaState has been utilized to track the change)
+     * @param int $storeId
+     * @return bool True if settings were reverted as a result of this function call
+     */
     protected function revertReplicaConfig(int $storeId): bool
     {
         if ($ogConfig = $this->replicaState->getOriginalSortConfiguration($storeId)) {

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -43,7 +43,12 @@ class ReplicaManager implements ReplicaManagerInterface
     public const ALGOLIA_SETTINGS_KEY_REPLICAS = 'replicas';
 
     protected const _DEBUG = true;
+
+    // LOCAL CACHING VARIABLES
+    /** @var array<string, string[]> */
     protected array $_algoliaReplicaConfig = [];
+
+    /** @var array<int, string[]>  */
     protected array $_magentoReplicaPossibleConfig = [];
 
     public function __construct(
@@ -89,7 +94,7 @@ class ReplicaManager implements ReplicaManagerInterface
     /**
      * @param $primaryIndexName
      * @param bool $refreshCache
-     * @return array<string, mixed>
+     * @return string[]
      * @throws LocalizedException
      */
     protected function getReplicaConfigurationFromAlgolia($primaryIndexName, bool $refreshCache = false): array
@@ -97,7 +102,7 @@ class ReplicaManager implements ReplicaManagerInterface
         if ($refreshCache || !isset($this->_algoliaReplicaConfig[$primaryIndexName])) {
             try {
                 $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName);
-                $this->_algoliaReplicaConfig[$primaryIndexName] = array_key_exists('replicas', $currentSettings)
+                $this->_algoliaReplicaConfig[$primaryIndexName] = array_key_exists(self::ALGOLIA_SETTINGS_KEY_REPLICAS, $currentSettings)
                     ? $currentSettings[self::ALGOLIA_SETTINGS_KEY_REPLICAS]
                     : [];
             } catch (\Exception $e) {
@@ -185,7 +190,7 @@ class ReplicaManager implements ReplicaManagerInterface
      *
      * @param int $storeId
      * @param bool $refreshCache
-     * @return array
+     * @return string[]
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @deprecated This method has been supplanted by the much simpler getMagentoReplicaSettings() method

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -423,9 +423,7 @@ class ReplicaManager implements ReplicaManagerInterface
     }
 
     /**
-     * @throws AlgoliaException
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
+     * @inheritDoc
      */
     public function deleteReplicasFromAlgolia(int $storeId, bool $unused = false): void
     {

--- a/Service/StoreNameFetcher.php
+++ b/Service/StoreNameFetcher.php
@@ -7,7 +7,7 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class StoreNameFetcher
 {
-    /** @var string[] */
+    /** @var array<int, string> */
     protected array $_storeNames = [];
 
     public function __construct(

--- a/Service/StoreNameFetcher.php
+++ b/Service/StoreNameFetcher.php
@@ -25,4 +25,19 @@ class StoreNameFetcher
         }
         return $this->_storeNames[$storeId];
     }
+
+    /**
+     * @param int[] $storeIds
+     * @return string[]
+     * @throws NoSuchEntityException
+     */
+    public function getStoreNames(array $storeIds): array
+    {
+        return array_map(
+            function($storeId) {
+                return $this->getStoreName($storeId);
+            },
+            $storeIds
+        );
+    }
 }

--- a/Service/StoreNameFetcher.php
+++ b/Service/StoreNameFetcher.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+
+class StoreNameFetcher
+{
+    /** @var string[] */
+    protected array $_storeNames = [];
+
+    public function __construct(
+        protected StoreManagerInterface $storeManager
+    )
+    {}
+
+    /**
+     * @throws NoSuchEntityException
+     */
+    public function getStoreName(int $storeId): string
+    {
+        if (!isset($this->_storeNames[$storeId])) {
+            $this->_storeNames[$storeId] = $this->storeManager->getStore($storeId)->getName();
+        }
+        return $this->_storeNames[$storeId];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -149,6 +149,7 @@
             <argument name="commands" xsi:type="array">
                 <item name="replica_sync_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand</item>
                 <item name="replica_delete_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDeleteCommand</item>
+                <item name="replica_rebuild_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -147,7 +147,8 @@
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="replica_sync_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaCommand</item>
+                <item name="replica_sync_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand</item>
+                <item name="replica_delete_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDeleteCommand</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -144,4 +144,11 @@
             <argument name="resourceModel" xsi:type="string">Algolia\AlgoliaSearch\Model\ResourceModel\QueueArchive\Collection</argument>
         </arguments>
     </virtualType>
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="replica_sync_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaCommand</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
This PR includes:
- Data cleanup operations in the `ReplicaManager` class
- Removal of unused and outdated replica method from `ProductHelper` class
- New `StoreNameFetcher` service
- Exposing index settings from `ProductHelper`
- New CLI namespace for store scoped replica management: `algolia:replicas` 
- CLI to manually initiate sync of replicas
- CLI to manually delete replicas (including identifying potentially unused replicas)
- CLI to manually rebuild replica configuration 

Sample interactions through CLI:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/aa2426b3-43c3-4302-9bb5-b011832eb0d4)
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/985c85e9-358d-4037-afdf-f0e837ac6903)
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/99f45a82-1f6a-4095-b701-7f30927105ea)

