### PR TITLE
MAGE-1023 Fix landing page typing

### DIFF
--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -215,7 +215,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
         return $this->_urlBuilder->getUrl('checkout/cart/add', $routeParams);
     }
 
-    protected function getCurrentLandingPage(): LandingPage|null|false
+    protected function getCurrentLandingPage(): \Algolia\AlgoliaSearch\Model\LandingPage|null|false
     {
         $landingPageId = $this->getRequest()->getParam('landing_page_id');
         if (!$landingPageId) {

--- a/Helper/LandingPageHelper.php
+++ b/Helper/LandingPageHelper.php
@@ -59,7 +59,7 @@ class LandingPageHelper extends \Magento\Framework\App\Helper\AbstractHelper
         parent::__construct($context);
     }
 
-    public function getLandingPage($pageId)
+    public function getLandingPage($pageId): LandingPage|null|false
     {
         if ($pageId !== null && $pageId !== $this->landingPage->getId()) {
             $this->landingPage->setStoreId($this->storeManager->getStore()->getId());


### PR DESCRIPTION
## Summary
This fixes a critical bug with landing pages render introduced in `3.14.0` by PHP strong typing on method return values. 

## Proof of fix
Creating a landing page for "blue shorts":
![image](https://github.com/user-attachments/assets/b0a8a235-fe8e-435e-9702-2c0c43b62bf8)
Store front render:
![image](https://github.com/user-attachments/assets/b1b2e13b-63bb-4722-b1f4-27d17689136d)
