### PR TITLE
MAGE-983: Fix facet query rules at store level

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1207,12 +1207,12 @@ class ProductHelper extends AbstractEntityHelper
     }
 
     /**
-     * @param $indexName
+     * @param string $indexName
      * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    protected function setFacetsQueryRules($indexName, int $storeId = null)
+    protected function setFacetsQueryRules(string $indexName, int $storeId = null)
     {
         $client = $this->algoliaHelper->getClient();
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -360,9 +360,9 @@ class ProductHelper extends AbstractEntityHelper
             $this->logger->log('Pushing the same settings to TMP index as well');
         }
 
-        $this->setFacetsQueryRules($indexName);
+        $this->setFacetsQueryRules($indexName, $storeId);
         if ($saveToTmpIndicesToo) {
-            $this->setFacetsQueryRules($indexNameTmp);
+            $this->setFacetsQueryRules($indexNameTmp, $storeId);
         }
 
         $this->replicaManager->syncReplicasToAlgolia($storeId, $indexSettings);
@@ -1208,17 +1208,18 @@ class ProductHelper extends AbstractEntityHelper
 
     /**
      * @param $indexName
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    protected function setFacetsQueryRules($indexName)
+    protected function setFacetsQueryRules($indexName, int $storeId = null)
     {
         $client = $this->algoliaHelper->getClient();
 
         $this->clearFacetsQueryRules($indexName);
 
         $rules = [];
-        $facets = $this->configHelper->getFacets();
+        $facets = $this->configHelper->getFacets($storeId);
         foreach ($facets as $facet) {
             if (!array_key_exists('create_rule', $facet) || $facet['create_rule'] !== '1') {
                 continue;


### PR DESCRIPTION
During the test for the multi-application IDs, I noticed that facet query rules configuration wasn't taken into account at store level. This change should fix it. 