### PR TITLE
MAGE-891: Handle tokens expiration

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -81,6 +81,7 @@ class ConfigHelper
     public const CC_ANALYTICS_IS_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/is_selector';
     public const CC_CONVERSION_ANALYTICS_MODE = 'algoliasearch_cc_analytics/cc_analytics_group/conversion_analytics_mode';
     public const CC_ADD_TO_CART_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector';
+    public const COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
 
     public const GA_ENABLE = 'algoliasearch_analytics/analytics_group/enable';
     public const GA_DELAY = 'algoliasearch_analytics/analytics_group/delay';
@@ -141,7 +142,7 @@ class ConfigHelper
     protected const IS_LOOKING_SIMILAR_ENABLED_IN_PDP = 'algoliasearch_recommend/recommend/looking_similar/is_looking_similar_enabled_on_pdp';
     protected const IS_LOOKING_SIMILAR_ENABLED_IN_SHOPPING_CART = 'algoliasearch_recommend/recommend/looking_similar/is_looking_similar_enabled_on_cart_page';
     protected const LOOKING_SIMILAR_TITLE = 'algoliasearch_recommend/recommend/looking_similar/title';
-    public const LEGACY_USE_VIRTUAL_REPLICA_ENABLED = 'algoliasearch_instant/instant/use_virtual_replica'; 
+    public const LEGACY_USE_VIRTUAL_REPLICA_ENABLED = 'algoliasearch_instant/instant/use_virtual_replica';
     protected const AUTOCOMPLETE_KEYBORAD_NAVIAGATION = 'algoliasearch_autocomplete/autocomplete/navigator';
     protected const FREQUENTLY_BOUGHT_TOGETHER_TITLE = 'algoliasearch_recommend/recommend/frequently_bought_together/title';
     protected const RELATED_PRODUCTS_TITLE = 'algoliasearch_recommend/recommend/related_product/title';
@@ -1855,5 +1856,14 @@ class ConfigHelper
     public function isCookieRestrictionModeEnabled()
     {
         return (bool)$this->cookieHelper->isCookieRestrictionModeEnabled();
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getCookieLifetime($storeId = null)
+    {
+        return $this->configInterface->getValue(self::COOKIE_LIFETIME, ScopeInterface::SCOPE_STORE, $storeId);
     }
 }

--- a/Helper/InsightsHelper.php
+++ b/Helper/InsightsHelper.php
@@ -158,6 +158,30 @@ class InsightsHelper
     }
 
     /**
+     * Sets a token for a non-authenticated user
+     *
+     * @return void
+     */
+    public function setNonAuthenticatedUserToken(): void
+    {
+        $metaData = $this->cookieMetadataFactory->createPublicCookieMetadata()
+            ->setDuration($this->configHelper->getCookieLifetime())
+            ->setPath('/')
+            ->setHttpOnly(false)
+            ->setSecure(false);
+
+        try {
+            $this->cookieManager->setPublicCookie(
+                InsightsHelper::ALGOLIA_ANON_USER_TOKEN_COOKIE_NAME,
+                (string) $this->cookieManager->getCookie(InsightsHelper::ALGOLIA_ANON_USER_TOKEN_COOKIE_NAME),
+                $metaData
+            );
+        } catch (LocalizedException $e) {
+            $this->logger->error("Error writing anonymous user cookie: " . $e->getMessage());
+        }
+    }
+
+    /**
      * @param int|null $storeId
      * @return bool
      */

--- a/Helper/InsightsHelper.php
+++ b/Helper/InsightsHelper.php
@@ -142,7 +142,7 @@ class InsightsHelper
         $userToken = $this->generateAuthenticatedUserToken($customer);
 
         $metaData = $this->cookieMetadataFactory->createPublicCookieMetadata()
-            ->setDurationOneYear()
+            ->setDuration($this->configHelper->getCookieLifetime())
             ->setPath('/')
             ->setHttpOnly(false)
             ->setSecure(false);

--- a/Helper/InsightsHelper.php
+++ b/Helper/InsightsHelper.php
@@ -28,9 +28,6 @@ class InsightsHelper
     /** @var int */
     public const ALGOLIA_USER_TOKEN_MAX_LENGTH = 64;
 
-    /** @var int */
-    public const ALGOLIA_USER_TOKEN_DEFAULT_LIFETIME = 15768000; // 6 months
-
     /** @var string */
     public const QUOTE_ITEM_QUERY_PARAM = 'algoliasearch_query_param';
 
@@ -158,30 +155,6 @@ class InsightsHelper
         }
 
         return $userToken;
