### PR TITLE
MAGE-970: Fix Category collection fetching (for 3.13.6)

### DIFF
--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -180,7 +180,7 @@ class CategoryHelper
     {
         /** @var \Magento\Store\Model\Store $store */
         $store = $this->storeManager->getStore($storeId);
-        $storeRootCategoryPath = sprintf('%d/%d', $this->getRootCategoryId(), $store->getRootCategoryId());
+        $storeRootCategoryPath = sprintf('%d/%d/', $this->getRootCategoryId(), $store->getRootCategoryId());
 
         $unserializedCategorysAttrs = $this->getAdditionalAttributes($storeId);
         $additionalAttr = array_column($unserializedCategorysAttrs, 'attribute');


### PR DESCRIPTION
Same PR as https://github.com/algolia/algoliasearch-magento-2/pull/1613 but targeting 3.13.6.