### PR TITLE
MAGE-980: Application credentials validation

### DIFF
--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -198,6 +198,23 @@ class Algolia extends Template implements CollectionDataSourceInterface
         return $this->date->gmtTimestamp('today midnight');
     }
 
+    /**
+     * @deprecated This function is deprecated as redirect routes must be derived on the frontend not backend
+     */
+    protected function getAddToCartUrl($additional = []): string
+    {
+        $continueUrl = $this->urlHelper->getEncodedUrl($this->_urlBuilder->getCurrentUrl());
+        $urlParamName = ActionInterface::PARAM_NAME_URL_ENCODED;
+        $routeParams = [
+            $urlParamName => $continueUrl,
+            '_secure' => $this->algoliaHelper->getRequest()->isSecure(),
+        ];
+        if ($additional !== []) {
+            $routeParams = array_merge($routeParams, $additional);
+        }
+        return $this->_urlBuilder->getUrl('checkout/cart/add', $routeParams);
+    }
+
     protected function getCurrentLandingPage(): LandingPage|null|false
     {
         $landingPageId = $this->getRequest()->getParam('landing_page_id');

--- a/Helper/AdapterHelper.php
+++ b/Helper/AdapterHelper.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Helper;
 
 use Algolia\AlgoliaSearch\Helper\Adapter\FiltersHelper;
 use Algolia\AlgoliaSearch\Helper\Data as AlgoliaDataHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Magento\CatalogSearch\Helper\Data as CatalogSearchDataHelper;
 
 class AdapterHelper
@@ -11,35 +12,14 @@ class AdapterHelper
     public const INSTANTSEARCH_ORDER_PARAM = 'sortBy';
     public const BACKEND_ORDER_PARAM = 'product_list_order';
 
-    /** @var CatalogSearchDataHelper */
-    private $catalogSearchHelper;
-
-    /** @var AlgoliaDataHelper */
-    private $algoliaHelper;
-
-    /** @var FiltersHelper */
-    private $filtersHelper;
-
-    /** @var ConfigHelper */
-    private $configHelper;
-
-    /**
-     * @param CatalogSearchDataHelper $catalogSearchHelper
-     * @param AlgoliaDataHelper $algoliaHelper
-     * @param FiltersHelper $filtersHelper
-     * @param ConfigHelper $configHelper
-     */
     public function __construct(
-        CatalogSearchDataHelper $catalogSearchHelper,
-        AlgoliaDataHelper $algoliaHelper,
-        FiltersHelper $filtersHelper,
-        ConfigHelper $configHelper
-    ) {
-        $this->catalogSearchHelper = $catalogSearchHelper;
-        $this->algoliaHelper = $algoliaHelper;
-        $this->filtersHelper = $filtersHelper;
-        $this->configHelper = $configHelper;
-    }
+        protected CatalogSearchDataHelper $catalogSearchHelper,
+        protected AlgoliaDataHelper $algoliaHelper,
+        protected FiltersHelper $filtersHelper,
+        protected ConfigHelper $configHelper,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
+    )
+    {}
 
     /**
      * Get search result from Algolia
@@ -142,8 +122,7 @@ class AdapterHelper
         $storeId = $this->getStoreId();
 
         return
-            $this->configHelper->getApplicationID($storeId)
-            && $this->configHelper->getAPIKey($storeId)
+            $this->algoliaCredentialsManager->checkCredentials($storeId)
             && $this->configHelper->isEnabledFrontEnd($storeId)
             && $this->configHelper->makeSeoRequest($storeId);
     }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -78,7 +78,7 @@ class AlgoliaHelper extends AbstractHelper
     /**
      * @return void
      */
