### PR TITLE
Feature/mage 962 - Integration test fix

### DIFF
--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -23,11 +23,11 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
     protected const UNUSED_OPTION_SHORTCUT = 'u';
 
     public function __construct(
-        protected ReplicaManagerInterface $replicaManager,
-        protected StoreManagerInterface   $storeManager,
-        State                             $state,
-        StoreNameFetcher                  $storeNameFetcher,
-        ?string                           $name = null
+        protected ReplicaManagerInterface\Proxy $replicaManager,
+        protected StoreManagerInterface         $storeManager,
+        State                                   $state,
+        StoreNameFetcher                        $storeNameFetcher,
+        ?string                                 $name = null
     )
     {
         parent::__construct($state, $storeNameFetcher, $name);

--- a/Console/Command/ReplicaDisableVirtualCommand.php
+++ b/Console/Command/ReplicaDisableVirtualCommand.php
@@ -25,18 +25,18 @@ class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements Rep
     use ReplicaSyncCommandTrait;
 
     public function __construct(
-        protected WriterInterface           $configWriter,
-        protected ConfigChecker             $configChecker,
-        protected ReinitableConfigInterface $scopeConfig,
-        protected SerializerInterface       $serializer,
-        protected ConfigHelper              $configHelper,
-        protected CacheManager              $cacheManager,
-        protected ReplicaManagerInterface   $replicaManager,
-        protected StoreManagerInterface     $storeManager,
-        protected ProductHelper             $productHelper,
-        State                               $state,
-        StoreNameFetcher                    $storeNameFetcher,
-        ?string                             $name = null
+        protected WriterInterface               $configWriter,
+        protected ConfigChecker                 $configChecker,
+        protected ReinitableConfigInterface     $scopeConfig,
+        protected SerializerInterface           $serializer,
+        protected ConfigHelper\Proxy            $configHelper,
+        protected CacheManager                  $cacheManager,
+        protected ReplicaManagerInterface\Proxy $replicaManager,
+        protected StoreManagerInterface         $storeManager,
+        protected ProductHelper\Proxy           $productHelper,
+        State                                   $state,
+        StoreNameFetcher                        $storeNameFetcher,
+        ?string                                 $name = null
     )
     {
         parent::__construct($state, $storeNameFetcher, $name);

--- a/Console/Command/ReplicaRebuildCommand.php
+++ b/Console/Command/ReplicaRebuildCommand.php
@@ -26,13 +26,13 @@ class ReplicaRebuildCommand
     use ReplicaDeleteCommandTrait;
 
     public function __construct(
-        protected ProductHelper           $productHelper,
-        protected ReplicaManagerInterface $replicaManager,
-        protected StoreManagerInterface   $storeManager,
-        protected ReplicaState            $replicaState,
-        AppState                          $appState,
-        StoreNameFetcher                  $storeNameFetcher,
-        ?string                           $name = null
+        protected ProductHelper\Proxy           $productHelper,
+        protected ReplicaManagerInterface\Proxy $replicaManager,
+        protected StoreManagerInterface         $storeManager,
+        protected ReplicaState                  $replicaState,
+        AppState                                $appState,
+        StoreNameFetcher                        $storeNameFetcher,
+        ?string                                 $name = null
     )
     {
         parent::__construct($appState, $storeNameFetcher, $name);

--- a/Console/Command/ReplicaSyncCommand.php
+++ b/Console/Command/ReplicaSyncCommand.php
@@ -24,13 +24,12 @@ class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCo
     use ReplicaSyncCommandTrait;
 
     public function __construct(
-
-        protected ProductHelper           $productHelper,
-        protected ReplicaManagerInterface $replicaManager,
-        protected StoreManagerInterface   $storeManager,
-        State                             $state,
-        StoreNameFetcher                  $storeNameFetcher,
-        ?string                           $name = null
+        protected ProductHelper\Proxy           $productHelper,
+        protected ReplicaManagerInterface\Proxy $replicaManager,
+        protected StoreManagerInterface         $storeManager,
+        State                                   $state,
+        StoreNameFetcher                        $storeNameFetcher,
+        ?string                                 $name = null
     )
     {
         parent::__construct($state, $storeNameFetcher, $name);


### PR DESCRIPTION
This issue was identified by integration testing. 

During `setup:install`, Magento will perform dependency injection for all CLI commands. Unfortunately, if any constructor dependencies ultimately depend on the store manager this will trigger the dependency chain prematurely leading to the following error:

```
Base table or view not found: 1146 Table 'magento_integration_tests.flag' doesn't exist
```

By switching to proxies these dependencies are deferred until needed. 

NOTE: If not able to add to 3.14.0 let's tag for 3.14.1. 