### PR TITLE
MAGE-6 Fix: recommend.js get null from script when script loading bef…

### DIFF
--- a/view/frontend/web/recommend.js
+++ b/view/frontend/web/recommend.js
@@ -8,107 +8,116 @@ define([
 ],function ($, algoliaBundle, recommend, recommendJs, recommendProductsHtml) {
     'use strict';
 
-    if (typeof algoliaConfig === 'undefined') {
-        return;
-    }
-
     return function (config, element) {
-        $(function ($) {
-            this.defaultIndexName = algoliaConfig.indexName + '_products';
-            const appId = algoliaConfig.applicationId;
-            const apiKey = algoliaConfig.apiKey;
-            const recommendClient = recommend(appId, apiKey);
-            const indexName = this.defaultIndexName;
-            if ($('body').hasClass('catalog-product-view') || $('body').hasClass('checkout-cart-index')) {
-                // --- Add the current product objectID here ---
-                if ((algoliaConfig.recommend.enabledFBT && $('body').hasClass('catalog-product-view')) || (algoliaConfig.recommend.enabledFBTInCart && $('body').hasClass('checkout-cart-index'))) {
-                    recommendJs.frequentlyBoughtTogether({
-                        container: '#frequentlyBoughtTogether',
-                        recommendClient,
-                        indexName,
-                        objectIDs: config.algoliObjectId,
-                        maxRecommendations: algoliaConfig.recommend.limitFBTProducts,
-                        transformItems:function (items) {
-                            return items.map((item, index) => ({
-                                ...item,
-                                position: index + 1,
-                            }));
-                        },
-                        headerComponent({html}) {
-                            return recommendProductsHtml.getHeaderHtml(html,algoliaConfig.recommend.FBTTitle);
-                        },
-                        itemComponent({item, html}) {
-                            return recommendProductsHtml.getItemHtml(item, html, algoliaConfig.recommend.isAddToCartEnabledInFBT);
-                        },
-                    });
-                }
-                if ((algoliaConfig.recommend.enabledRelated && $('body').hasClass('catalog-product-view')) || (algoliaConfig.recommend.enabledRelatedInCart && $('body').hasClass('checkout-cart-index'))) {
-                    recommendJs.relatedProducts({
-                        container: '#relatedProducts',
-                        recommendClient,
-                        indexName,
-                        objectIDs: config.algoliObjectId,
-                        maxRecommendations: algoliaConfig.recommend.limitRelatedProducts,
-                        transformItems:function (items) {
-                            return items.map((item, index) => ({
-                                ...item,
-                                position: index + 1,
-                            }));
-                        },
-                        headerComponent({html}) {
-                            return recommendProductsHtml.getHeaderHtml(html,algoliaConfig.recommend.relatedProductsTitle);
-                        },
-                        itemComponent({item, html}) {
-                            return recommendProductsHtml.getItemHtml(item, html, algoliaConfig.recommend.isAddToCartEnabledInRelatedProduct);
-                        },
-                    });
-                }
-            }
 
-            if ((algoliaConfig.recommend.isTrendItemsEnabledInPDP && $('body').hasClass('catalog-product-view')) || (algoliaConfig.recommend.isTrendItemsEnabledInCartPage && $('body').hasClass('checkout-cart-index'))) {
-                recommendJs.trendingItems({
-                    container: '#trendItems',
-                    facetName: algoliaConfig.recommend.trendItemFacetName ? algoliaConfig.recommend.trendItemFacetName : '',
-                    facetValue: algoliaConfig.recommend.trendItemFacetValue ? algoliaConfig.recommend.trendItemFacetValue : '',
-                    recommendClient,
-                    indexName,
-                    maxRecommendations: algoliaConfig.recommend.limitTrendingItems,
-                    transformItems:function (items) {
-                        return items.map((item, index) => ({
-                            ...item,
-                            position: index + 1,
-                        }));
-                    },
-                    headerComponent({html}) {
-                        return recommendProductsHtml.getHeaderHtml(html,algoliaConfig.recommend.trendingItemsTitle);
-                    },
-                    itemComponent({item, html}) {
-                        return recommendProductsHtml.getItemHtml(item, html, algoliaConfig.recommend.isAddToCartEnabledInTrendsItem);
-                    },
-                });
-            } else if (algoliaConfig.recommend.enabledTrendItems && typeof config.recommendTrendContainer !== "undefined") {
-                let containerValue = "#" + config.recommendTrendContainer;
-                recommendJs.trendingItems({
-                    container: containerValue,
-                    facetName: config.facetName ? config.facetName : '',
-                    facetValue: config.facetValue ? config.facetValue : '',
-                    recommendClient,
-                    indexName,
-                    maxRecommendations: config.numOfTrendsItem ? parseInt(config.numOfTrendsItem) : algoliaConfig.recommend.limitTrendingItems,
-                    transformItems:function (items) {
-                        return items.map((item, index) => ({
-                            ...item,
-                            position: index + 1,
-                        }));
-                    },
-                    headerComponent({html}) {
-                        return recommendProductsHtml.getHeaderHtml(html,algoliaConfig.recommend.trendingItemsTitle);
-                    },
-                    itemComponent({item, html}) {
-                        return recommendProductsHtml.getItemHtml(item, html, algoliaConfig.recommend.isAddToCartEnabledInTrendsItem);
-                    },
-                });
-            }
-        });
+        function checkerConfigLoading() {
+            if (typeof algoliaConfig === 'undefined')
+                setTimeout(checkerConfigLoading, '500')
+            else
+                exec()
+        }
+
+        function exec() {
+
+            $(function ($) {
+                this.defaultIndexName = algoliaConfig.indexName + '_products';
+                const appId = algoliaConfig.applicationId;
+                const apiKey = algoliaConfig.apiKey;
+                const recommendClient = recommend(appId, apiKey);
+                const indexName = this.defaultIndexName;
+                if ($('body').hasClass('catalog-product-view') || $('body').hasClass('checkout-cart-index')) {
+                    // --- Add the current product objectID here ---
+                    if ((algoliaConfig.recommend.enabledFBT && $('body').hasClass('catalog-product-view')) || (algoliaConfig.recommend.enabledFBTInCart && $('body').hasClass('checkout-cart-index'))) {
+                        recommendJs.frequentlyBoughtTogether({
+                            container: '#frequentlyBoughtTogether',
+                            recommendClient,
+                            indexName,
+                            objectIDs: config.algoliObjectId,
+                            maxRecommendations: algoliaConfig.recommend.limitFBTProducts,
+                            transformItems: function (items) {
+                                return items.map((item, index) => ({
+                                    ...item,
+                                    position: index + 1,
+                                }));
+                            },
+                            headerComponent({html}) {
+                                return recommendProductsHtml.getHeaderHtml(html, algoliaConfig.recommend.FBTTitle);
+                            },
+                            itemComponent({item, html}) {
+                                return recommendProductsHtml.getItemHtml(item, html, algoliaConfig.recommend.isAddToCartEnabledInFBT);
+                            },
+                        });
+                    }
+                    if ((algoliaConfig.recommend.enabledRelated && $('body').hasClass('catalog-product-view')) || (algoliaConfig.recommend.enabledRelatedInCart && $('body').hasClass('checkout-cart-index'))) {
+                        recommendJs.relatedProducts({
+                            container: '#relatedProducts',
+                            recommendClient,
+                            indexName,
+                            objectIDs: config.algoliObjectId,
+                            maxRecommendations: algoliaConfig.recommend.limitRelatedProducts,
+                            transformItems: function (items) {
+                                return items.map((item, index) => ({
+                                    ...item,
+                                    position: index + 1,
+                                }));
+                            },
+                            headerComponent({html}) {
+                                return recommendProductsHtml.getHeaderHtml(html, algoliaConfig.recommend.relatedProductsTitle);
+                            },
+                            itemComponent({item, html}) {
+                                return recommendProductsHtml.getItemHtml(item, html, algoliaConfig.recommend.isAddToCartEnabledInRelatedProduct);
+                            },
+                        });
+                    }
+                }
+
+                if ((algoliaConfig.recommend.isTrendItemsEnabledInPDP && $('body').hasClass('catalog-product-view')) || (algoliaConfig.recommend.isTrendItemsEnabledInCartPage && $('body').hasClass('checkout-cart-index'))) {
+                    recommendJs.trendingItems({
+                        container: '#trendItems',
+                        facetName: algoliaConfig.recommend.trendItemFacetName ? algoliaConfig.recommend.trendItemFacetName : '',
+                        facetValue: algoliaConfig.recommend.trendItemFacetValue ? algoliaConfig.recommend.trendItemFacetValue : '',
+                        recommendClient,
+                        indexName,
+                        maxRecommendations: algoliaConfig.recommend.limitTrendingItems,
+                        transformItems: function (items) {
+                            return items.map((item, index) => ({
+                                ...item,
+                                position: index + 1,
+                            }));
+                        },
+                        headerComponent({html}) {
+                            return recommendProductsHtml.getHeaderHtml(html, algoliaConfig.recommend.trendingItemsTitle);
+                        },
+                        itemComponent({item, html}) {
+                            return recommendProductsHtml.getItemHtml(item, html, algoliaConfig.recommend.isAddToCartEnabledInTrendsItem);
+                        },
+                    });
+                } else if (algoliaConfig.recommend.enabledTrendItems && typeof config.recommendTrendContainer !== "undefined") {
+                    let containerValue = "#" + config.recommendTrendContainer;
+                    recommendJs.trendingItems({
+                        container: containerValue,
+                        facetName: config.facetName ? config.facetName : '',
+                        facetValue: config.facetValue ? config.facetValue : '',
+                        recommendClient,
+                        indexName,
+                        maxRecommendations: config.numOfTrendsItem ? parseInt(config.numOfTrendsItem) : algoliaConfig.recommend.limitTrendingItems,
+                        transformItems: function (items) {
+                            return items.map((item, index) => ({
+                                ...item,
+                                position: index + 1,
+                            }));
+                        },
+                        headerComponent({html}) {
+                            return recommendProductsHtml.getHeaderHtml(html, algoliaConfig.recommend.trendingItemsTitle);
+                        },
+                        itemComponent({item, html}) {
+                            return recommendProductsHtml.getItemHtml(item, html, algoliaConfig.recommend.isAddToCartEnabledInTrendsItem);
+                        },
+                    });
+                }
+            });
+        }
+
+        checkerConfigLoading()
     }
 });


### PR DESCRIPTION
Hi.

I have seen your solution for when the configuration doesn't loading.

I think it’s not good because we can get other bugs if we use this module in other modules because we don’t have any guarantee that we will get object not null, for example:

require('Algolia_AlgoliaSearch/js/recommend.js',

```
function(recommend) {

    // recommend -> this is object or null ???

})
```

I think you should add some checker for it.

```

define([
    'jquery',
    'algoliaBundle',
    'recommend',
    'recommendJs',
    'recommendProductsHtml',
    'domReady!'
],function ($, algoliaBundle, recommend, recommendJs, recommendProductsHtml) {
    'use strict';

    return function (config, element) {

        function checkerConfigLoading() {
            if (typeof algoliaConfig === 'undefined')
                setTimeout(checkerConfigLoading, '500')
            else
                exec()
        }

        function exec() {

           ....

      }
});

```
      