-    public function createClient(): void
+    protected function createClient(): void
     {
         $storeId = $this->getStoreId();
         if ($this->algoliaCredentialsManager->checkCredentials($storeId)) {

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Configuration\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
@@ -40,12 +41,6 @@ class AlgoliaHelper extends AbstractHelper
     /** @var SearchClient[] */
     protected array $clients = [];
 
-    protected ConfigHelper $config;
-
-    protected ManagerInterface $messageManager;
-
-    protected ConsoleOutput $consoleOutput;
-
     protected ?int $maxRecordSize = null;
 
     /** @var string[] */
@@ -61,23 +56,14 @@ class AlgoliaHelper extends AbstractHelper
 
     protected static ?int $lastTaskId;
 
-    /**
-     * @param Context $context
-     * @param ConfigHelper $configHelper
-     * @param ManagerInterface $messageManager
-     * @param ConsoleOutput $consoleOutput
-     */
     public function __construct(
         Context $context,
-        ConfigHelper $configHelper,
-        ManagerInterface $messageManager,
-        ConsoleOutput $consoleOutput
+        protected ConfigHelper $config,
+        protected ManagerInterface $messageManager,
+        protected ConsoleOutput $consoleOutput,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
     ) {
         parent::__construct($context);
-
-        $this->config = $configHelper;
-        $this->messageManager = $messageManager;
-        $this->consoleOutput = $consoleOutput;
 
         $this->createClient();
         $this->addSegments();
@@ -95,7 +81,7 @@ class AlgoliaHelper extends AbstractHelper
     public function createClient(): void
     {
         $storeId = $this->getStoreId();
-        if ($this->config->getApplicationID($storeId) && $this->config->getAPIKey($storeId)) {
+        if ($this->algoliaCredentialsManager->checkCredentials($storeId)) {
             $config = SearchConfig::create(
                 $this->config->getApplicationID($storeId),
                 $this->config->getAPIKey($storeId)

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1200,6 +1200,18 @@ class ConfigHelper
 
     /**
      * @param $storeId
+     * @return bool
+     * @deprecated Use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager instead
+     */
+    public function credentialsAreConfigured($storeId = null)
+    {
+        return $this->getApplicationID($storeId) &&
+            $this->getAPIKey($storeId) &&
+            $this->getSearchOnlyAPIKey($storeId);
+    }
+
+    /**
+     * @param $storeId
      * @return mixed'
      */
     public function getApplicationID($storeId = null)

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1200,17 +1200,6 @@ class ConfigHelper
 
     /**
      * @param $storeId
-     * @return bool
-     */
-    public function credentialsAreConfigured($storeId = null)
-    {
-        return $this->getApplicationID($storeId) &&
-            $this->getAPIKey($storeId) &&
-            $this->getSearchOnlyAPIKey($storeId);
-    }
-
-    /**
-     * @param $storeId
      * @return mixed'
      */
     public function getApplicationID($storeId = null)

--- a/Helper/Configuration/AssetHelper.php
+++ b/Helper/Configuration/AssetHelper.php
@@ -2,17 +2,11 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Configuration;
 
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Magento\Framework\View\Asset\Repository as AssetRepository;
 
 class AssetHelper extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    /** @var ConfigHelper */
-    private $configHelper;
-
-    /** @var AssetRepository */
-    private $assetRepository;
-
     /** @var array */
     private $videosConfig = [
         'algoliasearch_credentials' => [
@@ -189,12 +183,9 @@ class AssetHelper extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        ConfigHelper $configHelper,
-        AssetRepository $assetRepository
+        protected AssetRepository $assetRepository,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
     ) {
-        $this->configHelper = $configHelper;
-        $this->assetRepository = $assetRepository;
-
         $this->icons = [
             'iconDocs' => $this->assetRepository->getUrl('Algolia_AlgoliaSearch::images/icon-docs.svg'),
             'iconFaq' => $this->assetRepository->getUrl('Algolia_AlgoliaSearch::images/icon-faq.svg'),
@@ -236,9 +227,7 @@ class AssetHelper extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $configNotSet = false;
         // Check if all the mandatory credentials have been set
-        if (!$this->configHelper->getApplicationID()
-            || !$this->configHelper->getAPIKey()
-            || !$this->configHelper->getSearchOnlyAPIKey()) {
+        if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey()) {
             $configNotSet = true;
         }
 

--- a/Model/Indexer/AdditionalSection.php
+++ b/Model/Indexer/AdditionalSection.php
@@ -34,10 +34,7 @@ class AdditionalSection implements \Magento\Framework\Indexer\ActionInterface, \
             }
 
             if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                $errorMessage = 'Algolia reindexing failed for store :' . $storeId . ' (AdditionalSection indexer)
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-                $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+                $this->algoliaCredentialsManager->displayErrorMessage(self::class, $storeId);
 
                 return;
             }

--- a/Model/Indexer/Category.php
+++ b/Model/Indexer/Category.php
@@ -7,64 +7,39 @@ use Algolia\AlgoliaSearch\Helper\Data;
 use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Model\Queue;
-use Magento\Framework\Message\ManagerInterface;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Magento\Store\Model\StoreManagerInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Category implements \Magento\Framework\Indexer\ActionInterface, \Magento\Framework\Mview\ActionInterface
 {
-    private $storeManager;
-    private $categoryHelper;
-    private $fullAction;
-    private $queue;
-    private $configHelper;
-    private $messageManager;
-    private $output;
-
     public static $affectedProductIds = [];
 
     public function __construct(
-        StoreManagerInterface $storeManager,
-        CategoryHelper $categoryHelper,
-        Data $helper,
-        Queue $queue,
-        ConfigHelper $configHelper,
-        ManagerInterface $messageManager,
-        ConsoleOutput $output
-    ) {
-        $this->fullAction = $helper;
-        $this->storeManager = $storeManager;
-        $this->categoryHelper = $categoryHelper;
-        $this->queue = $queue;
-        $this->configHelper = $configHelper;
-        $this->messageManager = $messageManager;
-        $this->output = $output;
-    }
+        protected StoreManagerInterface $storeManager,
+        protected CategoryHelper $categoryHelper,
+        protected Data $fullAction,
+        protected Queue $queue,
+        protected ConfigHelper $configHelper,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
+    )
+    {}
 
     public function execute($categoryIds)
     {
-        if (!$this->configHelper->getApplicationID()
-            || !$this->configHelper->getAPIKey()
-            || !$this->configHelper->getSearchOnlyAPIKey()) {
-            $errorMessage = 'Algolia reindexing failed:
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-            if (php_sapi_name() === 'cli') {
-                $this->output->writeln($errorMessage);
-
-                return;
-            }
-
-            $this->messageManager->addErrorMessage($errorMessage);
-
-            return;
-        }
-
         $storeIds = array_keys($this->storeManager->getStores());
 
         foreach ($storeIds as $storeId) {
             if ($this->fullAction->isIndexingEnabled($storeId) === false) {
                 continue;
+            }
+
+            if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
+                $errorMessage = 'Algolia reindexing failed for store :' . $storeId . ' (Category indexer)
+                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
+
+                $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+
+                return;
             }
 
             $this->rebuildAffectedProducts($storeId);

--- a/Model/Indexer/Category.php
+++ b/Model/Indexer/Category.php
@@ -34,10 +34,7 @@ class Category implements \Magento\Framework\Indexer\ActionInterface, \Magento\F
             }
 
             if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                $errorMessage = 'Algolia reindexing failed for store :' . $storeId . ' (Category indexer)
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-                $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+                $this->algoliaCredentialsManager->displayErrorMessage(self::class, $storeId);
 
                 return;
             }

--- a/Model/Indexer/CategoryObserver.php
+++ b/Model/Indexer/CategoryObserver.php
@@ -2,8 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Model\Indexer;
 
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Model\Indexer\Category as CategoryIndexer;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Magento\Catalog\Model\Category as CategoryModel;
 use Magento\Catalog\Model\ResourceModel\Category as CategoryResourceModel;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
@@ -12,34 +12,15 @@ use Magento\Framework\Indexer\IndexerRegistry;
 
 class CategoryObserver
 {
-    /** @var IndexerRegistry */
-    private $indexerRegistry;
-
     /** @var CategoryIndexer */
     private $indexer;
 
-    /** @var ConfigHelper */
-    private $configHelper;
-
-    /** @var ResourceConnection */
-    protected $resource;
-
-    /**
-     * CategoryObserver constructor.
-     *
-     * @param IndexerRegistry $indexerRegistry
-     * @param ConfigHelper $configHelper
-     * @param ResourceConnection $resource
-     */
     public function __construct(
         IndexerRegistry $indexerRegistry,
-        ConfigHelper $configHelper,
-        ResourceConnection $resource
+        protected ResourceConnection $resource,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
     ) {
-        $this->indexerRegistry = $indexerRegistry;
         $this->indexer = $indexerRegistry->get('algolia_categories');
-        $this->configHelper = $configHelper;
-        $this->resource = $resource;
     }
 
     /**
@@ -54,9 +35,7 @@ class CategoryObserver
         CategoryResourceModel $result,
         CategoryModel $category
     ) {
-        if (!$this->configHelper->getApplicationID()
-            || !$this->configHelper->getAPIKey()
-            || !$this->configHelper->getSearchOnlyAPIKey()) {
+        if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey()) {
             return $result;
         }
         $categoryResource->addCommitCallback(function () use ($category) {

--- a/Model/Indexer/DeleteProduct.php
+++ b/Model/Indexer/DeleteProduct.php
@@ -34,10 +34,7 @@ class DeleteProduct implements \Magento\Framework\Indexer\ActionInterface, \Mage
             }
 
             if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                $errorMessage = 'Algolia reindexing failed for store :' . $storeId . '(DeleteProduct indexer)
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-                $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+                $this->algoliaCredentialsManager->displayErrorMessage(self::class, $storeId);
 
                 return;
             }

--- a/Model/Indexer/Page.php
+++ b/Model/Indexer/Page.php
@@ -37,10 +37,7 @@ class Page implements \Magento\Framework\Indexer\ActionInterface, \Magento\Frame
             }
 
             if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                $errorMessage = 'Algolia reindexing failed for store :' . $storeId . ' (Page indexer)
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-                $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+                $this->algoliaCredentialsManager->displayErrorMessage(self::class, $storeId);
 
                 return;
             }

--- a/Model/Indexer/Page.php
+++ b/Model/Indexer/Page.php
@@ -7,74 +7,21 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Data;
 use Algolia\AlgoliaSearch\Helper\Entity\PageHelper;
 use Algolia\AlgoliaSearch\Model\Queue;
-use Magento\Framework\Message\ManagerInterface;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Magento\Store\Model\StoreManagerInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Page implements \Magento\Framework\Indexer\ActionInterface, \Magento\Framework\Mview\ActionInterface
 {
-    /**
-     * @var Data
-     */
-    protected $fullAction;
-    /**
-     * @var StoreManagerInterface
-     */
-    protected $storeManager;
-    /**
-     * @var PageHelper
-     */
-    protected $pageHelper;
-    /**
-     * @var AlgoliaHelper
-     */
-    protected $algoliaHelper;
-    /**
-     * @var Queue
-     */
-    protected $queue;
-    /**
-     * @var ConfigHelper
-     */
-    protected $configHelper;
-    /**
-     * @var ManagerInterface
-     */
-    protected $messageManager;
-    /**
-     * @var ConsoleOutput
-     */
-    protected $output;
-
-    /**
-     * @param StoreManagerInterface $storeManager
-     * @param PageHelper $pageHelper
-     * @param Data $helper
-     * @param AlgoliaHelper $algoliaHelper
-     * @param Queue $queue
-     * @param ConfigHelper $configHelper
-     * @param ManagerInterface $messageManager
-     * @param ConsoleOutput $output
-     */
     public function __construct(
-        StoreManagerInterface $storeManager,
-        PageHelper $pageHelper,
-        Data $helper,
-        AlgoliaHelper $algoliaHelper,
-        Queue $queue,
-        ConfigHelper $configHelper,
-        ManagerInterface $messageManager,
-        ConsoleOutput $output
-    ) {
-        $this->fullAction = $helper;
-        $this->storeManager = $storeManager;
-        $this->pageHelper = $pageHelper;
-        $this->algoliaHelper = $algoliaHelper;
-        $this->queue = $queue;
-        $this->configHelper = $configHelper;
-        $this->messageManager = $messageManager;
-        $this->output = $output;
-    }
+        protected StoreManagerInterface $storeManager,
+        protected PageHelper $pageHelper,
+        protected Data $fullAction,
+        protected AlgoliaHelper $algoliaHelper,
+        protected Queue $queue,
+        protected ConfigHelper $configHelper,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
+    )
+    {}
 
     /**
      * @param $ids
@@ -82,28 +29,20 @@ class Page implements \Magento\Framework\Indexer\ActionInterface, \Magento\Frame
      */
     public function execute($ids)
     {
-        if (!$this->configHelper->getApplicationID()
-            || !$this->configHelper->getAPIKey()
-            || !$this->configHelper->getSearchOnlyAPIKey()) {
-            $errorMessage = 'Algolia reindexing failed:
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-            if (php_sapi_name() === 'cli') {
-                $this->output->writeln($errorMessage);
-
-                return;
-            }
-
-            $this->messageManager->addErrorMessage($errorMessage);
-
-            return;
-        }
-
         $storeIds = $this->pageHelper->getStores();
 
         foreach ($storeIds as $storeId) {
             if ($this->fullAction->isIndexingEnabled($storeId) === false) {
                 continue;
+            }
+
+            if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
+                $errorMessage = 'Algolia reindexing failed for store :' . $storeId . ' (Page indexer)
+                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
+
+                $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+
+                return;
             }
 
             if ($this->isPagesInAdditionalSections($storeId)) {
@@ -113,7 +52,7 @@ class Page implements \Magento\Framework\Indexer\ActionInterface, \Magento\Frame
                 }
 
                 $this->queue->addToQueue(
-                    $this->fullAction,
+                    Data::class,
                     'rebuildStorePageIndex',
                     $data,
                     is_array($ids) ? count($ids) : 1

--- a/Model/Indexer/PageObserver.php
+++ b/Model/Indexer/PageObserver.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Model\Indexer;
 
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Model\AbstractModel;
 
@@ -10,26 +10,18 @@ class PageObserver
 {
     private $indexer;
 
-    /**
-     * @var ConfigHelper
-     */
-    private $configHelper;
-
     public function __construct(
         IndexerRegistry $indexerRegistry,
-        ConfigHelper $configHelper
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
     ) {
         $this->indexer = $indexerRegistry->get('algolia_pages');
-        $this->configHelper = $configHelper;
     }
 
     public function beforeSave(
         \Magento\Cms\Model\ResourceModel\Page $pageResource,
         AbstractModel $page
     ) {
-        if (!$this->configHelper->getApplicationID()
-            || !$this->configHelper->getAPIKey()
-            || !$this->configHelper->getSearchOnlyAPIKey()) {
+        if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey()) {
             return [$page];
         }
 
@@ -46,9 +38,7 @@ class PageObserver
         \Magento\Cms\Model\ResourceModel\Page $pageResource,
         AbstractModel $page
     ) {
-        if (!$this->configHelper->getApplicationID()
-            || !$this->configHelper->getAPIKey()
-            || !$this->configHelper->getSearchOnlyAPIKey()) {
+        if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey()) {
             return [$page];
         }
 

--- a/Model/Indexer/Product.php
+++ b/Model/Indexer/Product.php
@@ -40,10 +40,7 @@ class Product implements \Magento\Framework\Indexer\ActionInterface, \Magento\Fr
             }
 
             if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                $errorMessage = 'Algolia reindexing failed for store :' . $storeId . ' (Product indexer)
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-                $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+                $this->algoliaCredentialsManager->displayErrorMessage(self::class, $storeId);
 
                 return;
             }

--- a/Model/Indexer/QueueRunner.php
+++ b/Model/Indexer/QueueRunner.php
@@ -25,10 +25,7 @@ class QueueRunner implements \Magento\Framework\Indexer\ActionInterface, \Magent
     public function executeFull()
     {
         if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey()) {
-            $errorMessage = 'Algolia reindexing failed (Queue Runner):
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-            $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+            $this->algoliaCredentialsManager->displayErrorMessage(self::class);
 
             return;
         }

--- a/Model/Indexer/Suggestion.php
+++ b/Model/Indexer/Suggestion.php
@@ -37,10 +37,7 @@ class Suggestion implements \Magento\Framework\Indexer\ActionInterface, \Magento
             }
 
             if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                $errorMessage = 'Algolia reindexing failed for store :' . $storeId . ' (Suggestion indexer)
-                You need to configure your Algolia credentials in Stores > Configuration > Algolia Search.';
-
-                $this->algoliaCredentialsManager->displayErrorMessage($errorMessage);
+                $this->algoliaCredentialsManager->displayErrorMessage(self::class, $storeId);
 
                 return;
             }

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -12,70 +12,25 @@ use Algolia\AlgoliaSearch\Helper\Entity\PageHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\SuggestionHelper;
 use Algolia\AlgoliaSearch\Helper\Logger;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 class IndicesConfigurator
 {
-    /** @var Data */
-    protected $baseHelper;
-
-    /** @var AlgoliaHelper */
-    protected $algoliaHelper;
-
-    /** @var ConfigHelper */
-    protected $configHelper;
-
-    /** @var ProductHelper */
-    protected $productHelper;
-
-    /** @var CategoryHelper */
-    protected $categoryHelper;
-
-    /** @var PageHelper */
-    protected $pageHelper;
-
-    /** @var SuggestionHelper */
-    protected $suggestionHelper;
-
-    /** @var AdditionalSectionHelper */
-    protected $additionalSectionHelper;
-
-    /** @var Logger */
-    protected $logger;
-
-    /**
-     * @param Data $baseHelper
-     * @param AlgoliaHelper $algoliaHelper
-     * @param ConfigHelper $configHelper
-     * @param ProductHelper $productHelper
-     * @param CategoryHelper $categoryHelper
-     * @param PageHelper $pageHelper
-     * @param SuggestionHelper $suggestionHelper
-     * @param AdditionalSectionHelper $additionalSectionHelper
-     * @param Logger $logger
-     */
     public function __construct(
-        Data $baseHelper,
-        AlgoliaHelper $algoliaHelper,
-        ConfigHelper $configHelper,
-        ProductHelper $productHelper,
-        CategoryHelper $categoryHelper,
-        PageHelper $pageHelper,
-        SuggestionHelper $suggestionHelper,
-        AdditionalSectionHelper $additionalSectionHelper,
-        Logger $logger
-    ) {
-        $this->baseHelper = $baseHelper;
-        $this->algoliaHelper = $algoliaHelper;
-        $this->configHelper = $configHelper;
-        $this->productHelper = $productHelper;
-        $this->categoryHelper = $categoryHelper;
-        $this->pageHelper = $pageHelper;
-        $this->suggestionHelper = $suggestionHelper;
-        $this->additionalSectionHelper = $additionalSectionHelper;
-        $this->logger = $logger;
-    }
+        protected Data $baseHelper,
+        protected AlgoliaHelper $algoliaHelper,
+        protected ConfigHelper $configHelper,
+        protected ProductHelper $productHelper,
+        protected CategoryHelper $categoryHelper,
+        protected PageHelper $pageHelper,
+        protected SuggestionHelper $suggestionHelper,
+        protected AdditionalSectionHelper $additionalSectionHelper,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager,
+        protected Logger $logger
+    )
+    {}
 
     /**
      * @param int $storeId
@@ -90,7 +45,7 @@ class IndicesConfigurator
         $logEventName = 'Save configuration to Algolia for store: ' . $this->logger->getStoreName($storeId);
         $this->logger->start($logEventName);
 
-        if (!($this->configHelper->getApplicationID($storeId) && $this->configHelper->getAPIKey($storeId))) {
+        if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
             $this->logger->log('Algolia credentials are not filled.');
             $this->logger->stop($logEventName);
 

--- a/Service/AlgoliaCredentialsManager.php
+++ b/Service/AlgoliaCredentialsManager.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Service;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -45,6 +46,7 @@ class AlgoliaCredentialsManager
      * @param string $class
      * @param int|null $storeId
      * @return void
+     * @throws NoSuchEntityException
      */
     public function displayErrorMessage(string $class, ?int $storeId = null): void
     {

--- a/Service/AlgoliaCredentialsManager.php
+++ b/Service/AlgoliaCredentialsManager.php
@@ -63,4 +63,25 @@ class AlgoliaCredentialsManager
 
         $this->messageManager->addErrorMessage($errorMessage);
     }
+
+    /**
+     * Checks if multiple application IDs are configured
+     *
+     * @return bool
+     */
+    public function hasMultipleApplicationIDs(): bool
+    {
+        $applications = [];
+
+        foreach ($this->storeManager->getStores() as $store) {
+            $storeId = $store->getId();
+            if ($this->checkCredentials($storeId)
+                && !isset($applications[$this->configHelper->getApplicationID($storeId)])
+            ) {
+                $applications[$this->configHelper->getApplicationID($storeId)] = true;
+            }
+        }
+
+        return count($applications) > 1;
+    }
 }

--- a/Service/AlgoliaCredentialsManager.php
+++ b/Service/AlgoliaCredentialsManager.php
@@ -75,13 +75,17 @@ class AlgoliaCredentialsManager
 
         foreach ($this->storeManager->getStores() as $store) {
             $storeId = $store->getId();
-            if ($this->checkCredentials($storeId)
-                && !isset($applications[$this->configHelper->getApplicationID($storeId)])
-            ) {
-                $applications[$this->configHelper->getApplicationID($storeId)] = true;
+            if ($this->checkCredentials($storeId)) {
+                if (!isset($applications[$this->configHelper->getApplicationID($storeId)])) {
+                    $applications[$this->configHelper->getApplicationID($storeId)] = true;
+                }
+
+                if (count($applications) > 1) {
+                    return true;
+                }
             }
         }
 
-        return count($applications) > 1;
+        return false;
     }
 }

--- a/Service/AlgoliaCredentialsManager.php
+++ b/Service/AlgoliaCredentialsManager.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Framework\Message\ManagerInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class AlgoliaCredentialsManager
+{
+    public function __construct(
+        protected ConfigHelper $configHelper,
+        protected ManagerInterface $messageManager,
+        protected ConsoleOutput $output
+    )
+    {}
+
+    /**
+     * Validates the credentials set on a given store level
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function checkCredentials(int $storeId = null): bool
+    {
+        return $this->configHelper->getApplicationID($storeId) && $this->configHelper->getAPIKey($storeId);
+    }
+
+    /**
+     * Validates the credentials set on a given store level with an additional check on the search only API Key
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function checkCredentialsWithSearchOnlyAPIKey(int $storeId = null): bool
+    {
+        return $this->checkCredentials($storeId) && $this->configHelper->getSearchOnlyAPIKey($storeId);
+    }
+
+    /**
+     * Displays an error message in the console or in the admin
+     *
+     * @param string $errorMessage
+     * @return void
+     */
+    public function displayErrorMessage(string $errorMessage): void
+    {
+        if (php_sapi_name() === 'cli') {
+            $this->output->writeln($errorMessage);
+
+            return;
+        }
+
+        $this->messageManager->addErrorMessage($errorMessage);
+    }
+}

--- a/Service/AlgoliaCredentialsManager.php
+++ b/Service/AlgoliaCredentialsManager.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Service;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Framework\Message\ManagerInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class AlgoliaCredentialsManager
@@ -11,7 +12,8 @@ class AlgoliaCredentialsManager
     public function __construct(
         protected ConfigHelper $configHelper,
         protected ManagerInterface $messageManager,
-        protected ConsoleOutput $output
+        protected ConsoleOutput $output,
+        protected StoreManagerInterface $storeManager
     )
     {}
 
@@ -40,11 +42,17 @@ class AlgoliaCredentialsManager
     /**
      * Displays an error message in the console or in the admin
      *
-     * @param string $errorMessage
+     * @param string $class
+     * @param int|null $storeId
      * @return void
      */
-    public function displayErrorMessage(string $errorMessage): void
+    public function displayErrorMessage(string $class, ?int $storeId = null): void
     {
+        $storeInfo = $storeId ? ' for store '. $this->storeManager->getStore($storeId)->getName() : '';
+        $errorMessage = '
+' . $class . ': Algolia credentials missing' . $storeInfo . '
+  => You need to configure your credentials in Stores > Configuration > Algolia Search.';
+
         if (php_sapi_name() === 'cli') {
             $this->output->writeln($errorMessage);
 

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -2,9 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Registry\ReplicaState;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State as AppState;
@@ -18,14 +18,14 @@ use Psr\Log\LoggerInterface;
 class RebuildReplicasPatch implements DataPatchInterface
 {
     public function __construct(
-        protected ModuleDataSetupInterface $moduleDataSetup,
-        protected StoreManagerInterface    $storeManager,
-        protected ReplicaManager           $replicaManager,
-        protected ProductHelper            $productHelper,
-        protected AppState                 $appState,
-        protected ReplicaState             $replicaState,
-        protected ConfigHelper             $configHelper,
-        protected LoggerInterface          $logger
+        protected ModuleDataSetupInterface  $moduleDataSetup,
+        protected StoreManagerInterface     $storeManager,
+        protected ReplicaManager            $replicaManager,
+        protected ProductHelper             $productHelper,
+        protected AppState                  $appState,
+        protected ReplicaState              $replicaState,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager,
+        protected LoggerInterface           $logger
     )
     {}
 
@@ -52,7 +52,7 @@ class RebuildReplicasPatch implements DataPatchInterface
      */
     public function apply(): PatchInterface
     {
-        if (!$this->configHelper->credentialsAreConfigured()) {
+        if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey()) {
             $this->logger->warning("Algolia credentials are not configured. Aborting replica rebuild patch. If you need to rebuild your replicas run `bin/magento algolia:replicas:rebuild`");
             return $this;
         }

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -63,7 +63,7 @@ class RebuildReplicasPatch implements DataPatchInterface
         // Delete all replicas before resyncing in case of incorrect replica assignments
         foreach ($storeIds as $storeId) {
             if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                $this->logger->warning("Algolia credentials are not configured for store $storeId. Aborting replica rebuild patch. If you need to rebuild your replicas run `bin/magento algolia:replicas:rebuild`");
+                $this->logger->warning("Algolia credentials are not configured for store $storeId. Skipping auto replica rebuild for this store. If you need to rebuild your replicas run `bin/magento algolia:replicas:rebuild`");
                 continue;
             }
 


### PR DESCRIPTION
Created an AlgoliaCredentialsManager class and centralize the credentials validation all accross the extension

- ApplicationID + Admin APIKey

```
$this->config->getApplicationID($storeId) && $this->config->getAPIKey($storeId)

// becomes

$this->algoliaCredentialsManager->checkCredentials($storeId)`
```

- ApplicationID + Admin APIKey + SearchOnly ApiKey

```
$this->configHelper->getApplicationID()
  && $this->configHelper->getAPIKey()
  && $this->configHelper->getSearchOnlyAPIKey()

// becomes

$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)
```

The algoliaCredentialsManager also handles the display of the error messages (both in console and Magento Admin)

⚠️ : In some places, it's impossible to define which store should be used, so I decided to make the `$storeId` parameter optional (in such case, the check remains unchanged compared to before)
