### PR TITLE
MAGE-1030: Fix client creation

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -85,6 +85,7 @@ class AlgoliaHelper extends AbstractHelper
             if ($storeId !== self::ALGOLIA_DEFAULT_SCOPE) {
                 $this->algoliaCredentialsManager->displayErrorMessage(AlgoliaHelper::class, $storeId);
             }
+            return;
         }
 
         $config = SearchConfig::create(

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -59,9 +59,6 @@ class AlgoliaHelper extends AbstractHelper
 
     protected static ?int $lastTaskId;
 
-    /**
-     * @throws AlgoliaException
-     */
     public function __construct(
         Context $context,
         protected ConfigHelper $config,
@@ -79,7 +76,6 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param bool $fromConstructor
      * @return void
      */
     protected function createClient(): void

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -71,13 +71,6 @@ class AlgoliaHelper extends AbstractHelper
     ) {
         parent::__construct($context);
 
-        try {
-            $this->createClient(true);
-            $this->addAlgoliaUserAgent();
-        } catch (AlgoliaException $e) {
-            // feedback handled by algoliaCredentialsManager
-        }
-
         // Merge non castable attributes set in config
         $this->nonCastableAttributes = array_merge(
             $this->nonCastableAttributes,
@@ -89,11 +82,11 @@ class AlgoliaHelper extends AbstractHelper
      * @param bool $fromConstructor
      * @return void
      */
-    protected function createClient(bool $fromConstructor = false): void
+    protected function createClient(): void
     {
         $storeId = $this->getStoreId();
         if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
-            if ($storeId !== self::ALGOLIA_DEFAULT_SCOPE || !$fromConstructor) {
+            if ($storeId !== self::ALGOLIA_DEFAULT_SCOPE) {
                 $this->algoliaCredentialsManager->displayErrorMessage(AlgoliaHelper::class, $storeId);
             }
         }
@@ -132,6 +125,7 @@ class AlgoliaHelper extends AbstractHelper
     {
         if (!isset($this->clients[$this->getStoreId()])) {
             $this->createClient();
+            $this->addAlgoliaUserAgent();
         }
 
         return $this->clients[$this->getStoreId()] ?? null;

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -93,7 +93,7 @@ class AlgoliaHelper extends AbstractHelper
     {
         $storeId = $this->getStoreId();
         if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
-            if ($storeId !== 0 || !$fromConstructor) {
+            if ($storeId !== self::ALGOLIA_DEFAULT_SCOPE || !$fromConstructor) {
                 $this->algoliaCredentialsManager->displayErrorMessage(AlgoliaHelper::class, $storeId);
             }
         }


### PR DESCRIPTION
This change includes:
- Removal of client creation in the constructor to avoid such issues in the future
- Prevented unhandled crash on category merchandising when no credentials are configured at Default level
- Feedback to the user is now handled by the `AlgoliaCredentialsManager` class