### PR TITLE
MAGE-950: readme.md updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Try the autocomplete and the instantsearch results page on our [live demo](https
 
 We are happy to announce that version 3.x of our extension is now compatible with Magento 2.4. Review the [Customisation](https://github.com/algolia/algoliasearch-magento-2#customisation) section to learn more about the differences between our extension versions.
 
-| Extension Version | End of Life |
-|-------------------| --- |
-| v3.13.x           | N/A |
-| v3.14.x           | N/A |
+| Extension Version | End of Life | Magento  | PHP |
+|-------------------| --- |----------| ---------|
+| v3.13.x           | N/A | `2.4.x` | `^7.2 \|\| ^8.0` |
+| v3.14.x           | N/A | `2.4.x` | `>=8.1` |
 
 ## Documentation
 
@@ -87,10 +87,10 @@ The extension does most of the heavy lifting when it comes to gathering and prep
 
 Depending on the extension version you are using, you could have a different PHP API client version powering the extension's backend functionality.
 
-| Extension Version | API Client Version     | PHP              | Magento   |
-|-------------------|------------------------|------------------|-----------|
-| v3.13.x           | [3.3.2](https://github.com/algolia/algoliasearch-client-php/tree/3.3.2)           | `^7.2 \|\| ^8.0` | `2.4.x` |           
-| v3.14.x           | `4.0.x`                | `>=8.1`          | `2.4.x`   |
+| Extension Version | API Client Version     |
+|-------------------|------------------------|
+| v3.13.x           | [3.3.2](https://github.com/algolia/algoliasearch-client-php/tree/3.3.2)           |         
+| v3.14.x           | `4.0.x`                |
 
 Refer to these docs when customising your Algolia Magento extension backend:
 - [Indexing](https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/)

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ The extension does most of the heavy lifting when it comes to gathering and prep
 
 Depending on the extension version you are using, you could have a different PHP API client version powering the extension's backend functionality.
 
-| Extension Version | API Client Version     |
-|-------------------|------------------------|
-| v3.x              | [2.5.1](https://github.com/algolia/algoliasearch-client-php/tree/2.5.1)   |
-| v3.6.x            | [3.2.0](https://github.com/algolia/algoliasearch-client-php/tree/3.2.0)   |
-| v3.11.0          | [3.3.2](https://github.com/algolia/algoliasearch-client-php/tree/3.3.2)   |          
-| >=v3.14.x         | `4.0.x`                |
+| Extension Version | API Client Version                                                      |
+|-------------------|-------------------------------------------------------------------------|
+| v3.x              | [2.5.1](https://github.com/algolia/algoliasearch-client-php/tree/2.5.1) |
+| v3.6.x            | [3.2.0](https://github.com/algolia/algoliasearch-client-php/tree/3.2.0) |
+| v3.11.0          | [3.3.2](https://github.com/algolia/algoliasearch-client-php/tree/3.3.2) |          
+| >=v3.14.x         | [4.0.x](https://github.com/algolia/algoliasearch-client-php/tree/4.0.0-beta.12)                                                               |
 
 Refer to these docs when customising your Algolia Magento extension backend:
 - [Indexing](https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Try the autocomplete and the instantsearch results page on our [live demo](https
 
 ## Magento 2.4 compatibility & extension versions End of Life
 
-We are happy to announce that version 3.x of our extension is now compatible with Magento 2.4. Review the [Customisation](https://github.com/algolia/algoliasearch-magento-2#customisation) section to learn more about the differences between our extension versions.
+Magento 2.3 and earlier versions are no longer supported by the Algolia extension.
+
+Version 3.x of our extension is compatible with Magento 2.4. Review the [Customisation](https://github.com/algolia/algoliasearch-magento-2#customisation) section to learn more about the differences between our extension versions.
 
 | Extension Version | End of Life | Magento  | PHP |
 |-------------------| --- |----------| ---------|
@@ -69,9 +71,12 @@ Knowing the version of the library will help you understand what is available in
 
 | Extension Version | 	autocomplete.js                                                  | instantsearch.js                                                   | search-insights.js | recommend.js                                                |
 |-------------------|-------------------------------------------------------------------|--------------------------------------------------------------------| --- |-------------------------------------------------------------|
-| v3.13.x           | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.41.0](https://github.com/algolia/instantsearch.js/tree/v4.41.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.8.0](https://github.com/algolia/recommend/tree/v1.8.0)   |
-| v3.14.x           | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.63.0](https://github.com/algolia/instantsearch/tree/instantsearch.js%404.63.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.15.0](https://github.com/algolia/recommend/tree/v1.15.0) |
-
+| v3.x            | [0.38.0](https://github.com/algolia/autocomplete.js/tree/v0.38.0) | [4.15.0](https://github.com/algolia/instantsearch.js/tree/v4.15.0) | [1.7.1](https://github.com/algolia/search-insights.js/tree/v1.7.1) | NA |
+| v3.9.1          | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.41.0](https://github.com/algolia/instantsearch.js/tree/v4.41.0) | [1.7.1](https://github.com/algolia/search-insights.js/tree/v1.7.1) | [1.5.0](https://github.com/algolia/recommend/tree/v1.5.0) |
+| v3.10.x         | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.41.0](https://github.com/algolia/instantsearch.js/tree/v4.41.0) | [1.7.1](https://github.com/algolia/search-insights.js/tree/v1.7.1) | [1.8.0](https://github.com/algolia/recommend/tree/v1.8.0) |
+| v3.11.0         | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.41.0](https://github.com/algolia/instantsearch.js/tree/v4.41.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.8.0](https://github.com/algolia/recommend/tree/v1.8.0) |
+| v3.13.0          | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.63.0](https://github.com/algolia/instantsearch/tree/instantsearch.js%404.63.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.8.0](https://github.com/algolia/recommend/tree/v1.8.0) |
+| >=v3.14.x         | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.63.0](https://github.com/algolia/instantsearch/tree/instantsearch.js%404.63.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.15.0](https://github.com/algolia/recommend/tree/v1.15.0) |
 The autocomplete and instantsearch libraries are accessible in the `algoliaBundle` global. This bundle is a prepackage javascript file that contains it's dependencies. What is included in this bundle can be seen here:
 
 The search-insights.js library is standalone.
@@ -89,8 +94,10 @@ Depending on the extension version you are using, you could have a different PHP
 
 | Extension Version | API Client Version     |
 |-------------------|------------------------|
-| v3.13.x           | [3.3.2](https://github.com/algolia/algoliasearch-client-php/tree/3.3.2)           |         
-| v3.14.x           | `4.0.x`                |
+| v3.x              | [2.5.1](https://github.com/algolia/algoliasearch-client-php/tree/2.5.1)   |
+| v3.6.x            | [3.2.0](https://github.com/algolia/algoliasearch-client-php/tree/3.2.0)   |
+| v3.11.0          | [3.3.2](https://github.com/algolia/algoliasearch-client-php/tree/3.3.2)   |          
+| >=v3.14.x         | `4.0.x`                |
 
 Refer to these docs when customising your Algolia Magento extension backend:
 - [Indexing](https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/)

--- a/README.md
+++ b/README.md
@@ -33,13 +33,10 @@ Try the autocomplete and the instantsearch results page on our [live demo](https
 
 We are happy to announce that version 3.x of our extension is now compatible with Magento 2.4. Review the [Customisation](https://github.com/algolia/algoliasearch-magento-2#customisation) section to learn more about the differences between our extension versions.
 
-The 1.x and 2.x versions of the extension are now End of Life (EOL). We no longer accept community PRs for those branches. 
-
 | Extension Version | End of Life |
-| --- | --- |
-| v1.x | Dec 2020 |
-| v2.x | Dec 2020 |
-| v3.x | N/A |
+|-------------------| --- |
+| v3.13.x           | N/A |
+| v3.14.x           | N/A |
 
 ## Documentation
 
@@ -55,14 +52,6 @@ The 1.x and 2.x versions of the extension are now End of Life (EOL). We no longe
 
 The easiest way to install the extension is to use [Composer](https://getcomposer.org/) and follow our [getting started guide](https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/).
 
-### Upgrading from 1.x to 2.x
-
-With the release of a new major version, we have decided to create minor and major version releases to allow those that want to continue on the minor version. This update will **break compatibility**. Please read the [upgrade guide](https://www.algolia.com/doc/integration/magento-2/getting-started/upgrading/#upgrading-from-v1-to-v2) for all of the file changes and updates included in this release. 
-
-If you would like to stay on a minor version, please upgrade your composer to only accept versions less than version 2 like the example:
-
-`"algolia/algoliasearch-magento-2": "3.12.0"`
-
 ### Customisation
 
 The extension uses libraries to help assist with the frontend implementation for autocomplete, instantsearch, and insight features. It also uses the Algolia PHP client to leverage indexing and search methods from the backend. When you approach customisations for either, you have to understand that you are customising the implementation itself and not the components it is based on.
@@ -74,21 +63,12 @@ Please check our [Custom Extension](https://github.com/algolia/algoliasearch-cus
 
 Knowing the version of the library will help you understand what is available in these libraries for you to leverage in terms of customisation. This table will help you determine which documentation to reference when you start working on your customisation.
 
-| Extension Version | 	autocomplete.js                                                  | instantsearch.js                                                   | search-insights.js | recommend.js |
-|-----------------|-------------------------------------------------------------------|--------------------------------------------------------------------| --- | --- |
-| v1.x            | [0.26.0](https://github.com/algolia/autocomplete.js/tree/v0.26.0) | [2.10.2](https://github.com/algolia/instantsearch.js/tree/v2.10.2) | [0.0.14](https://cdn.jsdelivr.net/npm/search-insights@0.0.14) | NA |
-| v2.x            | [0.38.0](https://github.com/algolia/autocomplete.js/tree/v0.38.0) | [4.7.2](https://github.com/algolia/instantsearch.js/tree/v4.7.2)   | [1.4.0](https://github.com/algolia/search-insights.js/tree/v1.4.0) | NA |
-| v3.x            | [0.38.0](https://github.com/algolia/autocomplete.js/tree/v0.38.0) | [4.15.0](https://github.com/algolia/instantsearch.js/tree/v4.15.0) | [1.7.1](https://github.com/algolia/search-insights.js/tree/v1.7.1) | NA |
-| v3.9.1          | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.41.0](https://github.com/algolia/instantsearch.js/tree/v4.41.0) | [1.7.1](https://github.com/algolia/search-insights.js/tree/v1.7.1) | [1.5.0](https://github.com/algolia/recommend/tree/v1.5.0) |
-| v3.10.x         | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.41.0](https://github.com/algolia/instantsearch.js/tree/v4.41.0) | [1.7.1](https://github.com/algolia/search-insights.js/tree/v1.7.1) | [1.8.0](https://github.com/algolia/recommend/tree/v1.8.0) |
-| v3.11.0         | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.41.0](https://github.com/algolia/instantsearch.js/tree/v4.41.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.8.0](https://github.com/algolia/recommend/tree/v1.8.0) |
-| >=v3.13.0        | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.63.0](https://github.com/algolia/instantsearch/tree/instantsearch.js%404.63.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.8.0](https://github.com/algolia/recommend/tree/v1.8.0) |
-
+| Extension Version | 	autocomplete.js                                                  | instantsearch.js                                                   | search-insights.js | recommend.js                                                |
+|-------------------|-------------------------------------------------------------------|--------------------------------------------------------------------| --- |-------------------------------------------------------------|
+| v3.13.x           | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.41.0](https://github.com/algolia/instantsearch.js/tree/v4.41.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.8.0](https://github.com/algolia/recommend/tree/v1.8.0)   |
+| v3.14.x           | [1.6.3](https://github.com/algolia/autocomplete.js/tree/v1.6.3)   | [4.63.0](https://github.com/algolia/instantsearch/tree/instantsearch.js%404.63.0) | [2.6.0](https://github.com/algolia/search-insights.js/tree/v2.6.0) | [1.15.0](https://github.com/algolia/recommend/tree/v1.15.0) |
 
 The autocomplete and instantsearch libraries are accessible in the `algoliaBundle` global. This bundle is a prepackage javascript file that contains it's dependencies. What is included in this bundle can be seen here:
-
-v1.x latest bundle: https://github.com/algolia/algoliasearch-extensions-bundle/blob/ISv2/package.json \
-v2.x latest bundle: https://github.com/algolia/algoliasearch-extensions-bundle/blob/ISv4/package.json
 
 The search-insights.js library is standalone.
 
@@ -103,13 +83,10 @@ The extension does most of the heavy lifting when it comes to gathering and prep
 
 Depending on the extension version you are using, you could have a different PHP API client version powering the extension's backend functionality.
 
-| Extension Version | API Client Version                                                        |
-|-------------------|---------------------------------------------------------------------------|
-| v1.x              | [1.28.0](https://github.com/algolia/algoliasearch-client-php/tree/1.28.0) |
-| v2.x              | [2.5.1](https://github.com/algolia/algoliasearch-client-php/tree/2.5.1)   |
-| v3.x              | [2.5.1](https://github.com/algolia/algoliasearch-client-php/tree/2.5.1)   |
-| v3.6.x            | [3.2.0](https://github.com/algolia/algoliasearch-client-php/tree/3.2.0)   |
-| >= v3.11.0        | [3.3.2](https://github.com/algolia/algoliasearch-client-php/tree/3.3.2)   |
+| Extension Version | API Client Version     | PHP              | Magento   |
+|-------------------|------------------------|------------------|-----------|
+| v3.13.x           | [3.3.2](https://github.com/algolia/algoliasearch-client-php/tree/3.3.2)           | `^7.2 \|\| ^8.0` | `2.4.x` |           
+| v3.14.x           | `4.0.x`                | `>=8.1`          | `2.4.x`   |
 
 Refer to these docs when customising your Algolia Magento extension backend:
 - [Indexing](https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing/)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ We are happy to announce that version 3.x of our extension is now compatible wit
 
 The easiest way to install the extension is to use [Composer](https://getcomposer.org/) and follow our [getting started guide](https://www.algolia.com/doc/integration/magento-2/getting-started/quick-start/).
 
+If you would like to stay on a minor version, please upgrade your composer to only accept minor versions. The following example will keep you on the minor version and will update patches automatically.
+
+`"algolia/algoliasearch-magento-2": "~3.14.0"`
+
 ### Customisation
 
 The extension uses libraries to help assist with the frontend implementation for autocomplete, instantsearch, and insight features. It also uses the Algolia PHP client to leverage indexing and search methods from the backend. When you approach customisations for either, you have to understand that you are customising the implementation itself and not the components it is based on.


### PR DESCRIPTION
**Summary**

Readme.md updated as follows:

- Since 1.x and 2.x reached EOL, all documentation related to those versions removed.
- PHP and Magento compatible versions included