-    }
-
-    /**
-     * Sets a token for a non-authenticated user
-     *
-     * @return void
-     */
-    public function setNonAuthenticatedUserToken(): void
-    {
-        $metaData = $this->cookieMetadataFactory->createPublicCookieMetadata()
-            ->setDuration(InsightsHelper::ALGOLIA_USER_TOKEN_DEFAULT_LIFETIME)
-            ->setPath('/')
-            ->setHttpOnly(false)
-            ->setSecure(false);
-
-        try {
-            $this->cookieManager->setPublicCookie(
-                InsightsHelper::ALGOLIA_ANON_USER_TOKEN_COOKIE_NAME,
-                (string) $this->cookieManager->getCookie(InsightsHelper::ALGOLIA_ANON_USER_TOKEN_COOKIE_NAME),
-                $metaData
-            );
-        } catch (LocalizedException $e) {
-            $this->logger->error("Error writing anonymous user cookie: " . $e->getMessage());
-        }
     }
 
     /**

--- a/Helper/InsightsHelper.php
+++ b/Helper/InsightsHelper.php
@@ -28,6 +28,9 @@ class InsightsHelper
     /** @var int */
     public const ALGOLIA_USER_TOKEN_MAX_LENGTH = 64;
 
+    /** @var int */
+    public const ALGOLIA_USER_TOKEN_DEFAULT_LIFETIME = 15768000; // 6 months
+
     /** @var string */
     public const QUOTE_ITEM_QUERY_PARAM = 'algoliasearch_query_param';
 
@@ -165,7 +168,7 @@ class InsightsHelper
     public function setNonAuthenticatedUserToken(): void
     {
         $metaData = $this->cookieMetadataFactory->createPublicCookieMetadata()
-            ->setDuration($this->configHelper->getCookieLifetime())
+            ->setDuration(InsightsHelper::ALGOLIA_USER_TOKEN_DEFAULT_LIFETIME)
             ->setPath('/')
             ->setHttpOnly(false)
             ->setSecure(false);

--- a/Observer/Insights/CookieRefresherObserver.php
+++ b/Observer/Insights/CookieRefresherObserver.php
@@ -32,8 +32,6 @@ class CookieRefresherObserver implements ObserverInterface
     {
         if ($this->customerSession->isLoggedIn()) {
             $this->insightsHelper->setAuthenticatedUserToken($this->customerSession->getCustomer());
-        } else {
-            $this->insightsHelper->setNonAuthenticatedUserToken();
         }
     }
 }

--- a/Observer/Insights/CookieRefresherObserver.php
+++ b/Observer/Insights/CookieRefresherObserver.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Observer\Insights;
+
+use Algolia\AlgoliaSearch\Helper\InsightsHelper;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class CookieRefresherObserver implements ObserverInterface
+{
+    /**
+     * CookieRefresherObserver observer constructor.
+     *
+     * @param CustomerSession  $customerSession
+     * @param InsightsHelper $insightsHelper
+     *
+     */
+    public function __construct(
+        private readonly CustomerSession  $customerSession,
+        private readonly InsightsHelper $insightsHelper,
+    ) {}
+
+    /**
+     * Renew anonymous or customer session token to update the lifetime
+     *
+     * @param Observer $observer
+     *
+     * @return void
+     */
+    public function execute(Observer $observer): void
+    {
+        if ($this->customerSession->isLoggedIn()) {
+            $this->insightsHelper->setAuthenticatedUserToken($this->customerSession->getCustomer());
+        } else {
+            $this->insightsHelper->setNonAuthenticatedUserToken();
+        }
+    }
+}

--- a/Observer/Insights/CustomerLogout.php
+++ b/Observer/Insights/CustomerLogout.php
@@ -47,6 +47,7 @@ class CustomerLogout implements ObserverInterface
             try {
                 $this->cookieManager->setPublicCookie(self::UNSET_AUTHENTICATION_USER_TOKEN_COOKIE_NAME, 1, $metaDataUnset);
                 $this->cookieManager->deleteCookie(InsightsHelper::ALGOLIA_CUSTOMER_USER_TOKEN_COOKIE_NAME, $metadata);
+                $this->cookieManager->deleteCookie(InsightsHelper::ALGOLIA_ANON_USER_TOKEN_COOKIE_NAME, $metadata);
             } catch (LocalizedException $e) {
                 $this->logger->error("Error writing Algolia customer cookies: " . $e->getMessage());
             }

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -32,4 +32,7 @@
     <event name="catalog_controller_product_init_after">
         <observer name="algoliasearch_current_product" instance="Algolia\AlgoliaSearch\Observer\RegisterCurrentProductObserver"/>
     </event>
+    <event name="controller_action_predispatch">
+        <observer name="algoliasearch_cookie_refresher" instance="Algolia\AlgoliaSearch\Observer\Insights\CookieRefresherObserver" shared="false" />
+    </event>
 </config>


### PR DESCRIPTION
Ensure authenticated and non-authenticated tokens lifetime:
On page load If the customer is logged in, we renew `_ALGOLIA_MAGENTO_AUTH`

In such case, the `web/cookie/cookie_lifetime` value from admin is applied to follow the `PHPSSESID` cookie lifetime