### PR TITLE
Fixing get category collection when two root categories start with th…

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -180,7 +180,7 @@ class CategoryHelper
     {
         /** @var \Magento\Store\Model\Store $store */
         $store = $this->storeManager->getStore($storeId);
-        $storeRootCategoryPath = sprintf('%d/%d', $this->getRootCategoryId(), $store->getRootCategoryId());
+        $storeRootCategoryPath = sprintf('%d/%d/', $this->getRootCategoryId(), $store->getRootCategoryId());
 
         $unserializedCategorysAttrs = $this->getAdditionalAttributes($storeId);
         $additionalAttr = array_column($unserializedCategorysAttrs, 'attribute');


### PR DESCRIPTION
Problem:
When we create a new category inside the root category, the category's index is being created in the other store_view besides the one we created.

We have the stores
Store Test 01 (id: 1 and root_category_id: 2)
Store Test 02 (id: 8 and root_category_id: 2258)

The problem happens when we created a new category (id 2910) on Store Test 02.

When Algolia's code tries to get Category collection for Store Test 01 it SHOULD return an empty result and it's returning one result.

This is happening because Algolia's code for Magento is getting the category collection filtering with the regexp 1/2.
Since the root category of both stores starts with 2, it will get the wrong result.
Example in the image below:
![image](https://github.com/user-attachments/assets/cb38deed-6241-4ea6-88eb-14604bf9f014)


Impacts of the problem:
The category is created on the index of the store correctly, but with the base url from the first store:
![image](https://github.com/user-attachments/assets/05269bb0-423a-4469-8d58-11344fe4a92d)

The category is created on the index of the first store when it should not:
![image](https://github.com/user-attachments/assets/e38cc672-e2c5-437d-8fd3-5f748c9fdbd9)


Solving the problem:
Since Algolia is trying to get the Category collection for that root category the regexp MUST be "1/2/" instead of "1/2"


Evidence of success:

We executed the code below to show that our solution is working.
We simulated the get category collection with our fixing and with the original code.
```
<?php

use Magento\Framework\App\Bootstrap;

$home_dir = '/app/';

require $home_dir . '/app/bootstrap.php';
$bootstrap = Bootstrap::create(BP, $_SERVER);
$obj = $bootstrap->getObjectManager();
$state = $obj->get('Magento\Framework\App\State');
$state->setAreaCode('frontend');

function getCategoryCollectionQuery($storeId, $categoryIds = null, $objManager, $rootCategory, $storeCategory, $path = '')
{
   $storeRootCategoryPath = sprintf("%d/%d{$path}", $rootCategory, $storeCategory);

   $categoryCollectionFactory = $objManager->get('Magento\Catalog\Model\ResourceModel\Category\CollectionFactory');

   $categories = $categoryCollectionFactory->create()
      ->distinct(true)
      ->addNameToResult()
      ->setStoreId($storeId)
      ->addUrlRewriteToResult()
      ->addAttributeToFilter('level', ['gt' => 1])
      ->addPathFilter($storeRootCategoryPath)
      ->addAttributeToSelect(array_merge(['is_active', 'include_in_menu']))
      ->addOrderField('entity_id');

   if ($categoryIds) {
      $categories->addAttributeToFilter('entity_id', ['in' => $categoryIds]);
   }

   return $categories;
}

$storeId = 8;
$categoryIds = [2910];

$colection = getCategoryCollectionQuery($storeId, $categoryIds, $obj, 1, 2258);

echo "Store id {$storeId}" . PHP_EOL;
foreach ($colection as $category) {
   print_r($category->getData());
}

$colection = getCategoryCollectionQuery($storeId, $categoryIds, $obj, 1, 2258, '/');

echo "Store id {$storeId} with / in end path" . PHP_EOL;
foreach ($colection as $category) {
   print_r($category->getData());
}

$storeId = 1;

$colection = getCategoryCollectionQuery($storeId, $categoryIds, $obj, 1, 2);

echo "Store id {$storeId}" . PHP_EOL;
foreach ($colection as $category) {
   print_r($category->getData());
}

$colection = getCategoryCollectionQuery($storeId, $categoryIds, $obj, 1, 2, '/');

echo "Store id {$storeId} with / in end path" . PHP_EOL;
foreach ($colection as $category) {
   print_r($category->getData());
}
```

And the result was:

```
Store id 8
Array
(
    [entity_id] => 2910
    [attribute_set_id] => 3
    [parent_id] => 2258
    [created_at] => 2024-08-06 16:21:06
    [updated_at] => 2024-08-06 17:23:11
    [path] => 1/2258/2910
    [position] => 16
    [level] => 2
    [children_count] => 0
    [row_id] => 3105
    [created_in] => 1
    [updated_in] => 2147483647
    [request_path] => teste-ti-final
    [name] => Teste TI Final 2
    [is_active] => 1
    [include_in_menu] => 0
)
Store id 8 with / in end path
Array
(
    [entity_id] => 2910
    [attribute_set_id] => 3
    [parent_id] => 2258
    [created_at] => 2024-08-06 16:21:06
    [updated_at] => 2024-08-06 17:23:11
    [path] => 1/2258/2910
    [position] => 16
    [level] => 2
    [children_count] => 0
    [row_id] => 3105
    [created_in] => 1
    [updated_in] => 2147483647
    [request_path] => teste-ti-final
    [name] => Teste TI Final 2
    [is_active] => 1
    [include_in_menu] => 0
)
Store id 1
Array
(
    [entity_id] => 2910
    [attribute_set_id] => 3
    [parent_id] => 2258
    [created_at] => 2024-08-06 16:21:06
    [updated_at] => 2024-08-06 17:23:11
    [path] => 1/2258/2910
    [position] => 16
    [level] => 2
    [children_count] => 0
    [row_id] => 3105
    [created_in] => 1
    [updated_in] => 2147483647
    [request_path] => 
    [name] => Teste TI Final 2
    [is_active] => 1
    [include_in_menu] => 0
)
Store id 1 with / in end path

```
