### PR TITLE
MAGE-1010 Fix Magento coding standards error with proxy injection

### DIFF
--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -23,11 +23,11 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
     protected const UNUSED_OPTION_SHORTCUT = 'u';
 
     public function __construct(
-        protected ReplicaManagerInterface\Proxy $replicaManager,
-        protected StoreManagerInterface         $storeManager,
-        State                                   $state,
-        StoreNameFetcher                        $storeNameFetcher,
-        ?string                                 $name = null
+        protected ReplicaManagerInterface $replicaManager,
+        protected StoreManagerInterface   $storeManager,
+        State                             $state,
+        StoreNameFetcher                  $storeNameFetcher,
+        ?string                           $name = null
     )
     {
         parent::__construct($state, $storeNameFetcher, $name);

--- a/Console/Command/ReplicaDisableVirtualCommand.php
+++ b/Console/Command/ReplicaDisableVirtualCommand.php
@@ -25,18 +25,18 @@ class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements Rep
     use ReplicaSyncCommandTrait;
 
     public function __construct(
-        protected WriterInterface               $configWriter,
-        protected ConfigChecker                 $configChecker,
-        protected ReinitableConfigInterface     $scopeConfig,
-        protected SerializerInterface           $serializer,
-        protected ConfigHelper\Proxy            $configHelper,
-        protected CacheManager                  $cacheManager,
-        protected ReplicaManagerInterface\Proxy $replicaManager,
-        protected StoreManagerInterface         $storeManager,
-        protected ProductHelper\Proxy           $productHelper,
-        State                                   $state,
-        StoreNameFetcher                        $storeNameFetcher,
-        ?string                                 $name = null
+        protected WriterInterface           $configWriter,
+        protected ConfigChecker             $configChecker,
+        protected ReinitableConfigInterface $scopeConfig,
+        protected SerializerInterface       $serializer,
+        protected ConfigHelper              $configHelper,
+        protected CacheManager              $cacheManager,
+        protected ReplicaManagerInterface   $replicaManager,
+        protected StoreManagerInterface     $storeManager,
+        protected ProductHelper             $productHelper,
+        State                               $state,
+        StoreNameFetcher                    $storeNameFetcher,
+        ?string                             $name = null
     )
     {
         parent::__construct($state, $storeNameFetcher, $name);

--- a/Console/Command/ReplicaRebuildCommand.php
+++ b/Console/Command/ReplicaRebuildCommand.php
@@ -26,13 +26,13 @@ class ReplicaRebuildCommand
     use ReplicaDeleteCommandTrait;
 
     public function __construct(
-        protected ProductHelper\Proxy           $productHelper,
-        protected ReplicaManagerInterface\Proxy $replicaManager,
-        protected StoreManagerInterface         $storeManager,
-        protected ReplicaState                  $replicaState,
-        AppState                                $appState,
-        StoreNameFetcher                        $storeNameFetcher,
-        ?string                                 $name = null
+        protected ReplicaManagerInterface $replicaManager,
+        protected ProductHelper           $productHelper,
+        protected StoreManagerInterface   $storeManager,
+        protected ReplicaState            $replicaState,
+        AppState                          $appState,
+        StoreNameFetcher                  $storeNameFetcher,
+        ?string                           $name = null
     )
     {
         parent::__construct($appState, $storeNameFetcher, $name);

--- a/Console/Command/ReplicaSyncCommand.php
+++ b/Console/Command/ReplicaSyncCommand.php
@@ -24,12 +24,12 @@ class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCo
     use ReplicaSyncCommandTrait;
 
     public function __construct(
-        protected ProductHelper\Proxy           $productHelper,
-        protected ReplicaManagerInterface\Proxy $replicaManager,
-        protected StoreManagerInterface         $storeManager,
-        State                                   $state,
-        StoreNameFetcher                        $storeNameFetcher,
-        ?string                                 $name = null
+        protected ReplicaManagerInterface $replicaManager,
+        protected ProductHelper           $productHelper,
+        protected StoreManagerInterface   $storeManager,
+        State                             $state,
+        StoreNameFetcher                  $storeNameFetcher,
+        ?string                           $name = null
     )
     {
         parent::__construct($state, $storeNameFetcher, $name);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -154,4 +154,33 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand">
+        <arguments>
+            <argument name="replicaManager" xsi:type="object">Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface\Proxy</argument>
+            <argument name="productHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\Entity\ProductHelper\Proxy</argument>
+        </arguments>
+    </type>
+
+    <type name="Algolia\AlgoliaSearch\Console\Command\ReplicaDeleteCommand">
+        <arguments>
+            <argument name="replicaManager" xsi:type="object">Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface\Proxy</argument>
+        </arguments>
+    </type>
+
+    <type name="Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand">
+        <arguments>
+            <argument name="replicaManager" xsi:type="object">Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface\Proxy</argument>
+            <argument name="productHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\Entity\ProductHelper\Proxy</argument>
+        </arguments>
+    </type>
+
+    <type name="Algolia\AlgoliaSearch\Console\Command\ReplicaDisableVirtualCommand">
+        <arguments>
+            <argument name="configHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\ConfigHelper\Proxy</argument>
+            <argument name="replicaManager" xsi:type="object">Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface\Proxy</argument>
+            <argument name="productHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\Entity\ProductHelper\Proxy</argument>
+        </arguments>
+    </type>
+
 </config>


### PR DESCRIPTION
CodeSniffer yields a complaint on our injection method for proxy objects. Using `di.xml` over constructor is the preferred approach here.

Before applying fix:
![image](https://github.com/user-attachments/assets/9de039ec-66e1-483d-9e1b-26830deb80df)
After:
![image](https://github.com/user-attachments/assets/96f34182-f675-4d8f-a179-13b3312197cb)

