### PR TITLE
MAGE-1060: POC for multi-store indexing testing

### DIFF
--- a/Test/Integration/MultiStoreCategoriesTest.php
+++ b/Test/Integration/MultiStoreCategoriesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration;
+
+use Algolia\AlgoliaSearch\Model\Indexer\Category;
+
+/**
+ * @magentoDataFixture Magento/Store/_files/second_website_with_two_stores.php
+ * @magentoDbIsolation disabled
+ * @magentoAppIsolation enabled
+ */
+class MultiStoreCategoriesTest extends MultiStoreTestCase
+{
+    /** @var Category */
+    protected $categoriesIndexer;
+
+    public function setUp():void
+    {
+        parent::setUp();
+
+        /** @var Category $categoriesIndexer */
+        $this->categoriesIndexer = $this->getObjectManager()->create(Category::class);
+
+        $this->categoriesIndexer->executeFull();
+        $this->algoliaHelper->waitLastTask();
+    }
+
+    public function testMultiStoreCategoryIndices()
+    {
+        foreach ($this->storeManager->getStores() as $store) {
+            $this->assertNbOfRecordsPerStore($store->getCode(), 'categories', $this->assertValues->expectedCategory);
+        }
+    }
+}

--- a/Test/Integration/MultiStoreConfigTest.php
+++ b/Test/Integration/MultiStoreConfigTest.php
@@ -2,32 +2,11 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration;
 
-use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
-use Magento\Store\Api\Data\StoreInterface;
-use Magento\Store\Model\StoreManager;
-
-class MultiStoreConfigTest extends TestCase
+/**
+ * @magentoDataFixture Magento/Store/_files/second_website_with_two_stores.php
+ */
+class MultiStoreConfigTest extends MultiStoreTestCase
 {
-    /** @var StoreManager */
-    protected $storeManager;
-
-    /** @var IndicesConfigurator */
-    protected $indicesConfigurator;
-
-    public function setUp():void
-    {
-        /** @var StoreManager $storeManager */
-        $this->storeManager = $this->getObjectManager()->create(StoreManager::class);
-
-        /** @var IndicesConfigurator $indicesConfigurator */
-        $this->indicesConfigurator = $this->getObjectManager()->create(IndicesConfigurator::class);
-
-        parent::setUp();
-    }
-
-    /**
-     * @magentoDataFixture Magento/Store/_files/second_website_with_two_stores.php
-     */
     public function testMultiStoreIndicesCreation()
     {
         $websites = $this->storeManager->getWebsites();
@@ -54,31 +33,5 @@ class MultiStoreConfigTest extends TestCase
 
         // Check that the configuration created the appropriate number of indices (4 per store => 3*4=12)
         $this->assertEquals($indicesCreatedByTest, 12);
-    }
-
-    private function setupStore(StoreInterface $store): void
-    {
-        $this->setConfig(
-            'algoliasearch_credentials/credentials/application_id',
-            getenv('ALGOLIA_APPLICATION_ID'),
-            $store->getCode()
-        );
-        $this->setConfig(
-            'algoliasearch_credentials/credentials/search_only_api_key',
-            getenv('ALGOLIA_SEARCH_KEY_1') ?: getenv('ALGOLIA_SEARCH_API_KEY'),
-            $store->getCode()
-        );
-        $this->setConfig(
-            'algoliasearch_credentials/credentials/api_key',
-            getenv('ALGOLIA_API_KEY'),
-            $store->getCode()
-        );
-        $this->setConfig(
-            'algoliasearch_credentials/credentials/index_prefix',
-            $this->indexPrefix,
-            $store->getCode()
-        );
-
-        $this->indicesConfigurator->saveConfigurationToAlgolia($store->getId());
     }
 }

--- a/Test/Integration/MultiStoreConfigTest.php
+++ b/Test/Integration/MultiStoreConfigTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration;
+
+use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManager;
+
+class MultiStoreConfigTest extends TestCase
+{
+    /** @var StoreManager */
+    protected $storeManager;
+
+    /** @var IndicesConfigurator */
+    protected $indicesConfigurator;
+
+    public function setUp():void
+    {
+        /** @var StoreManager $storeManager */
+        $this->storeManager = $this->getObjectManager()->create(StoreManager::class);
+
+        /** @var IndicesConfigurator $indicesConfigurator */
+        $this->indicesConfigurator = $this->getObjectManager()->create(IndicesConfigurator::class);
+
+        parent::setUp();
+    }
+
+    /**
+     * @magentoDataFixture Magento/Store/_files/second_website_with_two_stores.php
+     */
+    public function testMultiStoreIndicesCreation()
+    {
+        $websites = $this->storeManager->getWebsites();
+        $stores = $this->storeManager->getStores();
+
+        // Check that stores and websites are properly created
+        $this->assertEquals(count($websites), 2);
+        $this->assertEquals(count($stores), 3);
+
+        foreach ($stores as $store) {
+            $this->setupStore($store);
+        }
+
+        $indicesCreatedByTest = 0;
+        $indices = $this->algoliaHelper->listIndexes();
+
+        foreach ($indices['items'] as $index) {
+            $name = $index['name'];
+
+            if (mb_strpos($name, $this->indexPrefix) === 0) {
+                $indicesCreatedByTest++;
+            }
+        }
+
+        // Check that the configuration created the appropriate number of indices (4 per store => 3*4=12)
+        $this->assertEquals($indicesCreatedByTest, 12);
+    }
+
+    private function setupStore(StoreInterface $store): void
+    {
+        $this->setConfig(
+            'algoliasearch_credentials/credentials/application_id',
+            getenv('ALGOLIA_APPLICATION_ID'),
+            $store->getCode()
+        );
+        $this->setConfig(
+            'algoliasearch_credentials/credentials/search_only_api_key',
+            getenv('ALGOLIA_SEARCH_KEY_1') ?: getenv('ALGOLIA_SEARCH_API_KEY'),
+            $store->getCode()
+        );
+        $this->setConfig(
+            'algoliasearch_credentials/credentials/api_key',
+            getenv('ALGOLIA_API_KEY'),
+            $store->getCode()
+        );
+        $this->setConfig(
+            'algoliasearch_credentials/credentials/index_prefix',
+            $this->indexPrefix,
+            $store->getCode()
+        );
+
+        $this->indicesConfigurator->saveConfigurationToAlgolia($store->getId());
+    }
+}

