### PR TITLE
Feature/mage 899 mixin compat

### DIFF
--- a/view/adminhtml/web/css/landing-page.css
+++ b/view/adminhtml/web/css/landing-page.css
@@ -1069,53 +1069,6 @@ a.ais-current-refined-values--link:hover {
     margin-bottom: 20px;
 }
 
-/** Search Box */
-
-#algolia-searchbox {
-    position: relative;
-}
-
-#algolia-searchbox .clear-cross, #algolia_instant_selector .clear-cross {
-    position: absolute;
-    display: none;
-    cursor: pointer;
-    width: 16px;
-    height: 16px;
-}
-
-#algolia-searchbox .clear-query-autocomplete {
-    bottom: 22px;
-    right: 9px;
-}
-
-#algolia_instant_selector .cross-wrapper .clear-refinement {
-    display: block;
-    position: relative;
-    top: 5px;
-    left: 5px;
-}
-
-#algolia-searchbox .magnifying-glass {
-    position: absolute;
-    bottom: 21px;
-    right: 7px;
-    width: 20px;
-    height: 20px;
-    display: block;
-}
-
-@media (min-width: 768px) {
-    #algolia-searchbox .magnifying-glass {
-        bottom: 6px;
-    }
-}
-
-@media (min-width: 768px) {
-    #algolia-searchbox .clear-query-autocomplete {
-        bottom: 8px;
-    }
-}
-
 /** PAGINATION */
 
 #instant-search-pagination-container {
@@ -1155,21 +1108,6 @@ a.ais-current-refined-values--link:hover {
 .ais-pagination--item.ais-pagination--item__previous a {
     font-weight: bold;
     color: #606060;
-}
-
-
-#algolia-searchbox .algolia-search-input:focus:not([value=""]) {
-    background: transparent;
-}
-
-#algolia-searchbox .algolia-search-input {
-    position: static !important;
-}
-
-#algolia-searchbox .algolia-search-input:focus {
-    outline: 0;
-    box-shadow: none;
-    border: solid 1px #54A5CD;
 }
 
 #algolia_instant_selector .ais-current-refined-values.facet .ais-current-refined-values--body {

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -52,6 +52,9 @@ const config = {
         'algoliaMustacheLib': 'Algolia_AlgoliaSearch/js/lib/mustache.min',
         'algoliaHoganLib'   : 'Algolia_AlgoliaSearch/js/lib/hogan.min',
 
+        // Utils
+        'algoliaBase64' : 'Algolia_AlgoliaSearch/js/internals/base64',
+
         // DEPRECATED - to be removed in a future release
         'algoliaBundle': 'Algolia_AlgoliaSearch/js/internals/algoliaBundle.min',
         'rangeSlider'  : 'Algolia_AlgoliaSearch/js/navigation/range-slider-widget'

--- a/view/frontend/web/css/autocomplete.css
+++ b/view/frontend/web/css/autocomplete.css
@@ -429,52 +429,9 @@ html {
     max-width: 130px;
 }
 
-#algolia-searchbox .algolia-search-input:focus:not([value=""]) {
-    background: transparent;
-}
-
-#algolia-searchbox .algolia-search-input {
-    position: static !important;
-}
-
-#algolia-searchbox .algolia-search-input:focus {
-    outline: 0;
-    box-shadow: none;
-    border: solid 1px #54A5CD;
-}
-
 #algolia-autocomplete-container:after, .autocomplete-wrapper:after {
     clear: both;
     content: '';
-}
-
-#algolia-searchbox {
-    position: relative;
-}
-
-#algolia-searchbox .clear-cross, #algolia_instant_selector .clear-cross {
-    position: absolute;
-    display: none;
-    background: url("data:image/svg+xml;utf8,<svg width=\'12\' height=\'12\' viewBox=\'0 0 12 12\' xmlns=\'http://www.w3.org/2000/svg\' opacity=\'0.6\'><path d=\'M.566 1.698L0 1.13 1.132 0l.565.566L6 4.868 10.302.566 10.868 0 12 1.132l-.566.565L7.132 6l4.302 4.3.566.568L10.868 12l-.565-.566L6 7.132l-4.3 4.302L1.13 12 0 10.868l.566-.565L4.868 6 .566 1.698z\'></path></svg>") no-repeat center center / contain;
-    cursor: pointer;
-    width: 16px;
-    height: 16px;
-}
-
-#algolia-searchbox .clear-query-autocomplete {
-    bottom: 8px;
-    right: 9px;
-}
-
-#algolia-searchbox .magnifying-glass {
-    background: url("data:image/svg+xml;utf8,<svg width=\'40\' height=\'40\' viewBox=\'0 0 40 40\'  fill=\'%23A6A6A6\' xmlns=\'http://www.w3.org/2000/svg\'><path d=\'M15.553 31.107c8.59 0 15.554-6.964 15.554-15.554S24.143 0 15.553 0 0 6.964 0 15.553c0 8.59 6.964 15.554 15.553 15.554zm0-3.888c6.443 0 11.666-5.225 11.666-11.668 0-6.442-5.225-11.665-11.668-11.665-6.442 0-11.665 5.223-11.665 11.665 0 6.443 5.223 11.666 11.665 11.666zm12.21 3.84a2.005 2.005 0 0 1 .002-2.833l.463-.463a2.008 2.008 0 0 1 2.833-.003l8.17 8.168c.78.78.78 2.05-.004 2.833l-.462.463a2.008 2.008 0 0 1-2.834.004l-8.168-8.17z\' fill-rule=\'evenodd\'/></svg>") no-repeat center right / 20px;
-    border: none;
-    bottom: 7px;
-    box-shadow: none;
-    height: 20px;
-    position: absolute;
-    right: 7px;
-    width: 20px;
 }
 
 #algolia_instant_selector .cross-wrapper .clear-refinement {
