### PR TITLE
Feature/mage 848 - Granular virtual replica migration

### DIFF
--- a/Console/Command/AbstractReplicaCommand.php
+++ b/Console/Command/AbstractReplicaCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 abstract class AbstractReplicaCommand extends Command
 {
@@ -102,5 +103,22 @@ abstract class AbstractReplicaCommand extends Command
         return ($storeIds)
             ? "<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>'
             : "<info>$msg</info>";
+    }
+
+    protected function confirmOperation(string $okMessage = '', string $cancelMessage = 'Operation cancelled'): bool
+    {
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('<question>Are you sure wish to proceed? (y/n)</question> ', false);
+        if (!$helper->ask($this->input, $this->output, $question)) {
+            if ($cancelMessage) {
+                $this->output->writeln("<comment>$cancelMessage</comment>");
+            }
+            return false;
+        }
+
+        if ($okMessage) {
+            $this->output->writeln("<comment>$okMessage</comment>");
+        }
+        return true;
     }
 }

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -143,18 +143,10 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
         return true;
     }
 
-
     protected function confirmDelete(): bool
     {
-        $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion('<question>Are you sure wish to proceed? (y/n)</question> ', false);
-        if (!$helper->ask($this->input, $this->output, $question)) {
-            $this->output->writeln('<comment>Operation cancelled.</comment>');
-            return false;
-        }
-
-        $this->output->writeln('<comment>Please note that you can restore these deleted replicas by running "algolia:replicas:sync".</comment>');
-        return true;
+        $okMsg = 'Please note that you can restore these deleted replicas by running "algolia:replicas:sync".';
+        return $this->confirmOperation($okMsg);
     }
 
 }

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -25,12 +25,12 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
     public function __construct(
         protected ReplicaManagerInterface $replicaManager,
         protected StoreManagerInterface   $storeManager,
-        protected StoreNameFetcher        $storeNameFetcher,
-        protected State                   $state,
+        State                             $state,
+        StoreNameFetcher                  $storeNameFetcher,
         ?string                           $name = null
     )
     {
-        parent::__construct($state, $name);
+        parent::__construct($state, $storeNameFetcher, $name);
     }
 
     protected function getReplicaCommandName(): string
@@ -68,12 +68,12 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
         $storeIds = $this->getStoreIds($input);
         $unused = $input->getOption(self::UNUSED_OPTION);
 