--- a/Test/Integration/MultiStoreTestCase.php
+++ b/Test/Integration/MultiStoreTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration;
+
+use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManager;
+
+abstract class MultiStoreTestCase extends IndexingTestCase
+{
+    /** @var StoreManager */
+    protected $storeManager;
+
+    /** @var IndicesConfigurator */
+    protected $indicesConfigurator;
+
+    public function setUp():void
+    {
+        /** @var StoreManager $storeManager */
+        $this->storeManager = $this->getObjectManager()->create(StoreManager::class);
+
+        /** @var IndicesConfigurator $indicesConfigurator */
+        $this->indicesConfigurator = $this->getObjectManager()->create(IndicesConfigurator::class);
+
+        parent::setUp();
+
+        foreach ($this->storeManager->getStores() as $store) {
+            $this->setupStore($store);
+        }
+    }
+
+    protected function assertNbOfRecordsPerStore(string $storeCode, string $entity, int $expectedNumber)
+    {
+        $resultsDefault = $this->algoliaHelper->query($this->indexPrefix .  $storeCode . '_' . $entity, '', []);
+
+        $this->assertEquals($expectedNumber, $resultsDefault['results'][0]['nbHits']);
+    }
+
+    protected function setupStore(StoreInterface $store): void
+    {
+        $this->setConfig(
+            'algoliasearch_credentials/credentials/application_id',
+            getenv('ALGOLIA_APPLICATION_ID'),
+            $store->getCode()
+        );
+        $this->setConfig(
+            'algoliasearch_credentials/credentials/search_only_api_key',
+            getenv('ALGOLIA_SEARCH_KEY_1') ?: getenv('ALGOLIA_SEARCH_API_KEY'),
+            $store->getCode()
+        );
+        $this->setConfig(
+            'algoliasearch_credentials/credentials/api_key',
+            getenv('ALGOLIA_API_KEY'),
+            $store->getCode()
+        );
+        $this->setConfig(
+            'algoliasearch_credentials/credentials/index_prefix',
+            $this->indexPrefix,
+            $store->getCode()
+        );
+
+        $this->indicesConfigurator->saveConfigurationToAlgolia($store->getId());
+    }
+
+}

--- a/Test/Integration/MultiStoreTestCase.php
+++ b/Test/Integration/MultiStoreTestCase.php
@@ -2,7 +2,10 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration;
 
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManager;
 
@@ -29,13 +32,29 @@ abstract class MultiStoreTestCase extends IndexingTestCase
         }
     }
 
-    protected function assertNbOfRecordsPerStore(string $storeCode, string $entity, int $expectedNumber)
+    /**
+     * @param string $storeCode
+     * @param string $entity
+     * @param int $expectedNumber
+     *
+     * @return void
+     * @throws AlgoliaException
+     */
+    protected function assertNbOfRecordsPerStore(string $storeCode, string $entity, int $expectedNumber): void
     {
         $resultsDefault = $this->algoliaHelper->query($this->indexPrefix .  $storeCode . '_' . $entity, '', []);
 
         $this->assertEquals($expectedNumber, $resultsDefault['results'][0]['nbHits']);
     }
 
+    /**
+     * @param StoreInterface $store
+     *
+     * @return void
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
     protected function setupStore(StoreInterface $store): void
     {
         $this->setConfig(

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -58,13 +58,16 @@ abstract class TestCase extends \TC
         }
     }
 
-    protected function setConfig($path, $value)
-    {
+    protected function setConfig(
+        $path,
+        $value,
+        $scopeCode = 'default'
+    ) {
         $this->getObjectManager()->get(\Magento\Framework\App\Config\MutableScopeConfigInterface::class)->setValue(
             $path,
             $value,
             ScopeInterface::SCOPE_STORE,
-            'default'
+            $scopeCode
         );
     }
 


### PR DESCRIPTION
This PR act as a POC for multi-stores bootstrap testing.

We create 2 additional stores and make sure that the extension creates appropriate number of indices in the application.
The `setupStore()` method allows to set different credentials per store, which will allow us to test multi applications scenarios in the future.