### PR TITLE
MAGE-928: Fix generated url for insights (3.13.6)

### DIFF
--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -210,7 +210,7 @@ define([
                     indexName: hit.__autocomplete_indexName,
                 });
                 if (hit.url.indexOf('?') > -1) {
-                    hit.urlForInsights += insightsDataUrlString;
+                    hit.urlForInsights += '&' + insightsDataUrlString;
                 } else {
                     hit.urlForInsights += '?' + insightsDataUrlString;
                 }

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -237,7 +237,7 @@ define(['jquery', 'algoliaBundle'], function ($, algoliaBundle) {
                     indexName: hit.__indexName
                 });
                 if (hit.url.indexOf('?') > -1) {
-                    hit.urlForInsights += insightsDataUrlString
+                    hit.urlForInsights += '&' + insightsDataUrlString;
                 } else {
                     hit.urlForInsights += '?' + insightsDataUrlString;
                 }


### PR DESCRIPTION
backport this change (https://github.com/algolia/algoliasearch-magento-2/pull/1583) for 3.13.6.