-        $msg = 'Deleting' . ($unused ? ' unused ' : ' ') . 'replicas for ' . ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
-        if ($storeIds) {
-            $output->writeln("<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>');
-        } else {
-            $output->writeln("<info>$msg</info>");
-        }
+        $output->writeln(
+            $this->decorateOperationAnnouncementMessage(
+                'Deleting' . ($unused ? ' unused ' : ' ') . 'replicas for {{target}}',
+                $storeIds
+            )
+        );
 
         if ($unused) {
             $unusedReplicas = $this->getUnusedReplicas($storeIds);

--- a/Console/Command/ReplicaDisableVirtualCommand.php
+++ b/Console/Command/ReplicaDisableVirtualCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Command;
+
+use Algolia\AlgoliaSearch\Api\Console\ReplicaSyncCommandInterface;
+use Algolia\AlgoliaSearch\Console\Traits\ReplicaSyncCommandTrait;
+use Magento\Framework\Console\Cli;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements ReplicaSyncCommandInterface
+{
+    use ReplicaSyncCommandTrait;
+
+    protected function getReplicaCommandName(): string
+    {
+        return 'disable-virtual-replicas';
+    }
+
+    protected function getCommandDescription(): string
+    {
+        return 'Disable virtual replicas for all product sorting attributes and revert to standard replicas';
+    }
+
+    protected function getStoreArgumentDescription(): string
+    {
+        return 'ID(s) for store(s) to disable virtual replicas (optional), if not specified disable virtual replicas for all stores';
+    }
+
+    protected function getAdditionalDefinition(): array
+    {
+        return [];
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->output = $output;
+        $this->input = $input;
+        $this->setAreaCode();
+
+        $storeIds = $this->getStoreIds($input);
+
+        $output->writeln($this->decorateOperationAnnouncementMessage('Disabling virtual replicas for {{target}}', $storeIds));
+
+        if (!$this->confirmOperation()) {
+            return CLI::RETURN_SUCCESS;
+        }
+
+        return Cli::RETURN_SUCCESS;
+    }
+
+    protected function confirmOperation(): bool
+    {
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('<question>Are you sure wish to proceed? (y/n)</question> ', false);
+        if (!$helper->ask($this->input, $this->output, $question)) {
+            $this->output->writeln('<comment>Operation cancelled.</comment>');
+            return false;
+        }
+
+        $this->output->writeln('<comment>Configure virtual replicas by attribute under: Stores > Configuration > Algolia Search > InstantSearch Results Page > Sorting</comment>');
+        return true;
+    }
+}

--- a/Console/Command/ReplicaDisableVirtualCommand.php
+++ b/Console/Command/ReplicaDisableVirtualCommand.php
@@ -111,7 +111,7 @@ class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements Rep
         $isStoreScoped = false;
 
         if ($this->configChecker->isSettingAppliedForScopeAndCode(
-            ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED,
+            ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED,
             ScopeInterface::SCOPE_STORES,
             $storeId)
         ) {
@@ -138,7 +138,7 @@ class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements Rep
 
     protected function disableVirtualReplicasForAllStores(): void
     {
-        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, [$this, 'removeLegacyVirtualReplicaConfig']);
+        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, [$this, 'removeLegacyVirtualReplicaConfig']);
 
         $this->configChecker->checkAndApplyAllScopes(ConfigHelper::SORTING_INDICES, [$this, 'disableVirtualReplicaSortConfig']);
 
@@ -149,12 +149,12 @@ class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements Rep
 
     public function removeLegacyVirtualReplicaConfig(string $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, int $scopeId = 0): void
     {
-        $value = $this->scopeConfig->getValue(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
+        $value = $this->scopeConfig->getValue(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
         if (is_null($value)) {
             return;
         }
-        $this->output->writeln("<info>Removing legacy configuration " . ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED . " for $scope scope" . ($scope != ScopeConfigInterface::SCOPE_TYPE_DEFAULT ? " (ID=$scopeId)" : "") . "</info>");
-        $this->configWriter->delete(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
+        $this->output->writeln("<info>Removing legacy configuration " . ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED . " for $scope scope" . ($scope != ScopeConfigInterface::SCOPE_TYPE_DEFAULT ? " (ID=$scopeId)" : "") . "</info>");
+        $this->configWriter->delete(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
     }
 
     public function disableVirtualReplicaSortConfig(string $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, int $scopeId = 0): void

--- a/Console/Command/ReplicaDisableVirtualCommand.php
+++ b/Console/Command/ReplicaDisableVirtualCommand.php
@@ -43,23 +43,12 @@ class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements Rep
 
         $output->writeln($this->decorateOperationAnnouncementMessage('Disabling virtual replicas for {{target}}', $storeIds));
 
-        if (!$this->confirmOperation()) {
+        $okMsg = 'Configure virtual replicas by attribute under: Stores > Configuration > Algolia Search > InstantSearch Results Page > Sorting';
+        if (!$this->confirmOperation($okMsg)) {
             return CLI::RETURN_SUCCESS;
         }
 
         return Cli::RETURN_SUCCESS;
     }
 
-    protected function confirmOperation(): bool
-    {
-        $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion('<question>Are you sure wish to proceed? (y/n)</question> ', false);
-        if (!$helper->ask($this->input, $this->output, $question)) {
-            $this->output->writeln('<comment>Operation cancelled.</comment>');
-            return false;
-        }
-
-        $this->output->writeln('<comment>Configure virtual replicas by attribute under: Stores > Configuration > Algolia Search > InstantSearch Results Page > Sorting</comment>');
-        return true;
-    }
 }

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -141,7 +141,7 @@ class ConfigHelper
     protected const IS_LOOKING_SIMILAR_ENABLED_IN_PDP = 'algoliasearch_recommend/recommend/looking_similar/is_looking_similar_enabled_on_pdp';
     protected const IS_LOOKING_SIMILAR_ENABLED_IN_SHOPPING_CART = 'algoliasearch_recommend/recommend/looking_similar/is_looking_similar_enabled_on_cart_page';
     protected const LOOKING_SIMILAR_TITLE = 'algoliasearch_recommend/recommend/looking_similar/title';
-    protected const USE_VIRTUAL_REPLICA_ENABLED = 'algoliasearch_instant/instant/use_virtual_replica'; //legacy config
+    public const USE_VIRTUAL_REPLICA_ENABLED = 'algoliasearch_instant/instant/use_virtual_replica'; //legacy config
     protected const AUTOCOMPLETE_KEYBORAD_NAVIAGATION = 'algoliasearch_autocomplete/autocomplete/navigator';
     protected const FREQUENTLY_BOUGHT_TOGETHER_TITLE = 'algoliasearch_recommend/recommend/frequently_bought_together/title';
     protected const RELATED_PRODUCTS_TITLE = 'algoliasearch_recommend/recommend/related_product/title';

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -141,7 +141,7 @@ class ConfigHelper
     protected const IS_LOOKING_SIMILAR_ENABLED_IN_PDP = 'algoliasearch_recommend/recommend/looking_similar/is_looking_similar_enabled_on_pdp';
     protected const IS_LOOKING_SIMILAR_ENABLED_IN_SHOPPING_CART = 'algoliasearch_recommend/recommend/looking_similar/is_looking_similar_enabled_on_cart_page';
     protected const LOOKING_SIMILAR_TITLE = 'algoliasearch_recommend/recommend/looking_similar/title';
-    public const USE_VIRTUAL_REPLICA_ENABLED = 'algoliasearch_instant/instant/use_virtual_replica'; //legacy config
+    public const LEGACY_USE_VIRTUAL_REPLICA_ENABLED = 'algoliasearch_instant/instant/use_virtual_replica'; 
     protected const AUTOCOMPLETE_KEYBORAD_NAVIAGATION = 'algoliasearch_autocomplete/autocomplete/navigator';
     protected const FREQUENTLY_BOUGHT_TOGETHER_TITLE = 'algoliasearch_recommend/recommend/frequently_bought_together/title';
     protected const RELATED_PRODUCTS_TITLE = 'algoliasearch_recommend/recommend/related_product/title';

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -86,7 +86,9 @@ class ReplicaManager implements ReplicaManagerInterface
             default:
                 $primaryIndexName = $this->indexNameFetcher->getProductIndexName($storeId);
                 $old = $this->getMagentoReplicaConfigurationFromAlgolia($primaryIndexName);
-                $new = $this->sortingTransformer->transformSortingIndicesToReplicaSetting($this->sortingTransformer->getSortingIndices($storeId));
+                $new = $this->sortingTransformer->transformSortingIndicesToReplicaSetting(
+                    $this->sortingTransformer->getSortingIndices($storeId, null, null, true)
+                );
                 sort($old);
                 sort($new);
                 return $old !== $new;

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -351,13 +351,17 @@ class ReplicaManager implements ReplicaManagerInterface
 
     /**
      * @param array $replicasToDelete
+     * @param bool $waitLastTask
      * @return void
      * @throws AlgoliaException
      */
-    protected function deleteIndices(array $replicasToDelete): void
+    protected function deleteIndices(array $replicasToDelete, bool $waitLastTask = false): void
     {
         foreach ($replicasToDelete as $deletedReplica) {
             $this->algoliaHelper->deleteIndex($deletedReplica);
+            if ($waitLastTask) {
+                $this->algoliaHelper->waitLastTask($deletedReplica);
+            }
         }
     }
 

--- a/Service/Product/SortingTransformer.php
+++ b/Service/Product/SortingTransformer.php
@@ -38,6 +38,7 @@ class SortingTransformer
      * @param ?int $storeId
      * @param ?int $currentCustomerGroupId
      * @param ?array $attrs - serialized array of sorting attributes to transform (defaults to saved sorting config)
+     * @param bool $clearCache - If set to true will update the cache
      * @return array of transformed sorting / replica objects
      * @throws LocalizedException
      * @throws NoSuchEntityException
@@ -45,11 +46,16 @@ class SortingTransformer
     public function getSortingIndices(
         ?int   $storeId = null,
         ?int   $currentCustomerGroupId = null,
-        ?array $attrs = null
+        ?array $attrs = null,
+        bool   $clearCache = false
     ): array
     {
         // Selectively cache this result - only cache manipulation of saved settings per store
         $useCache = is_null($currentCustomerGroupId) && is_null($attrs);
+
+        if ($clearCache) {
+            unset($this->_sortingIndices[$storeId]);
+        }
 
         if ($useCache
             && array_key_exists($storeId, $this->_sortingIndices)

--- a/Setup/Patch/Data/MigrateConversionAnalyticsModePatch.php
+++ b/Setup/Patch/Data/MigrateConversionAnalyticsModePatch.php
@@ -17,12 +17,21 @@ class MigrateConversionAnalyticsModePatch implements DataPatchInterface
 {
     public function __construct(
         protected ModuleDataSetupInterface $moduleDataSetup,
-        protected WriterInterface $configWriter,
-        protected ConfigInterface $config,
-        protected ScopeConfigInterface $scopeConfig,
-        protected ConfigChecker $configChecker,
-        protected StoreManagerInterface $storeManager
-    ) {}
+        protected WriterInterface          $configWriter,
+        protected ConfigInterface          $config,
+        protected ScopeConfigInterface     $scopeConfig,
+        protected ConfigChecker            $configChecker,
+        protected StoreManagerInterface    $storeManager
+    )
+    {}
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
 
     /**
      * @inheritDoc
@@ -60,14 +69,6 @@ class MigrateConversionAnalyticsModePatch implements DataPatchInterface
                 $scope,
                 $scopeId);
         }
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public static function getDependencies(): array
-    {
-        return [];
     }
 
     /**

--- a/Setup/Patch/Data/MigrateInstantSearchConfigPatch.php
+++ b/Setup/Patch/Data/MigrateInstantSearchConfigPatch.php
@@ -8,8 +8,6 @@ use Magento\Framework\Setup\Patch\PatchInterface;
 
 class MigrateInstantSearchConfigPatch implements DataPatchInterface
 {
-
-
     public function __construct(
         protected ModuleDataSetupInterface $moduleDataSetup,
     ) {}

--- a/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
+++ b/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
+
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Helper\Configuration\ConfigChecker;
+use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchInterface;
+
+class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
+{
+    public function __construct(
+        protected ModuleDataSetupInterface $moduleDataSetup,
+        protected WriterInterface          $configWriter,
+        protected ConfigInterface          $config,
+        protected ScopeConfigInterface     $scopeConfig,
+        protected ConfigChecker            $configChecker,
+        protected ReplicaManagerInterface  $replicaManager
+    )
+    {}
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply(): PatchInterface
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+
+        // do stuff
+
+        $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
+++ b/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
@@ -3,24 +3,40 @@
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Exception\ReplicaLimitExceededException;
+use Algolia\AlgoliaSearch\Exception\TooManyCustomerGroupsAsReplicasException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Configuration\ConfigChecker;
+use Algolia\AlgoliaSearch\Service\Product\SortingTransformer;
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Algolia\AlgoliaSearch\Validator\VirtualReplicaValidatorFactory;
 use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
 {
     public function __construct(
-        protected ModuleDataSetupInterface $moduleDataSetup,
-        protected WriterInterface          $configWriter,
-        protected ConfigInterface          $config,
-        protected ScopeConfigInterface     $scopeConfig,
-        protected ConfigChecker            $configChecker,
-        protected ReplicaManagerInterface  $replicaManager
+        protected ModuleDataSetupInterface       $moduleDataSetup,
+        protected WriterInterface                $configWriter,
+        protected ConfigInterface                $config,
+        protected ScopeConfigInterface           $scopeConfig,
+        protected ConfigHelper                   $configHelper,
+        protected ConfigChecker                  $configChecker,
+        protected ReplicaManagerInterface        $replicaManager,
+        protected SortingTransformer             $sortingTransformer,
+        protected VirtualReplicaValidatorFactory $validatorFactory,
+        protected StoreManagerInterface          $storeManager,
+        protected StoreNameFetcher               $storeNameFetcher,
+        protected SerializerInterface            $serializer
     )
     {}
 
@@ -33,27 +49,87 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
 
         $this->configChecker->checkAndApplyAllScopes(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, [$this, 'migrateSetting']);
 
-        // rebuild everything after
-
         $this->moduleDataSetup->getConnection()->endSetup();
 
         return $this;
     }
 
+    /**
+     * Seek each scoped global replica config and attempt to apply to the sorting config
+     * Note that a scoping mismatch could occur so this patch will create a matching scoped sort
+     * based on the scope of the original legacy virtual replica config
+     *
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
     public function migrateSetting(string $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, int $scopeId = 0): void
     {
-        $value = (bool) $this->scopeConfig->getValue(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
-        // not enabled moving on...
-        if (!$value) {
+        // If not enabled - delete this old setting and move on...
+        if (!$this->scopeConfig->isSetFlag(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId)) {
+            $this->deleteLegacyConfig($scope, $scopeId);
             return;
         }
 
-        // TODO...
-        // retrieve the sorting config
-        // turn on virtual replicas for all attributes
-        // run the validator, throw ReplicaExceedsException if needed
+        // Replicate the global settings by turning on virtual replicas for all attributes
+        $virtualizedSorts = $this->simulateFullVirtualReplicas($scope, $scopeId);
 
-        //if all is copacetic then save the new sorting config
+        // Get all stores affected by this configuration
+        $storeIds = $this->configChecker->getAffectedStoreIds(
+            ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED,
+            $scope,
+            $scopeId
+        );
+
+        // Retrieve the sorting config
+        foreach ($storeIds as $storeId) {
+            $sortingIndices = $this->sortingTransformer->getSortingIndices($storeId, null, $virtualizedSorts);
+
+            $validator = $this->validatorFactory->create();
+            if (!$validator->isReplicaConfigurationValid($sortingIndices)) {
+                $storeName = $this->storeNameFetcher->getStoreName($storeId) . " (Store ID=$storeId)";
+                $prefix = "Error encountered while attempting to migrate your virtual replica configuration.\n";
+                $postfix = "\nPlease note that there can be no more than " . $this->replicaManager->getMaxVirtualReplicasPerIndex() . " virtual replicas per index.";
+                $postfix .= "\nYou can now configure virtual replicas by attribute under: Stores > Configuration > Algolia Search > InstantSearch Results Page > Sorting";
+                $postfix .= "\nRun the \"bin/magento algolia:replicas:disable-virtual-replicas\" before running \"setup:upgrade\" and configure your virtual replicas in the Magento admin.";
+                if ($validator->isTooManyCustomerGroups()) {
+                    throw (new TooManyCustomerGroupsAsReplicasException(__("{$prefix}You have too many customer groups to enable virtual replicas on the pricing sort for $storeName.$postfix")))
+                        ->withReplicaCount($validator->getReplicaCount())
+                        ->withPriceSortReplicaCount($validator->getPriceSortReplicaCount());
+                }
+                else {
+                    throw (new ReplicaLimitExceededException(__("{$prefix}Replica limit exceeded for $storeName.$postfix")))
+                        ->withReplicaCount($validator->getReplicaCount());
+                }
+            }
+
+            // If all is copacetic then save the new sorting config
+            // Save to store scope if we are not already there or if a store scope override exists
+            if ($scope != ScopeInterface::SCOPE_STORES
+                && $this->configChecker->isSettingAppliedForScopeAndCode(ConfigHelper::SORTING_INDICES, ScopeInterface::SCOPE_STORES, $storeId)) {
+                $this->configHelper->setSorting($virtualizedSorts, ScopeInterface::SCOPE_STORES, $storeId);
+            }
+        }
+
+        // Save in the matching scope to the original legacy global config
+        $this->configHelper->setSorting($virtualizedSorts, $scope, $scopeId);
+        $this->deleteLegacyConfig($scope, $scopeId);
+    }
+
+    protected function deleteLegacyConfig($scope, $scopeId): void
+    {
+        $this->configWriter->delete(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
+    }
+
+    protected function simulateFullVirtualReplicas(string $scope, int $scopeId): array
+    {
+        $raw = $this->scopeConfig->getValue(ConfigHelper::SORTING_INDICES, $scope, $scopeId);
+        return array_map(
+            function($sort) {
+                $sort[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA] = 1;
+                return $sort;
+            },
+            $this->serializer->unserialize($raw)
+        );
     }
 
     /**

--- a/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
+++ b/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
@@ -11,6 +11,7 @@ use Algolia\AlgoliaSearch\Service\Product\SortingTransformer;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use Algolia\AlgoliaSearch\Validator\VirtualReplicaValidatorFactory;
 use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
+use Magento\Framework\App\Config\ReinitableConfigInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -28,7 +29,7 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
         protected ModuleDataSetupInterface       $moduleDataSetup,
         protected WriterInterface                $configWriter,
         protected ConfigInterface                $config,
-        protected ScopeConfigInterface           $scopeConfig,
+        protected ReinitableConfigInterface      $scopeConfig,
         protected ConfigHelper                   $configHelper,
         protected ConfigChecker                  $configChecker,
         protected ReplicaManagerInterface        $replicaManager,
@@ -48,6 +49,8 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
         $this->moduleDataSetup->getConnection()->startSetup();
 
         $this->configChecker->checkAndApplyAllScopes(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, [$this, 'migrateSetting']);
+
+        $this->scopeConfig->reinit();
 
         $this->moduleDataSetup->getConnection()->endSetup();
 

--- a/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
+++ b/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Configuration\ConfigChecker;
 use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -26,7 +27,39 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
     /**
      * @inheritDoc
      */
-    public static function getDependencies()
+    public function apply(): PatchInterface
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+
+        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, [$this, 'migrateSetting']);
+
+        // rebuild everything after
+
+        $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
+    }
+
+    public function migrateSetting(string $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, int $scopeId = 0): void
+    {
+        $value = (bool) $this->scopeConfig->getValue(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
+        // not enabled moving on...
+        if (!$value) {
+            return;
+        }
+
+        // TODO...
+        // retrieve the sorting config
+        // turn on virtual replicas for all attributes
+        // run the validator, throw ReplicaExceedsException if needed
+
+        //if all is copacetic then save the new sorting config
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies(): array
     {
         return [];
     }
@@ -34,21 +67,7 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
     /**
      * @inheritDoc
      */
-    public function apply(): PatchInterface
-    {
-        $this->moduleDataSetup->getConnection()->startSetup();
-
-        // do stuff
-
-        $this->moduleDataSetup->getConnection()->endSetup();
-
-        return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getAliases()
+    public function getAliases(): array
     {
         return [];
     }

--- a/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
+++ b/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
@@ -47,7 +47,7 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
     {
         $this->moduleDataSetup->getConnection()->startSetup();
 
-        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, [$this, 'migrateSetting']);
+        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, [$this, 'migrateSetting']);
 
         $this->moduleDataSetup->getConnection()->endSetup();
 
@@ -65,14 +65,14 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
     public function migrateSetting(string $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, int $scopeId = 0): void
     {
         // If not enabled - delete this old setting and move on...
-        if (!$this->scopeConfig->isSetFlag(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId)) {
+        if (!$this->scopeConfig->isSetFlag(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId)) {
             $this->deleteLegacyConfig($scope, $scopeId);
             return;
         }
 
         // Get all stores affected by this configuration
         $storeIds = $this->configChecker->getAffectedStoreIds(
-            ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED,
+            ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED,
             $scope,
             $scopeId
         );
@@ -126,7 +126,7 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
 
     protected function deleteLegacyConfig($scope, $scopeId): void
     {
-        $this->configWriter->delete(ConfigHelper::USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
+        $this->configWriter->delete(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, $scope, $scopeId);
     }
 
     protected function simulateFullVirtualReplicas(string $scope, int $scopeId): array

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -48,8 +48,11 @@ class RebuildReplicasPatch implements DataPatchInterface
         $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
 
         $storeIds = array_keys($this->storeManager->getStores());
+        // Delete all replicas before resyncing in case of incorrect replica assignments
         foreach ($storeIds as $storeId) {
             $this->replicaManager->deleteReplicasFromAlgolia($storeId);
+        }
+        foreach ($storeIds as $storeId) {
             $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
         }
 

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
+
+use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
+use Magento\Framework\App\State;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class RebuildReplicasPatch implements DataPatchInterface
+{
+    public function __construct(
+        protected ModuleDataSetupInterface $moduleDataSetup,
+        protected StoreManagerInterface    $storeManager,
+        protected ReplicaManager           $replicaManager,
+        protected ProductHelper            $productHelper,
+        protected State                    $state
+    )
+    {}
+
+        /**
+     * @inheritDoc
+     */
+    public static function getDependencies(): array
+    {
+        return [
+            MigrateVirtualReplicaConfigPatch::class
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply(): PatchInterface
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
+
+        $storeIds = array_keys($this->storeManager->getStores());
+        foreach ($storeIds as $storeId) {
+            $this->replicaManager->deleteReplicasFromAlgolia($storeId);
+            $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
+        }
+
+        $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -150,6 +150,7 @@
                 <item name="replica_sync_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand</item>
                 <item name="replica_delete_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDeleteCommand</item>
                 <item name="replica_rebuild_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand</item>
+                <item name="replica_disable_virtual_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDisableVirtualCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
This PR includes:
- Refactored CLI classes for code reuse
- A new `disable-virtual-replicas` command to facilitate upgrades and allow a way to selectively roll back invalid configurations
- Forcing replica state on replica rebuilds to bypass Algolia API latency
- Bug fixes for the `ConfigChecker` class to handle more nested scoping config scenarios 
- A new data patch to migrate legacy global virtual configuration to granular sorting attribute configuration
- A new data patch to run after to fully rebuild the replica configuration 
- Error handling if replica limit is exceeded with detailed instructions on how to remedy (this should hopefully prevent upgrading with unexpected results to existing replica configurations)

Sample CLI output:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/35db2103-e8c1-4c99-b74b-22eeca5d80ed)
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/abc2b162-7f80-4224-b647-1018904f95f9)

Sample `setup:upgrade` failure:
![image](https://github.com/algolia/algoliasearch-magento-2/assets/986313/4a1e5551-9183-490e-9e87-336fb7b5dacf)


