### PR TITLE
Quickfix: Remove a warning during the indexing of entities with no `created_at` attribute

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -593,7 +593,9 @@ class AlgoliaHelper extends AbstractHelper
         foreach ($objects as $key => &$object) {
             $object['algoliaLastUpdateAtCET'] = $currentCET;
             // Convert created_at to UTC timestamp
-            $object['created_at'] = strtotime($object['created_at']);
+            if (isset($object['created_at'])) {
+                $object['created_at'] = strtotime($object['created_at']);
+            }
 
             $previousObject = $object;
 


### PR DESCRIPTION
While performing a category reindexing in the console, I noticed an unwanted warning related to a missing check on the `created_at` attribute.

![image](https://github.com/user-attachments/assets/24444e4e-2cad-4194-8bff-e7269197cc7b)


This should fix it.