### PR TITLE
MAGE-979: Multi Apps indexing support

### DIFF
--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -198,23 +198,6 @@ class Algolia extends Template implements CollectionDataSourceInterface
         return $this->date->gmtTimestamp('today midnight');
     }
 
-    /**
-     * @deprecated This function is deprecated as redirect routes must be derived on the frontend not backend
-     */
-    protected function getAddToCartUrl($additional = []): string
-    {
-        $continueUrl = $this->urlHelper->getEncodedUrl($this->_urlBuilder->getCurrentUrl());
-        $urlParamName = ActionInterface::PARAM_NAME_URL_ENCODED;
-        $routeParams = [
-            $urlParamName => $continueUrl,
-            '_secure' => $this->algoliaHelper->getRequest()->isSecure(),
-        ];
-        if ($additional !== []) {
-            $routeParams = array_merge($routeParams, $additional);
-        }
-        return $this->_urlBuilder->getUrl('checkout/cart/add', $routeParams);
-    }
-
     protected function getCurrentLandingPage(): LandingPage|null|false
     {
         $landingPageId = $this->getRequest()->getParam('landing_page_id');

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -94,14 +94,6 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @return RequestInterface
-     */
-    public function getRequest(): RequestInterface
-    {
-        return $this->_getRequest();
-    }
-
-    /**
      * @return void
      */
     public function resetCredentialsFromConfig(): void

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -165,6 +165,8 @@ class Data
             return;
         }
 
+        $this->algoliaHelper->setStoreId($storeId);
+
         $additionalSections = $this->configHelper->getAutocompleteSections();
 
         $protectedSections = ['products', 'categories', 'pages', 'suggestions'];
@@ -188,6 +190,8 @@ class Data
             $this->algoliaHelper->moveIndex($tempIndexName, $indexName);
 
             $this->algoliaHelper->setSettings($indexName, $this->additionalSectionHelper->getIndexSettings($storeId));
+
+            $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
         }
     }
 
@@ -208,6 +212,8 @@ class Data
             $this->logger->log('Pages Indexing is not enabled for the store.');
             return;
         }
+
+        $this->algoliaHelper->setStoreId($storeId);
 
         $indexName = $this->pageHelper->getIndexName($storeId);
 
@@ -252,6 +258,7 @@ class Data
             $this->algoliaHelper->moveIndex($tempIndexName, $indexName);
         }
         $this->algoliaHelper->setSettings($indexName, $this->pageHelper->getIndexSettings($storeId));
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**
@@ -351,11 +358,12 @@ class Data
         if ($this->isIndexingEnabled($storeId) === false) {
             return;
         }
-
+        $this->algoliaHelper->setStoreId($storeId);
         $tmpIndexName = $this->suggestionHelper->getTempIndexName($storeId);
         $indexName = $this->suggestionHelper->getIndexName($storeId);
         $this->algoliaHelper->copyQueryRules($indexName, $tmpIndexName);
         $this->algoliaHelper->moveIndex($tmpIndexName, $indexName);
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**
@@ -462,6 +470,7 @@ class Data
             return;
         }
 
+        $this->algoliaHelper->setStoreId($storeId);
         $collection = clone $collectionDefault;
         $collection->setCurPage($page)->setPageSize($pageSize);
         $collection->load();
@@ -483,6 +492,7 @@ class Data
         unset($indexData);
         $collection->walk('clearInstance');
         $collection->clear();
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
         unset($collection);
     }
 
@@ -495,6 +505,7 @@ class Data
         if ($this->isIndexingEnabled($storeId) === false) {
             return;
         }
+        $this->algoliaHelper->setStoreId($storeId);
         $collection->setCurPage($page)->setPageSize($pageSize);
         $collection->load();
         $indexName = $this->categoryHelper->getIndexName($storeId);
@@ -519,6 +530,7 @@ class Data
         $collection->walk('clearInstance');
         $collection->clear();
         unset($collection);
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**
@@ -682,6 +694,8 @@ class Data
             return;
         }
 
+        $this->algoliaHelper->setStoreId($storeId);
+
         $wrapperLogMessage = 'rebuildStoreProductIndexPage: ' . $this->logger->getStoreName($storeId) . ',
             page ' . $page . ',
             pageSize ' . $pageSize;
@@ -743,6 +757,9 @@ class Data
         if ($emulationInfo === null) {
             $this->stopEmulation();
         }
+
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
+
         $this->logger->stop($wrapperLogMessage);
     }
 
@@ -856,6 +873,7 @@ class Data
     public function deleteInactiveProducts($storeId): void
     {
         $indexName = $this->productHelper->getIndexName($storeId);
+        $this->algoliaHelper->setStoreId($storeId);
         $client = $this->algoliaHelper->getClient();
         $objectIds = [];
         $counter = 0;
@@ -876,6 +894,7 @@ class Data
         if (!empty($objectIds)) {
             $this->deleteInactiveIds($storeId, $objectIds, $indexName);
         }
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -350,6 +350,7 @@ class ProductHelper extends AbstractEntityHelper
      */
     public function setSettings(string $indexName, string $indexNameTmp, int $storeId, bool $saveToTmpIndicesToo = false): void
     {
+        $this->algoliaHelper->setStoreId($storeId);
         $indexSettings = $this->getIndexSettings($storeId);
 
         $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
@@ -375,6 +376,7 @@ class ProductHelper extends AbstractEntityHelper
                     ');
             } catch (AlgoliaException $e) {
                 $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
+                $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
             }
 
             try {
@@ -387,8 +389,10 @@ class ProductHelper extends AbstractEntityHelper
                 if ($e->getCode() !== 404) {
                     throw $e;
                 }
+                $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
             }
         }
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**

--- a/Model/IndexMover.php
+++ b/Model/IndexMover.php
@@ -44,7 +44,9 @@ class IndexMover
             return;
         }
 
+        $this->algoliaHelper->setStoreId($storeId);
         $this->algoliaHelper->moveIndex($tmpIndexName, $indexName);
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -90,7 +90,7 @@ class IndicesConfigurator
         $logEventName = 'Save configuration to Algolia for store: ' . $this->logger->getStoreName($storeId);
         $this->logger->start($logEventName);
 
-        if (!($this->configHelper->getApplicationID() && $this->configHelper->getAPIKey())) {
+        if (!($this->configHelper->getApplicationID($storeId) && $this->configHelper->getAPIKey($storeId))) {
             $this->logger->log('Algolia credentials are not filled.');
             $this->logger->stop($logEventName);
 
@@ -102,6 +102,8 @@ class IndicesConfigurator
             $this->logger->stop($logEventName);
             return;
         }
+
+        $this->algoliaHelper->setStoreId($storeId);
 
         $this->setCategoriesSettings($storeId);
         /* heck if we want to index CMS pages */
@@ -122,6 +124,8 @@ class IndicesConfigurator
         $this->setProductsSettings($storeId, $useTmpIndex);
 
         $this->setExtraSettings($storeId, $useTmpIndex);
+
+        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**


### PR DESCRIPTION
Extension now handles multi applications support for indexing:
- Products
- Categories
- Pages 
- Suggestions

Tested on two different applications (one with virtual replicas, the other one without virtual replicas), with and without indexing queue activated, for full reindex and reindex events.

TODO on this epic:
- Application validation refactoring
- Backend features testing
- Frontend features testing
- E2E testing

