### PR TITLE
Feature/mage 878

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -94,6 +94,7 @@ class ConfigHelper
     public const MAKE_SEO_REQUEST = 'algoliasearch_advanced/advanced/make_seo_request';
     public const REMOVE_BRANDING = 'algoliasearch_advanced/advanced/remove_branding';
     public const AUTOCOMPLETE_SELECTOR = 'algoliasearch_autocomplete/autocomplete/autocomplete_selector';
+    public const INCLUDE_NON_VISIBLE_PRODUCTS_IN_INDEX = 'algoliasearch_products/products/include_non_visible_products_in_index';
     public const IDX_PRODUCT_ON_CAT_PRODUCTS_UPD = 'algoliasearch_advanced/advanced/index_product_on_category_products_update';
     public const PREVENT_BACKEND_RENDERING = 'algoliasearch_advanced/advanced/prevent_backend_rendering';
     public const PREVENT_BACKEND_RENDERING_DISPLAY_MODE =
@@ -232,6 +233,21 @@ class ConfigHelper
     public function getAutocompleteSelector($storeId = null)
     {
         return $this->configInterface->getValue(self::AUTOCOMPLETE_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * Returns config value
+     *
+     * @param $storeId
+     * @return mixed
+     */
+    public function includeNonVisibleProductsInIndex($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::INCLUDE_NON_VISIBLE_PRODUCTS_IN_INDEX,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -376,7 +376,7 @@ class Data
         $this->logger->start('Indexing');
         try {
             $this->logger->start('ok');
-            $onlyVisible = $this->configHelper->includeNonVisibleProductsInIndex();
+            $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex($storeId);
             $collection = $this->productHelper->getProductCollectionQuery($storeId, $productIds, $onlyVisible);
             $size = $collection->getSize();
             if (!empty($productIds)) {
@@ -421,7 +421,8 @@ class Data
         if ($this->isIndexingEnabled($storeId) === false) {
             return;
         }
-        $collection = $this->productHelper->getProductCollectionQuery($storeId, null, $useTmpIndex);
+        $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex($storeId);
+        $collection = $this->productHelper->getProductCollectionQuery($storeId, null, $onlyVisible);
         $this->rebuildStoreProductIndexPage($storeId, $collection, $page, $pageSize, null, $productIds, $useTmpIndex);
     }
 
@@ -928,7 +929,8 @@ class Data
      */
     protected function deleteInactiveIds($storeId, $objectIds, $indexName): void
     {
-        $collection = $this->productHelper->getProductCollectionQuery($storeId, $objectIds);
+        $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex($storeId);
+        $collection = $this->productHelper->getProductCollectionQuery($storeId, $objectIds, $onlyVisible);
         $dbIds = $collection->getAllIds();
         $collection = null;
         $idsToDeleteFromAlgolia = array_diff($objectIds, $dbIds);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -376,7 +376,8 @@ class Data
         $this->logger->start('Indexing');
         try {
             $this->logger->start('ok');
-            $collection = $this->productHelper->getProductCollectionQuery($storeId, $productIds);
+            $onlyVisible = $this->configHelper->includeNonVisibleProductsInIndex();
+            $collection = $this->productHelper->getProductCollectionQuery($storeId, $productIds, $onlyVisible);
             $size = $collection->getSize();
             if (!empty($productIds)) {
                 $size = max(count($productIds), $size);

--- a/Model/Indexer/Product.php
+++ b/Model/Indexer/Product.php
@@ -95,7 +95,8 @@ class Product implements \Magento\Framework\Indexer\ActionInterface, \Magento\Fr
             }
 
             $useTmpIndex = $this->configHelper->isQueueActive($storeId);
-            $collection = $this->productHelper->getProductCollectionQuery($storeId, $productIds, $useTmpIndex);
+            $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex();
+            $collection = $this->productHelper->getProductCollectionQuery($storeId, $productIds, $onlyVisible);
             $size = $collection->getSize();
 
             $pages = ceil($size / $productsPerPage);

--- a/ViewModel/Recommend/Cart.php
+++ b/ViewModel/Recommend/Cart.php
@@ -64,7 +64,8 @@ class Cart implements ArgumentInterface
             $cartItems[] = $item->getProductId();
         }
         $storeId = $this->storeManager->getStore()->getId();
-        $cartProductCollection = $this->productHelper->getProductCollectionQuery($storeId, array_unique($cartItems));
+        $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex();
+        $cartProductCollection = $this->productHelper->getProductCollectionQuery($storeId, array_unique($cartItems), $onlyVisible);
         if ($cartProductCollection->getSize() > 0 ){
             foreach ($cartProductCollection as $product) {
                 $visibleCartItem[] = $product->getId();

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -580,6 +580,13 @@
                         ]]>
                     </comment>
                 </field>
+                <field id="include_non_visible_products_in_index" translate="label comment" type="select" sortOrder="55" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Include non visible products in index</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        Include non visible products in index. Default value is <strong>No</strong>
+                    </comment>
+                </field>
                 <field id="category_page_id_attribute_name" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Category page ID attribute</label>
                     <comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -46,6 +46,7 @@
                 <custom_ranking_product_attributes><![CDATA[{"_1600352070901_901":{"attribute":"in_stock","order":"desc"},"_1600352075148_148":{"attribute":"ordered_qty","order":"desc"},"_1600352080300_300":{"attribute":"created_at","order":"desc"}}]]></custom_ranking_product_attributes>
                 <enable_visual_merchandising>0</enable_visual_merchandising>
                 <category_page_id_attribute_name>categoryPageId</category_page_id_attribute_name>
+                <include_non_visible_products_in_index>0</include_non_visible_products_in_index>
             </products>
         </algoliasearch_products>
         <algoliasearch_categories>


### PR DESCRIPTION
**Summary**
Include Non Visible Product to Index moved to admin configuration. Based on config settings product collection pulls items
<img width="1335" alt="Screenshot 2024-07-09 at 8 38 22 PM" src="https://github.com/algolia/algoliasearch-magento-2/assets/167926401/4915bbac-9e48-4019-9725-33a300fc0f6c">