@@ -664,8 +621,4 @@ html {
 }
 .aa-Panel .aa-PanelLayout section .aa-SourceNoResults{
     padding: 5px;
-}
-
-.clear-query-autocomplete {
-    display: none !important;
 }

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -48,6 +48,10 @@ define([
     };
 
     return Component.extend({
+        DEFAULT_HITS_PER_SECTION,
+        DEBOUNCE_MS,
+        MIN_SEARCH_LENGTH_CHARS,
+
         initialize(config, element) {
             // console.log('AC initialized with', config, element);
             this.buildAutocomplete($);
@@ -99,7 +103,7 @@ define([
         },
 
         buildAutocompleteOptions(searchClient, sources, plugins) {
-            const debounced = this.debounce(items => Promise.resolve(items), DEBOUNCE_MS);
+            const debounced = this.debounce(items => Promise.resolve(items), this.DEBOUNCE_MS);
         
             let options = algoliaCommon.triggerHooks('beforeAutocompleteOptions', {}); 
 
@@ -123,7 +127,7 @@ define([
                     return this.filterMinChars(query, debounced(this.transformSources(searchClient, sources)));
                 },
                 shouldPanelOpen: ({state}) => {
-                    return state.query.length >= MIN_SEARCH_LENGTH_CHARS;
+                    return state.query.length >= this.MIN_SEARCH_LENGTH_CHARS;
                 },
                 // Set debug to true, to be able to remove keyboard and be able to scroll in autocomplete menu
                 debug: algoliaCommon.isMobile(),
@@ -265,7 +269,7 @@ define([
          */
         buildAutocompleteSourceDefault(section) {
             const options = {
-                hitsPerPage   : section.hitsPerPage || DEFAULT_HITS_PER_SECTION,
+                hitsPerPage   : section.hitsPerPage || this.DEFAULT_HITS_PER_SECTION,
                 analyticsTags : 'autocomplete',
                 clickAnalytics: true,
                 distinct      : true,

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -246,15 +246,16 @@ define([
         buildAutocompleteSource(section, searchClient) {
             const defaultSourceConfig = this.buildAutocompleteSourceDefault(section);
 
-            if (section.name === 'products') {
-                return this.buildAutocompleteSourceProducts(section, defaultSourceConfig);
-            } else if (section.name === 'categories') {
-                return this.buildAutocompleteSourceCategories(section, defaultSourceConfig);
-            } else if (section.name === 'pages') {
-                return this.buildAutocompleteSourcePages(section, defaultSourceConfig);
-            } else {
-                /** If is not products, categories, pages or suggestions, it's additional section **/
-                return this.buildAutocompleteSourceAdditional(section, defaultSourceConfig);
+            switch (section.name) {
+                case 'products':
+                    return this.buildAutocompleteSourceProducts(section, defaultSourceConfig);
+                case 'categories':
+                    return this.buildAutocompleteSourceCategories(section, defaultSourceConfig);
+                case 'pages':
+                    return this.buildAutocompleteSourcePages(section, defaultSourceConfig);
+                default:
+                    /** If is not products, categories, or pages, it's an additional section **/
+                    return this.buildAutocompleteSourceAdditional(section, defaultSourceConfig);
             }
         },
 

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -41,10 +41,10 @@ define([
     const DEBOUNCE_MS = algoliaConfig.autocomplete.debounceMilliseconds;
     const MIN_SEARCH_LENGTH_CHARS = algoliaConfig.autocomplete.minimumCharacters;
 
-    // global state
-    let suggestionSection = false;
+    // Global state
     const state = {
-        hasRendered: false
+        hasRendered: false,
+        hasSuggestionSection: false
     };
 
     return Component.extend({
@@ -316,14 +316,6 @@ define([
                     return productsHtml.getHeaderHtml({items, html});
                 },
                 item: ({item, components, html}) => {
-                    if (suggestionSection) { //TODO: relies on global - needs refactor
-                        $('.aa-Panel').addClass('productColumn2');
-                        $('.aa-Panel').removeClass('productColumn1');
-                    } else {
-                        $('.aa-Panel').removeClass('productColumn2');
-                        $('.aa-Panel').addClass('productColumn1');
-                    }
-                    
                     const _data = this.transformAutocompleteHit(item, algoliaConfig.priceKey);
                     return productsHtml.getItemHtml({item: _data, components, html});
                 },
@@ -496,7 +488,7 @@ define([
             let plugins = [];
             
             if (algoliaConfig.autocomplete.nbOfQueriesSuggestions > 0) {
-                suggestionSection = true; //TODO: relies on global - needs refactor
+                state.hasSuggestionSection = true; 
                 plugins.push(this.buildSuggestionsPlugin(searchClient));
             }
             return algoliaCommon.triggerHooks(
@@ -696,6 +688,13 @@ define([
             return query.length >= MIN_SEARCH_LENGTH_CHARS ? result : [];
         },
 
+        /**
+         * Tells Autocomplete to “wait” for a set time after typing stops before returning results
+         * See https://www.algolia.com/doc/ui-libraries/autocomplete/guides/debouncing-sources/#select-a-debounce-delay
+         * @param fn Function to debounce
+         * @param time Delay in ms before function executes
+         * @returns 
+         */
         debounce(fn, time) {
             let timerId = undefined;
 
@@ -819,6 +818,7 @@ define([
                         mutation.addedNodes.forEach(node => {
                             if (node.nodeType === Node.ELEMENT_NODE && node.classList.contains('aa-PanelLayout')) {
                                 this.addFooter();
+                                this.handleSuggestionsLayout();
                                 //We only care about the first occurrence
                                 observer.disconnect();
                             }
@@ -835,6 +835,17 @@ define([
                 const algoliaFooter = `<div id="algoliaFooter" class="footer_algolia"><span class="algolia-search-by-label">${algoliaConfig.translations.searchBy}</span><a href="https://www.algolia.com/?utm_source=magento&utm_medium=link&utm_campaign=magento_autocompletion_menu" title="${algoliaConfig.translations.searchBy} Algolia" target="_blank"><img src="${algoliaConfig.urls.logo}" alt="${algoliaConfig.translations.searchBy} Algolia" /></a></div>`;
                 $('.aa-PanelLayout').append(algoliaFooter);
             } 
+        },
+
+        handleSuggestionsLayout() {
+            if (state.hasSuggestionSection) { 
+                $('.aa-Panel').addClass('productColumn2');
+                $('.aa-Panel').removeClass('productColumn1');
+            } else {
+                $('.aa-Panel').removeClass('productColumn2');
+                $('.aa-Panel').addClass('productColumn1');
+            }
+            
         }
     });
 });

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -225,7 +225,7 @@ define([
                 this.buildAutocompleteSource(section, searchClient)
             );
 
-            // DEPRECATED location - retaining for backward compatibility but `beforeAutcompleteSources` behavior belongs earlier in the process and will be relocated in a future version
+            // DEPRECATED - retaining for backward compatibility but `beforeAutcompleteSources` may be removed or relocated in a future version
             sources = algoliaCommon.triggerHooks(
                 'beforeAutocompleteSources',
                 sources,
@@ -387,15 +387,15 @@ define([
          * @returns options object
          */
         buildProductSourceOptions(section, options) {
-            options.facets = ['categories.level0'];
-            options.numericFilters = 'visibility_search=1';
-            options.ruleContexts = ['magento_filters', '']; // Empty context to keep backward compatibility for already created rules in dashboard
-
-            // DEPRECATED - retaining for backward compatibility but `beforeAutocompleteProductSourceOptions` will likely be removed in a future version
+            // DEPRECATED - retaining for backward compatibility but `beforeAutocompleteProductSourceOptions` may be removed in a future version
             options = algoliaCommon.triggerHooks(
                 'beforeAutocompleteProductSourceOptions',
                 options
             ); 
+
+            options.facets = ['categories.level0'];
+            options.numericFilters = 'visibility_search=1';
+            options.ruleContexts = ['magento_filters', '']; // Empty context to keep backward compatibility for already created rules in dashboard
             
             options = algoliaCommon.triggerHooks(
                 'afterAutocompleteProductSourceOptions',

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -65,7 +65,7 @@ define([
             const debouncePromise = (fn, time) => {
                 let timerId = undefined;
 
-                return function debounced(...args) {
+                return (...args) => {
                     if (timerId) {
                         clearTimeout(timerId);
                     }
@@ -104,6 +104,7 @@ define([
             let sources = algoliaConfig.autocomplete.sections.map((section) =>
                 this.buildAutocompleteSource(section, searchClient)
             );
+
             sources = algoliaCommon.triggerHooks(
                 'beforeAutocompleteSources',
                 sources,

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -18,10 +18,8 @@ define([
     'algoliaAutocompleteSuggestionsHtml',
     'algoliaAutocompleteAdditionalHtml',
 
-    // TODO: Refactor legacy global object dependencies
     'algoliaInsights',
     'algoliaHooks',
-
     'domReady!'
 ], function (
     Component,
@@ -35,7 +33,8 @@ define([
     categoriesHtml,
     pagesHtml,
     suggestionsHtml,
-    additionalHtml
+    additionalHtml,
+    algoliaInsights
 ) {
     const DEFAULT_HITS_PER_SECTION = 2;
     const DEBOUNCE_MS = algoliaConfig.autocomplete.debounceMilliseconds;

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -54,7 +54,7 @@ define([
 
         initialize(config, element) {
             // console.log('AC initialized with', config, element);
-            this.buildAutocomplete($);
+            this.buildAutocomplete();
         },
 
         /**

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -10,18 +10,18 @@ define([
     // Algolia integration dependencies
     'algoliaCommon',
     'algoliaBase64',
-    
+
     // HTML templates
     'algoliaAutocompleteProductsHtml',
     'algoliaAutocompleteCategoriesHtml',
     'algoliaAutocompletePagesHtml',
     'algoliaAutocompleteSuggestionsHtml',
     'algoliaAutocompleteAdditionalHtml',
-    
+
     // TODO: Refactor legacy global object dependencies
     'algoliaInsights',
     'algoliaHooks',
-    
+
     'domReady!'
 ], function (
     Component,
@@ -45,684 +45,687 @@ define([
     let suggestionSection = false;
     let algoliaFooter;
 
-    /** We have nothing to do here if autocomplete is disabled **/
-    if (
-        typeof algoliaConfig === 'undefined' ||
-        !algoliaConfig.autocomplete.enabled
-    ) {
-        return;
-    }
-
-    /**
-     * Initialise Algolia client
-     * Docs: https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/
-     **/
-    const searchClient = algoliasearch(
-        algoliaConfig.applicationId,
-        algoliaConfig.apiKey
-    );
-    searchClient.addAlgoliaAgent(
-        'Magento2 integration (' + algoliaConfig.extensionVersion + ')'
-    );
-
-    // autocomplete code moved from common.js to autocomplete.js
-    const transformAutocompleteHit = function (hit, price_key, helper) {
-        if (Array.isArray(hit.categories))
-            hit.categories = hit.categories.join(', ');
-
-        if (
-            hit._highlightResult.categories_without_path &&
-            Array.isArray(hit.categories_without_path)
-        ) {
-            hit.categories_without_path = $.map(
-                hit._highlightResult.categories_without_path,
-                function (category) {
-                    return category.value;
-                }
-            );
-
-            hit.categories_without_path = hit.categories_without_path.join(', ');
-        }
-
-        let matchedColors = [];
-
-        // TODO: Adapt this migrated code from common.js - helper not utilized
-        if (helper && algoliaConfig.useAdaptiveImage === true) {
-            if (hit.images_data && helper.state.facetsRefinements.color) {
-                matchedColors = helper.state.facetsRefinements.color.slice(0); // slice to clone
-            }
-
-            if (hit.images_data && helper.state.disjunctiveFacetsRefinements.color) {
-                matchedColors =
-                    helper.state.disjunctiveFacetsRefinements.color.slice(0); // slice to clone
-            }
-        }
-
-        if (Array.isArray(hit.color)) {
-            let colors = [];
-
-            $.each(hit._highlightResult.color, function (i, color) {
-                if (color.matchLevel === undefined || color.matchLevel === 'none') {
-                    return;
-                }
-
-                colors.push(color.value);
-
-                if (algoliaConfig.useAdaptiveImage === true) {
-                    const matchedColor = color.matchedWords.join(' ');
-                    if (
-                        hit.images_data &&
-                        color.fullyHighlighted &&
-                        color.fullyHighlighted === true
-                    ) {
-                        matchedColors.push(matchedColor);
-                    }
-                }
-            });
-
-            colors = colors.join(', ');
-            hit._highlightResult.color = {value: colors};
-        } else {
-            if (
-                hit._highlightResult.color &&
-                hit._highlightResult.color.matchLevel === 'none'
-            ) {
-                hit._highlightResult.color = {value: ''};
-            }
-        }
-
-        if (algoliaConfig.useAdaptiveImage === true) {
-            $.each(matchedColors, function (i, color) {
-                color = color.toLowerCase();
-
-                if (hit.images_data[color]) {
-                    hit.image_url = hit.images_data[color];
-                    hit.thumbnail_url = hit.images_data[color];
-
-                    return false;
-                }
-            });
-        }
-
-        if (
-            hit._highlightResult.color &&
-            hit._highlightResult.color.value &&
-            hit.categories_without_path
-        ) {
-            if (
-                hit.categories_without_path.indexOf('<em>') === -1 &&
-                hit._highlightResult.color.value.indexOf('<em>') !== -1
-            ) {
-                hit.categories_without_path = '';
-            }
-        }
-
-        if (Array.isArray(hit._highlightResult.name))
-            hit._highlightResult.name = hit._highlightResult.name[0];
-
-        if (Array.isArray(hit.price)) {
-            hit.price = hit.price[0];
-            if (
-                hit['price'] !== undefined &&
-                price_key !== '.' + algoliaConfig.currencyCode + '.default' &&
-                hit['price'][algoliaConfig.currencyCode][
-                price_key.substr(1) + '_formated'
-                    ] !== hit['price'][algoliaConfig.currencyCode]['default_formated']
-            ) {
-                hit['price'][algoliaConfig.currencyCode][
-                price_key.substr(1) + '_original_formated'
-                    ] = hit['price'][algoliaConfig.currencyCode]['default_formated'];
-            }
-
-            if (
-                hit['price'][algoliaConfig.currencyCode]['default_original_formated'] &&
-                hit['price'][algoliaConfig.currencyCode]['special_to_date']
-            ) {
-                const priceExpiration =
-                    hit['price'][algoliaConfig.currencyCode]['special_to_date'];
-
-                if (algoliaConfig.now > priceExpiration + 1) {
-                    hit['price'][algoliaConfig.currencyCode]['default_formated'] =
-                        hit['price'][algoliaConfig.currencyCode][
-                            'default_original_formated'
-                            ];
-                    hit['price'][algoliaConfig.currencyCode][
-                        'default_original_formated'
-                        ] = false;
-                }
-            }
-        }
-
-        // Add to cart parameters
-        const action =
-            algoliaConfig.instant.addToCartParams.action +
-            'product/' +
-            hit.objectID +
-            '/';
-
-        const correctFKey = algoliaCommon.getCookie('form_key');
-
-        if (
-            correctFKey != '' &&
-            algoliaConfig.instant.addToCartParams.formKey != correctFKey
-        ) {
-            algoliaConfig.instant.addToCartParams.formKey = correctFKey;
-        }
-
-        hit.addToCart = {
-            action : action,
-            uenc   : algoliaBase64.mageEncode(action),
-            formKey: algoliaConfig.instant.addToCartParams.formKey,
-        };
-
-        if (hit.__autocomplete_queryID) {
-            hit.urlForInsights = hit.url;
-
-            if (
-                algoliaConfig.ccAnalytics.enabled &&
-                algoliaConfig.ccAnalytics.conversionAnalyticsMode !== 'disabled'
-            ) {
-                const insightsDataUrlString = $.param({
-                    queryID  : hit.__autocomplete_queryID,
-                    objectID : hit.objectID,
-                    indexName: hit.__autocomplete_indexName,
-                });
-                if (hit.url.indexOf('?') > -1) {
-                    hit.urlForInsights += '&' + insightsDataUrlString;
-                } else {
-                    hit.urlForInsights += '?' + insightsDataUrlString;
-                }
-            }
-        }
-
-        return hit;
-    };
-
-    const getNavigatorUrl = function (url) {
-        if (algoliaConfig.autocomplete.isNavigatorEnabled) {
-            return url;
-        }
-    };
-
-    /**
-     * Build pre-baked sources
-     * @param section
-     * @param searchClient
-     * @returns object representing a single source
-     */
-    const buildAutocompleteSource = function (section, searchClient) {
-        let options = {
-            hitsPerPage   : section.hitsPerPage || DEFAULT_HITS_PER_SECTION,
-            analyticsTags : 'autocomplete',
-            clickAnalytics: true,
-            distinct      : true,
-        };
-
-        const getItemUrl = ({item}) => {
-            return getNavigatorUrl(item.url);
-        };
-
-        const transformResponse = ({results, hits}) => {
-            const resDetail = results[0];
-
-            return hits.map((res) => {
-                return res.map((hit, i) => {
-                    return {
-                        ...hit,
-                        query   : resDetail.query,
-                        position: i + 1,
-                    };
-                });
-            });
-        };
-
-        const defaultSectionIndex = `${algoliaConfig.indexName}_${section.name}`;
-
-        // Default values for source
-        const source = {
-            sourceId : section.name,
-            options,
-            getItemUrl,
-            transformResponse,
-            indexName: defaultSectionIndex,
-        };
-
-        if (section.name === 'products') {
-            options.facets = ['categories.level0'];
-            options.numericFilters = 'visibility_search=1';
-            options.ruleContexts = ['magento_filters', '']; // Empty context to keep backward compatibility for already created rules in dashboard
-
-            // Allow custom override
-            options = algoliaCommon.triggerHooks(
-                'beforeAutocompleteProductSourceOptions',
-                options
-            ); //DEPRECATED - retaining for backward compatibility
-            source.options = algoliaCommon.triggerHooks(
-                'afterAutocompleteProductSourceOptions',
-                options
-            );
-
-            source.templates = {
-                noResults({html}) {
-                    return productsHtml.getNoResultHtml({html});
-                },
-                header({items, html}) {
-                    return productsHtml.getHeaderHtml({items, html});
-                },
-                item({item, components, html}) {
-                    if (suggestionSection) {
-                        $('.aa-Panel').addClass('productColumn2');
-                        $('.aa-Panel').removeClass('productColumn1');
-                    } else {
-                        $('.aa-Panel').removeClass('productColumn2');
-                        $('.aa-Panel').addClass('productColumn1');
-                    }
-                    if (
-                        algoliaFooter &&
-                        algoliaFooter !== undefined &&
-                        algoliaFooter !== null &&
-                        $('#algoliaFooter').length === 0
-                    ) {
-                        $('.aa-PanelLayout').append(algoliaFooter);
-                    }
-                    const _data = transformAutocompleteHit(item, algoliaConfig.priceKey);
-                    return productsHtml.getItemHtml({item: _data, components, html});
-                },
-                footer({items, html}) {
-                    const resultDetails = {};
-                    if (items.length) {
-                        const firstItem = items[0];
-                        resultDetails.allDepartmentsUrl =
-                            algoliaConfig.resultPageUrl +
-                            '?q=' +
-                            encodeURIComponent(firstItem.query);
-                        resultDetails.nbHits = firstItem.nbHits;
-
-                        if (
-                            algoliaConfig.facets.find(
-                                (facet) => facet.attribute === 'categories'
-                            )
-                        ) {
-                            let allCategories = [];
-                            if (typeof firstItem.allCategories !== 'undefined') {
-                                allCategories = Object.keys(firstItem.allCategories).map(
-                                    (key) => {
-                                        const url =
-                                            resultDetails.allDepartmentsUrl +
-                                            '&categories=' +
-                                            encodeURIComponent(key);
-                                        return {
-                                            name : key,
-                                            value: firstItem.allCategories[key],
-                                            url,
-                                        };
-                                    }
-                                );
-                            }
-                            //reverse value sort apparently...
-                            allCategories.sort((a, b) => b.value - a.value);
-                            resultDetails.allCategories = allCategories.slice(0, 2);
-                        }
-                    }
-                    return productsHtml.getFooterHtml({html, ...resultDetails});
-                },
-            };
-            source.transformResponse = ({results, hits}) => {
-                const resDetail = results[0];
-                return hits.map((res) => {
-                    return res.map((hit, i) => {
-                        return {
-                            ...hit,
-                            nbHits       : resDetail.nbHits,
-                            allCategories: resDetail.facets['categories.level0'],
-                            query        : resDetail.query,
-                            position     : i + 1,
-                        };
-                    });
-                });
-            };
-        } else if (section.name === 'categories') {
-            if (
-                section.name === 'categories' &&
-                algoliaConfig.showCatsNotIncludedInNavigation === false
-            ) {
-                options.numericFilters = 'include_in_menu=1';
-            }
-            source.templates = {
-                noResults({html}) {
-                    return categoriesHtml.getNoResultHtml({html});
-                },
-                header({html, items}) {
-                    return categoriesHtml.getHeaderHtml({section, html, items});
-                },
-                item({item, components, html}) {
-                    return categoriesHtml.getItemHtml({item, components, html});
-                },
-                footer({html, items}) {
-                    return categoriesHtml.getFooterHtml({section, html, items});
-                },
-            };
-        } else if (section.name === 'pages') {
-            source.templates = {
-                noResults({html}) {
-                    return pagesHtml.getNoResultHtml({html});
-                },
-                header({html, items}) {
-                    return pagesHtml.getHeaderHtml({section, html, items});
-                },
-                item({item, components, html}) {
-                    return pagesHtml.getItemHtml({item, components, html});
-                },
-                footer({html, items}) {
-                    return pagesHtml.getFooterHtml({section, html, items});
-                },
-            };
-        } else {
-            /** If is not products, categories, pages or suggestions, it's additional section **/
-            source.indexName = `${algoliaConfig.indexName}_section_${section.name}`;
-            source.templates = {
-                noResults({html}) {
-                    return additionalHtml.getNoResultHtml({html});
-                },
-                header({html, items}) {
-                    return additionalHtml.getHeaderHtml({section, html, items});
-                },
-                item({item, components, html}) {
-                    return additionalHtml.getItemHtml({
-                        item,
-                        components,
-                        html,
-                        section,
-                    });
-                },
-                footer({html, items}) {
-                    return additionalHtml.getFooterHtml({section, html, items});
-                },
-            };
-        }
-
-        return source;
-    };
-
-    const buildSuggestionsPlugin = function () {
-        return querySuggestionsPlugin.createQuerySuggestionsPlugin(
-            {
-                searchClient,
-                indexName: `${algoliaConfig.indexName}_suggestions`,
-                getSearchParams() {
-                    return {
-                        hitsPerPage   : algoliaConfig.autocomplete.nbOfQueriesSuggestions,
-                        clickAnalytics: true,
-                    };
-                },
-                transformSource({source}) {
-                    return {
-                        ...source,
-                        getItems({query}) {
-                            const items = filterMinChars(query, source.getItems());
-                            const oldTransform = items.transformResponse;
-                            items.transformResponse = (arg) => {
-                                const hits = oldTransform ? oldTransform(arg) : arg.hits;
-                                return hits.map((hit, i) => {
-                                    return {
-                                        ...hit,
-                                        position: i + 1,
-                                    };
-                                });
-                            };
-                            return items;
-                        },
-                        getItemUrl({item}) {
-                            return getNavigatorUrl(
-                                algoliaConfig.resultPageUrl + `?q=${item.query}`
-                            );
-                        },
-                        templates: {
-                            noResults({html}) {
-                                return suggestionsHtml.getNoResultHtml({html});
-                            },
-                            header({html, items}) {
-                                return suggestionsHtml.getHeaderHtml({html, items});
-                            },
-                            item({item, components, html}) {
-                                return suggestionsHtml.getItemHtml({item, components, html});
-                            },
-                            footer({html, items}) {
-                                return suggestionsHtml.getFooterHtml({html, items});
-                            },
-                        },
-                    };
-                },
-            }
-        );
-    };
-
-    const filterMinChars = (query, result) => {
-        return query.length >= MIN_SEARCH_LENGTH_CHARS ? result : [];
-    };
-
-    const debouncePromise = (fn, time) => {
-        let timerId = undefined;
-
-        return function debounced(...args) {
-            if (timerId) {
-                clearTimeout(timerId);
-            }
-
-            return new Promise((resolve) => {
-                timerId = setTimeout(() => resolve(fn(...args)), time);
-            });
-        };
-    };
-    const debounced = debouncePromise(
-        (items) => Promise.resolve(items),
-        DEBOUNCE_MS
-    );
-
-    /**
-     * Load suggestions, products and categories as configured
-     * NOTE: Sequence matters!
-     * **/
-    if (algoliaConfig.autocomplete.nbOfCategoriesSuggestions > 0) {
-        algoliaConfig.autocomplete.sections.unshift({
-            hitsPerPage: algoliaConfig.autocomplete.nbOfCategoriesSuggestions,
-            label      : algoliaConfig.translations.categories,
-            name       : 'categories',
-        });
-    }
-
-    if (algoliaConfig.autocomplete.nbOfProductsSuggestions > 0) {
-        algoliaConfig.autocomplete.sections.unshift({
-            hitsPerPage: algoliaConfig.autocomplete.nbOfProductsSuggestions,
-            label      : algoliaConfig.translations.products,
-            name       : 'products',
-        });
-    }
-
-    /** Setup autocomplete data sources **/
-    let sources = algoliaConfig.autocomplete.sections.map((section) =>
-        buildAutocompleteSource(section, searchClient)
-    );
-    sources = algoliaCommon.triggerHooks(
-        'beforeAutocompleteSources',
-        sources,
-        searchClient
-    ); // DEPRECATED
-    sources = algoliaCommon.triggerHooks(
-        'afterAutocompleteSources',
-        sources,
-        searchClient
-    );
-
-    let plugins = [];
-
-    if (algoliaConfig.autocomplete.nbOfQueriesSuggestions > 0) {
-        suggestionSection = true; //relies on global - needs refactor
-        plugins.push(buildSuggestionsPlugin());
-    }
-    plugins = algoliaCommon.triggerHooks(
-        'afterAutocompletePlugins',
-        plugins,
-        searchClient
-    );
-
-    /**
-     * Setup the autocomplete search input
-     * For autocomplete feature is used Algolia's autocomplete.js library
-     * Docs: https://github.com/algolia/autocomplete.js
-     **/
-
-    let autocompleteConfig = [];
-    let options = algoliaCommon.triggerHooks('beforeAutocompleteOptions', {}); //DEPRECATED
-
-    options = {
-        ...options,
-        container         : algoliaConfig.autocomplete.selector,
-        placeholder       : algoliaConfig.translations.placeholder,
-        debug             : algoliaConfig.autocomplete.isDebugEnabled,
-        detachedMediaQuery: 'none',
-        onSubmit(data) {
-            if (
-                data.state.query &&
-                data.state.query !== null &&
-                data.state.query !== ''
-            ) {
-                window.location.href =
-                    algoliaConfig.resultPageUrl +
-                    `?q=${encodeURIComponent(data.state.query)}`;
-            }
-        },
-        getSources({query}) {
-            return filterMinChars(query, debounced(autocompleteConfig));
-        },
-        shouldPanelOpen({state}) {
-            return state.query.length >= MIN_SEARCH_LENGTH_CHARS;
-        },
-    };
-
-    if (algoliaCommon.isMobile() === true) {
-        // Set debug to true, to be able to remove keyboard and be able to scroll in autocomplete menu
-        options.debug = true;
-    }
-
-    if (algoliaConfig.removeBranding === false) {
-        algoliaFooter = `<div id="algoliaFooter" class="footer_algolia"><span class="algolia-search-by-label">${algoliaConfig.translations.searchBy}</span><a href="https://www.algolia.com/?utm_source=magento&utm_medium=link&utm_campaign=magento_autocompletion_menu" title="${algoliaConfig.translations.searchBy} Algolia" target="_blank"><img src="${algoliaConfig.urls.logo}" alt="${algoliaConfig.translations.searchBy} Algolia" /></a></div>`;
-    }
-
-    // Keep for backward compatibility
-    if (typeof algoliaHookBeforeAutocompleteStart === 'function') {
-        console.warn(
-            "Deprecated! You are using an old API for Algolia's front end hooks. " +
-            'Please, replace your hook method with new hook API. ' +
-            'More information you can find on https://www.algolia.com/doc/integration/magento-2/customize/custom-front-end-events/'
-        );
-
-        const hookResult = algoliaHookBeforeAutocompleteStart(
-            sources,
-            options,
-            searchClient
-        );
-
-        sources = hookResult.shift();
-        options = hookResult.shift();
-    }
-
-    sources.forEach((data) => {
-        if (!data.sourceId) {
-            console.error(
-                'Algolia Autocomplete: sourceId is required for custom sources'
-            );
-            return;
-        }
-        const getItems = ({query}) => {
-            return autocomplete.getAlgoliaResults({
-                searchClient,
-                queries: [
-                    {
-                        query,
-                        indexName: data.indexName,
-                        params   : data.options,
-                    },
-                ],
-                // only set transformResponse if defined (necessary check for custom sources)
-                ...(data.transformResponse && {
-                    transformResponse: data.transformResponse,
-                }),
-            });
-        };
-        const fallbackTemplates = {
-            noResults: () => 'No results',
-            header   : () => data.sourceId,
-            item     : ({item}) => {
-                console.error(
-                    `Algolia Autocomplete: No template defined for source "${data.sourceId}"`
-                );
-                return '[ITEM TEMPLATE MISSING]';
-            },
-        };
-        autocompleteConfig.push({
-            sourceId : data.sourceId,
-            getItems,
-            templates: {...fallbackTemplates, ...(data.templates || {})},
-            // only set getItemUrl if defined (necessary check for custom sources)
-            ...(data.getItemUrl && {getItemUrl: data.getItemUrl}),
-        });
-    });
-    options.plugins = plugins;
-
-    options = algoliaCommon.triggerHooks('afterAutocompleteOptions', options);
-
-    /** Bind autocomplete feature to the input */
-    let algoliaAutocompleteInstance = autocomplete.autocomplete(options);
-    algoliaCommon.triggerHooks(
-        'afterAutocompleteStart',
-        algoliaAutocompleteInstance
-    );
-
-    //Autocomplete insight click conversion
-    // TODO: Switch to insights plugin
-    if (algoliaConfig.ccAnalytics.enabled) {
-        $(document).on('click', '.algoliasearch-autocomplete-hit', function () {
-            const $this = $(this);
-            if ($this.data('clicked')) return;
-
-            const objectId = $this.attr('data-objectId');
-            const indexName = $this.attr('data-index');
-            const queryId = $this.attr('data-queryId');
-            const position = $this.attr('data-position');
-
-            let useCookie = algoliaConfig.cookieConfiguration
-                .cookieRestrictionModeEnabled
-                ? !!algoliaCommon.getCookie(algoliaConfig.cookieConfiguration.consentCookieName)
-                : true;
-            if (useCookie !== false) {
-                algoliaInsights.initializeAnalytics();
-                const eventData = algoliaInsights.buildEventData(
-                    'Clicked',
-                    objectId,
-                    indexName,
-                    position,
-                    queryId
-                );
-                algoliaInsights.trackClick(eventData);
-                $this.attr('data-clicked', true);
-            }
-        });
-    }
-
-    if (algoliaConfig.autocomplete.isNavigatorEnabled) {
-        $('body').append(
-            '<style>.aa-Item[aria-selected="true"]{background-color: #f2f2f2;}</style>'
-        );
-    }
-
     return Component.extend({
         initialize(config, element) {
             // console.log('AC initialized with', config, element);
             this.buildAutocomplete($);
         },
+
         buildAutocomplete($) {
-            // stub
+            /** We have nothing to do here if autocomplete is disabled **/
+            if (
+                typeof algoliaConfig === 'undefined' ||
+                !algoliaConfig.autocomplete.enabled
+            ) {
+                return;
+            }
+
+            const searchClient = this.getSearchClient();
+
+            const getNavigatorUrl = function (url) {
+                if (algoliaConfig.autocomplete.isNavigatorEnabled) {
+                    return url;
+                }
+            };
+
+            const buildSuggestionsPlugin = function () {
+                return querySuggestionsPlugin.createQuerySuggestionsPlugin(
+                    {
+                        searchClient,
+                        indexName: `${algoliaConfig.indexName}_suggestions`,
+                        getSearchParams() {
+                            return {
+                                hitsPerPage   : algoliaConfig.autocomplete.nbOfQueriesSuggestions,
+                                clickAnalytics: true,
+                            };
+                        },
+                        transformSource({source}) {
+                            return {
+                                ...source,
+                                getItems({query}) {
+                                    const items = filterMinChars(query, source.getItems());
+                                    const oldTransform = items.transformResponse;
+                                    items.transformResponse = (arg) => {
+                                        const hits = oldTransform ? oldTransform(arg) : arg.hits;
+                                        return hits.map((hit, i) => {
+                                            return {
+                                                ...hit,
+                                                position: i + 1,
+                                            };
+                                        });
+                                    };
+                                    return items;
+                                },
+                                getItemUrl({item}) {
+                                    return getNavigatorUrl(
+                                        algoliaConfig.resultPageUrl + `?q=${item.query}`
+                                    );
+                                },
+                                templates: {
+                                    noResults({html}) {
+                                        return suggestionsHtml.getNoResultHtml({html});
+                                    },
+                                    header({html, items}) {
+                                        return suggestionsHtml.getHeaderHtml({html, items});
+                                    },
+                                    item({item, components, html}) {
+                                        return suggestionsHtml.getItemHtml({item, components, html});
+                                    },
+                                    footer({html, items}) {
+                                        return suggestionsHtml.getFooterHtml({html, items});
+                                    },
+                                },
+                            };
+                        },
+                    }
+                );
+            };
+
+            const filterMinChars = (query, result) => {
+                return query.length >= MIN_SEARCH_LENGTH_CHARS ? result : [];
+            };
+
+            const debouncePromise = (fn, time) => {
+                let timerId = undefined;
+
+                return function debounced(...args) {
+                    if (timerId) {
+                        clearTimeout(timerId);
+                    }
+
+                    return new Promise((resolve) => {
+                        timerId = setTimeout(() => resolve(fn(...args)), time);
+                    });
+                };
+            };
+            const debounced = debouncePromise(
+                (items) => Promise.resolve(items),
+                DEBOUNCE_MS
+            );
+
+            /**
+             * Load suggestions, products and categories as configured
+             * NOTE: Sequence matters!
+             * **/
+            if (algoliaConfig.autocomplete.nbOfCategoriesSuggestions > 0) {
+                algoliaConfig.autocomplete.sections.unshift({
+                    hitsPerPage: algoliaConfig.autocomplete.nbOfCategoriesSuggestions,
+                    label      : algoliaConfig.translations.categories,
+                    name       : 'categories',
+                });
+            }
+
+            if (algoliaConfig.autocomplete.nbOfProductsSuggestions > 0) {
+                algoliaConfig.autocomplete.sections.unshift({
+                    hitsPerPage: algoliaConfig.autocomplete.nbOfProductsSuggestions,
+                    label      : algoliaConfig.translations.products,
+                    name       : 'products',
+                });
+            }
+
+            /** Setup autocomplete data sources **/
+            let sources = algoliaConfig.autocomplete.sections.map((section) =>
+                this.buildAutocompleteSource(section, searchClient)
+            );
+            sources = algoliaCommon.triggerHooks(
+                'beforeAutocompleteSources',
+                sources,
+                searchClient
+            ); // DEPRECATED
+            sources = algoliaCommon.triggerHooks(
+                'afterAutocompleteSources',
+                sources,
+                searchClient
+            );
+
+            let plugins = [];
+
+            if (algoliaConfig.autocomplete.nbOfQueriesSuggestions > 0) {
+                suggestionSection = true; //relies on global - needs refactor
+                plugins.push(buildSuggestionsPlugin());
+            }
+            plugins = algoliaCommon.triggerHooks(
+                'afterAutocompletePlugins',
+                plugins,
+                searchClient
+            );
+
+            /**
+             * Setup the autocomplete search input
+             * For autocomplete feature is used Algolia's autocomplete.js library
+             * Docs: https://github.com/algolia/autocomplete.js
+             **/
+
+            let autocompleteConfig = [];
+            let options = algoliaCommon.triggerHooks('beforeAutocompleteOptions', {}); //DEPRECATED
+
+            options = {
+                ...options,
+                container         : algoliaConfig.autocomplete.selector,
+                placeholder       : algoliaConfig.translations.placeholder,
+                debug             : algoliaConfig.autocomplete.isDebugEnabled,
+                detachedMediaQuery: 'none',
+                onSubmit(data) {
+                    if (
+                        data.state.query &&
+                        data.state.query !== null &&
+                        data.state.query !== ''
+                    ) {
+                        window.location.href =
+                            algoliaConfig.resultPageUrl +
+                            `?q=${encodeURIComponent(data.state.query)}`;
+                    }
+                },
+                getSources({query}) {
+                    return filterMinChars(query, debounced(autocompleteConfig));
+                },
+                shouldPanelOpen({state}) {
+                    return state.query.length >= MIN_SEARCH_LENGTH_CHARS;
+                },
+            };
+
+            if (algoliaCommon.isMobile() === true) {
+                // Set debug to true, to be able to remove keyboard and be able to scroll in autocomplete menu
+                options.debug = true;
+            }
+
+            if (algoliaConfig.removeBranding === false) {
+                algoliaFooter = `<div id="algoliaFooter" class="footer_algolia"><span class="algolia-search-by-label">${algoliaConfig.translations.searchBy}</span><a href="https://www.algolia.com/?utm_source=magento&utm_medium=link&utm_campaign=magento_autocompletion_menu" title="${algoliaConfig.translations.searchBy} Algolia" target="_blank"><img src="${algoliaConfig.urls.logo}" alt="${algoliaConfig.translations.searchBy} Algolia" /></a></div>`;
+            }
+
+            // Keep for backward compatibility
+            if (typeof algoliaHookBeforeAutocompleteStart === 'function') {
+                console.warn(
+                    "Deprecated! You are using an old API for Algolia's front end hooks. " +
+                    'Please, replace your hook method with new hook API. ' +
+                    'More information you can find on https://www.algolia.com/doc/integration/magento-2/customize/custom-front-end-events/'
+                );
+
+                const hookResult = algoliaHookBeforeAutocompleteStart(
+                    sources,
+                    options,
+                    searchClient
+                );
+
+                sources = hookResult.shift();
+                options = hookResult.shift();
+            }
+
+            sources.forEach((data) => {
+                if (!data.sourceId) {
+                    console.error(
+                        'Algolia Autocomplete: sourceId is required for custom sources'
+                    );
+                    return;
+                }
+                const getItems = ({query}) => {
+                    return autocomplete.getAlgoliaResults({
+                        searchClient,
+                        queries: [
+                            {
+                                query,
+                                indexName: data.indexName,
+                                params   : data.options,
+                            },
+                        ],
+                        // only set transformResponse if defined (necessary check for custom sources)
+                        ...(data.transformResponse && {
+                            transformResponse: data.transformResponse,
+                        }),
+                    });
+                };
+                const fallbackTemplates = {
+                    noResults: () => 'No results',
+                    header   : () => data.sourceId,
+                    item     : ({item}) => {
+                        console.error(
+                            `Algolia Autocomplete: No template defined for source "${data.sourceId}"`
+                        );
+                        return '[ITEM TEMPLATE MISSING]';
+                    },
+                };
+                autocompleteConfig.push({
+                    sourceId : data.sourceId,
+                    getItems,
+                    templates: {...fallbackTemplates, ...(data.templates || {})},
+                    // only set getItemUrl if defined (necessary check for custom sources)
+                    ...(data.getItemUrl && {getItemUrl: data.getItemUrl}),
+                });
+            });
+            options.plugins = plugins;
+
+            options = algoliaCommon.triggerHooks('afterAutocompleteOptions', options);
+
+            /** Bind autocomplete feature to the input */
+            let algoliaAutocompleteInstance = autocomplete.autocomplete(options);
+            algoliaCommon.triggerHooks(
+                'afterAutocompleteStart',
+                algoliaAutocompleteInstance
+            );
+
+            //Autocomplete insight click conversion
+            // TODO: Switch to insights plugin
+            if (algoliaConfig.ccAnalytics.enabled) {
+                $(document).on('click', '.algoliasearch-autocomplete-hit', function () {
+                    const $this = $(this);
+                    if ($this.data('clicked')) return;
+
+                    const objectId = $this.attr('data-objectId');
+                    const indexName = $this.attr('data-index');
+                    const queryId = $this.attr('data-queryId');
+                    const position = $this.attr('data-position');
+
+                    let useCookie = algoliaConfig.cookieConfiguration
+                        .cookieRestrictionModeEnabled
+                        ? !!algoliaCommon.getCookie(algoliaConfig.cookieConfiguration.consentCookieName)
+                        : true;
+                    if (useCookie !== false) {
+                        algoliaInsights.initializeAnalytics();
+                        const eventData = algoliaInsights.buildEventData(
+                            'Clicked',
+                            objectId,
+                            indexName,
+                            position,
+                            queryId
+                        );
+                        algoliaInsights.trackClick(eventData);
+                        $this.attr('data-clicked', true);
+                    }
+                });
+            }
+
+            if (algoliaConfig.autocomplete.isNavigatorEnabled) {
+                $('body').append(
+                    '<style>.aa-Item[aria-selected="true"]{background-color: #f2f2f2;}</style>'
+                );
+            }
+        },
+
+        getSearchClient() {
+            /**
+             * Initialise Algolia client
+             * Docs: https://www.algolia.com/doc/api-client/getting-started/instantiate-client-index/
+             **/
+              const searchClient = algoliasearch(
+                algoliaConfig.applicationId,
+                algoliaConfig.apiKey
+            );
+            searchClient.addAlgoliaAgent(
+                'Magento2 integration (' + algoliaConfig.extensionVersion + ')'
+            );
+            return searchClient;
+        },
+
+        /**
+         * Build pre-baked sources
+         * @param section
+         * @param searchClient
+         * @returns object representing a single source
+         */
+        buildAutocompleteSource(section, searchClient) {
+            let options = {
+                hitsPerPage   : section.hitsPerPage || DEFAULT_HITS_PER_SECTION,
+                analyticsTags : 'autocomplete',
+                clickAnalytics: true,
+                distinct      : true,
+            };
+
+            const getItemUrl = ({item}) => {
+                return getNavigatorUrl(item.url);
+            };
+
+            const transformResponse = ({results, hits}) => {
+                const resDetail = results[0];
+
+                return hits.map((res) => {
+                    return res.map((hit, i) => {
+                        return {
+                            ...hit,
+                            query   : resDetail.query,
+                            position: i + 1,
+                        };
+                    });
+                });
+            };
+
+            const defaultSectionIndex = `${algoliaConfig.indexName}_${section.name}`;
+
+            // Default values for source
+            const source = {
+                sourceId : section.name,
+                options,
+                getItemUrl,
+                transformResponse,
+                indexName: defaultSectionIndex,
+            };
+
+            if (section.name === 'products') {
+                options.facets = ['categories.level0'];
+                options.numericFilters = 'visibility_search=1';
+                options.ruleContexts = ['magento_filters', '']; // Empty context to keep backward compatibility for already created rules in dashboard
+
+                // Allow custom override
+                options = algoliaCommon.triggerHooks(
+                    'beforeAutocompleteProductSourceOptions',
+                    options
+                ); //DEPRECATED - retaining for backward compatibility
+                source.options = algoliaCommon.triggerHooks(
+                    'afterAutocompleteProductSourceOptions',
+                    options
+                );
+
+                source.templates = {
+                    noResults({html}) {
+                        return productsHtml.getNoResultHtml({html});
+                    },
+                    header({items, html}) {
+                        return productsHtml.getHeaderHtml({items, html});
+                    },
+                    item: ({item, components, html}) =>{
+                        if (suggestionSection) {
+                            $('.aa-Panel').addClass('productColumn2');
+                            $('.aa-Panel').removeClass('productColumn1');
+                        } else {
+                            $('.aa-Panel').removeClass('productColumn2');
+                            $('.aa-Panel').addClass('productColumn1');
+                        }
+                        if (
+                            algoliaFooter &&
+                            algoliaFooter !== undefined &&
+                            algoliaFooter !== null &&
+                            $('#algoliaFooter').length === 0
+                        ) {
+                            $('.aa-PanelLayout').append(algoliaFooter);
+                        }
+                        const _data = this.transformAutocompleteHit(item, algoliaConfig.priceKey);
+                        return productsHtml.getItemHtml({item: _data, components, html});
+                    },
+                    footer({items, html}) {
+                        const resultDetails = {};
+                        if (items.length) {
+                            const firstItem = items[0];
+                            resultDetails.allDepartmentsUrl =
+                                algoliaConfig.resultPageUrl +
+                                '?q=' +
+                                encodeURIComponent(firstItem.query);
+                            resultDetails.nbHits = firstItem.nbHits;
+
+                            if (
+                                algoliaConfig.facets.find(
+                                    (facet) => facet.attribute === 'categories'
+                                )
+                            ) {
+                                let allCategories = [];
+                                if (typeof firstItem.allCategories !== 'undefined') {
+                                    allCategories = Object.keys(firstItem.allCategories).map(
+                                        (key) => {
+                                            const url =
+                                                resultDetails.allDepartmentsUrl +
+                                                '&categories=' +
+                                                encodeURIComponent(key);
+                                            return {
+                                                name : key,
+                                                value: firstItem.allCategories[key],
+                                                url,
+                                            };
+                                        }
+                                    );
+                                }
+                                //reverse value sort apparently...
+                                allCategories.sort((a, b) => b.value - a.value);
+                                resultDetails.allCategories = allCategories.slice(0, 2);
+                            }
+                        }
+                        return productsHtml.getFooterHtml({html, ...resultDetails});
+                    },
+                };
+                source.transformResponse = ({results, hits}) => {
+                    const resDetail = results[0];
+                    return hits.map((res) => {
+                        return res.map((hit, i) => {
+                            return {
+                                ...hit,
+                                nbHits       : resDetail.nbHits,
+                                allCategories: resDetail.facets['categories.level0'],
+                                query        : resDetail.query,
+                                position     : i + 1,
+                            };
+                        });
+                    });
+                };
+            } else if (section.name === 'categories') {
+                if (
+                    section.name === 'categories' &&
+                    algoliaConfig.showCatsNotIncludedInNavigation === false
+                ) {
+                    options.numericFilters = 'include_in_menu=1';
+                }
+                source.templates = {
+                    noResults({html}) {
+                        return categoriesHtml.getNoResultHtml({html});
+                    },
+                    header({html, items}) {
+                        return categoriesHtml.getHeaderHtml({section, html, items});
+                    },
+                    item({item, components, html}) {
+                        return categoriesHtml.getItemHtml({item, components, html});
+                    },
+                    footer({html, items}) {
+                        return categoriesHtml.getFooterHtml({section, html, items});
+                    },
+                };
+            } else if (section.name === 'pages') {
+                source.templates = {
+                    noResults({html}) {
+                        return pagesHtml.getNoResultHtml({html});
+                    },
+                    header({html, items}) {
+                        return pagesHtml.getHeaderHtml({section, html, items});
+                    },
+                    item({item, components, html}) {
+                        return pagesHtml.getItemHtml({item, components, html});
+                    },
+                    footer({html, items}) {
+                        return pagesHtml.getFooterHtml({section, html, items});
+                    },
+                };
+            } else {
+                /** If is not products, categories, pages or suggestions, it's additional section **/
+                source.indexName = `${algoliaConfig.indexName}_section_${section.name}`;
+                source.templates = {
+                    noResults({html}) {
+                        return additionalHtml.getNoResultHtml({html});
+                    },
+                    header({html, items}) {
+                        return additionalHtml.getHeaderHtml({section, html, items});
+                    },
+                    item({item, components, html}) {
+                        return additionalHtml.getItemHtml({
+                            item,
+                            components,
+                            html,
+                            section,
+                        });
+                    },
+                    footer({html, items}) {
+                        return additionalHtml.getFooterHtml({section, html, items});
+                    },
+                };
+            }
+
+            return source;
+        },
+
+        transformAutocompleteHit(hit, price_key, helper) {
+            if (Array.isArray(hit.categories))
+                hit.categories = hit.categories.join(', ');
+
+            if (
+                hit._highlightResult.categories_without_path &&
+                Array.isArray(hit.categories_without_path)
+            ) {
+                hit.categories_without_path = $.map(
+                    hit._highlightResult.categories_without_path,
+                    function (category) {
+                        return category.value;
+                    }
+                );
+
+                hit.categories_without_path = hit.categories_without_path.join(', ');
+            }
+
+            let matchedColors = [];
+
+            // TODO: Adapt this migrated code from common.js - helper not utilized
+            if (helper && algoliaConfig.useAdaptiveImage === true) {
+                if (hit.images_data && helper.state.facetsRefinements.color) {
+                    matchedColors = helper.state.facetsRefinements.color.slice(0); // slice to clone
+                }
+
+                if (hit.images_data && helper.state.disjunctiveFacetsRefinements.color) {
+                    matchedColors =
+                        helper.state.disjunctiveFacetsRefinements.color.slice(0); // slice to clone
+                }
+            }
+
+            if (Array.isArray(hit.color)) {
+                let colors = [];
+
+                $.each(hit._highlightResult.color, function (i, color) {
+                    if (color.matchLevel === undefined || color.matchLevel === 'none') {
+                        return;
+                    }
+
+                    colors.push(color.value);
+
+                    if (algoliaConfig.useAdaptiveImage === true) {
+                        const matchedColor = color.matchedWords.join(' ');
+                        if (
+                            hit.images_data &&
+                            color.fullyHighlighted &&
+                            color.fullyHighlighted === true
+                        ) {
+                            matchedColors.push(matchedColor);
+                        }
+                    }
+                });
+
+                colors = colors.join(', ');
+                hit._highlightResult.color = {value: colors};
+            } else {
+                if (
+                    hit._highlightResult.color &&
+                    hit._highlightResult.color.matchLevel === 'none'
+                ) {
+                    hit._highlightResult.color = {value: ''};
+                }
+            }
+
+            if (algoliaConfig.useAdaptiveImage === true) {
+                $.each(matchedColors, function (i, color) {
+                    color = color.toLowerCase();
+
+                    if (hit.images_data[color]) {
+                        hit.image_url = hit.images_data[color];
+                        hit.thumbnail_url = hit.images_data[color];
+
+                        return false;
+                    }
+                });
+            }
+
+            if (
+                hit._highlightResult.color &&
+                hit._highlightResult.color.value &&
+                hit.categories_without_path
+            ) {
+                if (
+                    hit.categories_without_path.indexOf('<em>') === -1 &&
+                    hit._highlightResult.color.value.indexOf('<em>') !== -1
+                ) {
+                    hit.categories_without_path = '';
+                }
+            }
+
+            if (Array.isArray(hit._highlightResult.name))
+                hit._highlightResult.name = hit._highlightResult.name[0];
+
+            if (Array.isArray(hit.price)) {
+                hit.price = hit.price[0];
+                if (
+                    hit['price'] !== undefined &&
+                    price_key !== '.' + algoliaConfig.currencyCode + '.default' &&
+                    hit['price'][algoliaConfig.currencyCode][
+                    price_key.substr(1) + '_formated'
+                        ] !== hit['price'][algoliaConfig.currencyCode]['default_formated']
+                ) {
+                    hit['price'][algoliaConfig.currencyCode][
+                    price_key.substr(1) + '_original_formated'
+                        ] = hit['price'][algoliaConfig.currencyCode]['default_formated'];
+                }
+
+                if (
+                    hit['price'][algoliaConfig.currencyCode]['default_original_formated'] &&
+                    hit['price'][algoliaConfig.currencyCode]['special_to_date']
+                ) {
+                    const priceExpiration =
+                        hit['price'][algoliaConfig.currencyCode]['special_to_date'];
+
+                    if (algoliaConfig.now > priceExpiration + 1) {
+                        hit['price'][algoliaConfig.currencyCode]['default_formated'] =
+                            hit['price'][algoliaConfig.currencyCode][
+                                'default_original_formated'
+                                ];
+                        hit['price'][algoliaConfig.currencyCode][
+                            'default_original_formated'
+                            ] = false;
+                    }
+                }
+            }
+
+            // Add to cart parameters
+            const action =
+                algoliaConfig.instant.addToCartParams.action +
+                'product/' +
+                hit.objectID +
+                '/';
+
+            const correctFKey = algoliaCommon.getCookie('form_key');
+
+            if (
+                correctFKey != '' &&
+                algoliaConfig.instant.addToCartParams.formKey != correctFKey
+            ) {
+                algoliaConfig.instant.addToCartParams.formKey = correctFKey;
+            }
+
+            hit.addToCart = {
+                action : action,
+                uenc   : algoliaBase64.mageEncode(action),
+                formKey: algoliaConfig.instant.addToCartParams.formKey,
+            };
+
+            if (hit.__autocomplete_queryID) {
+                hit.urlForInsights = hit.url;
+
+                if (
+                    algoliaConfig.ccAnalytics.enabled &&
+                    algoliaConfig.ccAnalytics.conversionAnalyticsMode !== 'disabled'
+                ) {
+                    const insightsDataUrlString = $.param({
+                        queryID  : hit.__autocomplete_queryID,
+                        objectID : hit.objectID,
+                        indexName: hit.__autocomplete_indexName,
+                    });
+                    if (hit.url.indexOf('?') > -1) {
+                        hit.urlForInsights += '&' + insightsDataUrlString;
+                    } else {
+                        hit.urlForInsights += '?' + insightsDataUrlString;
+                    }
+                }
+            }
+
+            return hit;
         }
     });
 });

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -1,30 +1,41 @@
 define([
+    'uiComponent',
     'jquery',
+
+    // Algolia core UI libs
     'algoliaSearchLib',
     'algoliaAutocompleteLib',
     'algoliaQuerySuggestionsPluginLib',
-    'algoliaAutocompletePagesHtml',
-    'algoliaAutocompleteCategoriesHtml',
-    'algoliaAutocompleteProductsHtml',
-    'algoliaAutocompleteSuggestionsHtml',
-    'algoliaAutocompleteAdditionalHtml',
+
+    // Algolia integration dependencies
     'algoliaCommon',
     'algoliaBase64',
+    
+    // HTML templates
+    'algoliaAutocompleteProductsHtml',
+    'algoliaAutocompleteCategoriesHtml',
+    'algoliaAutocompletePagesHtml',
+    'algoliaAutocompleteSuggestionsHtml',
+    'algoliaAutocompleteAdditionalHtml',
+    
+    // TODO: Refactor legacy global object dependencies
     'algoliaInsights',
     'algoliaHooks',
-    'domReady!',
+    
+    'domReady!'
 ], function (
+    Component,
     $,
     algoliasearch,
     autocomplete,
     querySuggestionsPlugin,
-    pagesHtml,
-    categoriesHtml,
-    productsHtml,
-    suggestionsHtml,
-    additionalHtml,
     algoliaCommon,
-    algoliaBase64
+    algoliaBase64,
+    productsHtml,
+    categoriesHtml,
+    pagesHtml,
+    suggestionsHtml,
+    additionalHtml
 ) {
     const DEFAULT_HITS_PER_SECTION = 2;
     const DEBOUNCE_MS = algoliaConfig.autocomplete.debounceMilliseconds;
@@ -704,4 +715,14 @@ define([
             '<style>.aa-Item[aria-selected="true"]{background-color: #f2f2f2;}</style>'
         );
     }
+
+    return Component.extend({
+        initialize(config, element) {
+            // console.log('AC initialized with', config, element);
+            this.buildAutocomplete($);
+        },
+        buildAutocomplete($) {
+            // stub
+        }
+    });
 });

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -21,7 +21,8 @@ define([
     categoriesHtml,
     productsHtml,
     suggestionsHtml,
-    additionalHtml
+    additionalHtml,
+    algoliaCommon
 ) {
     const DEFAULT_HITS_PER_SECTION = 2;
     const DEBOUNCE_MS = algoliaConfig.autocomplete.debounceMilliseconds;
@@ -186,7 +187,7 @@ define([
             hit.objectID +
             '/';
 
-        const correctFKey = getCookie('form_key');
+        const correctFKey = algoliaCommon.getCookie('form_key');
 
         if (
             correctFKey != '' &&
@@ -197,7 +198,7 @@ define([
 
         hit.addToCart = {
             action : action,
-            uenc   : AlgoliaBase64.mageEncode(action),
+            uenc   : algoliaCommon.AlgoliaBase64.mageEncode(action),
             formKey: algoliaConfig.instant.addToCartParams.formKey,
         };
 
@@ -279,11 +280,11 @@ define([
             options.ruleContexts = ['magento_filters', '']; // Empty context to keep backward compatibility for already created rules in dashboard
 
             // Allow custom override
-            options = algolia.triggerHooks(
+            options = algoliaCommon.algolia.triggerHooks(
                 'beforeAutocompleteProductSourceOptions',
                 options
             ); //DEPRECATED - retaining for backward compatibility
-            source.options = algolia.triggerHooks(
+            source.options = algoliaCommon.algolia.triggerHooks(
                 'afterAutocompleteProductSourceOptions',
                 options
             );
@@ -529,12 +530,12 @@ define([
     let sources = algoliaConfig.autocomplete.sections.map((section) =>
         buildAutocompleteSource(section, searchClient)
     );
-    sources = algolia.triggerHooks(
+    sources = algoliaCommon.algolia.triggerHooks(
         'beforeAutocompleteSources',
         sources,
         searchClient
     ); // DEPRECATED
-    sources = algolia.triggerHooks(
+    sources = algoliaCommon.algolia.triggerHooks(
         'afterAutocompleteSources',
         sources,
         searchClient
@@ -546,7 +547,7 @@ define([
         suggestionSection = true; //relies on global - needs refactor
         plugins.push(buildSuggestionsPlugin());
     }
-    plugins = algolia.triggerHooks(
+    plugins = algoliaCommon.algolia.triggerHooks(
         'afterAutocompletePlugins',
         plugins,
         searchClient
@@ -559,7 +560,7 @@ define([
      **/
 
     let autocompleteConfig = [];
-    let options = algolia.triggerHooks('beforeAutocompleteOptions', {}); //DEPRECATED
+    let options = algoliaCommon.algolia.triggerHooks('beforeAutocompleteOptions', {}); //DEPRECATED
 
     options = {
         ...options,
@@ -586,7 +587,7 @@ define([
         },
     };
 
-    if (isMobile() === true) {
+    if (algoliaCommon.isMobile() === true) {
         // Set debug to true, to be able to remove keyboard and be able to scroll in autocomplete menu
         options.debug = true;
     }
@@ -656,11 +657,11 @@ define([
     });
     options.plugins = plugins;
 
-    options = algolia.triggerHooks('afterAutocompleteOptions', options);
+    options = algoliaCommon.algolia.triggerHooks('afterAutocompleteOptions', options);
 
     /** Bind autocomplete feature to the input */
     let algoliaAutocompleteInstance = autocomplete.autocomplete(options);
-    algolia.triggerHooks(
+    algoliaCommon.algolia.triggerHooks(
         'afterAutocompleteStart',
         algoliaAutocompleteInstance
     );
@@ -679,7 +680,7 @@ define([
 
             let useCookie = algoliaConfig.cookieConfiguration
                 .cookieRestrictionModeEnabled
-                ? !!getCookie(algoliaConfig.cookieConfiguration.consentCookieName)
+                ? !!algoliaCommon.getCookie(algoliaConfig.cookieConfiguration.consentCookieName)
                 : true;
             if (useCookie !== false) {
                 algoliaInsights.initializeAnalytics();

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -306,7 +306,7 @@ define([
          * @param source - default values for the source object
          * @returns source object
          */
-        buildAutocompleteSourceProducts(section, source, options) {
+        buildAutocompleteSourceProducts(section, source) {
             source.options = this.buildProductSourceOptions(section, source.options);
             source.templates = {
                 noResults: ({html}) => {
@@ -411,7 +411,7 @@ define([
                 section.name === 'categories' &&
                 algoliaConfig.showCatsNotIncludedInNavigation === false
             ) {
-                options.numericFilters = 'include_in_menu=1';
+                source.options.numericFilters = 'include_in_menu=1';
             }
             source.templates = {
                 noResults: ({html}) => {

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -9,6 +9,7 @@ define([
     'algoliaAutocompleteSuggestionsHtml',
     'algoliaAutocompleteAdditionalHtml',
     'algoliaCommon',
+    'algoliaBase64',
     'algoliaInsights',
     'algoliaHooks',
     'domReady!',
@@ -22,7 +23,8 @@ define([
     productsHtml,
     suggestionsHtml,
     additionalHtml,
-    algoliaCommon
+    algoliaCommon,
+    algoliaBase64
 ) {
     const DEFAULT_HITS_PER_SECTION = 2;
     const DEBOUNCE_MS = algoliaConfig.autocomplete.debounceMilliseconds;
@@ -198,7 +200,7 @@ define([
 
         hit.addToCart = {
             action : action,
-            uenc   : algoliaCommon.AlgoliaBase64.mageEncode(action),
+            uenc   : algoliaBase64.mageEncode(action),
             formKey: algoliaConfig.instant.addToCartParams.formKey,
         };
 

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -166,6 +166,24 @@ define([
                 options.debug = true;
             }
 
+            // DEPRECATED Do not use - Retained for backward compatibility but `algoliaHookBeforeAutocompleteStart` will be removed in a future version 
+            if (typeof algoliaHookBeforeAutocompleteStart === 'function') {
+                console.warn(
+                    "Deprecated! You are using an old API for Algolia's front end hooks. " +
+                    'Please, replace your hook method with new hook API. ' +
+                    'More information you can find on https://www.algolia.com/doc/integration/magento-2/customize/custom-front-end-events/'
+                );
+
+                const hookResult = algoliaHookBeforeAutocompleteStart(
+                    sources,
+                    options,
+                    searchClient
+                );
+
+                sources = hookResult.shift();
+                options = hookResult.shift();
+            }
+
             sources.forEach((data) => {
                 if (!data.sourceId) {
                     console.error(
@@ -544,27 +562,9 @@ define([
          * @param options 
          * @returns the Algolia Autocomplete instance 
          */
-        startAutocomplete(searchClient, sources, options) {
-            // DEPRECATED Do not use - Retained for backward compatibility but `algoliaHookBeforeAutocompleteStart` will be removed in a future version 
-            if (typeof algoliaHookBeforeAutocompleteStart === 'function') {
-                console.warn(
-                    "Deprecated! You are using an old API for Algolia's front end hooks. " +
-                    'Please, replace your hook method with new hook API. ' +
-                    'More information you can find on https://www.algolia.com/doc/integration/magento-2/customize/custom-front-end-events/'
-                );
-
-                const hookResult = algoliaHookBeforeAutocompleteStart(
-                    sources,
-                    options,
-                    searchClient
-                );
-
-                sources = hookResult.shift();
-                options = hookResult.shift();
-            }
-
+        startAutocomplete(options) {
             /** Bind autocomplete feature to the input */
-            let algoliaAutocompleteInstance = autocomplete.autocomplete(options);
+            const algoliaAutocompleteInstance = autocomplete.autocomplete(options);
             return algoliaCommon.triggerHooks(
                 'afterAutocompleteStart',
                 algoliaAutocompleteInstance

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -282,11 +282,11 @@ define([
             options.ruleContexts = ['magento_filters', '']; // Empty context to keep backward compatibility for already created rules in dashboard
 
             // Allow custom override
-            options = algoliaCommon.algolia.triggerHooks(
+            options = algoliaCommon.triggerHooks(
                 'beforeAutocompleteProductSourceOptions',
                 options
             ); //DEPRECATED - retaining for backward compatibility
-            source.options = algoliaCommon.algolia.triggerHooks(
+            source.options = algoliaCommon.triggerHooks(
                 'afterAutocompleteProductSourceOptions',
                 options
             );
@@ -532,12 +532,12 @@ define([
     let sources = algoliaConfig.autocomplete.sections.map((section) =>
         buildAutocompleteSource(section, searchClient)
     );
-    sources = algoliaCommon.algolia.triggerHooks(
+    sources = algoliaCommon.triggerHooks(
         'beforeAutocompleteSources',
         sources,
         searchClient
     ); // DEPRECATED
-    sources = algoliaCommon.algolia.triggerHooks(
+    sources = algoliaCommon.triggerHooks(
         'afterAutocompleteSources',
         sources,
         searchClient
@@ -549,7 +549,7 @@ define([
         suggestionSection = true; //relies on global - needs refactor
         plugins.push(buildSuggestionsPlugin());
     }
-    plugins = algoliaCommon.algolia.triggerHooks(
+    plugins = algoliaCommon.triggerHooks(
         'afterAutocompletePlugins',
         plugins,
         searchClient
@@ -562,7 +562,7 @@ define([
      **/
 
     let autocompleteConfig = [];
-    let options = algoliaCommon.algolia.triggerHooks('beforeAutocompleteOptions', {}); //DEPRECATED
+    let options = algoliaCommon.triggerHooks('beforeAutocompleteOptions', {}); //DEPRECATED
 
     options = {
         ...options,
@@ -659,11 +659,11 @@ define([
     });
     options.plugins = plugins;
 
-    options = algoliaCommon.algolia.triggerHooks('afterAutocompleteOptions', options);
+    options = algoliaCommon.triggerHooks('afterAutocompleteOptions', options);
 
     /** Bind autocomplete feature to the input */
     let algoliaAutocompleteInstance = autocomplete.autocomplete(options);
-    algoliaCommon.algolia.triggerHooks(
+    algoliaCommon.triggerHooks(
         'afterAutocompleteStart',
         algoliaAutocompleteInstance
     );

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -80,11 +80,7 @@ define([
 
             this.addFooter();
 
-            if (algoliaConfig.autocomplete.isNavigatorEnabled) {
-                $('body').append(
-                    '<style>.aa-Item[aria-selected="true"]{background-color: #f2f2f2;}</style>'
-                );
-            }
+            this.addKeyboardNavigation();
         },
 
         getSearchClient() {
@@ -850,6 +846,14 @@ define([
                 $('.aa-Panel').addClass('productColumn1');
             }
             
+        },
+
+        addKeyboardNavigation() {
+            if (algoliaConfig.autocomplete.isNavigatorEnabled) {
+                $('body').append(
+                    '<style>.aa-Item[aria-selected="true"]{background-color: #f2f2f2;}</style>'
+                );
+            }
         }
     });
 });

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -61,24 +61,8 @@ define([
             }
 
             const searchClient = this.getSearchClient();
-
-            const debouncePromise = (fn, time) => {
-                let timerId = undefined;
-
-                return (...args) => {
-                    if (timerId) {
-                        clearTimeout(timerId);
-                    }
-
-                    return new Promise((resolve) => {
-                        timerId = setTimeout(() => resolve(fn(...args)), time);
-                    });
-                };
-            };
-            const debounced = debouncePromise(
-                (items) => Promise.resolve(items),
-                DEBOUNCE_MS
-            );
+            
+            const debounced = this.debounce(items => Promise.resolve(items), DEBOUNCE_MS);
 
             /**
              * Load suggestions, products and categories as configured
@@ -668,6 +652,20 @@ define([
 
         filterMinChars(query, result) {
             return query.length >= MIN_SEARCH_LENGTH_CHARS ? result : [];
+        },
+
+        debounce(fn, time) {
+            let timerId = undefined;
+
+            return (...args) => {
+                if (timerId) {
+                    clearTimeout(timerId);
+                }
+
+                return new Promise((resolve) => {
+                    timerId = setTimeout(() => resolve(fn(...args)), time);
+                });
+            };
         },
 
         getNavigatorUrl(url) {

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -76,36 +76,7 @@ define([
 
             this.startAutocomplete(options);
 
-            //Autocomplete insight click conversion
-            // TODO: Switch to insights plugin
-            if (algoliaConfig.ccAnalytics.enabled) {
-                $(document).on('click', '.algoliasearch-autocomplete-hit', function () {
-                    const $this = $(this);
-                    if ($this.data('clicked')) return;
-
-                    const objectId = $this.attr('data-objectId');
-                    const indexName = $this.attr('data-index');
-                    const queryId = $this.attr('data-queryId');
-                    const position = $this.attr('data-position');
-
-                    let useCookie = algoliaConfig.cookieConfiguration
-                        .cookieRestrictionModeEnabled
-                        ? !!algoliaCommon.getCookie(algoliaConfig.cookieConfiguration.consentCookieName)
-                        : true;
-                    if (useCookie !== false) {
-                        algoliaInsights.initializeAnalytics();
-                        const eventData = algoliaInsights.buildEventData(
-                            'Clicked',
-                            objectId,
-                            indexName,
-                            position,
-                            queryId
-                        );
-                        algoliaInsights.trackClick(eventData);
-                        $this.attr('data-clicked', true);
-                    }
-                });
-            }
+            this.trackClicks();
 
             if (algoliaConfig.autocomplete.isNavigatorEnabled) {
                 $('body').append(
@@ -821,6 +792,41 @@ define([
                     },
                 }
             );
-        }
+        },
+
+        /**
+         * Autocomplete insight click conversion
+         */
+        trackClicks() {
+            // TODO: Switch to insights plugin
+            if (algoliaConfig.ccAnalytics.enabled) {
+                $(document).on('click', '.algoliasearch-autocomplete-hit', function () {
+                    const $this = $(this);
+                    if ($this.data('clicked')) return;
+
+                    const objectId = $this.attr('data-objectId');
+                    const indexName = $this.attr('data-index');
+                    const queryId = $this.attr('data-queryId');
+                    const position = $this.attr('data-position');
+
+                    let useCookie = algoliaConfig.cookieConfiguration
+                        .cookieRestrictionModeEnabled
+                        ? !!algoliaCommon.getCookie(algoliaConfig.cookieConfiguration.consentCookieName)
+                        : true;
+                    if (useCookie !== false) {
+                        algoliaInsights.initializeAnalytics();
+                        const eventData = algoliaInsights.buildEventData(
+                            'Clicked',
+                            objectId,
+                            indexName,
+                            position,
+                            queryId
+                        );
+                        algoliaInsights.trackClick(eventData);
+                        $this.attr('data-clicked', true);
+                    }
+                });
+            }
+        },
     });
 });

--- a/view/frontend/web/js/autocomplete.js
+++ b/view/frontend/web/js/autocomplete.js
@@ -53,7 +53,6 @@ define([
             this.buildAutocomplete($);
         },
 
-
         /**
          * Setup the autocomplete search input
          * For autocomplete feature is used Algolia's autocomplete.js library
@@ -130,24 +129,6 @@ define([
                 debug: algoliaCommon.isMobile(),
                 plugins
             };
-
-            // DEPRECATED Do not use - Retained for backward compatibility but `algoliaHookBeforeAutocompleteStart` will be removed in a future version 
-            if (typeof algoliaHookBeforeAutocompleteStart === 'function') {
-                console.warn(
-                    "Deprecated! You are using an old API for Algolia's front end hooks. " +
-                    'Please, replace your hook method with new hook API. ' +
-                    'More information you can find on https://www.algolia.com/doc/integration/magento-2/customize/custom-front-end-events/'
-                );
-
-                const hookResult = algoliaHookBeforeAutocompleteStart(
-                    sources,
-                    options,
-                    searchClient
-                );
-
-                sources = hookResult.shift();
-                options = hookResult.shift();
-            }
 
             options = algoliaCommon.triggerHooks('afterAutocompleteOptions', options);
             

--- a/view/frontend/web/js/insights.js
+++ b/view/frontend/web/js/insights.js
@@ -90,7 +90,7 @@ define([
                 return;
             }
 
-            algoliaCommon.algolia.registerHook(
+            algoliaCommon.registerHook(
                 'beforeWidgetInitialization',
                 (allWidgetConfiguration) => {
 
@@ -101,7 +101,7 @@ define([
                 }
             );
 
-            algoliaCommon.algolia.registerHook(
+            algoliaCommon.registerHook(
                 'afterAutocompleteProductSourceOptions',
                 (options) => {
                     return algoliaInsights.applyInsightsToSearchParams(options);
@@ -136,7 +136,7 @@ define([
             this.bindClickedEvents();
             this.bindViewedEvents();
 
-            algoliaCommon.algolia.triggerHooks('afterInsightsBindEvents', this);
+            algoliaCommon.triggerHooks('afterInsightsBindEvents', this);
         },
 
         bindClickedEvents() {
@@ -220,7 +220,7 @@ define([
                         containers.push('.' + elem.className);
                     }
 
-                    algoliaCommon.algolia.registerHook(
+                    algoliaCommon.registerHook(
                         'afterInstantsearchStart',
                         function (search) {
                             var selectors = document.querySelectorAll(containers.join(', '));

--- a/view/frontend/web/js/insights.js
+++ b/view/frontend/web/js/insights.js
@@ -4,13 +4,23 @@ define([
     'algoliaCommon',
     'mage/cookies',
 ], function ($, algoliaAnalyticsWrapper, algoliaCommon) {
+    const USE_GLOBALS = true;
+
     algoliaAnalytics = algoliaAnalyticsWrapper.default;
 
-    window.algoliaInsights = {
+    const algoliaInsights = {
         config            : null,
         defaultIndexName  : null,
         isTracking        : false,
         hasAddedParameters: false,
+
+        initialize() {
+            if (!window.algoliaConfig) return;
+
+            this.addSearchParameters();
+            this.bindConsentButtonClick(algoliaConfig);
+            this.track(algoliaConfig);            
+        },
 
         useCookie() {
             return !this.config.cookieConfiguration.cookieRestrictionModeEnabled
@@ -95,7 +105,7 @@ define([
                 (allWidgetConfiguration) => {
 
                     allWidgetConfiguration.configure =
-                        algoliaInsights.applyInsightsToSearchParams(allWidgetConfiguration.configure);
+                        this.applyInsightsToSearchParams(allWidgetConfiguration.configure);
 
                     return allWidgetConfiguration;
                 }
@@ -104,7 +114,7 @@ define([
             algoliaCommon.registerHook(
                 'afterAutocompleteProductSourceOptions',
                 (options) => {
-                    return algoliaInsights.applyInsightsToSearchParams(options);
+                    return this.applyInsightsToSearchParams(options);
                 }
             );
 
@@ -343,20 +353,19 @@ define([
                 algoliaConfig.cookieConfiguration.cookieAllowButtonSelector,
                 (event) => {
                     event.preventDefault();
-                    algoliaInsights.initializeAnalytics(algoliaConfig, true);
+                    this.initializeAnalytics(algoliaConfig, true);
                 }
             );
         }
     };
 
-    algoliaInsights.addSearchParameters();
-
     $(function ($) {
-        if (window.algoliaConfig) {
-            algoliaInsights.bindConsentButtonClick(algoliaConfig);
-            algoliaInsights.track(algoliaConfig);
-        }
+        algoliaInsights.initialize()
     });
+
+    if (USE_GLOBALS) {
+        window.algoliaInsights = algoliaInsights;
+    }
 
     return algoliaInsights;
 });

--- a/view/frontend/web/js/insights.js
+++ b/view/frontend/web/js/insights.js
@@ -3,7 +3,7 @@ define([
     'algoliaAnalyticsLib',
     'algoliaCommon',
     'mage/cookies',
-], function ($, algoliaAnalyticsWrapper) {
+], function ($, algoliaAnalyticsWrapper, algoliaCommon) {
     algoliaAnalytics = algoliaAnalyticsWrapper.default;
 
     window.algoliaInsights = {
@@ -14,7 +14,7 @@ define([
 
         useCookie() {
             return !this.config.cookieConfiguration.cookieRestrictionModeEnabled
-                || !!getCookie(this.config.cookieConfiguration.consentCookieName);
+                || !!algoliaCommon.getCookie(this.config.cookieConfiguration.consentCookieName);
         },
 
         // Although events can accept both auth and anon tokens, queries can only accept a single token
@@ -59,8 +59,8 @@ define([
             algoliaAnalytics.addAlgoliaAgent(userAgent);
 
             // TODO: Reevaluate need for unset cookie
-            const userToken = getCookie(algoliaConfig.cookieConfiguration.customerTokenCookie);
-            const unsetAuthenticationToken = getCookie('unset_authentication_token');
+            const userToken = algoliaCommon.getCookie(algoliaConfig.cookieConfiguration.customerTokenCookie);
+            const unsetAuthenticationToken = algoliaCommon.getCookie('unset_authentication_token');
             if (userToken && userToken !== '') {
                 algoliaAnalytics.setAuthenticatedUserToken(userToken);
             } else if (unsetAuthenticationToken && unsetAuthenticationToken !== '') {
@@ -90,7 +90,7 @@ define([
                 return;
             }
 
-            algolia.registerHook(
+            algoliaCommon.algolia.registerHook(
                 'beforeWidgetInitialization',
                 (allWidgetConfiguration) => {
 
@@ -101,7 +101,7 @@ define([
                 }
             );
 
-            algolia.registerHook(
+            algoliaCommon.algolia.registerHook(
                 'afterAutocompleteProductSourceOptions',
                 (options) => {
                     return algoliaInsights.applyInsightsToSearchParams(options);
@@ -136,7 +136,7 @@ define([
             this.bindClickedEvents();
             this.bindViewedEvents();
 
-            algolia.triggerHooks('afterInsightsBindEvents', this);
+            algoliaCommon.algolia.triggerHooks('afterInsightsBindEvents', this);
         },
 
         bindClickedEvents() {
@@ -216,11 +216,11 @@ define([
                     var facets = this.config.facets;
                     var containers = [];
                     for (var i = 0; i < facets.length; i++) {
-                        var elem = createISWidgetContainer(facets[i].attribute);
+                        var elem = algoliaCommon.createISWidgetContainer(facets[i].attribute);
                         containers.push('.' + elem.className);
                     }
 
-                    algolia.registerHook(
+                    algoliaCommon.algolia.registerHook(
                         'afterInstantsearchStart',
                         function (search) {
                             var selectors = document.querySelectorAll(containers.join(', '));

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -782,6 +782,8 @@ define([
     
             /** Initialise searching **/
             startInstantSearch();
+
+            this.addMobileRefinementsToggle();
         },
 
         getFacetWidget(facet, templates) {
@@ -965,6 +967,16 @@ define([
             }
     
             return options;
+        },
+
+        addMobileRefinementsToggle() {
+            $('#refine-toggle').on('click', function () {
+                $('#instant-search-facets-container').toggleClass('hidden-sm').toggleClass('hidden-xs');
+                if ($(this).html().trim()[0] === '+')
+                    $(this).html('- ' + algoliaConfig.translations.refine);
+                else
+                    $(this).html('+ ' + algoliaConfig.translations.refine);
+            });
         },
 
         /**

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -71,28 +71,28 @@ define([
     
             /** BC of old hooks **/
             if (typeof algoliaHookBeforeInstantsearchInit === 'function') {
-                algolia.registerHook(
+                algoliaCommon.algolia.registerHook(
                     'beforeInstantsearchInit',
                     algoliaHookBeforeInstantsearchInit
                 );
             }
     
             if (typeof algoliaHookBeforeWidgetInitialization === 'function') {
-                algolia.registerHook(
+                algoliaCommon.algolia.registerHook(
                     'beforeWidgetInitialization',
                     algoliaHookBeforeWidgetInitialization
                 );
             }
     
             if (typeof algoliaHookBeforeInstantsearchStart === 'function') {
-                algolia.registerHook(
+                algoliaCommon.algolia.registerHook(
                     'beforeInstantsearchStart',
                     algoliaHookBeforeInstantsearchStart
                 );
             }
     
             if (typeof algoliaHookAfterInstantsearchStart === 'function') {
-                algolia.registerHook(
+                algoliaCommon.algolia.registerHook(
                     'afterInstantsearchStart',
                     algoliaHookAfterInstantsearchStart
                 );
@@ -185,7 +185,7 @@ define([
                 }:"${algoliaConfig.request.path.replace(/"/g, '\\"')}"`;
             }
     
-            instantsearchOptions = algolia.triggerHooks(
+            instantsearchOptions = algoliaCommon.algolia.triggerHooks(
                 'beforeInstantsearchInit',
                 instantsearchOptions,
                 mockAlgoliaBundle
@@ -238,7 +238,7 @@ define([
                                 location.hash.length < 1
                             ) {
                                 return searchParameters.setQuery(
-                                    algolia.htmlspecialcharsDecode(algoliaConfig.request.query)
+                                    algoliaCommon.algolia.htmlspecialcharsDecode(algoliaConfig.request.query)
                                 );
                             }
                             return searchParameters;
@@ -511,7 +511,7 @@ define([
                             $('.page-title-wrapper span.base').html(
                                 algoliaConfig.translations.searchTitle +
                                 ": '" +
-                                algolia.htmlspecialcharsEncode(inputValue) +
+                                algoliaCommon.algolia.htmlspecialcharsEncode(inputValue) +
                                 "'"
                             );
                         }
@@ -540,8 +540,7 @@ define([
                     transformItems: function (items) {
                         return items.map(function (item) {
                             item.__indexName = search.helper.lastResults.index;
-                            item = transformHit(item, algoliaConfig.priceKey, search.helper);
-                            // FIXME: transformHit is a global
+                            item = algoliaCommon.transformHit(item, algoliaConfig.priceKey, search.helper);
                             item.isAddToCartEnabled = algoliaConfig.instant.isAddToCartEnabled;
                             return item;
                         });
@@ -578,8 +577,7 @@ define([
                         }
                         return items.map(function (item) {
                             item.__indexName = search.helper.lastResults.index;
-                            item = transformHit(item, algoliaConfig.priceKey, search.helper);
-                            // FIXME: transformHit is a global
+                            item = algoliaCommon.transformHit(item, algoliaConfig.priceKey, search.helper);
                             item.isAddToCartEnabled = algoliaConfig.instant.isAddToCartEnabled;
                             item.algoliaConfig = window.algoliaConfig;
                             return item;
@@ -621,7 +619,7 @@ define([
     
                     const hierarchicalMenuParams = {
                         container      : facet.wrapper.appendChild(
-                            createISWidgetContainer(facet.attribute)
+                            algoliaCommon.createISWidgetContainer(facet.attribute)
                         ),
                         attributes     : hierarchical_levels,
                         separator      : algoliaConfig.instant.categorySeparator,
@@ -725,7 +723,7 @@ define([
                 };
             }
     
-            allWidgetConfiguration = algolia.triggerHooks(
+            allWidgetConfiguration = algoliaCommon.algolia.triggerHooks(
                 'beforeWidgetInitialization',
                 allWidgetConfiguration,
                 mockAlgoliaBundle
@@ -752,7 +750,7 @@ define([
                             const url = `${algoliaConfig.request.url}${window.location.search}`;
                             e.target.elements[
                                 algoliaConfig.instant.addToCartParams.redirectUrlParam
-                                ].value = AlgoliaBase64.mageEncode(url);
+                                ].value = algoliaCommon.AlgoliaBase64.mageEncode(url);
                         });
                     });
                 });
@@ -765,13 +763,13 @@ define([
                     return;
                 }
     
-                search = algolia.triggerHooks(
+                search = algoliaCommon.algolia.triggerHooks(
                     'beforeInstantsearchStart',
                     search,
                     mockAlgoliaBundle
                 );
                 search.start();
-                search = algolia.triggerHooks(
+                search = algoliaCommon.algolia.triggerHooks(
                     'afterInstantsearchStart',
                     search,
                     mockAlgoliaBundle
@@ -832,7 +830,7 @@ define([
                     'rangeInput',
                     {
                         container   : facet.wrapper.appendChild(
-                            createISWidgetContainer(facet.attribute)
+                            algoliaCommon.createISWidgetContainer(facet.attribute)
                         ),
                         attribute   : facet.attribute,
                         templates   : $.extend(
@@ -853,7 +851,7 @@ define([
             if (facet.type === 'conjunctive') {
                 var refinementListOptions = {
                     container   : facet.wrapper.appendChild(
-                        createISWidgetContainer(facet.attribute)
+                        algoliaCommon.createISWidgetContainer(facet.attribute)
                     ),
                     attribute   : facet.attribute,
                     limit       : algoliaConfig.maxValuesPerFacet,
@@ -877,7 +875,7 @@ define([
             if (facet.type === 'disjunctive') {
                 var refinementListOptions = {
                     container   : facet.wrapper.appendChild(
-                        createISWidgetContainer(facet.attribute)
+                        algoliaCommon.createISWidgetContainer(facet.attribute)
                     ),
                     attribute   : facet.attribute,
                     limit       : algoliaConfig.maxValuesPerFacet,
@@ -905,7 +903,7 @@ define([
                     'rangeSlider',
                     {
                         container   : facet.wrapper.appendChild(
-                            createISWidgetContainer(facet.attribute)
+                            algoliaCommon.createISWidgetContainer(facet.attribute)
                         ),
                         attribute   : facet.attribute,
                         templates   : templates,

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -73,28 +73,28 @@ define([
     
             /** BC of old hooks **/
             if (typeof algoliaHookBeforeInstantsearchInit === 'function') {
-                algoliaCommon.algolia.registerHook(
+                algoliaCommon.registerHook(
                     'beforeInstantsearchInit',
                     algoliaHookBeforeInstantsearchInit
                 );
             }
     
             if (typeof algoliaHookBeforeWidgetInitialization === 'function') {
-                algoliaCommon.algolia.registerHook(
+                algoliaCommon.registerHook(
                     'beforeWidgetInitialization',
                     algoliaHookBeforeWidgetInitialization
                 );
             }
     
             if (typeof algoliaHookBeforeInstantsearchStart === 'function') {
-                algoliaCommon.algolia.registerHook(
+                algoliaCommon.registerHook(
                     'beforeInstantsearchStart',
                     algoliaHookBeforeInstantsearchStart
                 );
             }
     
             if (typeof algoliaHookAfterInstantsearchStart === 'function') {
-                algoliaCommon.algolia.registerHook(
+                algoliaCommon.registerHook(
                     'afterInstantsearchStart',
                     algoliaHookAfterInstantsearchStart
                 );
@@ -187,7 +187,7 @@ define([
                 }:"${algoliaConfig.request.path.replace(/"/g, '\\"')}"`;
             }
     
-            instantsearchOptions = algoliaCommon.algolia.triggerHooks(
+            instantsearchOptions = algoliaCommon.triggerHooks(
                 'beforeInstantsearchInit',
                 instantsearchOptions,
                 mockAlgoliaBundle
@@ -240,7 +240,7 @@ define([
                                 location.hash.length < 1
                             ) {
                                 return searchParameters.setQuery(
-                                    algoliaCommon.algolia.htmlspecialcharsDecode(algoliaConfig.request.query)
+                                    algoliaCommon.htmlspecialcharsDecode(algoliaConfig.request.query)
                                 );
                             }
                             return searchParameters;
@@ -513,7 +513,7 @@ define([
                             $('.page-title-wrapper span.base').html(
                                 algoliaConfig.translations.searchTitle +
                                 ": '" +
-                                algoliaCommon.algolia.htmlspecialcharsEncode(inputValue) +
+                                algoliaCommon.htmlspecialcharsEncode(inputValue) +
                                 "'"
                             );
                         }
@@ -725,7 +725,7 @@ define([
                 };
             }
     
-            allWidgetConfiguration = algoliaCommon.algolia.triggerHooks(
+            allWidgetConfiguration = algoliaCommon.triggerHooks(
                 'beforeWidgetInitialization',
                 allWidgetConfiguration,
                 mockAlgoliaBundle
@@ -765,13 +765,13 @@ define([
                     return;
                 }
     
-                search = algoliaCommon.algolia.triggerHooks(
+                search = algoliaCommon.triggerHooks(
                     'beforeInstantsearchStart',
                     search,
                     mockAlgoliaBundle
                 );
                 search.start();
-                search = algoliaCommon.algolia.triggerHooks(
+                search = algoliaCommon.triggerHooks(
                     'afterInstantsearchStart',
                     search,
                     mockAlgoliaBundle

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -16,7 +16,7 @@ define([
     'algoliaCommon',
     'algoliaInsights',
     'algoliaHooks',
-], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils) {
+], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils, algoliaCommon) {
 
     return Component.extend({
         initialize(config, element) {
@@ -161,7 +161,7 @@ define([
             var instantsearchOptions = {
                 searchClient: searchClient,
                 indexName   : indexName,
-                routing     : window.routing,
+                routing     : algoliaCommon.routing,
             };
     
             if (

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -19,12 +19,12 @@ define([
 ], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils) {
 
     return Component.extend({
-        initialize: function(config, element) {
+        initialize(config, element) {
             // console.log('IS initialized with', config, element);
             this.buildInstantSearch($);
         },
 
-        buildInstantSearch: async function($) {
+        async buildInstantSearch($) {
             const templateProcessor = await templateEngine.getSelectedEngineAdapter();
             const mockAlgoliaBundle = this.mockAlgoliaBundle();
     
@@ -668,148 +668,8 @@ define([
             };
     
             /** Add all facet widgets to instantsearch object **/
-            window.getFacetWidget = (facet, templates) => {
-                var panelOptions = {
-                    templates: {
-                        header:
-                            '<div class="name">' +
-                            (facet.label ? facet.label : facet.attribute) +
-                            '</div>',
-                    },
-                    hidden   : function (options) {
-                        if (
-                            options.results.nbPages <= 1 &&
-                            algoliaConfig.instant.hidePagination === true
-                        ) {
-                            document.getElementById(
-                                'instant-search-pagination-container'
-                            ).style.display = 'none';
-                        } else {
-                            document.getElementById(
-                                'instant-search-pagination-container'
-                            ).style.display = 'block';
-                        }
-                        if (!options.results) return true;
-                        switch (facet.type) {
-                            case 'conjunctive':
-                                var facetsNames = options.results.facets.map(function (f) {
-                                    return f.name;
-                                });
-                                return facetsNames.indexOf(facet.attribute) === -1;
-                            case 'disjunctive':
-                                var disjunctiveFacetsNames =
-                                    options.results.disjunctiveFacets.map(function (f) {
-                                        return f.name;
-                                    });
-                                return disjunctiveFacetsNames.indexOf(facet.attribute) === -1;
-                            default:
-                                return false;
-                        }
-                    },
-                };
-                if (facet.type === 'priceRanges') {
-                    delete templates.item;
-    
-                    return [
-                        'rangeInput',
-                        {
-                            container   : facet.wrapper.appendChild(
-                                createISWidgetContainer(facet.attribute)
-                            ),
-                            attribute   : facet.attribute,
-                            templates   : $.extend(
-                                {
-                                    separatorText: algoliaConfig.translations.to,
-                                    submitText   : algoliaConfig.translations.go,
-                                },
-                                templates
-                            ),
-                            cssClasses  : {
-                                root: 'conjunctive',
-                            },
-                            panelOptions: panelOptions,
-                        },
-                    ];
-                }
-    
-                if (facet.type === 'conjunctive') {
-                    var refinementListOptions = {
-                        container   : facet.wrapper.appendChild(
-                            createISWidgetContainer(facet.attribute)
-                        ),
-                        attribute   : facet.attribute,
-                        limit       : algoliaConfig.maxValuesPerFacet,
-                        operator    : 'and',
-                        templates   : templates,
-                        sortBy      : ['count:desc', 'name:asc'],
-                        cssClasses  : {
-                            root: 'conjunctive',
-                        },
-                        panelOptions: panelOptions,
-                    };
-    
-                    refinementListOptions = this.addSearchForFacetValues(
-                        facet,
-                        refinementListOptions
-                    );
-    
-                    return ['refinementList', refinementListOptions];
-                }
-    
-                if (facet.type === 'disjunctive') {
-                    var refinementListOptions = {
-                        container   : facet.wrapper.appendChild(
-                            createISWidgetContainer(facet.attribute)
-                        ),
-                        attribute   : facet.attribute,
-                        limit       : algoliaConfig.maxValuesPerFacet,
-                        operator    : 'or',
-                        templates   : templates,
-                        sortBy      : ['count:desc', 'name:asc'],
-                        panelOptions: panelOptions,
-                        cssClasses  : {
-                            root: 'disjunctive',
-                        },
-                    };
-    
-                    refinementListOptions = this.addSearchForFacetValues(
-                        facet,
-                        refinementListOptions
-                    );
-    
-                    return ['refinementList', refinementListOptions];
-                }
-    
-                if (facet.type === 'slider') {
-                    delete templates.item;
-    
-                    return [
-                        'rangeSlider',
-                        {
-                            container   : facet.wrapper.appendChild(
-                                createISWidgetContainer(facet.attribute)
-                            ),
-                            attribute   : facet.attribute,
-                            templates   : templates,
-                            pips        : false,
-                            panelOptions: panelOptions,
-                            tooltips    : {
-                                format: function (formattedValue) {
-                                    return facet.attribute.match(/price/) === null
-                                        ? parseInt(formattedValue)
-                                        : priceUtils.formatPrice(
-                                            formattedValue,
-                                            algoliaConfig.priceFormat
-                                        );
-                                },
-                            },
-                        },
-                    ];
-                }
-            };
-    
             var wrapper = document.getElementById('instant-search-facets-container');
-            $.each(algoliaConfig.facets, function (i, facet) {
+            $.each(algoliaConfig.facets, (i, facet) => {
                 if (facet.attribute.indexOf('price') !== -1)
                     facet.attribute = facet.attribute + algoliaConfig.priceKey;
     
@@ -818,11 +678,11 @@ define([
                 var templates = {
                     item: $('#refinements-lists-item-template').html(),
                 };
-    
+
                 var widgetInfo =
                     customAttributeFacet[facet.attribute] !== undefined
                         ? customAttributeFacet[facet.attribute](facet, templates)
-                        : getFacetWidget(facet, templates);
+                        : this.getFacetWidget(facet, templates);
     
                 var widgetType = widgetInfo[0],
                     widgetConfig = widgetInfo[1];
@@ -924,7 +784,147 @@ define([
             startInstantSearch();
         },
 
-        addWidget: function(search, type, config) {
+        getFacetWidget(facet, templates) {
+            var panelOptions = {
+                templates: {
+                    header:
+                        '<div class="name">' +
+                        (facet.label ? facet.label : facet.attribute) +
+                        '</div>',
+                },
+                hidden   : function (options) {
+                    if (
+                        options.results.nbPages <= 1 &&
+                        algoliaConfig.instant.hidePagination === true
+                    ) {
+                        document.getElementById(
+                            'instant-search-pagination-container'
+                        ).style.display = 'none';
+                    } else {
+                        document.getElementById(
+                            'instant-search-pagination-container'
+                        ).style.display = 'block';
+                    }
+                    if (!options.results) return true;
+                    switch (facet.type) {
+                        case 'conjunctive':
+                            var facetsNames = options.results.facets.map(function (f) {
+                                return f.name;
+                            });
+                            return facetsNames.indexOf(facet.attribute) === -1;
+                        case 'disjunctive':
+                            var disjunctiveFacetsNames =
+                                options.results.disjunctiveFacets.map(function (f) {
+                                    return f.name;
+                                });
+                            return disjunctiveFacetsNames.indexOf(facet.attribute) === -1;
+                        default:
+                            return false;
+                    }
+                },
+            };
+            if (facet.type === 'priceRanges') {
+                delete templates.item;
+
+                return [
+                    'rangeInput',
+                    {
+                        container   : facet.wrapper.appendChild(
+                            createISWidgetContainer(facet.attribute)
+                        ),
+                        attribute   : facet.attribute,
+                        templates   : $.extend(
+                            {
+                                separatorText: algoliaConfig.translations.to,
+                                submitText   : algoliaConfig.translations.go,
+                            },
+                            templates
+                        ),
+                        cssClasses  : {
+                            root: 'conjunctive',
+                        },
+                        panelOptions: panelOptions,
+                    },
+                ];
+            }
+
+            if (facet.type === 'conjunctive') {
+                var refinementListOptions = {
+                    container   : facet.wrapper.appendChild(
+                        createISWidgetContainer(facet.attribute)
+                    ),
+                    attribute   : facet.attribute,
+                    limit       : algoliaConfig.maxValuesPerFacet,
+                    operator    : 'and',
+                    templates   : templates,
+                    sortBy      : ['count:desc', 'name:asc'],
+                    cssClasses  : {
+                        root: 'conjunctive',
+                    },
+                    panelOptions: panelOptions,
+                };
+
+                refinementListOptions = this.addSearchForFacetValues(
+                    facet,
+                    refinementListOptions
+                );
+
+                return ['refinementList', refinementListOptions];
+            }
+
+            if (facet.type === 'disjunctive') {
+                var refinementListOptions = {
+                    container   : facet.wrapper.appendChild(
+                        createISWidgetContainer(facet.attribute)
+                    ),
+                    attribute   : facet.attribute,
+                    limit       : algoliaConfig.maxValuesPerFacet,
+                    operator    : 'or',
+                    templates   : templates,
+                    sortBy      : ['count:desc', 'name:asc'],
+                    panelOptions: panelOptions,
+                    cssClasses  : {
+                        root: 'disjunctive',
+                    },
+                };
+
+                refinementListOptions = this.addSearchForFacetValues(
+                    facet,
+                    refinementListOptions
+                );
+
+                return ['refinementList', refinementListOptions];
+            }
+
+            if (facet.type === 'slider') {
+                delete templates.item;
+
+                return [
+                    'rangeSlider',
+                    {
+                        container   : facet.wrapper.appendChild(
+                            createISWidgetContainer(facet.attribute)
+                        ),
+                        attribute   : facet.attribute,
+                        templates   : templates,
+                        pips        : false,
+                        panelOptions: panelOptions,
+                        tooltips    : {
+                            format: function (formattedValue) {
+                                return facet.attribute.match(/price/) === null
+                                    ? parseInt(formattedValue)
+                                    : priceUtils.formatPrice(
+                                        formattedValue,
+                                        algoliaConfig.priceFormat
+                                    );
+                            },
+                        },
+                    },
+                ];
+            }
+        },
+
+        addWidget(search, type, config) {
             if (type === 'custom') {
                 search.addWidgets([config]);
                 return;
@@ -951,7 +951,7 @@ define([
             search.addWidgets([widget(config)]);
         },
 
-        addSearchForFacetValues: function(facet, options) {
+        addSearchForFacetValues(facet, options) {
             if (facet.searchable === '1') {
                 options.searchable = true;
                 options.searchableIsAlwaysActive = false;
@@ -983,7 +983,7 @@ define([
          * and make it available to your hook.
          * TODO: Mixin and documentation to come on how to do this...
          */
-        mockAlgoliaBundle: function() {
+        mockAlgoliaBundle() {
             return {
                 $,
                 algoliasearch,

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -12,11 +12,13 @@ define([
     // Magento core libs
     'Magento_Catalog/js/price-utils',
 
-    // TODO: Refactor legacy global object dependencies
     'algoliaCommon',
+    'algoliaBase64',
+
+    // TODO: Refactor legacy global object dependencies
     'algoliaInsights',
     'algoliaHooks',
-], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils, algoliaCommon) {
+], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils, algoliaCommon, algoliaBase64) {
 
     return Component.extend({
         initialize(config, element) {
@@ -750,7 +752,7 @@ define([
                             const url = `${algoliaConfig.request.url}${window.location.search}`;
                             e.target.elements[
                                 algoliaConfig.instant.addToCartParams.redirectUrlParam
-                                ].value = algoliaCommon.AlgoliaBase64.mageEncode(url);
+                                ].value = algoliaBase64.mageEncode(url);
                         });
                     });
                 });

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -7,18 +7,17 @@ define([
     'algoliaInstantSearchLib',
 
     // Algolia integration dependencies
-    'algoliaTemplateEngine',
-
-    // Magento core libs
-    'Magento_Catalog/js/price-utils',
-
     'algoliaCommon',
     'algoliaBase64',
+    'algoliaTemplateEngine',
+    
+    // Magento core libs
+    'Magento_Catalog/js/price-utils',
 
     // TODO: Refactor legacy global object dependencies
     'algoliaInsights',
     'algoliaHooks',
-], function (Component, $, algoliasearch, instantsearch, templateEngine, priceUtils, algoliaCommon, algoliaBase64) {
+], function (Component, $, algoliasearch, instantsearch, algoliaCommon, algoliaBase64, templateEngine, priceUtils) {
 
     return Component.extend({
         initialize(config, element) {

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -14,7 +14,6 @@ define([
     // Magento core libs
     'Magento_Catalog/js/price-utils',
 
-    // TODO: Refactor legacy global object dependencies
     'algoliaInsights',
     'algoliaHooks',
 ], function (Component, $, algoliasearch, instantsearch, algoliaCommon, algoliaBase64, templateEngine, priceUtils) {
@@ -793,7 +792,7 @@ define([
                         (facet.label ? facet.label : facet.attribute) +
                         '</div>',
                 },
-                hidden   : function (options) {
+                hidden: (options) => {
                     if (
                         options.results.nbPages <= 1 &&
                         algoliaConfig.instant.hidePagination === true

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -22,10 +22,10 @@ define([
     return Component.extend({
         initialize(config, element) {
             // console.log('IS initialized with', config, element);
-            this.buildInstantSearch($);
+            this.buildInstantSearch();
         },
 
-        async buildInstantSearch($) {
+        async buildInstantSearch() {
             const templateProcessor = await templateEngine.getSelectedEngineAdapter();
             const mockAlgoliaBundle = this.mockAlgoliaBundle();
     

--- a/view/frontend/web/js/internals/base64.js
+++ b/view/frontend/web/js/internals/base64.js
@@ -1,0 +1,156 @@
+define([], function () {
+    const USE_GLOBALS = true;
+
+    // Taken from Magento's tools.js - not included on frontend, only in backend
+    const AlgoliaBase64 = {
+        // private property
+        _keyStr: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+        //'+/=', '-_,'
+        // public method for encoding
+        encode: function (input) {
+            var output = "";
+            var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
+            var i = 0;
+
+            if (typeof window.btoa === "function") {
+                return window.btoa(input);
+            }
+
+            input = AlgoliaBase64._utf8_encode(input);
+
+            while (i < input.length) {
+
+                chr1 = input.charCodeAt(i++);
+                chr2 = input.charCodeAt(i++);
+                chr3 = input.charCodeAt(i++);
+
+                enc1 = chr1 >> 2;
+                enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+                enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+                enc4 = chr3 & 63;
+
+                if (isNaN(chr2)) {
+                    enc3 = enc4 = 64;
+                } else if (isNaN(chr3)) {
+                    enc4 = 64;
+                }
+                output = output +
+                    this._keyStr.charAt(enc1) + this._keyStr.charAt(enc2) +
+                    this._keyStr.charAt(enc3) + this._keyStr.charAt(enc4);
+            }
+
+            return output;
+        },
+
+        // public method for decoding
+        decode: function (input) {
+            var output = "";
+            var chr1, chr2, chr3;
+            var enc1, enc2, enc3, enc4;
+            var i = 0;
+
+            if (typeof window.atob === "function") {
+                return window.atob(input);
+            }
+
+            input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
+
+            while (i < input.length) {
+
+                enc1 = this._keyStr.indexOf(input.charAt(i++));
+                enc2 = this._keyStr.indexOf(input.charAt(i++));
+                enc3 = this._keyStr.indexOf(input.charAt(i++));
+                enc4 = this._keyStr.indexOf(input.charAt(i++));
+
+                chr1 = (enc1 << 2) | (enc2 >> 4);
+                chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+                chr3 = ((enc3 & 3) << 6) | enc4;
+
+                output = output + String.fromCharCode(chr1);
+
+                if (enc3 !== 64) {
+                    output = output + String.fromCharCode(chr2);
+                }
+                if (enc4 !== 64) {
+                    output = output + String.fromCharCode(chr3);
+                }
+            }
+            output = AlgoliaBase64._utf8_decode(output);
+            return output;
+        },
+
+        mageEncode: function (input) {
+            return this.encode(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ',');
+        },
+
+        mageDecode: function (output) {
+            output = output.replace(/\-/g, '+').replace(/_/g, '/').replace(/,/g, '=');
+            return this.decode(output);
+        },
+
+        idEncode: function (input) {
+            return this.encode(input).replace(/\+/g, ':').replace(/\//g, '_').replace(/=/g, '-');
+        },
+
+        idDecode: function (output) {
+            output = output.replace(/\-/g, '=').replace(/_/g, '/').replace(/\:/g, '\+');
+            return this.decode(output);
+        },
+
+        // private method for UTF-8 encoding
+        _utf8_encode: function (string) {
+            string = string.replace(/\r\n/g, "\n");
+            var utftext = "";
+
+            for (var n = 0; n < string.length; n++) {
+
+                var c = string.charCodeAt(n);
+
+                if (c < 128) {
+                    utftext += String.fromCharCode(c);
+                } else if ((c > 127) && (c < 2048)) {
+                    utftext += String.fromCharCode((c >> 6) | 192);
+                    utftext += String.fromCharCode((c & 63) | 128);
+                } else {
+                    utftext += String.fromCharCode((c >> 12) | 224);
+                    utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+                    utftext += String.fromCharCode((c & 63) | 128);
+                }
+            }
+            return utftext;
+        },
+
+        // private method for UTF-8 decoding
+        _utf8_decode: function (utftext) {
+            var string = "";
+            var i = 0;
+            var c = c1 = c2 = 0;
+
+            while (i < utftext.length) {
+
+                c = utftext.charCodeAt(i);
+
+                if (c < 128) {
+                    string += String.fromCharCode(c);
+                    i++;
+                } else if ((c > 191) && (c < 224)) {
+                    c2 = utftext.charCodeAt(i + 1);
+                    string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
+                    i += 2;
+                } else {
+                    c2 = utftext.charCodeAt(i + 1);
+                    c3 = utftext.charCodeAt(i + 2);
+                    string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
+                    i += 3;
+                }
+            }
+            return string;
+        }
+    };
+
+    if (USE_GLOBALS) {
+        window.AlgoliaBase64 = AlgoliaBase64;
+    }
+
+    return AlgoliaBase64;
+});

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -238,15 +238,20 @@ define(['jquery', 'algoliaInstantSearchLib', 'algoliaBase64'], function ($, inst
         }
     };
 
+    const utils = {
+        isMobileUserAgent: () => {
+            const mobileRegex = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini|mobile/i;
+            return mobileRegex.test(navigator.userAgent);
+        },
+        
+        isTouchDevice: () => {
+            return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+        }
+    };
+    
     const legacyGlobalFunctions = {
         isMobile: () => {
-            var check = false;
-    
-            (function (a) {
-                if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0, 4))) check = true;
-            })(navigator.userAgent || navigator.vendor || window.opera);
-    
-            return check;
+            return utils.isMobileUserAgent() || utils.isTouchDevice();
         },
 
         getCookie: (name) => {
@@ -497,6 +502,7 @@ define(['jquery', 'algoliaInstantSearchLib', 'algoliaBase64'], function ($, inst
     return {
         ...algolia,
         routing,
+        ...utils,
         ...legacyGlobalFunctions
     };
 

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -1,4 +1,4 @@
-define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
+define(['jquery', 'algoliaInstantSearchLib', 'algoliaBase64'], function ($, instantsearch, algoliaBase64) {
     const USE_GLOBALS = true;
 
     // Character maps supplied for more performant Regex ops
@@ -238,153 +238,6 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         }
     };
 
-    // Taken from Magento's tools.js - not included on frontend, only in backend
-    const AlgoliaBase64 = {
-        // private property
-        _keyStr: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
-        //'+/=', '-_,'
-        // public method for encoding
-        encode: function (input) {
-            var output = "";
-            var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
-            var i = 0;
-
-            if (typeof window.btoa === "function") {
-                return window.btoa(input);
-            }
-
-            input = AlgoliaBase64._utf8_encode(input);
-
-            while (i < input.length) {
-
-                chr1 = input.charCodeAt(i++);
-                chr2 = input.charCodeAt(i++);
-                chr3 = input.charCodeAt(i++);
-
-                enc1 = chr1 >> 2;
-                enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
-                enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
-                enc4 = chr3 & 63;
-
-                if (isNaN(chr2)) {
-                    enc3 = enc4 = 64;
-                } else if (isNaN(chr3)) {
-                    enc4 = 64;
-                }
-                output = output +
-                    this._keyStr.charAt(enc1) + this._keyStr.charAt(enc2) +
-                    this._keyStr.charAt(enc3) + this._keyStr.charAt(enc4);
-            }
-
-            return output;
-        },
-
-        // public method for decoding
-        decode: function (input) {
-            var output = "";
-            var chr1, chr2, chr3;
-            var enc1, enc2, enc3, enc4;
-            var i = 0;
-
-            if (typeof window.atob === "function") {
-                return window.atob(input);
-            }
-
-            input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
-
-            while (i < input.length) {
-
-                enc1 = this._keyStr.indexOf(input.charAt(i++));
-                enc2 = this._keyStr.indexOf(input.charAt(i++));
-                enc3 = this._keyStr.indexOf(input.charAt(i++));
-                enc4 = this._keyStr.indexOf(input.charAt(i++));
-
-                chr1 = (enc1 << 2) | (enc2 >> 4);
-                chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
-                chr3 = ((enc3 & 3) << 6) | enc4;
-
-                output = output + String.fromCharCode(chr1);
-
-                if (enc3 !== 64) {
-                    output = output + String.fromCharCode(chr2);
-                }
-                if (enc4 !== 64) {
-                    output = output + String.fromCharCode(chr3);
-                }
-            }
-            output = AlgoliaBase64._utf8_decode(output);
-            return output;
-        },
-
-        mageEncode: function (input) {
-            return this.encode(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, ',');
-        },
-
-        mageDecode: function (output) {
-            output = output.replace(/\-/g, '+').replace(/_/g, '/').replace(/,/g, '=');
-            return this.decode(output);
-        },
-
-        idEncode: function (input) {
-            return this.encode(input).replace(/\+/g, ':').replace(/\//g, '_').replace(/=/g, '-');
-        },
-
-        idDecode: function (output) {
-            output = output.replace(/\-/g, '=').replace(/_/g, '/').replace(/\:/g, '\+');
-            return this.decode(output);
-        },
-
-        // private method for UTF-8 encoding
-        _utf8_encode: function (string) {
-            string = string.replace(/\r\n/g, "\n");
-            var utftext = "";
-
-            for (var n = 0; n < string.length; n++) {
-
-                var c = string.charCodeAt(n);
-
-                if (c < 128) {
-                    utftext += String.fromCharCode(c);
-                } else if ((c > 127) && (c < 2048)) {
-                    utftext += String.fromCharCode((c >> 6) | 192);
-                    utftext += String.fromCharCode((c & 63) | 128);
-                } else {
-                    utftext += String.fromCharCode((c >> 12) | 224);
-                    utftext += String.fromCharCode(((c >> 6) & 63) | 128);
-                    utftext += String.fromCharCode((c & 63) | 128);
-                }
-            }
-            return utftext;
-        },
-
-        // private method for UTF-8 decoding
-        _utf8_decode: function (utftext) {
-            var string = "";
-            var i = 0;
-            var c = c1 = c2 = 0;
-
-            while (i < utftext.length) {
-
-                c = utftext.charCodeAt(i);
-
-                if (c < 128) {
-                    string += String.fromCharCode(c);
-                    i++;
-                } else if ((c > 191) && (c < 224)) {
-                    c2 = utftext.charCodeAt(i + 1);
-                    string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
-                    i += 2;
-                } else {
-                    c2 = utftext.charCodeAt(i + 1);
-                    c3 = utftext.charCodeAt(i + 2);
-                    string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
-                    i += 3;
-                }
-            }
-            return string;
-        }
-    };
-
     const legacyGlobalFunctions = {
         isMobile: () => {
             var check = false;
@@ -520,7 +373,7 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
             hit.addToCart = {
                 'action': action,
                 'redirectUrlParam': algoliaConfig.instant.addToCartParams.redirectUrlParam,
-                'uenc': AlgoliaBase64.mageEncode(action),
+                'uenc': algoliaBase64.mageEncode(action),
                 'formKey': algoliaConfig.instant.addToCartParams.formKey
             };
     
@@ -607,8 +460,7 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
             window, 
             {
                 algolia,
-                routing,
-                AlgoliaBase64
+                routing
             },
             legacyGlobalFunctions
         );
@@ -645,7 +497,6 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
     return {
         algolia,
         routing,
-        AlgoliaBase64,
         ...legacyGlobalFunctions
     };
 

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -396,14 +396,12 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
             return check;
         },
 
-        getCookie: () => {
-            var value = "; " + document.cookie;
-            var parts = value.split("; " + name + "=");
-            if (parts.length == 2) {
-                return parts.pop().split(";").shift();
-            }
-    
-            return "";
+        getCookie: (name) => {
+            const value = `; ${document.cookie}`;
+            const parts = value.split(`; ${name}=`);
+            return (parts.length === 2) 
+                ? parts.pop().split(';').shift() 
+                : '';
         },
 
         // @deprecated This function will be removed from this module in a future version

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -613,6 +613,7 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         );
     }
 
+    // TODO move as mixable to autocomplete.js
     const handleAutoCompleteSubmit = (e) => {
         let query = $(this).find(algoliaConfig.autocomplete.selector).val();
 
@@ -632,15 +633,6 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         }
         $(algoliaConfig.autocomplete.selector).each(function () {
             $(this).closest('form').on('submit', handleAutoCompleteSubmit);
-        });
-
-        /** Handle small screen **/
-        $('body').on('click', '#refine-toggle', function () {
-            $('#instant-search-facets-container').toggleClass('hidden-sm').toggleClass('hidden-xs');
-            if ($(this).html().trim()[0] === '+')
-                $(this).html('- ' + algoliaConfig.translations.refine);
-            else
-                $(this).html('+ ' + algoliaConfig.translations.refine);
         });
     }
 

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -1,4 +1,6 @@
 define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
+    const USE_GLOBALS = true;
+
     // Character maps supplied for more performant Regex ops
     const SPECIAL_CHAR_ENCODE_MAP = {
         '&': '&amp;',
@@ -14,7 +16,7 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         return acc;
     }, {});
 
-    window.algolia = {
+    const algolia = {
         deprecatedHooks: [
             'beforeAutocompleteProductSourceOptions',
             'beforeAutocompleteSources'
@@ -88,223 +90,11 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         }
     };
 
-    window.isMobile = function () {
-        var check = false;
-
-        (function (a) {
-            if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0, 4))) check = true;
-        })(navigator.userAgent || navigator.vendor || window.opera);
-
-        return check;
-    };
-
-    window.getCookie = function (name) {
-        var value = "; " + document.cookie;
-        var parts = value.split("; " + name + "=");
-        if (parts.length == 2) {
-            return parts.pop().split(";").shift();
-        }
-
-        return "";
-    };
-
-    window.transformHit = function (hit, price_key, helper) {
-        if (Array.isArray(hit.categories))
-            hit.categories = hit.categories.join(', ');
-
-        if (hit._highlightResult.categories_without_path && Array.isArray(hit.categories_without_path)) {
-            hit.categories_without_path = $.map(hit._highlightResult.categories_without_path, function (category) {
-                return category.value;
-            });
-
-            hit.categories_without_path = hit.categories_without_path.join(', ');
-        }
-
-        var matchedColors = [];
-
-        if (helper && algoliaConfig.useAdaptiveImage === true) {
-            if (hit.images_data && helper.state.facetsRefinements.color) {
-                matchedColors = helper.state.facetsRefinements.color.slice(0); // slice to clone
-            }
-
-            if (hit.images_data && helper.state.disjunctiveFacetsRefinements.color) {
-                matchedColors = helper.state.disjunctiveFacetsRefinements.color.slice(0); // slice to clone
-            }
-        }
-
-        if (Array.isArray(hit.color)) {
-            var colors = [];
-
-            $.each(hit._highlightResult.color, function (i, color) {
-                if (color.matchLevel === undefined || color.matchLevel === 'none') {
-                    return;
-                }
-
-                colors.push(color);
-
-                if (algoliaConfig.useAdaptiveImage === true) {
-                    var matchedColor = color.matchedWords.join(' ');
-                    if (hit.images_data && color.fullyHighlighted && color.fullyHighlighted === true) {
-                        matchedColors.push(matchedColor);
-                    }
-                }
-            });
-
-            hit._highlightResult.color = colors;
-        } else {
-            if (hit._highlightResult.color && hit._highlightResult.color.matchLevel === 'none') {
-                hit._highlightResult.color = {value: ''};
-            }
-        }
-
-        if (algoliaConfig.useAdaptiveImage === true) {
-            $.each(matchedColors, function (i, color) {
-                color = color.toLowerCase();
-
-                if (hit.images_data[color]) {
-                    hit.image_url = hit.images_data[color];
-                    hit.thumbnail_url = hit.images_data[color];
-
-                    return false;
-                }
-            });
-        }
-
-        if (hit._highlightResult.color && hit._highlightResult.color.value && hit.categories_without_path) {
-            if (hit.categories_without_path.indexOf('<em>') === -1 && hit._highlightResult.color.value.indexOf('<em>') !== -1) {
-                hit.categories_without_path = '';
-            }
-        }
-
-        if (Array.isArray(hit._highlightResult.name))
-            hit._highlightResult.name = hit._highlightResult.name[0];
-
-        if (Array.isArray(hit.price)) {
-            hit.price = hit.price[0];
-            if (hit['price'] !== undefined && price_key !== '.' + algoliaConfig.currencyCode + '.default' && hit['price'][algoliaConfig.currencyCode][price_key.substr(1) + '_formated'] !== hit['price'][algoliaConfig.currencyCode]['default_formated']) {
-                hit['price'][algoliaConfig.currencyCode][price_key.substr(1) + '_original_formated'] = hit['price'][algoliaConfig.currencyCode]['default_formated'];
-            }
-
-            if (hit['price'][algoliaConfig.currencyCode]['default_original_formated']
-                && hit['price'][algoliaConfig.currencyCode]['special_to_date']) {
-                var priceExpiration = hit['price'][algoliaConfig.currencyCode]['special_to_date'];
-
-                if (algoliaConfig.now > priceExpiration + 1) {
-                    hit['price'][algoliaConfig.currencyCode]['default_formated'] = hit['price'][algoliaConfig.currencyCode]['default_original_formated'];
-                    hit['price'][algoliaConfig.currencyCode]['default_original_formated'] = false;
-                }
-            }
-        }
-
-        /* Added code to bind default bundle options for add to cart */
-        if (hit.default_bundle_options) {
-            var default_bundle_option = [];
-            for (const property in hit.default_bundle_options) {
-                const optionsData = {
-                    optionId: property,
-                    selectionId : hit.default_bundle_options[property]
-                }
-                default_bundle_option.push(optionsData);
-            }
-            hit._highlightResult.default_bundle_options = default_bundle_option;
-        }
-
-        // Add to cart parameters
-        var action = algoliaConfig.instant.addToCartParams.action + 'product/' + hit.objectID + '/';
-
-        var correctFKey = getCookie('form_key');
-
-        if (correctFKey != "" && algoliaConfig.instant.addToCartParams.formKey != correctFKey) {
-            algoliaConfig.instant.addToCartParams.formKey = correctFKey;
-        }
-
-        hit.addToCart = {
-            'action': action,
-            'redirectUrlParam': algoliaConfig.instant.addToCartParams.redirectUrlParam,
-            'uenc': AlgoliaBase64.mageEncode(action),
-            'formKey': algoliaConfig.instant.addToCartParams.formKey
-        };
-
-        if (hit.__queryID) {
-
-            hit.urlForInsights = hit.url;
-
-            if (algoliaConfig.ccAnalytics.enabled
-                && algoliaConfig.ccAnalytics.conversionAnalyticsMode !== 'disabled') {
-                var insightsDataUrlString = $.param({
-                    queryID: hit.__queryID,
-                    objectID: hit.objectID,
-                    indexName: hit.__indexName
-                });
-                if (hit.url.indexOf('?') > -1) {
-                    hit.urlForInsights += '&' + insightsDataUrlString;
-                } else {
-                    hit.urlForInsights += '?' + insightsDataUrlString;
-                }
-            }
-        }
-
-        return hit;
-    };
-
-    window.fixAutocompleteCssHeight = function () {
-        if ($(document).width() > 768) {
-            $(".other-sections").css('min-height', '0');
-            $(".aa-dataset-products").css('min-height', '0');
-            var height = Math.max($(".other-sections").outerHeight(), $(".aa-dataset-products").outerHeight());
-            $(".aa-dataset-products").css('min-height', height);
-        }
-    };
-
-    window.fixAutocompleteCssSticky = function (menu) {
-        var dropdown_menu = $('#algolia-autocomplete-container .aa-dropdown-menu');
-        var autocomplete_container = $('#algolia-autocomplete-container');
-        autocomplete_container.removeClass('reverse');
-
-        /** Reset computation **/
-        dropdown_menu.css('top', '0px');
-
-        /** Stick menu vertically to the input **/
-        var targetOffset = Math.round(menu.offset().top + menu.outerHeight());
-        var currentOffset = Math.round(autocomplete_container.offset().top);
-
-        dropdown_menu.css('top', (targetOffset - currentOffset) + 'px');
-
-        if (menu.offset().left + menu.outerWidth() / 2 > $(document).width() / 2) {
-            /** Stick menu horizontally align on right to the input **/
-            dropdown_menu.css('right', '0px');
-            dropdown_menu.css('left', 'auto');
-
-            var targetOffset = Math.round(menu.offset().left + menu.outerWidth());
-            var currentOffset = Math.round(autocomplete_container.offset().left + autocomplete_container.outerWidth());
-
-            dropdown_menu.css('right', (currentOffset - targetOffset) + 'px');
-        } else {
-            /** Stick menu horizontally align on left to the input **/
-            dropdown_menu.css('left', 'auto');
-            dropdown_menu.css('right', '0px');
-            autocomplete_container.addClass('reverse');
-
-            var targetOffset = Math.round(menu.offset().left);
-            var currentOffset = Math.round(autocomplete_container.offset().left);
-
-            dropdown_menu.css('left', (targetOffset - currentOffset) + 'px');
-        }
-    };
-
-    window.createISWidgetContainer = function (attributeName) {
-        var div = document.createElement('div');
-        div.className = 'is-widget-container-' + attributeName.split('.').join('_');
-        div.dataset.attr = attributeName;
-
-        return div;
-    };
-
     // The url is now rendered as follows : http://website.com?q=searchquery&facet1=value&facet2=value1~value2
     // "?" and "&" are used to be fetched easily inside Magento for the backend rendering
     // Multivalued facets use "~" as separator
     // Targeted index is defined by sortBy parameter
-    window.routing = {
+    const routing = {
         router: instantsearch.routers.history({
             parseURL: function (qsObject) {
                 var location = qsObject.location,
@@ -449,7 +239,7 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
     };
 
     // Taken from Magento's tools.js - not included on frontend, only in backend
-    window.AlgoliaBase64 = {
+    const AlgoliaBase64 = {
         // private property
         _keyStr: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
         //'+/=', '-_,'
@@ -595,6 +385,233 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         }
     };
 
+    const legacyGlobalFunctions = {
+        isMobile: () => {
+            var check = false;
+    
+            (function (a) {
+                if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0, 4))) check = true;
+            })(navigator.userAgent || navigator.vendor || window.opera);
+    
+            return check;
+        },
+
+        getCookie: () => {
+            var value = "; " + document.cookie;
+            var parts = value.split("; " + name + "=");
+            if (parts.length == 2) {
+                return parts.pop().split(";").shift();
+            }
+    
+            return "";
+        },
+
+        transformHit: (hit, price_key, helper) => {
+            if (Array.isArray(hit.categories))
+                hit.categories = hit.categories.join(', ');
+    
+            if (hit._highlightResult.categories_without_path && Array.isArray(hit.categories_without_path)) {
+                hit.categories_without_path = $.map(hit._highlightResult.categories_without_path, function (category) {
+                    return category.value;
+                });
+    
+                hit.categories_without_path = hit.categories_without_path.join(', ');
+            }
+    
+            var matchedColors = [];
+    
+            if (helper && algoliaConfig.useAdaptiveImage === true) {
+                if (hit.images_data && helper.state.facetsRefinements.color) {
+                    matchedColors = helper.state.facetsRefinements.color.slice(0); // slice to clone
+                }
+    
+                if (hit.images_data && helper.state.disjunctiveFacetsRefinements.color) {
+                    matchedColors = helper.state.disjunctiveFacetsRefinements.color.slice(0); // slice to clone
+                }
+            }
+    
+            if (Array.isArray(hit.color)) {
+                var colors = [];
+    
+                $.each(hit._highlightResult.color, function (i, color) {
+                    if (color.matchLevel === undefined || color.matchLevel === 'none') {
+                        return;
+                    }
+    
+                    colors.push(color);
+    
+                    if (algoliaConfig.useAdaptiveImage === true) {
+                        var matchedColor = color.matchedWords.join(' ');
+                        if (hit.images_data && color.fullyHighlighted && color.fullyHighlighted === true) {
+                            matchedColors.push(matchedColor);
+                        }
+                    }
+                });
+    
+                hit._highlightResult.color = colors;
+            } else {
+                if (hit._highlightResult.color && hit._highlightResult.color.matchLevel === 'none') {
+                    hit._highlightResult.color = {value: ''};
+                }
+            }
+    
+            if (algoliaConfig.useAdaptiveImage === true) {
+                $.each(matchedColors, function (i, color) {
+                    color = color.toLowerCase();
+    
+                    if (hit.images_data[color]) {
+                        hit.image_url = hit.images_data[color];
+                        hit.thumbnail_url = hit.images_data[color];
+    
+                        return false;
+                    }
+                });
+            }
+    
+            if (hit._highlightResult.color && hit._highlightResult.color.value && hit.categories_without_path) {
+                if (hit.categories_without_path.indexOf('<em>') === -1 && hit._highlightResult.color.value.indexOf('<em>') !== -1) {
+                    hit.categories_without_path = '';
+                }
+            }
+    
+            if (Array.isArray(hit._highlightResult.name))
+                hit._highlightResult.name = hit._highlightResult.name[0];
+    
+            if (Array.isArray(hit.price)) {
+                hit.price = hit.price[0];
+                if (hit['price'] !== undefined && price_key !== '.' + algoliaConfig.currencyCode + '.default' && hit['price'][algoliaConfig.currencyCode][price_key.substr(1) + '_formated'] !== hit['price'][algoliaConfig.currencyCode]['default_formated']) {
+                    hit['price'][algoliaConfig.currencyCode][price_key.substr(1) + '_original_formated'] = hit['price'][algoliaConfig.currencyCode]['default_formated'];
+                }
+    
+                if (hit['price'][algoliaConfig.currencyCode]['default_original_formated']
+                    && hit['price'][algoliaConfig.currencyCode]['special_to_date']) {
+                    var priceExpiration = hit['price'][algoliaConfig.currencyCode]['special_to_date'];
+    
+                    if (algoliaConfig.now > priceExpiration + 1) {
+                        hit['price'][algoliaConfig.currencyCode]['default_formated'] = hit['price'][algoliaConfig.currencyCode]['default_original_formated'];
+                        hit['price'][algoliaConfig.currencyCode]['default_original_formated'] = false;
+                    }
+                }
+            }
+    
+            /* Added code to bind default bundle options for add to cart */
+            if (hit.default_bundle_options) {
+                var default_bundle_option = [];
+                for (const property in hit.default_bundle_options) {
+                    const optionsData = {
+                        optionId: property,
+                        selectionId : hit.default_bundle_options[property]
+                    }
+                    default_bundle_option.push(optionsData);
+                }
+                hit._highlightResult.default_bundle_options = default_bundle_option;
+            }
+    
+            // Add to cart parameters
+            var action = algoliaConfig.instant.addToCartParams.action + 'product/' + hit.objectID + '/';
+    
+            var correctFKey = getCookie('form_key');
+    
+            if (correctFKey != "" && algoliaConfig.instant.addToCartParams.formKey != correctFKey) {
+                algoliaConfig.instant.addToCartParams.formKey = correctFKey;
+            }
+    
+            hit.addToCart = {
+                'action': action,
+                'redirectUrlParam': algoliaConfig.instant.addToCartParams.redirectUrlParam,
+                'uenc': AlgoliaBase64.mageEncode(action),
+                'formKey': algoliaConfig.instant.addToCartParams.formKey
+            };
+    
+            if (hit.__queryID) {
+    
+                hit.urlForInsights = hit.url;
+    
+                if (algoliaConfig.ccAnalytics.enabled
+                    && algoliaConfig.ccAnalytics.conversionAnalyticsMode !== 'disabled') {
+                    var insightsDataUrlString = $.param({
+                        queryID: hit.__queryID,
+                        objectID: hit.objectID,
+                        indexName: hit.__indexName
+                    });
+                    if (hit.url.indexOf('?') > -1) {
+                        hit.urlForInsights += '&' + insightsDataUrlString;
+                    } else {
+                        hit.urlForInsights += '?' + insightsDataUrlString;
+                    }
+                }
+            }
+    
+            return hit;
+        },
+
+        /** @deprecated This function should no longer be used and will be removed in a future version */
+        fixAutocompleteCssHeight: () => {
+            if ($(document).width() > 768) {
+                $(".other-sections").css('min-height', '0');
+                $(".aa-dataset-products").css('min-height', '0');
+                var height = Math.max($(".other-sections").outerHeight(), $(".aa-dataset-products").outerHeight());
+                $(".aa-dataset-products").css('min-height', height);
+            }
+        },
+
+        /** @deprecated This function should no longer be used and will be removed in a future version */
+        fixAutocompleteCssSticky: (menu) => {
+            var dropdown_menu = $('#algolia-autocomplete-container .aa-dropdown-menu');
+            var autocomplete_container = $('#algolia-autocomplete-container');
+            autocomplete_container.removeClass('reverse');
+    
+            /** Reset computation **/
+            dropdown_menu.css('top', '0px');
+    
+            /** Stick menu vertically to the input **/
+            var targetOffset = Math.round(menu.offset().top + menu.outerHeight());
+            var currentOffset = Math.round(autocomplete_container.offset().top);
+    
+            dropdown_menu.css('top', (targetOffset - currentOffset) + 'px');
+    
+            if (menu.offset().left + menu.outerWidth() / 2 > $(document).width() / 2) {
+                /** Stick menu horizontally align on right to the input **/
+                dropdown_menu.css('right', '0px');
+                dropdown_menu.css('left', 'auto');
+    
+                var targetOffset = Math.round(menu.offset().left + menu.outerWidth());
+                var currentOffset = Math.round(autocomplete_container.offset().left + autocomplete_container.outerWidth());
+    
+                dropdown_menu.css('right', (currentOffset - targetOffset) + 'px');
+            } else {
+                /** Stick menu horizontally align on left to the input **/
+                dropdown_menu.css('left', 'auto');
+                dropdown_menu.css('right', '0px');
+                autocomplete_container.addClass('reverse');
+    
+                var targetOffset = Math.round(menu.offset().left);
+                var currentOffset = Math.round(autocomplete_container.offset().left);
+    
+                dropdown_menu.css('left', (targetOffset - currentOffset) + 'px');
+            }
+        },
+
+        createISWidgetContainer: (attributeName) => {
+            var div = document.createElement('div');
+            div.className = 'is-widget-container-' + attributeName.split('.').join('_');
+            div.dataset.attr = attributeName;
+    
+            return div;
+        }
+    };
+
+    if (USE_GLOBALS) {
+        Object.assign(
+            window, 
+            {
+                algolia,
+                routing,
+                AlgoliaBase64
+            },
+            legacyGlobalFunctions
+        );
+    }
 
     $(function ($) {
         if (typeof algoliaConfig === 'undefined') {

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -406,6 +406,9 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
             return "";
         },
 
+        // @deprecated This function will be removed from this module in a future version
+        // This global function is highly specific to InstantSearch and has never been used for anything else
+        // It will eventually be relocated to the algoliaInstantSearch lib
         transformHit: (hit, price_key, helper) => {
             if (Array.isArray(hit.categories))
                 hit.categories = hit.categories.join(', ');
@@ -510,7 +513,7 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
             // Add to cart parameters
             var action = algoliaConfig.instant.addToCartParams.action + 'product/' + hit.objectID + '/';
     
-            var correctFKey = getCookie('form_key');
+            var correctFKey = this.getCookie('form_key');
     
             if (correctFKey != "" && algoliaConfig.instant.addToCartParams.formKey != correctFKey) {
                 algoliaConfig.instant.addToCartParams.formKey = correctFKey;

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -613,34 +613,38 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         );
     }
 
-    $(function ($) {
+    // TODO: Evaluate removal of these methods - referencing legacy DOM selector
+    const handleInputCrossAutocomplete = (input) => {
+        console.log("####", (new Error()).stack?.split("\n")[1]?.trim().split(" ")[1]);
+        if (input.val().length > 0) {
+            input.closest('#algolia-searchbox').find('.clear-query-autocomplete').show();
+            input.closest('#algolia-searchbox').find('.magnifying-glass').hide();
+        } else {
+            input.closest('#algolia-searchbox').find('.clear-query-autocomplete').hide();
+            input.closest('#algolia-searchbox').find('.magnifying-glass').show();
+        }
+    };
+
+    const handleAutoCompleteSubmit = (e) => {
+        let query = $(this).find(algoliaConfig.autocomplete.selector).val();
+
+        query = encodeURIComponent(query);
+
+        if (algoliaConfig.instant.enabled && query === '')
+            query = '__empty__';
+
+        window.location = $(this).attr('action') + '?q=' + query;
+
+        return false;
+    };
+
+    const initialize = () => {
         if (typeof algoliaConfig === 'undefined') {
             return;
         }
         $(algoliaConfig.autocomplete.selector).each(function () {
-            $(this).closest('form').on('submit', function (e) {
-                let query = $(this).find(algoliaConfig.autocomplete.selector).val();
-
-                query = encodeURIComponent(query);
-
-                if (algoliaConfig.instant.enabled && query === '')
-                    query = '__empty__';
-
-                window.location = $(this).attr('action') + '?q=' + query;
-
-                return false;
-            });
+            $(this).closest('form').on('submit', handleAutoCompleteSubmit);
         });
-
-        function handleInputCrossAutocomplete(input) {
-            if (input.val().length > 0) {
-                input.closest('#algolia-searchbox').find('.clear-query-autocomplete').show();
-                input.closest('#algolia-searchbox').find('.magnifying-glass').hide();
-            } else {
-                input.closest('#algolia-searchbox').find('.clear-query-autocomplete').hide();
-                input.closest('#algolia-searchbox').find('.magnifying-glass').show();
-            }
-        }
 
         $(document).on('click', '.clear-query-autocomplete', function () {
             var input = $(this).closest('#algolia-searchbox').find('input');
@@ -661,8 +665,18 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
             else
                 $(this).html('+ ' + algoliaConfig.translations.refine);
         });
+    }
 
 
+    $(function ($) {
+        initialize();
     });
+
+    return {
+        algolia,
+        routing,
+        AlgoliaBase64,
+        ...legacyGlobalFunctions
+    };
 
 });

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -495,7 +495,7 @@ define(['jquery', 'algoliaInstantSearchLib', 'algoliaBase64'], function ($, inst
     });
 
     return {
-        algolia,
+        ...algolia,
         routing,
         ...legacyGlobalFunctions
     };

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -471,34 +471,6 @@ define(['jquery', 'algoliaInstantSearchLib', 'algoliaBase64'], function ($, inst
         );
     }
 
-    // TODO move as mixable to autocomplete.js
-    const handleAutoCompleteSubmit = (e) => {
-        let query = $(this).find(algoliaConfig.autocomplete.selector).val();
-
-        query = encodeURIComponent(query);
-
-        if (algoliaConfig.instant.enabled && query === '')
-            query = '__empty__';
-
-        window.location = $(this).attr('action') + '?q=' + query;
-
-        return false;
-    };
-
-    const initialize = () => {
-        if (typeof algoliaConfig === 'undefined') {
-            return;
-        }
-        $(algoliaConfig.autocomplete.selector).each(function () {
-            $(this).closest('form').on('submit', handleAutoCompleteSubmit);
-        });
-    }
-
-
-    $(function ($) {
-        initialize();
-    });
-
     return {
         ...algolia,
         routing,

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -613,18 +613,6 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         );
     }
 
-    // TODO: Evaluate removal of these methods - referencing legacy DOM selector
-    const handleInputCrossAutocomplete = (input) => {
-        console.log("####", (new Error()).stack?.split("\n")[1]?.trim().split(" ")[1]);
-        if (input.val().length > 0) {
-            input.closest('#algolia-searchbox').find('.clear-query-autocomplete').show();
-            input.closest('#algolia-searchbox').find('.magnifying-glass').hide();
-        } else {
-            input.closest('#algolia-searchbox').find('.clear-query-autocomplete').hide();
-            input.closest('#algolia-searchbox').find('.magnifying-glass').show();
-        }
-    };
-
     const handleAutoCompleteSubmit = (e) => {
         let query = $(this).find(algoliaConfig.autocomplete.selector).val();
 
@@ -644,17 +632,6 @@ define(['jquery', 'algoliaInstantSearchLib'], function ($, instantsearch) {
         }
         $(algoliaConfig.autocomplete.selector).each(function () {
             $(this).closest('form').on('submit', handleAutoCompleteSubmit);
-        });
-
-        $(document).on('click', '.clear-query-autocomplete', function () {
-            var input = $(this).closest('#algolia-searchbox').find('input');
-
-            input.val('');
-            if (input.length) {
-                input.get(0).dispatchEvent(new Event('input'));
-            }
-
-            handleInputCrossAutocomplete(input);
         });
 
         /** Handle small screen **/

--- a/view/frontend/web/js/template/recommend/products.js
+++ b/view/frontend/web/js/template/recommend/products.js
@@ -1,4 +1,4 @@
-define([algoliaCommon], function (algoliaCommon) {
+define(['algoliaCommon'], function (algoliaCommon) {
     return {
         getItemHtml: function (item, html, addTocart) {
             let correctFKey = algoliaCommon.getCookie('form_key');

--- a/view/frontend/web/js/template/recommend/products.js
+++ b/view/frontend/web/js/template/recommend/products.js
@@ -1,7 +1,7 @@
-define([], function () {
+define([algoliaCommon], function (algoliaCommon) {
     return {
         getItemHtml: function (item, html, addTocart) {
-            let correctFKey = getCookie('form_key');
+            let correctFKey = algoliaCommon.getCookie('form_key');
             let action = algoliaConfig.recommend.addToCartParams.action + 'product/' + item.objectID + '/';
             if(correctFKey != "" && algoliaConfig.recommend.addToCartParams.formKey != correctFKey) {
                 algoliaConfig.recommend.addToCartParams.formKey = correctFKey;
@@ -14,7 +14,7 @@ define([], function () {
                     ${addTocart && html`
                         <form class="addTocartForm" action="${action}" method="post" data-role="tocart-form">
                             <input type="hidden" name="form_key" value="${algoliaConfig.recommend.addToCartParams.formKey}" />
-                            <input type="hidden" name="unec" value="${AlgoliaBase64.mageEncode(action)}"/>
+                            <input type="hidden" name="unec" value="${algoliaCommon.AlgoliaBase64.mageEncode(action)}"/>
                             <input type="hidden" name="product" value="${item.objectID}" />
                             <button type="submit" class="action tocart primary">
                                 <span>${algoliaConfig.translations.addToCart}</span>

--- a/view/frontend/web/js/template/recommend/products.js
+++ b/view/frontend/web/js/template/recommend/products.js
@@ -1,4 +1,4 @@
-define(['algoliaCommon'], function (algoliaCommon) {
+define(['algoliaCommon', 'algoliaBase64'], function (algoliaCommon, algoliaBase64) {
     return {
         getItemHtml: function (item, html, addTocart) {
             let correctFKey = algoliaCommon.getCookie('form_key');
@@ -14,7 +14,7 @@ define(['algoliaCommon'], function (algoliaCommon) {
                     ${addTocart && html`
                         <form class="addTocartForm" action="${action}" method="post" data-role="tocart-form">
                             <input type="hidden" name="form_key" value="${algoliaConfig.recommend.addToCartParams.formKey}" />
-                            <input type="hidden" name="unec" value="${algoliaCommon.AlgoliaBase64.mageEncode(action)}"/>
+                            <input type="hidden" name="unec" value="${algoliaBase64.mageEncode(action)}"/>
                             <input type="hidden" name="product" value="${item.objectID}" />
                             <button type="submit" class="action tocart primary">
                                 <span>${algoliaConfig.translations.addToCart}</span>


### PR DESCRIPTION
This PR aims to:
- Treat Algolia libs that inject Autocomplete and InstantSearch as proper `uiComponents`
- Eliminate dependencies on the global `window` object
- Maintain `window` objects for backward compatibility
- Eliminate monolithic anonymous functions
- Allow the use of RequireJS mixins to override targeted functionality in the Algolia Magento extension vs overriding entire JS files enabling code reuse and preventing implementation drift on future updates (from copy/paste overrides) 
- Ensure that modules return mixable objects and that dependencies are loaded properly through the `define` method signature
- Keep UI lib callbacks as pure as possible (and eliminate pollution with obscure implementation) 
- Reduce scoping of variables across mega methods
- Remove and/or modernize dated / obsolete code