### PR TITLE
Update Configuration.php

### DIFF
--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -269,7 +269,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
             'autofocus' => true,
             'resultPageUrl' => $this->getCatalogSearchHelper()->getResultUrl(),
             'request' => [
-                'query' =>  htmlspecialchars(html_entity_decode($query)),
+                'query' =>  htmlspecialchars(html_entity_decode((string)$query)),
                 'refinementKey' => $refinementKey,
                 'refinementValue' => $refinementValue,
                 'categoryId' => $categoryId,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

If the search results page (`/catalogsearch/result`) is requested and the `q` query parameter is not present the page will error.  The code errors when generating the `algoliaConfig` JS variable which means that Algolia can not be instantiated.  This means no products show on the page - the expected result is that a blank search query would be performed and thus a set of products would be displayed.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Visit `/catalogsearch/result` and observe that this error is thrown in the Magento `var/log/system.log` log file.

```
Exception: Deprecated Functionality: html_entity_decode(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/algolia/algoliasearch-magento-2/Block/Configuration.php on line 272 in vendor/magento/framework/App/ErrorHandler.php:62
```

This results in a broken page.
![image](https://github.com/user-attachments/assets/13f38f3c-4c61-4b56-a20e-9ea093274afd)

With this change implemented, the page loads products and no error is thrown.
![image](https://github.com/user-attachments/assets/fc0d4f06-03e3-400c-9952-b4cc1ffc241d)

**Explanation**
typecast the $query variable to comply with the PHP 8 standards of [html_entity_decode](https://www.php.net/manual/en/function.html-entity-decode.php)

**Tested On**
- PHP 7.4.3
- PHP 8.1.2


