### PR TITLE
Feature/mage 1044 replica testing

### DIFF
--- a/Console/Command/ReplicaSyncCommand.php
+++ b/Console/Command/ReplicaSyncCommand.php
@@ -11,7 +11,7 @@ use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
-use Magento\Framework\App\State;
+use Magento\Framework\App\State as AppState;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -27,12 +27,12 @@ class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCo
         protected ReplicaManagerInterface $replicaManager,
         protected ProductHelper           $productHelper,
         protected StoreManagerInterface   $storeManager,
-        State                             $state,
+        AppState                          $appState,
         StoreNameFetcher                  $storeNameFetcher,
         ?string                           $name = null
     )
     {
-        parent::__construct($state, $storeNameFetcher, $name);
+        parent::__construct($appState, $storeNameFetcher, $name);
     }
 
     protected function getReplicaCommandName(): string

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1157,7 +1157,7 @@ class ConfigHelper
      * @param int|null $scopeId
      * @return void
      */
-    public function setSorting(array $sorting, ?string $scope = null, ?int $scopeId = null): void
+    public function setSorting(array $sorting, string $scope = Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?int $scopeId = null): void
     {
         $this->configWriter->save(
             self::SORTING_INDICES,

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -133,12 +133,14 @@ class ReplicaManager implements ReplicaManagerInterface
      * relevant to the Magento integration
      *
      * @param string $primaryIndexName
+     * @param bool $refreshCache
      * @return string[] Array of replica index names
      * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
-    protected function getMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName): array
+    protected function getMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName, bool $refreshCache = false): array
     {
-        $algoliaReplicas = $this->getReplicaConfigurationFromAlgolia($primaryIndexName);
+        $algoliaReplicas = $this->getReplicaConfigurationFromAlgolia($primaryIndexName, $refreshCache);
         $magentoReplicas = $this->getMagentoReplicaSettings($primaryIndexName, $algoliaReplicas);
         return array_values(array_intersect($magentoReplicas, $algoliaReplicas));
     }
@@ -241,7 +243,7 @@ class ReplicaManager implements ReplicaManagerInterface
         $indexName = $this->indexNameFetcher->getProductIndexName($storeId);
         $sortingIndices = $this->sortingTransformer->getSortingIndices($storeId);
         $newMagentoReplicasSetting = $this->sortingTransformer->transformSortingIndicesToReplicaSetting($sortingIndices);
-        $oldMagentoReplicasSetting = $this->getMagentoReplicaConfigurationFromAlgolia($indexName);
+        $oldMagentoReplicasSetting = $this->getMagentoReplicaConfigurationFromAlgolia($indexName, true);
         $nonMagentoReplicasSetting = $this->getNonMagentoReplicaConfigurationFromAlgolia($indexName);
         $oldMagentoReplicaIndices = $this->getBareIndexNamesFromReplicaSetting($oldMagentoReplicasSetting);
         $newMagentoReplicaIndices = $this->getBareIndexNamesFromReplicaSetting($newMagentoReplicasSetting);

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -139,7 +139,7 @@ class ReplicaIndexingTest extends IndexingTestCase
     }
 
     /**
-     * ConfigHelper::setSorting used WriterInterface which does not update unless DB isolation is disabled
+     * ConfigHelper::setSorting uses WriterInterface which does not update unless DB isolation is disabled
      * This provides a workaround to test using MutableScopeConfigInterface with DB isolation enabled
      */
     protected function mockSortUpdate(string $sortAttr, string $sortDir, array $attr): void
@@ -201,7 +201,15 @@ class ReplicaIndexingTest extends IndexingTestCase
         $this->assertArrayHasKey('replicas', $currentSettings);
         $replicas = $currentSettings['replicas'];
 
