### PR TITLE
MAGE-958: release number increased and change log updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGE LOG
 
+## 3.13.5
+
+### Updates
+- Polyfill.io removed from CSP whitelist
+- Hide Recommend Titles when not in use
+- Incorporate community fix for higher specificity CSS selectors on Recommend
+
+### Bug Fixes
+- Incorporate community fix for missing DOM element selector
+
 ## 3.13.4
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## 3.13.5
 
 ### Updates
-- Polyfill.io removed from CSP whitelist
+- Polyfill.io removed from CSP whitelist - Thank you @hostep
 - Hide Recommend Titles when not in use
-- Incorporate community fix for higher specificity CSS selectors on Recommend
+- Incorporate community fix for higher specificity CSS selectors on Recommend - Thank you @sgeleon
 
 ### Bug Fixes
-- Incorporate community fix for missing DOM element selector
+- Incorporate community fix for missing DOM element selector - Thank you @sgeleon
 
 ## 3.13.4
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Algolia Search & Discovery extension for Magento 2
 ==================================================
 
-![Latest version](https://img.shields.io/badge/latest-3.13.4-green)
+![Latest version](https://img.shields.io/badge/latest-3.13.5-green)
 ![Magento 2](https://img.shields.io/badge/Magento-2.4.x-orange)
 
 ![PHP](https://img.shields.io/badge/PHP-8.2%2C8.1%2C7.4-blue)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.13.4",
+  "version": "3.13.5",
   "require": {
     "magento/framework": "~102.0|~103.0",
     "algolia/algoliasearch-client-php": "3.3.2",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.13.4">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.13.5">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
**Summary**
Release Notes:

Updates:
- Polyfill.io removed from CSP whitelist
- Hide Recommend Titles when not in use
- Incorporate community fix for higher specificity CSS selectors on Recommend

Bug Fix:
- Incorporate community fix for missing DOM element selector
