### PR TITLE
Including FPT on indexed product final price!

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -55,8 +55,8 @@ abstract class ProductWithChildren extends ProductWithoutChildren
                 } else {
                     $minPrice = $specialPrice[0];
                 }
-                $price     = $minPrice ?? $this->getTaxPrice($product, $subProduct->getFinalPrice(), $withTax);
-                $basePrice = $this->getTaxPrice($product, $subProduct->getPrice(), $withTax);
+                $price     = $minPrice ?? $this->getTaxPrice($product, $subProduct->getFinalPrice(), $withTax) + $this->weeeTax->getWeeeAmount($subProduct);
+                $basePrice = $this->getTaxPrice($product, $subProduct->getPrice(), $withTax) + $this->weeeTax->getWeeeAmount($subProduct);
                 $min = min($min, $price);
                 $original = min($original, $basePrice);
                 $max = max($max, $price);


### PR DESCRIPTION
**Summary**

Tested on Magento **2.4.5-p7**.

The FPT configured on the products are not included in the final product price! If we configure the FPT at the level of:
![image](https://github.com/user-attachments/assets/81bad21c-2cc3-4a6f-b453-34c4ba5d0ac0)

And we create a new attribute of type 'Fixed Product Tax' and assign it to an Attribute Set:
![image](https://github.com/user-attachments/assets/5688af8c-133e-4bf9-8416-7f70588a86e8)

Then we configure the product price to 59 MAD.
![image](https://github.com/user-attachments/assets/d55cd0d4-8a1b-48e5-9673-1c2b6bfc7061)

And the attribute we created has a tax of 10 MAD.
![image](https://github.com/user-attachments/assets/a9374fa1-1fd5-4023-b844-7c87f0d5ca13)


The product is displayed on the product list and on the product page as:
![image](https://github.com/user-attachments/assets/d53377b3-50ae-40d5-8f2b-50986a86d75b)
![image](https://github.com/user-attachments/assets/5889d8be-a671-4ae2-8287-97ec2e51c60b)
 

**Actual Result**
The price indexed on Algolia is 59 MAD instead of the customer purchase price of 69 MAD.

**Expected Result**
The price indexed on Algolia includes the FPTs (which is 69 MAD in this case).