-        $this->assertTrue(count($replicas) >= count($sorting));
+        $this->assertEquals(count($sorting), count($replicas));
+
+        foreach ($sorting as $sortAttr) {
+            $replicaIndexName = $sortAttr['name'];
+            $needle = array_key_exists('virtualReplica', $sortAttr) && $sortAttr['virtualReplica']
+                ? "virtual($replicaIndexName)"
+                : $replicaIndexName;
+            $this->assertContains($needle, $replicas);
+        }
 
     }
 

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration\Product;
+
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
+use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
+use Algolia\AlgoliaSearch\Test\Integration\IndexingTestCase;
+
+class ReplicaIndexingTest extends IndexingTestCase
+{
+    protected ?ReplicaManagerInterface $replicaManager;
+    protected ?ProductIndexer $productIndexer;
+
+    protected ?IndicesConfigurator $indicesConfigurator;
+
+    protected ?string $indexSuffix;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->productIndexer = $this->objectManager->get(ProductIndexer::class);
+        $this->replicaManager = $this->objectManager->get(ReplicaManagerInterface::class);
+        $this->indicesConfigurator = $this->getObjectManager()->get(IndicesConfigurator::class);
+        $this->indexSuffix = 'products';
+
+    }
+
+    protected function getIndexName(string $storeIndexPart): string
+    {
+        return $this->indexPrefix . $storeIndexPart . $this->indexSuffix;
+    }
+
+    public function processFullReindexProducts(): void
+    {
+        $this->processFullReindex($this->productIndexer, $this->indexSuffix);
+    }
+
+    public function testReplicaIndex(): void
+    {
+        $sorting = $this->configHelper->getSorting();
+        $sortAttr = 'created_at';
+
+        // Has created_at sort
+        $this->assertTrue(
+            (bool)
+            array_filter(
+                $sorting,
+                function($sort) use ($sortAttr) {
+                    return $sort['attribute'] == $sortAttr;
+                }
+            )
+        );
+
+        // Expected replica max
+        $this->assertEquals($this->replicaManager->getMaxVirtualReplicasPerIndex(), 20);
+
+        // Replicas will not get created if InstantSearch is not used
+        $this->setConfig('algoliasearch_instant/instant/is_instant_enabled', 1);
+
+        $this->indicesConfigurator->saveConfigurationToAlgolia(1);
+        $this->algoliaHelper->waitLastTask();
+
+        // Assert replica config created
+        $indexName = $this->getIndexName('default_');
+        $currentSettings = $this->algoliaHelper->getSettings($indexName);
+        $this->assertArrayHasKey('replicas', $currentSettings);
+
+        $this->assertTrue(
+            (bool)
+            array_filter(
+                $currentSettings['replicas'],
+                function($replicaIndex) use ($indexName, $sortAttr) {
+                    return str_contains($replicaIndex, $indexName . '_' . $sortAttr);
+                }
+            )
+        );
+    }
+}

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -10,14 +10,14 @@ use Algolia\AlgoliaSearch\Test\Integration\IndexingTestCase;
 
 class ReplicaIndexingTest extends IndexingTestCase
 {
-    protected ?ReplicaManagerInterface $replicaManager;
-    protected ?ProductIndexer $productIndexer;
+    protected ?ReplicaManagerInterface $replicaManager = null;
+    protected ?ProductIndexer $productIndexer = null;
 
-    protected ?IndicesConfigurator $indicesConfigurator;
+    protected ?IndicesConfigurator $indicesConfigurator = null;
 
-    protected ?string $indexSuffix;
+    protected ?string $indexSuffix = null;
 
-    protected ?array $ogSortingState;
+    protected ?array $ogSortingState = null;
 
     public function setUp(): void
     {
@@ -107,6 +107,7 @@ class ReplicaIndexingTest extends IndexingTestCase
 
     /**
      * @magentoDbIsolation disabled
+     * @group virtual
      */
     public function testVirtualReplicaConfig(): void
     {
@@ -124,33 +125,13 @@ class ReplicaIndexingTest extends IndexingTestCase
             'sort' => $sortDir,
             'sortLabel' => $sortAttr
         ];
-        $encoded = json_encode($sorting);
-//        $this->setConfig('algoliasearch_instant/instant_sorts/sorts', $encoded);
         $this->configHelper->setSorting($sorting);
 
-        $connection = $this->objectManager->create(\Magento\Framework\App\ResourceConnection::class)
-            ->getConnection();
-//        $connection->beginTransaction();
-//        $this->objectManager->get(\Magento\Framework\App\Config\Storage\WriterInterface::class)->save(
-//            \Algolia\AlgoliaSearch\Helper\ConfigHelper::SORTING_INDICES,
-//            $encoded,
-//            'default'
-//        );
-//        $connection->commit();
+        $this->assertConfigInDb('algoliasearch_instant/instant_sorts/sorts', json_encode($sorting));
 
+        $this->refreshConfigFromDb();
 
-        $select = $connection->select()
-            ->from('core_config_data', 'value')
-            ->where('path = ?', 'algoliasearch_instant/instant_sorts/sorts')
-            ->where('scope = ?', 'default')
-            ->where('scope_id = ?', 0);
-
-        $configValue = $connection->fetchOne($select);
-
-        // Assert that the correct value was written to the database
-        $this->assertEquals($encoded, $configValue);
-
-//        $this->assertSortingAttribute($sortAttr, $sortDir);
+        $this->assertSortingAttribute($sortAttr, $sortDir);
 
     }
 

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -96,7 +96,7 @@ class ReplicaIndexingTest extends IndexingTestCase
 
         // Assert standard replica ranking config
         $this->assertArrayHasKey('ranking', $replicaSettings);
-        $this->assertContains("$sortDir($sortAttr)", $replicaSettings['ranking']);
+        $this->assertEquals("$sortDir($sortAttr)", array_shift($replicaSettings['ranking']));
 
     }
 
