### PR TITLE
MAGE-928: Fix generated url for insights

### DIFF
--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -210,7 +210,7 @@ define([
                     indexName: hit.__autocomplete_indexName,
                 });
                 if (hit.url.indexOf('?') > -1) {
-                    hit.urlForInsights += insightsDataUrlString;
+                    hit.urlForInsights += '&' + insightsDataUrlString;
                 } else {
                     hit.urlForInsights += '?' + insightsDataUrlString;
                 }

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -237,7 +237,7 @@ define(['jquery', 'algoliaBundle'], function ($, algoliaBundle) {
                     indexName: hit.__indexName
                 });
                 if (hit.url.indexOf('?') > -1) {
-                    hit.urlForInsights += insightsDataUrlString
+                    hit.urlForInsights += '&' + insightsDataUrlString;
                 } else {
                     hit.urlForInsights += '?' + insightsDataUrlString;
                 }


### PR DESCRIPTION
The URL formatted for Insights does not handle the case where URL already has parameters (which includes a "?"), this fix adds a "&" prior to the generated string in such case.  (see related ticket in MAGE-928). 