### PR TITLE
Feature/mage 1015 bundle stuffing

### DIFF
--- a/Block/Algolia.php
+++ b/Block/Algolia.php
@@ -215,7 +215,7 @@ class Algolia extends Template implements CollectionDataSourceInterface
         return $this->_urlBuilder->getUrl('checkout/cart/add', $routeParams);
     }
 
-    protected function getCurrentLandingPage(): LandingPage|null|false
+    protected function getCurrentLandingPage(): \Algolia\AlgoliaSearch\Model\LandingPage|null|false
     {
         $landingPageId = $this->getRequest()->getParam('landing_page_id');
         if (!$landingPageId) {

--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -13,7 +13,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
     //Placeholder for future implementation (requires custom renderer for hierarchicalMenu widget)
     private const IS_CATEGORY_NAVIGATION_ENABLED = false;
 
-    public function isSearchPage()
+    public function isSearchPage(): bool
     {
         if ($this->getConfigHelper()->isInstantEnabled()) {
             /** @var Http $request */
@@ -79,8 +79,6 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
         $categoryHelper = $this->getCategoryHelper();
 
         $suggestionHelper = $this->getSuggestionHelper();
-
-        $productHelper = $this->getProductHelper();
 
         $algoliaHelper = $this->getAlgoliaHelper();
 
@@ -254,7 +252,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
             'attributeFilter' => $attributesToFilter,
             'facets' => $facets,
             'areCategoriesInFacets' => $areCategoriesInFacets,
-            'hitsPerPage' => (int) $config->getNumberOfProductResults(),
+            'hitsPerPage' => $config->getNumberOfProductResults(),
             'sortingIndices' => array_values($this->sortingTransformer->getSortingIndices(
                 $this->getStoreId(),
                 $customerGroupId
@@ -421,7 +419,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
         return $ids;
     }
 
-    protected function isLandingPage()
+    protected function isLandingPage(): bool
     {
         return $this->getRequest()->getFullActionName() === 'algolia_landingpage_view';
     }
@@ -439,5 +437,16 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
     protected function getLandingPageConfiguration()
     {
         return $this->isLandingPage() ? $this->getCurrentLandingPage()->getConfiguration() : json_encode([]);
+    }
+
+    public function canLoadInstantSearch(): bool
+    {
+        return $this->getConfigHelper()->isInstantEnabled()
+            && $this->isProductListingPage();
+    }
+
+    protected function isProductListingPage(): bool
+    {
+        return $this->isSearchPage() || $this->isLandingPage();
     }
 }

--- a/Helper/LandingPageHelper.php
+++ b/Helper/LandingPageHelper.php
@@ -59,7 +59,7 @@ class LandingPageHelper extends \Magento\Framework\App\Helper\AbstractHelper
         parent::__construct($context);
     }
 
-    public function getLandingPage($pageId)
+    public function getLandingPage($pageId): LandingPage|null|false
     {
         if ($pageId !== null && $pageId !== $this->landingPage->getId()) {
             $this->landingPage->setStoreId($this->storeManager->getStore()->getId());

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -55,7 +55,6 @@ const config = {
 
     },
     deps : [
-        'algoliaInstantSearch', 
         'algoliaInsights'
     ],
     config: {

--- a/view/frontend/templates/internals/configuration.phtml
+++ b/view/frontend/templates/internals/configuration.phtml
@@ -7,7 +7,7 @@ $configuration = $block->getConfiguration();
 if (class_exists('\Magento\Framework\View\Helper\SecureHtmlRenderer')) : ?>
     <?php
         /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-        if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true)  {
+        if ($block->canLoadInstantSearch())  {
             $css = /* @noEscape */ $secureRenderer->renderTag('style', [],  $configuration['instant']['selector'] . ' {display:none}', false);
             /* @noEscape */ echo $secureRenderer->renderTag('script', [], 'document.write(\'' . $css . '\');' , false);
         }
@@ -17,7 +17,7 @@ if (class_exists('\Magento\Framework\View\Helper\SecureHtmlRenderer')) : ?>
 <?php else: ?>
     <script>
         <?php
-        if ($configuration['instant']['enabled'] === true && $configuration['isSearchPage'] === true) :
+        if ($block->canLoadInstantSearch()):
         $css = '<style type="text/css">' . $configuration['instant']['selector'] . ' {display:none}</style>';
         ?>
         // Hide the instant-search selector ASAP to remove flickering. Will be re-displayed later with JS.
@@ -29,3 +29,14 @@ if (class_exists('\Magento\Framework\View\Helper\SecureHtmlRenderer')) : ?>
         window.algoliaConfig = <?php /* @noEscape */ echo json_encode($configuration); ?>;
     </script>
 <?php endif; ?>
+
+
+<?php if ($block->canLoadInstantSearch()) : ?>
+    <script type="text/x-magento-init">
+        {
+            "*": {
+                "algoliaInstantSearch": {}
+            }
+        }
+    </script>
+<?php endif;?>

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -1,4 +1,5 @@
 define([
+    'uiComponent',
     'jquery',
 
     // Algolia core UI libs
@@ -15,930 +16,7 @@ define([
     'algoliaCommon',
     'algoliaInsights',
     'algoliaHooks',
-], function ($, algoliasearch, instantsearch, templateEngine, priceUtils) {
-
-    /**
-     * @deprecated algoliaBundle is going away! 
-     * This mock only includes libraries available to this module
-     * The following have been removed:
-     *  - Hogan
-     *  - algoliasearchHelper
-     *  - autocomplete
-     *  - createAlgoliaInsightsPlugin
-     *  - createLocalStorageRecentSearchesPlugin
-     *  - createQuerySuggestionsPlugin
-     *  - getAlgoliaResults
-     * However if you've used or require any of these additional libs in your customizations,
-     * you can either augment this mock as you need or include the global dependency in your module
-     * and make it available to your hook.
-     * TODO: Mixin and documentation to come on how to do this...
-     */
-    const mockAlgoliaBundle = () => {
-        return {
-            $,
-            algoliasearch,
-            instantsearch
-        }
-    };
-
-    $(async function ($) {
-        const templateProcessor = await templateEngine.getSelectedEngineAdapter();
-
-        /** We have nothing to do here if instantsearch is not enabled **/
-        if (
-            typeof algoliaConfig === 'undefined' ||
-            !algoliaConfig.instant.enabled ||
-            !(algoliaConfig.isSearchPage || !algoliaConfig.autocomplete.enabled)
-        ) {
-            return;
-        }
-
-        if ($(algoliaConfig.instant.selector).length <= 0) {
-            throw (
-                '[Algolia] Invalid instant-search selector: ' +
-                algoliaConfig.instant.selector
-            );
-        }
-
-        if (
-            algoliaConfig.autocomplete.enabled &&
-            $(algoliaConfig.instant.selector).find(
-                algoliaConfig.autocomplete.selector
-            ).length > 0
-        ) {
-            throw (
-                '[Algolia] You can\'t have a search input matching "' +
-                algoliaConfig.autocomplete.selector +
-                '" inside you instant selector "' +
-                algoliaConfig.instant.selector +
-                '"'
-            );
-        }
-
-        var findAutocomplete =
-            algoliaConfig.autocomplete.enabled &&
-            $(algoliaConfig.instant.selector).find('#algolia-autocomplete-container')
-                .length > 0;
-        if (findAutocomplete) {
-            $(algoliaConfig.instant.selector)
-                .find('#algolia-autocomplete-container')
-                .remove();
-        }
-
-        /** BC of old hooks **/
-        if (typeof algoliaHookBeforeInstantsearchInit === 'function') {
-            algolia.registerHook(
-                'beforeInstantsearchInit',
-                algoliaHookBeforeInstantsearchInit
-            );
-        }
-
-        if (typeof algoliaHookBeforeWidgetInitialization === 'function') {
-            algolia.registerHook(
-                'beforeWidgetInitialization',
-                algoliaHookBeforeWidgetInitialization
-            );
-        }
-
-        if (typeof algoliaHookBeforeInstantsearchStart === 'function') {
-            algolia.registerHook(
-                'beforeInstantsearchStart',
-                algoliaHookBeforeInstantsearchStart
-            );
-        }
-
-        if (typeof algoliaHookAfterInstantsearchStart === 'function') {
-            algolia.registerHook(
-                'afterInstantsearchStart',
-                algoliaHookAfterInstantsearchStart
-            );
-        }
-
-        /**
-         * Setup wrapper
-         *
-         * For templating is used Hogan library
-         * Docs: http://twitter.github.io/hogan.js/
-         * 
-         * Alternatively use Mustache
-         * https://github.com/janl/mustache.js
-         **/
-        var instant_selector = '#instant-search-bar';
-
-        var div = document.createElement('div');
-        $(div).addClass('algolia-instant-results-wrapper');
-
-        $(algoliaConfig.instant.selector).addClass(
-            'algolia-instant-replaced-content'
-        );
-        $(algoliaConfig.instant.selector).wrap(div);
-
-        $('.algolia-instant-results-wrapper').append(
-            '<div class="algolia-instant-selector-results"></div>'
-        );
-
-        const template = $('#instant_wrapper_template').html();
-        const templateVars = {
-            second_bar      : algoliaConfig.instant.enabled,
-            findAutocomplete: findAutocomplete,
-            config          : algoliaConfig.instant,
-            translations    : algoliaConfig.translations,
-        };
-
-        const wrapperHtml = templateProcessor.process(template, templateVars);
-        $('.algolia-instant-selector-results').html(wrapperHtml).show();
-
-        /**
-         * Initialise instant search
-         * For rendering instant search page is used Algolia's instantsearch.js library
-         * Docs: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/
-         **/
-
-        var ruleContexts = ['magento_filters', '']; // Empty context to keep BC for already create rules in dashboard
-        if (algoliaConfig.request.categoryId.length > 0) {
-            ruleContexts.push('magento-category-' + algoliaConfig.request.categoryId);
-        }
-
-        if (algoliaConfig.request.landingPageId.length > 0) {
-            ruleContexts.push(
-                'magento-landingpage-' + algoliaConfig.request.landingPageId
-            );
-        }
-
-        var searchClient = algoliasearch(
-            algoliaConfig.applicationId,
-            algoliaConfig.apiKey
-        );
-        var indexName = algoliaConfig.indexName + '_products';
-        var searchParameters = {
-            hitsPerPage : algoliaConfig.hitsPerPage,
-            ruleContexts: ruleContexts,
-        };
-        var instantsearchOptions = {
-            searchClient: searchClient,
-            indexName   : indexName,
-            routing     : window.routing,
-        };
-
-        if (
-            algoliaConfig.request.path.length > 0 &&
-            window.location.hash.indexOf('categories.level0') === -1
-        ) {
-            if (algoliaConfig.areCategoriesInFacets === false) {
-                searchParameters['facetsRefinements'] = {};
-                searchParameters['facetsRefinements'][
-                'categories.level' + algoliaConfig.request.level
-                    ] = [algoliaConfig.request.path];
-            }
-        }
-
-        if (
-            algoliaConfig.instant.isVisualMerchEnabled &&
-            algoliaConfig.isCategoryPage
-        ) {
-            searchParameters.filters = `${
-                algoliaConfig.instant.categoryPageIdAttribute
-            }:"${algoliaConfig.request.path.replace(/"/g, '\\"')}"`;
-        }
-
-        instantsearchOptions = algolia.triggerHooks(
-            'beforeInstantsearchInit',
-            instantsearchOptions,
-            mockAlgoliaBundle()
-        );
-
-        var search = instantsearch(instantsearchOptions);
-
-        search.client.addAlgoliaAgent(
-            'Magento2 integration (' + algoliaConfig.extensionVersion + ')'
-        );
-
-        /** Prepare sorting indices data */
-        algoliaConfig.sortingIndices.unshift({
-            name : indexName,
-            label: algoliaConfig.translations.relevance,
-        });
-
-        /** Setup attributes for current refinements widget **/
-        var attributes = [];
-        $.each(algoliaConfig.facets, function (i, facet) {
-            var name = facet.attribute;
-
-            if (name === 'categories') {
-                name = 'categories.level0';
-            }
-
-            if (name === 'price') {
-                name = facet.attribute + algoliaConfig.priceKey;
-            }
-
-            attributes.push({
-                name : name,
-                label: facet.label ? facet.label : facet.attribute,
-            });
-        });
-
-        var allWidgetConfiguration = {
-            infiniteHits: {},
-            hits        : {},
-            configure   : searchParameters,
-            custom      : [
-                /**
-                 * Custom widget - this widget is used to refine results for search page or catalog page
-                 * Docs: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-own-widgets/js/
-                 **/
-                {
-                    getWidgetSearchParameters: function (searchParameters) {
-                        if (
-                            algoliaConfig.request.query.length > 0 &&
-                            location.hash.length < 1
-                        ) {
-                            return searchParameters.setQuery(
-                                algolia.htmlspecialcharsDecode(algoliaConfig.request.query)
-                            );
-                        }
-                        return searchParameters;
-                    },
-                    init                     : function (data) {
-                        var page = data.helper.state.page;
-
-                        if (algoliaConfig.request.refinementKey.length > 0) {
-                            data.helper.toggleRefine(
-                                algoliaConfig.request.refinementKey,
-                                algoliaConfig.request.refinementValue
-                            );
-                        }
-
-                        if (algoliaConfig.isCategoryPage) {
-                            data.helper.addNumericRefinement('visibility_catalog', '=', 1);
-                        } else {
-                            data.helper.addNumericRefinement('visibility_search', '=', 1);
-                        }
-
-                        data.helper.setPage(page);
-                    },
-                    render                   : function (data) {
-                        if (!algoliaConfig.isSearchPage) {
-                            if (
-                                data.results.query.length === 0 &&
-                                data.results.nbHits === 0
-                            ) {
-                                $('.algolia-instant-replaced-content').show();
-                                $('.algolia-instant-selector-results').hide();
-                            } else {
-                                $('.algolia-instant-replaced-content').hide();
-                                $('.algolia-instant-selector-results').show();
-                            }
-                        }
-                    },
-                },
-                /**
-                 * Custom widget - Suggestions
-                 * This widget renders suggestion queries which might be interesting for your customer
-                 * Docs: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-own-widgets/js/
-                 **/
-                {
-                    suggestions: [],
-                    init       : function () {
-                        if (algoliaConfig.showSuggestionsOnNoResultsPage) {
-                            var $this = this;
-                            $.each(
-                                algoliaConfig.popularQueries.slice(
-                                    0,
-                                    Math.min(4, algoliaConfig.popularQueries.length)
-                                ),
-                                function (i, query) {
-                                    query = $('<div>').html(query).text(); //xss
-                                    $this.suggestions.push(
-                                        '<a href="' +
-                                        algoliaConfig.baseUrl +
-                                        '/catalogsearch/result/?q=' +
-                                        encodeURIComponent(query) +
-                                        '">' +
-                                        query +
-                                        '</a>'
-                                    );
-                                }
-                            );
-                        }
-                    },
-                    render     : function (data) {
-                        if (data.results.hits.length === 0) {
-                            var content = '<div class="no-results">';
-                            content +=
-                                '<div><b>' +
-                                algoliaConfig.translations.noProducts +
-                                ' "' +
-                                $('<div>').text(data.results.query).html() +
-                                '</b>"</div>';
-                            content += '<div class="popular-searches">';
-
-                            if (
-                                algoliaConfig.showSuggestionsOnNoResultsPage &&
-                                this.suggestions.length > 0
-                            ) {
-                                content +=
-                                    '<div>' +
-                                    algoliaConfig.translations.popularQueries +
-                                    '</div>' +
-                                    this.suggestions.join(', ');
-                            }
-
-                            content += '</div>';
-                            content +=
-                                algoliaConfig.translations.or +
-                                ' <a href="' +
-                                algoliaConfig.baseUrl +
-                                '/catalogsearch/result/?q=__empty__">' +
-                                algoliaConfig.translations.seeAll +
-                                '</a>';
-
-                            content += '</div>';
-
-                            $('#instant-empty-results-container').html(content);
-                        } else {
-                            $('#instant-empty-results-container').html('');
-                        }
-                    },
-                },
-            ],
-            /**
-             * stats
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/stats/js/
-             **/
-            stats: {
-                container: '#algolia-stats',
-                templates: {
-                    text: function (data) {
-                        data.first = data.page * data.hitsPerPage + 1;
-                        data.last = Math.min(
-                            data.page * data.hitsPerPage + data.hitsPerPage,
-                            data.nbHits
-                        );
-                        data.seconds = data.processingTimeMS / 1000;
-                        data.translations = window.algoliaConfig.translations;
-
-                        // TODO: Revisit this injected jQuery logic
-                        const searchParams = new URLSearchParams(window.location.search);
-                        const searchQuery = searchParams.has('q') || '';
-                        if (searchQuery === '' && !algoliaConfig.isSearchPage) {
-                            $('.algolia-instant-replaced-content').show();
-                            $('.algolia-instant-selector-results').hide();
-                        } else {
-                            $('.algolia-instant-replaced-content').hide();
-                            $('.algolia-instant-selector-results').show();
-                        }
-
-                        const template = $('#instant-stats-template').html();
-                        return templateProcessor.process(template, data);
-                    },
-                },
-            },
-            /**
-             * sortBy
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
-             **/
-            sortBy: {
-                container: '#algolia-sorts',
-                items    : algoliaConfig.sortingIndices.map(function (sortingIndice) {
-                    return {
-                        label: sortingIndice.label,
-                        value: sortingIndice.name,
-                    };
-                }),
-            },
-            /**
-             * currentRefinements
-             * Widget displays all filters and refinements applied on query. It also let your customer to clear them one by one
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/current-refinements/js/
-             **/
-            currentRefinements: {
-                container: '#current-refinements',
-                // TODO: Remove this - it does nothing
-                templates         : {
-                    item: $('#current-refinements-template').html(),
-                },
-                includedAttributes: attributes.map((attribute) => {
-                    if (
-                        attribute.name.indexOf('categories') === -1 ||
-                        !algoliaConfig.isCategoryPage
-                    )
-                        // For category browse, requires a custom renderer to prevent removal of the root node from hierarchicalMenu widget
-                        return attribute.name;
-                }),
-
-                transformItems: (items) => {
-                    return (
-                        items
-                            // This filter is only applicable if categories facet is included as an attribute
-                            .filter((item) => {
-                                return (
-                                    !algoliaConfig.isCategoryPage ||
-                                    item.refinements.filter(
-                                        (refinement) =>
-                                            refinement.value !== algoliaConfig.request.path
-                                    ).length
-                                ); // do not expose the category root
-                            })
-                            .map((item) => {
-                                const attribute = attributes.filter((_attribute) => {
-                                    return item.attribute === _attribute.name;
-                                })[0];
-                                if (!attribute) return item;
-                                item.label = attribute.label;
-                                item.refinements.forEach(function (refinement) {
-                                    if (refinement.type !== 'hierarchical') return refinement;
-
-                                    const levels = refinement.label.split(
-                                        algoliaConfig.instant.categorySeparator
-                                    );
-                                    const lastLevel = levels[levels.length - 1];
-                                    refinement.label = lastLevel;
-                                });
-                                return item;
-                            })
-                    );
-                },
-            },
-
-            /*
-             * clearRefinements
-             * Widget displays a button that lets the user clean every refinement applied to the search. You can control which attributes are impacted by the button with the options.
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/
-             **/
-            clearRefinements: {
-                container         : '#clear-refinements',
-                templates         : {
-                    resetLabel: algoliaConfig.translations.clearAll,
-                },
-                includedAttributes: attributes.map(function (attribute) {
-                    if (
-                        !(
-                            algoliaConfig.isCategoryPage &&
-                            attribute.name.indexOf('categories') > -1
-                        )
-                    ) {
-                        return attribute.name;
-                    }
-                }),
-                cssClasses        : {
-                    button: ['action', 'primary'],
-                },
-                transformItems    : function (items) {
-                    return items.map(function (item) {
-                        var attribute = attributes.filter(function (_attribute) {
-                            return item.attribute === _attribute.name;
-                        })[0];
-                        if (!attribute) return item;
-                        item.label = attribute.label;
-                        return item;
-                    });
-                },
-            },
-
-            /*
-             * queryRuleCustomData
-             * The queryRuleCustomData widget displays custom data from Query Rules.
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/query-rule-custom-data/js/
-             **/
-            queryRuleCustomData: {
-                container: '#algolia-banner',
-                templates: {
-                    default: '{{#items}} {{#banner}} {{{banner}}} {{/banner}} {{/items}}',
-                },
-            },
-        };
-
-        if (algoliaConfig.instant.isSearchBoxEnabled) {
-            /**
-             * searchBox
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/search-box/js/
-             **/
-            allWidgetConfiguration.searchBox = {
-                container  : instant_selector,
-                placeholder: algoliaConfig.translations.searchFor,
-                showSubmit : false,
-                queryHook  : (inputValue, search) => {
-                    if (
-                        algoliaConfig.isSearchPage &&
-                        !algoliaConfig.request.categoryId &&
-                        !algoliaConfig.request.landingPageId.length
-                    ) {
-                        $('.page-title-wrapper span.base').html(
-                            algoliaConfig.translations.searchTitle +
-                            ": '" +
-                            algolia.htmlspecialcharsEncode(inputValue) +
-                            "'"
-                        );
-                    }
-                    return search(inputValue);
-                },
-            };
-        }
-
-        if (algoliaConfig.instant.infiniteScrollEnabled === true) {
-            /**
-             * infiniteHits
-             * This widget renders all products into result page
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/infinite-hits/js/
-             **/
-            allWidgetConfiguration.infiniteHits = {
-                container     : '#instant-search-results-container',
-                templates     : {
-                    empty       : '',
-                    item        : $('#instant-hit-template').html(),
-                    showMoreText: algoliaConfig.translations.showMore,
-                },
-                cssClasses    : {
-                    loadPrevious: ['action', 'primary'],
-                    loadMore    : ['action', 'primary'],
-                },
-                transformItems: function (items) {
-                    return items.map(function (item) {
-                        item.__indexName = search.helper.lastResults.index;
-                        item = transformHit(item, algoliaConfig.priceKey, search.helper);
-                        // FIXME: transformHit is a global
-                        item.isAddToCartEnabled = algoliaConfig.instant.isAddToCartEnabled;
-                        return item;
-                    });
-                },
-                showPrevious  : true,
-                escapeHits    : true,
-            };
-
-            delete allWidgetConfiguration.hits;
-        } else {
-            /**
-             * hits
-             * This widget renders all products into result page
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/hits/js/
-             **/
-            allWidgetConfiguration.hits = {
-                container     : '#instant-search-results-container',
-                templates     : {
-                    empty: '',
-                    item : $('#instant-hit-template').html(),
-                },
-                transformItems: function (items, {results}) {
-                    if (
-                        results.nbPages <= 1 &&
-                        algoliaConfig.instant.hidePagination === true
-                    ) {
-                        document.getElementById(
-                            'instant-search-pagination-container'
-                        ).style.display = 'none';
-                    } else {
-                        document.getElementById(
-                            'instant-search-pagination-container'
-                        ).style.display = 'block';
-                    }
-                    return items.map(function (item) {
-                        item.__indexName = search.helper.lastResults.index;
-                        item = transformHit(item, algoliaConfig.priceKey, search.helper);
-                        // FIXME: transformHit is a global
-                        item.isAddToCartEnabled = algoliaConfig.instant.isAddToCartEnabled;
-                        item.algoliaConfig = window.algoliaConfig;
-                        return item;
-                    });
-                },
-            };
-
-            /**
-             * pagination
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/pagination/js/
-             **/
-            allWidgetConfiguration.pagination = {
-                container   : '#instant-search-pagination-container',
-                showFirst   : false,
-                showLast    : false,
-                showNext    : true,
-                showPrevious: true,
-                totalPages  : 1000,
-                templates   : {
-                    previous: algoliaConfig.translations.previousPage,
-                    next    : algoliaConfig.translations.nextPage,
-                },
-            };
-
-            delete allWidgetConfiguration.infiniteHits;
-        }
-
-        /**
-         * Here are specified custom attributes widgets which require special code to run properly
-         * Custom widgets can be added to this object like [attribute]: function(facet, templates)
-         * Function must return an array [<widget name>: string, <widget options>: object]
-         **/
-        const customAttributeFacet = {
-            categories: function (facet, templates) {
-                const hierarchical_levels = [];
-                for (let l = 0; l < 10; l++) {
-                    hierarchical_levels.push('categories.level' + l.toString());
-                }
-
-                const hierarchicalMenuParams = {
-                    container      : facet.wrapper.appendChild(
-                        createISWidgetContainer(facet.attribute)
-                    ),
-                    attributes     : hierarchical_levels,
-                    separator      : algoliaConfig.instant.categorySeparator,
-                    templates      : templates,
-                    showParentLevel: true,
-                    limit          : algoliaConfig.maxValuesPerFacet,
-                    rootPath       : algoliaConfig.request.path,
-                    sortBy         : ['name:asc'],
-                    transformItems(items) {
-                        return algoliaConfig.isCategoryPage
-                            ? items.map((item) => {
-                                return {
-                                    ...item,
-                                    categoryUrl: algoliaConfig.instant
-                                        .isCategoryNavigationEnabled
-                                        ? algoliaConfig.request.childCategories[item.value]['url']
-                                        : '',
-                                };
-                            })
-                            : items;
-                    },
-                };
-
-                hierarchicalMenuParams.templates.item =
-                    '' +
-                    '<a class="{{cssClasses.link}} {{#isRefined}}{{cssClasses.link}}--selected{{/isRefined}}" href="{{categoryUrl}}">{{label}}' +
-                    ' ' +
-                    '<span class="{{cssClasses.count}}">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>' +
-                    '</a>';
-                hierarchicalMenuParams.panelOptions = {
-                    templates: {
-                        header:
-                            '<div class="name">' +
-                            (facet.label ? facet.label : facet.attribute) +
-                            '</div>',
-                    },
-                    hidden   : function ({items}) {
-                        return !items.length;
-                    },
-                };
-
-                return ['hierarchicalMenu', hierarchicalMenuParams];
-            },
-        };
-
-        /** Add all facet widgets to instantsearch object **/
-        window.getFacetWidget = function (facet, templates) {
-            var panelOptions = {
-                templates: {
-                    header:
-                        '<div class="name">' +
-                        (facet.label ? facet.label : facet.attribute) +
-                        '</div>',
-                },
-                hidden   : function (options) {
-                    if (
-                        options.results.nbPages <= 1 &&
-                        algoliaConfig.instant.hidePagination === true
-                    ) {
-                        document.getElementById(
-                            'instant-search-pagination-container'
-                        ).style.display = 'none';
-                    } else {
-                        document.getElementById(
-                            'instant-search-pagination-container'
-                        ).style.display = 'block';
-                    }
-                    if (!options.results) return true;
-                    switch (facet.type) {
-                        case 'conjunctive':
-                            var facetsNames = options.results.facets.map(function (f) {
-                                return f.name;
-                            });
-                            return facetsNames.indexOf(facet.attribute) === -1;
-                        case 'disjunctive':
-                            var disjunctiveFacetsNames =
-                                options.results.disjunctiveFacets.map(function (f) {
-                                    return f.name;
-                                });
-                            return disjunctiveFacetsNames.indexOf(facet.attribute) === -1;
-                        default:
-                            return false;
-                    }
-                },
-            };
-            if (facet.type === 'priceRanges') {
-                delete templates.item;
-
-                return [
-                    'rangeInput',
-                    {
-                        container   : facet.wrapper.appendChild(
-                            createISWidgetContainer(facet.attribute)
-                        ),
-                        attribute   : facet.attribute,
-                        templates   : $.extend(
-                            {
-                                separatorText: algoliaConfig.translations.to,
-                                submitText   : algoliaConfig.translations.go,
-                            },
-                            templates
-                        ),
-                        cssClasses  : {
-                            root: 'conjunctive',
-                        },
-                        panelOptions: panelOptions,
-                    },
-                ];
-            }
-
-            if (facet.type === 'conjunctive') {
-                var refinementListOptions = {
-                    container   : facet.wrapper.appendChild(
-                        createISWidgetContainer(facet.attribute)
-                    ),
-                    attribute   : facet.attribute,
-                    limit       : algoliaConfig.maxValuesPerFacet,
-                    operator    : 'and',
-                    templates   : templates,
-                    sortBy      : ['count:desc', 'name:asc'],
-                    cssClasses  : {
-                        root: 'conjunctive',
-                    },
-                    panelOptions: panelOptions,
-                };
-
-                refinementListOptions = addSearchForFacetValues(
-                    facet,
-                    refinementListOptions
-                );
-
-                return ['refinementList', refinementListOptions];
-            }
-
-            if (facet.type === 'disjunctive') {
-                var refinementListOptions = {
-                    container   : facet.wrapper.appendChild(
-                        createISWidgetContainer(facet.attribute)
-                    ),
-                    attribute   : facet.attribute,
-                    limit       : algoliaConfig.maxValuesPerFacet,
-                    operator    : 'or',
-                    templates   : templates,
-                    sortBy      : ['count:desc', 'name:asc'],
-                    panelOptions: panelOptions,
-                    cssClasses  : {
-                        root: 'disjunctive',
-                    },
-                };
-
-                refinementListOptions = addSearchForFacetValues(
-                    facet,
-                    refinementListOptions
-                );
-
-                return ['refinementList', refinementListOptions];
-            }
-
-            if (facet.type === 'slider') {
-                delete templates.item;
-
-                return [
-                    'rangeSlider',
-                    {
-                        container   : facet.wrapper.appendChild(
-                            createISWidgetContainer(facet.attribute)
-                        ),
-                        attribute   : facet.attribute,
-                        templates   : templates,
-                        pips        : false,
-                        panelOptions: panelOptions,
-                        tooltips    : {
-                            format: function (formattedValue) {
-                                return facet.attribute.match(/price/) === null
-                                    ? parseInt(formattedValue)
-                                    : priceUtils.formatPrice(
-                                        formattedValue,
-                                        algoliaConfig.priceFormat
-                                    );
-                            },
-                        },
-                    },
-                ];
-            }
-        };
-
-        var wrapper = document.getElementById('instant-search-facets-container');
-        $.each(algoliaConfig.facets, function (i, facet) {
-            if (facet.attribute.indexOf('price') !== -1)
-                facet.attribute = facet.attribute + algoliaConfig.priceKey;
-
-            facet.wrapper = wrapper;
-
-            var templates = {
-                item: $('#refinements-lists-item-template').html(),
-            };
-
-            var widgetInfo =
-                customAttributeFacet[facet.attribute] !== undefined
-                    ? customAttributeFacet[facet.attribute](facet, templates)
-                    : getFacetWidget(facet, templates);
-
-            var widgetType = widgetInfo[0],
-                widgetConfig = widgetInfo[1];
-
-            if (typeof allWidgetConfiguration[widgetType] === 'undefined') {
-                allWidgetConfiguration[widgetType] = [widgetConfig];
-            } else {
-                allWidgetConfiguration[widgetType].push(widgetConfig);
-            }
-        });
-
-        if (algoliaConfig.analytics.enabled) {
-            if (typeof algoliaAnalyticsPushFunction !== 'function') {
-                var algoliaAnalyticsPushFunction = function (
-                    formattedParameters,
-                    state,
-                    results
-                ) {
-                    var trackedUrl =
-                        '/catalogsearch/result/?q=' +
-                        state.query +
-                        '&' +
-                        formattedParameters +
-                        '&numberOfHits=' +
-                        results.nbHits;
-
-                    // Universal Analytics
-                    if (typeof window.ga !== 'undefined') {
-                        window.ga('set', 'page', trackedUrl);
-                        window.ga('send', 'pageView');
-                    }
-                };
-            }
-
-            allWidgetConfiguration['analytics'] = {
-                pushFunction          : algoliaAnalyticsPushFunction,
-                delay                 : algoliaConfig.analytics.delay,
-                triggerOnUIInteraction: algoliaConfig.analytics.triggerOnUiInteraction,
-                pushInitialSearch     : algoliaConfig.analytics.pushInitialSearch,
-            };
-        }
-
-        allWidgetConfiguration = algolia.triggerHooks(
-            'beforeWidgetInitialization',
-            allWidgetConfiguration,
-            mockAlgoliaBundle()
-        );
-
-        $.each(allWidgetConfiguration, function (widgetType, widgetConfig) {
-            if (Array.isArray(widgetConfig) === true) {
-                $.each(widgetConfig, function (i, widgetConfig) {
-                    addWidget(search, widgetType, widgetConfig);
-                });
-            } else {
-                addWidget(search, widgetType, widgetConfig);
-            }
-        });
-
-        // Capture active redirect URL with IS facet params for add to cart from PLP
-        if (algoliaConfig.instant.isAddToCartEnabled) {
-            search.on('render', () => {
-                const cartForms = document.querySelectorAll(
-                    '[data-role="tocart-form"]'
-                );
-                cartForms.forEach((form, i) => {
-                    form.addEventListener('submit', (e) => {
-                        const url = `${algoliaConfig.request.url}${window.location.search}`;
-                        e.target.elements[
-                            algoliaConfig.instant.addToCartParams.redirectUrlParam
-                            ].value = AlgoliaBase64.mageEncode(url);
-                    });
-                });
-            });
-        }
-
-        var isStarted = false;
-
-        function startInstantSearch() {
-            if (isStarted === true) {
-                return;
-            }
-
-            search = algolia.triggerHooks(
-                'beforeInstantsearchStart',
-                search,
-                mockAlgoliaBundle()
-            );
-            search.start();
-            search = algolia.triggerHooks(
-                'afterInstantsearchStart',
-                search,
-                mockAlgoliaBundle()
-            );
-
-            isStarted = true;
-        }
-
-        /** Initialise searching **/
-        startInstantSearch();
-    });
+], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils) {
 
     function addWidget(search, type, config) {
         if (type === 'custom') {
@@ -981,14 +59,938 @@ define([
         }
 
         return options;
-    }
+    }    
 
-    console.log("### InstantSearch loaded");
+    return Component.extend({
+        initialize: function(config, element) {
+            console.log('IS initialized with', config, element);
+            this.buildInstantSearch($);
+        },
 
-    return {
-        mockAlgoliaBundle,
-        algoliaInstantSearch: (...args) => {
-             console.log("#### algoliaInstantSearch˝:", this);
+        buildInstantSearch: async function($) {
+            const templateProcessor = await templateEngine.getSelectedEngineAdapter();
+            const mockAlgoliaBundle = this.mockAlgoliaBundle();
+    
+            /** We have nothing to do here if instantsearch is not enabled **/
+            if (
+                typeof algoliaConfig === 'undefined' ||
+                !algoliaConfig.instant.enabled ||
+                !(algoliaConfig.isSearchPage || !algoliaConfig.autocomplete.enabled)
+            ) {
+                return;
+            }
+    
+            if ($(algoliaConfig.instant.selector).length <= 0) {
+                throw (
+                    '[Algolia] Invalid instant-search selector: ' +
+                    algoliaConfig.instant.selector
+                );
+            }
+    
+            if (
+                algoliaConfig.autocomplete.enabled &&
+                $(algoliaConfig.instant.selector).find(
+                    algoliaConfig.autocomplete.selector
+                ).length > 0
+            ) {
+                throw (
+                    '[Algolia] You can\'t have a search input matching "' +
+                    algoliaConfig.autocomplete.selector +
+                    '" inside you instant selector "' +
+                    algoliaConfig.instant.selector +
+                    '"'
+                );
+            }
+    
+            var findAutocomplete =
+                algoliaConfig.autocomplete.enabled &&
+                $(algoliaConfig.instant.selector).find('#algolia-autocomplete-container')
+                    .length > 0;
+            if (findAutocomplete) {
+                $(algoliaConfig.instant.selector)
+                    .find('#algolia-autocomplete-container')
+                    .remove();
+            }
+    
+            /** BC of old hooks **/
+            if (typeof algoliaHookBeforeInstantsearchInit === 'function') {
+                algolia.registerHook(
+                    'beforeInstantsearchInit',
+                    algoliaHookBeforeInstantsearchInit
+                );
+            }
+    
+            if (typeof algoliaHookBeforeWidgetInitialization === 'function') {
+                algolia.registerHook(
+                    'beforeWidgetInitialization',
+                    algoliaHookBeforeWidgetInitialization
+                );
+            }
+    
+            if (typeof algoliaHookBeforeInstantsearchStart === 'function') {
+                algolia.registerHook(
+                    'beforeInstantsearchStart',
+                    algoliaHookBeforeInstantsearchStart
+                );
+            }
+    
+            if (typeof algoliaHookAfterInstantsearchStart === 'function') {
+                algolia.registerHook(
+                    'afterInstantsearchStart',
+                    algoliaHookAfterInstantsearchStart
+                );
+            }
+    
+            /**
+             * Setup wrapper
+             *
+             * For templating is used Hogan library
+             * Docs: http://twitter.github.io/hogan.js/
+             * 
+             * Alternatively use Mustache
+             * https://github.com/janl/mustache.js
+             **/
+            var instant_selector = '#instant-search-bar';
+    
+            var div = document.createElement('div');
+            $(div).addClass('algolia-instant-results-wrapper');
+    
+            $(algoliaConfig.instant.selector).addClass(
+                'algolia-instant-replaced-content'
+            );
+            $(algoliaConfig.instant.selector).wrap(div);
+    
+            $('.algolia-instant-results-wrapper').append(
+                '<div class="algolia-instant-selector-results"></div>'
+            );
+    
+            const template = $('#instant_wrapper_template').html();
+            const templateVars = {
+                second_bar      : algoliaConfig.instant.enabled,
+                findAutocomplete: findAutocomplete,
+                config          : algoliaConfig.instant,
+                translations    : algoliaConfig.translations,
+            };
+    
+            const wrapperHtml = templateProcessor.processAndMeasure(template, templateVars);
+            $('.algolia-instant-selector-results').html(wrapperHtml).show();
+    
+            /**
+             * Initialise instant search
+             * For rendering instant search page is used Algolia's instantsearch.js library
+             * Docs: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/
+             **/
+    
+            var ruleContexts = ['magento_filters', '']; // Empty context to keep BC for already create rules in dashboard
+            if (algoliaConfig.request.categoryId.length > 0) {
+                ruleContexts.push('magento-category-' + algoliaConfig.request.categoryId);
+            }
+    
+            if (algoliaConfig.request.landingPageId.length > 0) {
+                ruleContexts.push(
+                    'magento-landingpage-' + algoliaConfig.request.landingPageId
+                );
+            }
+    
+            var searchClient = algoliasearch(
+                algoliaConfig.applicationId,
+                algoliaConfig.apiKey
+            );
+            var indexName = algoliaConfig.indexName + '_products';
+            var searchParameters = {
+                hitsPerPage : algoliaConfig.hitsPerPage,
+                ruleContexts: ruleContexts,
+            };
+            var instantsearchOptions = {
+                searchClient: searchClient,
+                indexName   : indexName,
+                routing     : window.routing,
+            };
+    
+            if (
+                algoliaConfig.request.path.length > 0 &&
+                window.location.hash.indexOf('categories.level0') === -1
+            ) {
+                if (algoliaConfig.areCategoriesInFacets === false) {
+                    searchParameters['facetsRefinements'] = {};
+                    searchParameters['facetsRefinements'][
+                    'categories.level' + algoliaConfig.request.level
+                        ] = [algoliaConfig.request.path];
+                }
+            }
+    
+            if (
+                algoliaConfig.instant.isVisualMerchEnabled &&
+                algoliaConfig.isCategoryPage
+            ) {
+                searchParameters.filters = `${
+                    algoliaConfig.instant.categoryPageIdAttribute
+                }:"${algoliaConfig.request.path.replace(/"/g, '\\"')}"`;
+            }
+    
+            instantsearchOptions = algolia.triggerHooks(
+                'beforeInstantsearchInit',
+                instantsearchOptions,
+                mockAlgoliaBundle
+            );
+    
+            var search = instantsearch(instantsearchOptions);
+    
+            search.client.addAlgoliaAgent(
+                'Magento2 integration (' + algoliaConfig.extensionVersion + ')'
+            );
+    
+            /** Prepare sorting indices data */
+            algoliaConfig.sortingIndices.unshift({
+                name : indexName,
+                label: algoliaConfig.translations.relevance,
+            });
+    
+            /** Setup attributes for current refinements widget **/
+            var attributes = [];
+            $.each(algoliaConfig.facets, function (i, facet) {
+                var name = facet.attribute;
+    
+                if (name === 'categories') {
+                    name = 'categories.level0';
+                }
+    
+                if (name === 'price') {
+                    name = facet.attribute + algoliaConfig.priceKey;
+                }
+    
+                attributes.push({
+                    name : name,
+                    label: facet.label ? facet.label : facet.attribute,
+                });
+            });
+    
+            var allWidgetConfiguration = {
+                infiniteHits: {},
+                hits        : {},
+                configure   : searchParameters,
+                custom      : [
+                    /**
+                     * Custom widget - this widget is used to refine results for search page or catalog page
+                     * Docs: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-own-widgets/js/
+                     **/
+                    {
+                        getWidgetSearchParameters: function (searchParameters) {
+                            if (
+                                algoliaConfig.request.query.length > 0 &&
+                                location.hash.length < 1
+                            ) {
+                                return searchParameters.setQuery(
+                                    algolia.htmlspecialcharsDecode(algoliaConfig.request.query)
+                                );
+                            }
+                            return searchParameters;
+                        },
+                        init                     : function (data) {
+                            var page = data.helper.state.page;
+    
+                            if (algoliaConfig.request.refinementKey.length > 0) {
+                                data.helper.toggleRefine(
+                                    algoliaConfig.request.refinementKey,
+                                    algoliaConfig.request.refinementValue
+                                );
+                            }
+    
+                            if (algoliaConfig.isCategoryPage) {
+                                data.helper.addNumericRefinement('visibility_catalog', '=', 1);
+                            } else {
+                                data.helper.addNumericRefinement('visibility_search', '=', 1);
+                            }
+    
+                            data.helper.setPage(page);
+                        },
+                        render                   : function (data) {
+                            if (!algoliaConfig.isSearchPage) {
+                                if (
+                                    data.results.query.length === 0 &&
+                                    data.results.nbHits === 0
+                                ) {
+                                    $('.algolia-instant-replaced-content').show();
+                                    $('.algolia-instant-selector-results').hide();
+                                } else {
+                                    $('.algolia-instant-replaced-content').hide();
+                                    $('.algolia-instant-selector-results').show();
+                                }
+                            }
+                        },
+                    },
+                    /**
+                     * Custom widget - Suggestions
+                     * This widget renders suggestion queries which might be interesting for your customer
+                     * Docs: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-own-widgets/js/
+                     **/
+                    {
+                        suggestions: [],
+                        init       : function () {
+                            if (algoliaConfig.showSuggestionsOnNoResultsPage) {
+                                var $this = this;
+                                $.each(
+                                    algoliaConfig.popularQueries.slice(
+                                        0,
+                                        Math.min(4, algoliaConfig.popularQueries.length)
+                                    ),
+                                    function (i, query) {
+                                        query = $('<div>').html(query).text(); //xss
+                                        $this.suggestions.push(
+                                            '<a href="' +
+                                            algoliaConfig.baseUrl +
+                                            '/catalogsearch/result/?q=' +
+                                            encodeURIComponent(query) +
+                                            '">' +
+                                            query +
+                                            '</a>'
+                                        );
+                                    }
+                                );
+                            }
+                        },
+                        render     : function (data) {
+                            if (data.results.hits.length === 0) {
+                                var content = '<div class="no-results">';
+                                content +=
+                                    '<div><b>' +
+                                    algoliaConfig.translations.noProducts +
+                                    ' "' +
+                                    $('<div>').text(data.results.query).html() +
+                                    '</b>"</div>';
+                                content += '<div class="popular-searches">';
+    
+                                if (
+                                    algoliaConfig.showSuggestionsOnNoResultsPage &&
+                                    this.suggestions.length > 0
+                                ) {
+                                    content +=
+                                        '<div>' +
+                                        algoliaConfig.translations.popularQueries +
+                                        '</div>' +
+                                        this.suggestions.join(', ');
+                                }
+    
+                                content += '</div>';
+                                content +=
+                                    algoliaConfig.translations.or +
+                                    ' <a href="' +
+                                    algoliaConfig.baseUrl +
+                                    '/catalogsearch/result/?q=__empty__">' +
+                                    algoliaConfig.translations.seeAll +
+                                    '</a>';
+    
+                                content += '</div>';
+    
+                                $('#instant-empty-results-container').html(content);
+                            } else {
+                                $('#instant-empty-results-container').html('');
+                            }
+                        },
+                    },
+                ],
+                /**
+                 * stats
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/stats/js/
+                 **/
+                stats: {
+                    container: '#algolia-stats',
+                    templates: {
+                        text: function (data) {
+                            data.first = data.page * data.hitsPerPage + 1;
+                            data.last = Math.min(
+                                data.page * data.hitsPerPage + data.hitsPerPage,
+                                data.nbHits
+                            );
+                            data.seconds = data.processingTimeMS / 1000;
+                            data.translations = window.algoliaConfig.translations;
+    
+                            // TODO: Revisit this injected jQuery logic
+                            const searchParams = new URLSearchParams(window.location.search);
+                            const searchQuery = searchParams.has('q') || '';
+                            if (searchQuery === '' && !algoliaConfig.isSearchPage) {
+                                $('.algolia-instant-replaced-content').show();
+                                $('.algolia-instant-selector-results').hide();
+                            } else {
+                                $('.algolia-instant-replaced-content').hide();
+                                $('.algolia-instant-selector-results').show();
+                            }
+    
+                            const template = $('#instant-stats-template').html();
+                            return templateProcessor.process(template, data);
+                        },
+                    },
+                },
+                /**
+                 * sortBy
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
+                 **/
+                sortBy: {
+                    container: '#algolia-sorts',
+                    items    : algoliaConfig.sortingIndices.map(function (sortingIndice) {
+                        return {
+                            label: sortingIndice.label,
+                            value: sortingIndice.name,
+                        };
+                    }),
+                },
+                /**
+                 * currentRefinements
+                 * Widget displays all filters and refinements applied on query. It also let your customer to clear them one by one
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/current-refinements/js/
+                 **/
+                currentRefinements: {
+                    container: '#current-refinements',
+                    // TODO: Remove this - it does nothing
+                    templates         : {
+                        item: $('#current-refinements-template').html(),
+                    },
+                    includedAttributes: attributes.map((attribute) => {
+                        if (
+                            attribute.name.indexOf('categories') === -1 ||
+                            !algoliaConfig.isCategoryPage
+                        )
+                            // For category browse, requires a custom renderer to prevent removal of the root node from hierarchicalMenu widget
+                            return attribute.name;
+                    }),
+    
+                    transformItems: (items) => {
+                        return (
+                            items
+                                // This filter is only applicable if categories facet is included as an attribute
+                                .filter((item) => {
+                                    return (
+                                        !algoliaConfig.isCategoryPage ||
+                                        item.refinements.filter(
+                                            (refinement) =>
+                                                refinement.value !== algoliaConfig.request.path
+                                        ).length
+                                    ); // do not expose the category root
+                                })
+                                .map((item) => {
+                                    const attribute = attributes.filter((_attribute) => {
+                                        return item.attribute === _attribute.name;
+                                    })[0];
+                                    if (!attribute) return item;
+                                    item.label = attribute.label;
+                                    item.refinements.forEach(function (refinement) {
+                                        if (refinement.type !== 'hierarchical') return refinement;
+    
+                                        const levels = refinement.label.split(
+                                            algoliaConfig.instant.categorySeparator
+                                        );
+                                        const lastLevel = levels[levels.length - 1];
+                                        refinement.label = lastLevel;
+                                    });
+                                    return item;
+                                })
+                        );
+                    },
+                },
+    
+                /*
+                 * clearRefinements
+                 * Widget displays a button that lets the user clean every refinement applied to the search. You can control which attributes are impacted by the button with the options.
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/
+                 **/
+                clearRefinements: {
+                    container         : '#clear-refinements',
+                    templates         : {
+                        resetLabel: algoliaConfig.translations.clearAll,
+                    },
+                    includedAttributes: attributes.map(function (attribute) {
+                        if (
+                            !(
+                                algoliaConfig.isCategoryPage &&
+                                attribute.name.indexOf('categories') > -1
+                            )
+                        ) {
+                            return attribute.name;
+                        }
+                    }),
+                    cssClasses        : {
+                        button: ['action', 'primary'],
+                    },
+                    transformItems    : function (items) {
+                        return items.map(function (item) {
+                            var attribute = attributes.filter(function (_attribute) {
+                                return item.attribute === _attribute.name;
+                            })[0];
+                            if (!attribute) return item;
+                            item.label = attribute.label;
+                            return item;
+                        });
+                    },
+                },
+    
+                /*
+                 * queryRuleCustomData
+                 * The queryRuleCustomData widget displays custom data from Query Rules.
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/query-rule-custom-data/js/
+                 **/
+                queryRuleCustomData: {
+                    container: '#algolia-banner',
+                    templates: {
+                        default: '{{#items}} {{#banner}} {{{banner}}} {{/banner}} {{/items}}',
+                    },
+                },
+            };
+    
+            if (algoliaConfig.instant.isSearchBoxEnabled) {
+                /**
+                 * searchBox
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/search-box/js/
+                 **/
+                allWidgetConfiguration.searchBox = {
+                    container  : instant_selector,
+                    placeholder: algoliaConfig.translations.searchFor,
+                    showSubmit : false,
+                    queryHook  : (inputValue, search) => {
+                        if (
+                            algoliaConfig.isSearchPage &&
+                            !algoliaConfig.request.categoryId &&
+                            !algoliaConfig.request.landingPageId.length
+                        ) {
+                            $('.page-title-wrapper span.base').html(
+                                algoliaConfig.translations.searchTitle +
+                                ": '" +
+                                algolia.htmlspecialcharsEncode(inputValue) +
+                                "'"
+                            );
+                        }
+                        return search(inputValue);
+                    },
+                };
+            }
+    
+            if (algoliaConfig.instant.infiniteScrollEnabled === true) {
+                /**
+                 * infiniteHits
+                 * This widget renders all products into result page
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/infinite-hits/js/
+                 **/
+                allWidgetConfiguration.infiniteHits = {
+                    container     : '#instant-search-results-container',
+                    templates     : {
+                        empty       : '',
+                        item        : $('#instant-hit-template').html(),
+                        showMoreText: algoliaConfig.translations.showMore,
+                    },
+                    cssClasses    : {
+                        loadPrevious: ['action', 'primary'],
+                        loadMore    : ['action', 'primary'],
+                    },
+                    transformItems: function (items) {
+                        return items.map(function (item) {
+                            item.__indexName = search.helper.lastResults.index;
+                            item = transformHit(item, algoliaConfig.priceKey, search.helper);
+                            // FIXME: transformHit is a global
+                            item.isAddToCartEnabled = algoliaConfig.instant.isAddToCartEnabled;
+                            return item;
+                        });
+                    },
+                    showPrevious  : true,
+                    escapeHits    : true,
+                };
+    
+                delete allWidgetConfiguration.hits;
+            } else {
+                /**
+                 * hits
+                 * This widget renders all products into result page
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/hits/js/
+                 **/
+                allWidgetConfiguration.hits = {
+                    container     : '#instant-search-results-container',
+                    templates     : {
+                        empty: '',
+                        item : $('#instant-hit-template').html(),
+                    },
+                    transformItems: function (items, {results}) {
+                        if (
+                            results.nbPages <= 1 &&
+                            algoliaConfig.instant.hidePagination === true
+                        ) {
+                            document.getElementById(
+                                'instant-search-pagination-container'
+                            ).style.display = 'none';
+                        } else {
+                            document.getElementById(
+                                'instant-search-pagination-container'
+                            ).style.display = 'block';
+                        }
+                        return items.map(function (item) {
+                            item.__indexName = search.helper.lastResults.index;
+                            item = transformHit(item, algoliaConfig.priceKey, search.helper);
+                            // FIXME: transformHit is a global
+                            item.isAddToCartEnabled = algoliaConfig.instant.isAddToCartEnabled;
+                            item.algoliaConfig = window.algoliaConfig;
+                            return item;
+                        });
+                    },
+                };
+    
+                /**
+                 * pagination
+                 * Docs: https://www.algolia.com/doc/api-reference/widgets/pagination/js/
+                 **/
+                allWidgetConfiguration.pagination = {
+                    container   : '#instant-search-pagination-container',
+                    showFirst   : false,
+                    showLast    : false,
+                    showNext    : true,
+                    showPrevious: true,
+                    totalPages  : 1000,
+                    templates   : {
+                        previous: algoliaConfig.translations.previousPage,
+                        next    : algoliaConfig.translations.nextPage,
+                    },
+                };
+    
+                delete allWidgetConfiguration.infiniteHits;
+            }
+    
+            /**
+             * Here are specified custom attributes widgets which require special code to run properly
+             * Custom widgets can be added to this object like [attribute]: function(facet, templates)
+             * Function must return an array [<widget name>: string, <widget options>: object]
+             **/
+            const customAttributeFacet = {
+                categories: function (facet, templates) {
+                    const hierarchical_levels = [];
+                    for (let l = 0; l < 10; l++) {
+                        hierarchical_levels.push('categories.level' + l.toString());
+                    }
+    
+                    const hierarchicalMenuParams = {
+                        container      : facet.wrapper.appendChild(
+                            createISWidgetContainer(facet.attribute)
+                        ),
+                        attributes     : hierarchical_levels,
+                        separator      : algoliaConfig.instant.categorySeparator,
+                        templates      : templates,
+                        showParentLevel: true,
+                        limit          : algoliaConfig.maxValuesPerFacet,
+                        rootPath       : algoliaConfig.request.path,
+                        sortBy         : ['name:asc'],
+                        transformItems(items) {
+                            return algoliaConfig.isCategoryPage
+                                ? items.map((item) => {
+                                    return {
+                                        ...item,
+                                        categoryUrl: algoliaConfig.instant
+                                            .isCategoryNavigationEnabled
+                                            ? algoliaConfig.request.childCategories[item.value]['url']
+                                            : '',
+                                    };
+                                })
+                                : items;
+                        },
+                    };
+    
+                    hierarchicalMenuParams.templates.item =
+                        '' +
+                        '<a class="{{cssClasses.link}} {{#isRefined}}{{cssClasses.link}}--selected{{/isRefined}}" href="{{categoryUrl}}">{{label}}' +
+                        ' ' +
+                        '<span class="{{cssClasses.count}}">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>' +
+                        '</a>';
+                    hierarchicalMenuParams.panelOptions = {
+                        templates: {
+                            header:
+                                '<div class="name">' +
+                                (facet.label ? facet.label : facet.attribute) +
+                                '</div>',
+                        },
+                        hidden   : function ({items}) {
+                            return !items.length;
+                        },
+                    };
+    
+                    return ['hierarchicalMenu', hierarchicalMenuParams];
+                },
+            };
+    
+            /** Add all facet widgets to instantsearch object **/
+            window.getFacetWidget = function (facet, templates) {
+                var panelOptions = {
+                    templates: {
+                        header:
+                            '<div class="name">' +
+                            (facet.label ? facet.label : facet.attribute) +
+                            '</div>',
+                    },
+                    hidden   : function (options) {
+                        if (
+                            options.results.nbPages <= 1 &&
+                            algoliaConfig.instant.hidePagination === true
+                        ) {
+                            document.getElementById(
+                                'instant-search-pagination-container'
+                            ).style.display = 'none';
+                        } else {
+                            document.getElementById(
+                                'instant-search-pagination-container'
+                            ).style.display = 'block';
+                        }
+                        if (!options.results) return true;
+                        switch (facet.type) {
+                            case 'conjunctive':
+                                var facetsNames = options.results.facets.map(function (f) {
+                                    return f.name;
+                                });
+                                return facetsNames.indexOf(facet.attribute) === -1;
+                            case 'disjunctive':
+                                var disjunctiveFacetsNames =
+                                    options.results.disjunctiveFacets.map(function (f) {
+                                        return f.name;
+                                    });
+                                return disjunctiveFacetsNames.indexOf(facet.attribute) === -1;
+                            default:
+                                return false;
+                        }
+                    },
+                };
+                if (facet.type === 'priceRanges') {
+                    delete templates.item;
+    
+                    return [
+                        'rangeInput',
+                        {
+                            container   : facet.wrapper.appendChild(
+                                createISWidgetContainer(facet.attribute)
+                            ),
+                            attribute   : facet.attribute,
+                            templates   : $.extend(
+                                {
+                                    separatorText: algoliaConfig.translations.to,
+                                    submitText   : algoliaConfig.translations.go,
+                                },
+                                templates
+                            ),
+                            cssClasses  : {
+                                root: 'conjunctive',
+                            },
+                            panelOptions: panelOptions,
+                        },
+                    ];
+                }
+    
+                if (facet.type === 'conjunctive') {
+                    var refinementListOptions = {
+                        container   : facet.wrapper.appendChild(
+                            createISWidgetContainer(facet.attribute)
+                        ),
+                        attribute   : facet.attribute,
+                        limit       : algoliaConfig.maxValuesPerFacet,
+                        operator    : 'and',
+                        templates   : templates,
+                        sortBy      : ['count:desc', 'name:asc'],
+                        cssClasses  : {
+                            root: 'conjunctive',
+                        },
+                        panelOptions: panelOptions,
+                    };
+    
+                    refinementListOptions = addSearchForFacetValues(
+                        facet,
+                        refinementListOptions
+                    );
+    
+                    return ['refinementList', refinementListOptions];
+                }
+    
+                if (facet.type === 'disjunctive') {
+                    var refinementListOptions = {
+                        container   : facet.wrapper.appendChild(
+                            createISWidgetContainer(facet.attribute)
+                        ),
+                        attribute   : facet.attribute,
+                        limit       : algoliaConfig.maxValuesPerFacet,
+                        operator    : 'or',
+                        templates   : templates,
+                        sortBy      : ['count:desc', 'name:asc'],
+                        panelOptions: panelOptions,
+                        cssClasses  : {
+                            root: 'disjunctive',
+                        },
+                    };
+    
+                    refinementListOptions = addSearchForFacetValues(
+                        facet,
+                        refinementListOptions
+                    );
+    
+                    return ['refinementList', refinementListOptions];
+                }
+    
+                if (facet.type === 'slider') {
+                    delete templates.item;
+    
+                    return [
+                        'rangeSlider',
+                        {
+                            container   : facet.wrapper.appendChild(
+                                createISWidgetContainer(facet.attribute)
+                            ),
+                            attribute   : facet.attribute,
+                            templates   : templates,
+                            pips        : false,
+                            panelOptions: panelOptions,
+                            tooltips    : {
+                                format: function (formattedValue) {
+                                    return facet.attribute.match(/price/) === null
+                                        ? parseInt(formattedValue)
+                                        : priceUtils.formatPrice(
+                                            formattedValue,
+                                            algoliaConfig.priceFormat
+                                        );
+                                },
+                            },
+                        },
+                    ];
+                }
+            };
+    
+            var wrapper = document.getElementById('instant-search-facets-container');
+            $.each(algoliaConfig.facets, function (i, facet) {
+                if (facet.attribute.indexOf('price') !== -1)
+                    facet.attribute = facet.attribute + algoliaConfig.priceKey;
+    
+                facet.wrapper = wrapper;
+    
+                var templates = {
+                    item: $('#refinements-lists-item-template').html(),
+                };
+    
+                var widgetInfo =
+                    customAttributeFacet[facet.attribute] !== undefined
+                        ? customAttributeFacet[facet.attribute](facet, templates)
+                        : getFacetWidget(facet, templates);
+    
+                var widgetType = widgetInfo[0],
+                    widgetConfig = widgetInfo[1];
+    
+                if (typeof allWidgetConfiguration[widgetType] === 'undefined') {
+                    allWidgetConfiguration[widgetType] = [widgetConfig];
+                } else {
+                    allWidgetConfiguration[widgetType].push(widgetConfig);
+                }
+            });
+    
+            if (algoliaConfig.analytics.enabled) {
+                if (typeof algoliaAnalyticsPushFunction !== 'function') {
+                    var algoliaAnalyticsPushFunction = function (
+                        formattedParameters,
+                        state,
+                        results
+                    ) {
+                        var trackedUrl =
+                            '/catalogsearch/result/?q=' +
+                            state.query +
+                            '&' +
+                            formattedParameters +
+                            '&numberOfHits=' +
+                            results.nbHits;
+    
+                        // Universal Analytics
+                        if (typeof window.ga !== 'undefined') {
+                            window.ga('set', 'page', trackedUrl);
+                            window.ga('send', 'pageView');
+                        }
+                    };
+                }
+    
+                allWidgetConfiguration['analytics'] = {
+                    pushFunction          : algoliaAnalyticsPushFunction,
+                    delay                 : algoliaConfig.analytics.delay,
+                    triggerOnUIInteraction: algoliaConfig.analytics.triggerOnUiInteraction,
+                    pushInitialSearch     : algoliaConfig.analytics.pushInitialSearch,
+                };
+            }
+    
+            allWidgetConfiguration = algolia.triggerHooks(
+                'beforeWidgetInitialization',
+                allWidgetConfiguration,
+                mockAlgoliaBundle
+            );
+    
+            $.each(allWidgetConfiguration, function (widgetType, widgetConfig) {
+                if (Array.isArray(widgetConfig) === true) {
+                    $.each(widgetConfig, function (i, widgetConfig) {
+                        addWidget(search, widgetType, widgetConfig);
+                    });
+                } else {
+                    addWidget(search, widgetType, widgetConfig);
+                }
+            });
+    
+            // Capture active redirect URL with IS facet params for add to cart from PLP
+            if (algoliaConfig.instant.isAddToCartEnabled) {
+                search.on('render', () => {
+                    const cartForms = document.querySelectorAll(
+                        '[data-role="tocart-form"]'
+                    );
+                    cartForms.forEach((form, i) => {
+                        form.addEventListener('submit', (e) => {
+                            const url = `${algoliaConfig.request.url}${window.location.search}`;
+                            e.target.elements[
+                                algoliaConfig.instant.addToCartParams.redirectUrlParam
+                                ].value = AlgoliaBase64.mageEncode(url);
+                        });
+                    });
+                });
+            }
+    
+            var isStarted = false;
+    
+            function startInstantSearch() {
+                if (isStarted === true) {
+                    return;
+                }
+    
+                search = algolia.triggerHooks(
+                    'beforeInstantsearchStart',
+                    search,
+                    mockAlgoliaBundle
+                );
+                search.start();
+                search = algolia.triggerHooks(
+                    'afterInstantsearchStart',
+                    search,
+                    mockAlgoliaBundle
+                );
+    
+                isStarted = true;
+            }
+    
+            /** Initialise searching **/
+            startInstantSearch();
+        },
+
+        /**
+         * @deprecated algoliaBundle is going away! 
+         * This mock only includes libraries available to this module
+         * The following have been removed:
+         *  - Hogan
+         *  - algoliasearchHelper
+         *  - autocomplete
+         *  - createAlgoliaInsightsPlugin
+         *  - createLocalStorageRecentSearchesPlugin
+         *  - createQuerySuggestionsPlugin
+         *  - getAlgoliaResults
+         * However if you've used or require any of these additional libs in your customizations,
+         * you can either augment this mock as you need or include the global dependency in your module
+         * and make it available to your hook.
+         * TODO: Mixin and documentation to come on how to do this...
+         */
+        mockAlgoliaBundle: function() {
+            console.log("#### REGULAR MOCK");
+            return {
+                $,
+                algoliasearch,
+                instantsearch
+            }
         }
-    };
+    });
+
 });

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -31,16 +31,18 @@ define([
      * However if you've used or require any of these additional libs in your customizations,
      * you can either augment this mock as you need or include the global dependency in your module
      * and make it available to your hook.
-     * TODO: Mixin and documentation to come on how to do this... 
+     * TODO: Mixin and documentation to come on how to do this...
      */
-    const mockAlgoliaBundle = {
-        $,
-        algoliasearch,
-        instantsearch
+    const mockAlgoliaBundle = () => {
+        return {
+            $,
+            algoliasearch,
+            instantsearch
+        }
     };
-    
+
     $(async function ($) {
-        const templateProcessor = await templateEngine.getSelectedEngineAdapter(); 
+        const templateProcessor = await templateEngine.getSelectedEngineAdapter();
 
         /** We have nothing to do here if instantsearch is not enabled **/
         if (
@@ -202,7 +204,7 @@ define([
         instantsearchOptions = algolia.triggerHooks(
             'beforeInstantsearchInit',
             instantsearchOptions,
-            mockAlgoliaBundle
+            mockAlgoliaBundle()
         );
 
         var search = instantsearch(instantsearchOptions);
@@ -882,7 +884,7 @@ define([
         allWidgetConfiguration = algolia.triggerHooks(
             'beforeWidgetInitialization',
             allWidgetConfiguration,
-            mockAlgoliaBundle
+            mockAlgoliaBundle()
         );
 
         $.each(allWidgetConfiguration, function (widgetType, widgetConfig) {
@@ -922,13 +924,13 @@ define([
             search = algolia.triggerHooks(
                 'beforeInstantsearchStart',
                 search,
-                mockAlgoliaBundle
+                mockAlgoliaBundle()
             );
             search.start();
             search = algolia.triggerHooks(
                 'afterInstantsearchStart',
                 search,
-                mockAlgoliaBundle
+                mockAlgoliaBundle()
             );
 
             isStarted = true;
@@ -980,4 +982,13 @@ define([
 
         return options;
     }
+
+    console.log("### InstantSearch loaded");
+
+    return {
+        mockAlgoliaBundle,
+        algoliaInstantSearch: (...args) => {
+             console.log("#### algoliaInstantSearch˝:", this);
+        }
+    };
 });

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -18,26 +18,9 @@ define([
     'algoliaHooks',
 ], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils) {
 
-
-    function addSearchForFacetValues(facet, options) {
-        if (facet.searchable === '1') {
-            options.searchable = true;
-            options.searchableIsAlwaysActive = false;
-            options.searchablePlaceholder =
-                algoliaConfig.translations.searchForFacetValuesPlaceholder;
-            options.templates = options.templates || {};
-            options.templates.searchableNoResults =
-                '<div class="sffv-no-results">' +
-                algoliaConfig.translations.noResults +
-                '</div>';
-        }
-
-        return options;
-    }    
-
     return Component.extend({
         initialize: function(config, element) {
-            console.log('IS initialized with', config, element);
+            // console.log('IS initialized with', config, element);
             this.buildInstantSearch($);
         },
 
@@ -685,7 +668,7 @@ define([
             };
     
             /** Add all facet widgets to instantsearch object **/
-            window.getFacetWidget = function (facet, templates) {
+            window.getFacetWidget = (facet, templates) => {
                 var panelOptions = {
                     templates: {
                         header:
@@ -765,7 +748,7 @@ define([
                         panelOptions: panelOptions,
                     };
     
-                    refinementListOptions = addSearchForFacetValues(
+                    refinementListOptions = this.addSearchForFacetValues(
                         facet,
                         refinementListOptions
                     );
@@ -789,7 +772,7 @@ define([
                         },
                     };
     
-                    refinementListOptions = addSearchForFacetValues(
+                    refinementListOptions = this.addSearchForFacetValues(
                         facet,
                         refinementListOptions
                     );
@@ -968,6 +951,22 @@ define([
             search.addWidgets([widget(config)]);
         },
 
+        addSearchForFacetValues: function(facet, options) {
+            if (facet.searchable === '1') {
+                options.searchable = true;
+                options.searchableIsAlwaysActive = false;
+                options.searchablePlaceholder =
+                    algoliaConfig.translations.searchForFacetValuesPlaceholder;
+                options.templates = options.templates || {};
+                options.templates.searchableNoResults =
+                    '<div class="sffv-no-results">' +
+                    algoliaConfig.translations.noResults +
+                    '</div>';
+            }
+    
+            return options;
+        },
+
         /**
          * @deprecated algoliaBundle is going away! 
          * This mock only includes libraries available to this module
@@ -985,7 +984,6 @@ define([
          * TODO: Mixin and documentation to come on how to do this...
          */
         mockAlgoliaBundle: function() {
-            console.log("#### REGULAR MOCK");
             return {
                 $,
                 algoliasearch,

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -18,32 +18,6 @@ define([
     'algoliaHooks',
 ], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils) {
 
-    function addWidget(search, type, config) {
-        if (type === 'custom') {
-            search.addWidgets([config]);
-            return;
-        }
-        var widget = instantsearch.widgets[type];
-        if (config.panelOptions) {
-            widget = instantsearch.widgets.panel(config.panelOptions)(
-                widget
-            );
-            delete config.panelOptions;
-        }
-        if (type === 'rangeSlider' && config.attribute.indexOf('price.') < 0) {
-            config.panelOptions = {
-                hidden(options) {
-                    return options.range.min === 0 && options.range.max === 0;
-                },
-            };
-            widget = instantsearch.widgets.panel(config.panelOptions)(
-                widget
-            );
-            delete config.panelOptions;
-        }
-
-        search.addWidgets([widget(config)]);
-    }
 
     function addSearchForFacetValues(facet, options) {
         if (facet.searchable === '1') {
@@ -172,7 +146,7 @@ define([
                 translations    : algoliaConfig.translations,
             };
     
-            const wrapperHtml = templateProcessor.processAndMeasure(template, templateVars);
+            const wrapperHtml = templateProcessor.process(template, templateVars);
             $('.algolia-instant-selector-results').html(wrapperHtml).show();
     
             /**
@@ -914,13 +888,13 @@ define([
                 mockAlgoliaBundle
             );
     
-            $.each(allWidgetConfiguration, function (widgetType, widgetConfig) {
+            $.each(allWidgetConfiguration, (widgetType, widgetConfig) => {
                 if (Array.isArray(widgetConfig) === true) {
-                    $.each(widgetConfig, function (i, widgetConfig) {
-                        addWidget(search, widgetType, widgetConfig);
+                    $.each(widgetConfig, (i, widgetConfig) => {
+                        this.addWidget(search, widgetType, widgetConfig);
                     });
                 } else {
-                    addWidget(search, widgetType, widgetConfig);
+                    this.addWidget(search, widgetType, widgetConfig);
                 }
             });
     
@@ -965,6 +939,33 @@ define([
     
             /** Initialise searching **/
             startInstantSearch();
+        },
+
+        addWidget: function(search, type, config) {
+            if (type === 'custom') {
+                search.addWidgets([config]);
+                return;
+            }
+            var widget = instantsearch.widgets[type];
+            if (config.panelOptions) {
+                widget = instantsearch.widgets.panel(config.panelOptions)(
+                    widget
+                );
+                delete config.panelOptions;
+            }
+            if (type === 'rangeSlider' && config.attribute.indexOf('price.') < 0) {
+                config.panelOptions = {
+                    hidden(options) {
+                        return options.range.min === 0 && options.range.max === 0;
+                    },
+                };
+                widget = instantsearch.widgets.panel(config.panelOptions)(
+                    widget
+                );
+                delete config.panelOptions;
+            }
+    
+            search.addWidgets([widget(config)]);
         },
 
         /**


### PR DESCRIPTION
This PR aims to do a few things:

1. Load the local InstantSearch lib as a `uiComponent` to take advantage of mixins (this is just a first pass - lots of globals and anonymous functions in use which need to be revisited as part of MAGE-899)
1. Load InstantSearch conditionally based on business rules to only load scripts as needed 
1. Provide a foundation for modifying the legacy `algoliaBundle` via a mixable `mockAlgoliaBundle` function (a sister PR to be submitted to https://github.com/algolia/algoliasearch-custom-algolia-magento-2 to show examples)

Removing from `deps` has the benefit of only loading IS where it's needed. e.g. not needed on cart, checkout, CMS pages, etc.

Before:
![2024-09-06_16-34-16](https://github.com/user-attachments/assets/6e9637a6-63bc-47ad-9e05-d25200915ccf)

After:
![2024-09-06_16-34-54](https://github.com/user-attachments/assets/a4b607e5-c2f3-4f89-a608-122cc6e8bd30)

