### PR TITLE
MAGE-1081 Pull fresh settings data if Algolia state changes over life…

### DIFF
--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -133,12 +133,14 @@ class ReplicaManager implements ReplicaManagerInterface
      * relevant to the Magento integration
      *
      * @param string $primaryIndexName
+     * @param bool $refreshCache
      * @return string[] Array of replica index names
      * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
-    protected function getMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName): array
+    protected function getMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName, bool $refreshCache = false): array
     {
-        $algoliaReplicas = $this->getReplicaConfigurationFromAlgolia($primaryIndexName);
+        $algoliaReplicas = $this->getReplicaConfigurationFromAlgolia($primaryIndexName, $refreshCache);
         $magentoReplicas = $this->getMagentoReplicaSettings($primaryIndexName, $algoliaReplicas);
         return array_values(array_intersect($magentoReplicas, $algoliaReplicas));
     }
@@ -241,7 +243,7 @@ class ReplicaManager implements ReplicaManagerInterface
         $indexName = $this->indexNameFetcher->getProductIndexName($storeId);
         $sortingIndices = $this->sortingTransformer->getSortingIndices($storeId);
         $newMagentoReplicasSetting = $this->sortingTransformer->transformSortingIndicesToReplicaSetting($sortingIndices);
-        $oldMagentoReplicasSetting = $this->getMagentoReplicaConfigurationFromAlgolia($indexName);
+        $oldMagentoReplicasSetting = $this->getMagentoReplicaConfigurationFromAlgolia($indexName, true);
         $nonMagentoReplicasSetting = $this->getNonMagentoReplicaConfigurationFromAlgolia($indexName);
         $oldMagentoReplicaIndices = $this->getBareIndexNamesFromReplicaSetting($oldMagentoReplicasSetting);
         $newMagentoReplicaIndices = $this->getBareIndexNamesFromReplicaSetting($newMagentoReplicasSetting);


### PR DESCRIPTION
While performing integration testing I discovered a bug in the way the `ReplicaManager` evaluates change state as a long-lived singleton.

If the state in Algolia changes over the life of the Magento singleton then its cached replica setting needs to be refreshed as well. 

This settings data is used to determine whether or not custom ranking logic should be applied. (If nothing appears to have changed in Algolia then it does not attempt to update the replica index with a new ranking.)

What is considered a change is based on whether:

- A new replica was added
- A replica was switched from standard to virtual
- A replica was switched from virtual to standard

Retrieving a fresh value from the settings API endpoint to make this comparison should resolve this issue.