### PR TITLE
Prevent unexisting created_at key

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -593,7 +593,7 @@ class AlgoliaHelper extends AbstractHelper
         foreach ($objects as $key => &$object) {
             $object['algoliaLastUpdateAtCET'] = $currentCET;
             // Convert created_at to UTC timestamp
-            $object['created_at'] = strtotime($object['created_at']);
+            $object['created_at'] = strtotime($object['created_at'] ?? 'now');
 
             $previousObject = $object;
 


### PR DESCRIPTION
This change introduce a critical error on indexing: https://github.com/algolia/algoliasearch-magento-2/commit/c4352abcbad4814822b3a721f5dd2342bae04f06

In some scenarios, the data may not have a 'created_at' field.