@@ -153,6 +153,10 @@ class ReplicaIndexingTest extends IndexingTestCase
         $replicaSettings = $this->algoliaHelper->getSettings($sortIndexName);
         $this->assertArrayHasKey('primary', $replicaSettings);
         $this->assertEquals($indexName, $replicaSettings['primary']);
+
+        // Assert virtual replica ranking config
+        $this->assertArrayHasKey('customRanking', $replicaSettings);
+        $this->assertEquals("$sortDir($sortAttr)", array_shift($replicaSettings['customRanking']));
 
         // Restore prior state (for this test only)
         $this->algoliaHelper->setSettings($indexName, $ogAlgoliaSettings);

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -325,9 +325,4 @@ class ReplicaIndexingTest extends IndexingTestCase
         $this->assertFalse($this->hasSortingAttribute($sortAttr, $sortDir));
     }
 
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
 }

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -148,6 +148,18 @@ abstract class TestCase extends \TC
         }
     }
 
+    /**
+     * @throws \ReflectionException
+     */
+    protected function mockProperty($object, $propertyName, $propertyClass): void
+    {
+        $mock = $this->createMock($propertyClass);
+        $reflection = new \ReflectionClass($object);
+        $property = $reflection->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($object, $mock);
+    }
+
     protected function clearIndices()
     {
         $indices = $this->algoliaHelper->listIndexes();

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -151,13 +151,21 @@ abstract class TestCase extends \TC
     /**
      * @throws \ReflectionException
      */
-    protected function mockProperty($object, $propertyName, $propertyClass): void
+    protected function mockProperty(object $object, string $propertyName, string $propertyClass): void
     {
         $mock = $this->createMock($propertyClass);
         $reflection = new \ReflectionClass($object);
         $property = $reflection->getProperty($propertyName);
-        $property->setAccessible(true);
         $property->setValue($object, $mock);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function callReflectedMethod(object $object, string $method, mixed ...$args): void
+    {
+        $reflection = new \ReflectionClass($object);
+        $reflection->getMethod($method)->invoke($object, ...$args);
     }
 
     protected function clearIndices()


### PR DESCRIPTION
This is a work in progress as I have many more use cases I'm working on but this provides a foundation for further replica testing. 

It is used to validate the bug fix needed on https://github.com/algolia/algoliasearch-magento-2/pull/1625/

I also introduced some reflection utilities for mocking and testing protected methods along with config assertions for working with `@magentoDbIsolation disabled`.

<img width="1478" alt="image" src="https://github.com/user-attachments/assets/3efeae19-43a7-4e6f-b404-22c790ee0240">