### PR TITLE
MAGE-1021: change Algolia assets observer class

### DIFF
--- a/Observer/AddAlgoliaAssetsObserver.php
+++ b/Observer/AddAlgoliaAssetsObserver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Model;
+namespace Algolia\AlgoliaSearch\Observer;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Framework\Event\ObserverInterface;
@@ -11,8 +11,9 @@ use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Algolia search observer model
+ * @todo Add AlgoliaCredentialsManager to this class once it's available
  */
-class Observer implements ObserverInterface
+class AddAlgoliaAssetsObserver implements ObserverInterface
 {
     protected $config;
     protected $registry;

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="layout_load_before">
-        <observer name="algolia_injection" instance="Algolia\AlgoliaSearch\Model\Observer" />
+        <observer name="algolia_injection" instance="Algolia\AlgoliaSearch\Observer\AddAlgoliaAssetsObserver" />
     </event>
     <event name="algolia_get_attributes_to_filter">
         <observer name="algoliasearch_apply_product_permissions" instance="Algolia\AlgoliaSearch\Model\Observer\CatalogPermissions\ApplyProductPermissionsFilter" />


### PR DESCRIPTION
Following this [PR](https://github.com/algolia/algoliasearch-magento-2/pull/1609) review, moving the Algolia Assets observer change to a separate branch/PR targeting 3.15.0-beta.