### PR TITLE
Feat/mage 1051 pricing testing

### DIFF
--- a/Test/Integration/AssertValues/Magento246.php
+++ b/Test/Integration/AssertValues/Magento246.php
@@ -5,9 +5,9 @@ namespace Algolia\AlgoliaSearch\Test\Integration\AssertValues;
 class Magento246
 {
     public $productsOnStockCount = 180;
-    public $productsOutOfStockCount = 181;
+    public $productsOutOfStockCount = 183;
     public $lastJobDataSize = 13;
-    public $expectedCategory = 16;
+    public $expectedCategory = 17;
     public $attributesForFaceting = 5;
     public $automaticalSetOfCategoryAttributesForFaceting = 4;
     public $expectedPages = 6;

--- a/Test/Integration/Category/MultiStoreCategoriesTest.php
+++ b/Test/Integration/Category/MultiStoreCategoriesTest.php
@@ -32,7 +32,7 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
     const BAGS_CATEGORY_NAME = "Bags";
     const BAGS_CATEGORY_NAME_ALT = "Bags Alt";
 
-    public function setUp():void
+    protected function setUp():void
     {
         parent::setUp();
 
@@ -152,7 +152,7 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
         return $categoryAlt;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $defaultStore = $this->storeRepository->get('default');
 

--- a/Test/Integration/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Config/MultiStoreConfigTest.php
@@ -110,7 +110,7 @@ class MultiStoreConfigTest extends MultiStoreTestCase
         $this->assertEquals(1, $fixtureProductIndexRules['nbHits']);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/Test/Integration/IndexingTestCase.php
+++ b/Test/Integration/IndexingTestCase.php
@@ -6,7 +6,7 @@ use Magento\Framework\Indexer\ActionInterface;
 
 abstract class IndexingTestCase extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Test/Integration/MultiStoreTestCase.php
+++ b/Test/Integration/MultiStoreTestCase.php
@@ -21,7 +21,7 @@ abstract class MultiStoreTestCase extends IndexingTestCase
     /** @var IndicesConfigurator */
     protected $indicesConfigurator;
 
-    public function setUp():void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Test/Integration/Product/MultiStoreProductsTest.php
+++ b/Test/Integration/Product/MultiStoreProductsTest.php
@@ -48,7 +48,7 @@ class MultiStoreProductsTest extends MultiStoreTestCase
         '24-WB01'
     ];
 
-    public function setUp():void
+    protected function setUp():void
     {
         parent::setUp();
 
@@ -186,7 +186,7 @@ class MultiStoreProductsTest extends MultiStoreTestCase
         return $productAlt;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $defaultStore = $this->storeRepository->get('default');
 

--- a/Test/Integration/Product/PricingTest.php
+++ b/Test/Integration/Product/PricingTest.php
@@ -22,12 +22,15 @@ class PricingTest extends TestCase
      */
     protected const PRODUCT_ID_SIMPLE_STANDARD_PRICE = 1;
     protected const PRODUCT_ID_CONFIGURABLE_STANDARD_PRICE = 62;
+
+    protected const PRODUCT_ID_CONFIGURABLE_CATALOG_PRICE_RULE = 1903;
     /**
      * @var array<int, float>
      */
     protected const ASSERT_PRODUCT_PRICES = [
-        self::PRODUCT_ID_SIMPLE_STANDARD_PRICE => 34,
-        self::PRODUCT_ID_CONFIGURABLE_STANDARD_PRICE => 52
+        self::PRODUCT_ID_SIMPLE_STANDARD_PRICE           => 34,
+        self::PRODUCT_ID_CONFIGURABLE_STANDARD_PRICE     => 52,
+        self::PRODUCT_ID_CONFIGURABLE_CATALOG_PRICE_RULE => 39.2
     ];
 
     protected ?ProductIndexer $productIndexer = null;
@@ -100,6 +103,19 @@ class PricingTest extends TestCase
     public function testRegularPriceConfigurable(): void
     {
         $productId = self::PRODUCT_ID_CONFIGURABLE_STANDARD_PRICE;
+        $this->indexProducts($productId);
+        $this->assertAlgoliaPrice($productId);
+    }
+
+    /**
+     * @depends testMagentoProductData
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws NoSuchEntityException
+     */
+    public function testCatalogPriceRule(): void
+    {
+        $productId = self::PRODUCT_ID_CONFIGURABLE_CATALOG_PRICE_RULE;
         $this->indexProducts($productId);
         $this->assertAlgoliaPrice($productId);
     }

--- a/Test/Integration/Product/PricingTest.php
+++ b/Test/Integration/Product/PricingTest.php
@@ -5,16 +5,15 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Product;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
-use Algolia\AlgoliaSearch\Test\Integration\TestCase;
+use Magento\Catalog\Model\Product;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Indexer\IndexerRegistry;
-use function PHPUnit\Framework\assertTrue;
 
 /**
  * @magentoDbIsolation disabled
  * @magentoAppIsolation enabled
  */
-class PricingTest extends TestCase
+class PricingTest extends ProductsIndexingTestCase
 {
 
     /**
@@ -24,6 +23,9 @@ class PricingTest extends TestCase
     protected const PRODUCT_ID_CONFIGURABLE_STANDARD_PRICE = 62;
 
     protected const PRODUCT_ID_CONFIGURABLE_CATALOG_PRICE_RULE = 1903;
+
+    const SPECIAL_PRICE_TEST_PRODUCT_ID = 9;
+
     /**
      * @var array<int, float>
      */
@@ -126,7 +128,7 @@ class PricingTest extends TestCase
     public function testMagentoProductData(int $productId, float $expectedPrice): void
     {
         /**
-         * @var \Magento\Catalog\Model\Product $product
+         * @var Product $product
          */
         $product = $this->objectManager->get('Magento\Catalog\Model\ProductRepository')->getById($productId);
         $this->assertTrue($product->isInStock(), "Product is not in stock");
@@ -144,6 +146,73 @@ class PricingTest extends TestCase
             array_keys(self::ASSERT_PRODUCT_PRICES),
             self::ASSERT_PRODUCT_PRICES
         );
+    }
+
+    public function testSpecialPrice()
+    {
+        $this->productIndexer->execute([self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
+        $this->algoliaHelper->waitLastTask();
+
+        $res = $this->algoliaHelper->getObjects(
+            $this->indexPrefix .
+            'default_products',
+            [(string) self::SPECIAL_PRICE_TEST_PRODUCT_ID]
+        );
+        $algoliaProduct = reset($res['results']);
+
+        if (!$algoliaProduct || !array_key_exists('price', $algoliaProduct)) {
+            $this->markTestIncomplete('Hit was not returned correctly from Algolia. No Hit to run assetions.');
+        }
+
+        $this->assertEquals(32, $algoliaProduct['price']['USD']['default']);
+        $this->assertEquals('', $algoliaProduct['price']['USD']['special_from_date']);
+        $this->assertEquals('', $algoliaProduct['price']['USD']['special_to_date']);
+
+        $specialPrice = 29;
+        $fromDatetime = new \DateTime();
+        $toDatetime = new \DateTime();
+        $priceFrom = $fromDatetime->modify('-2 day')->format('Y-m-d H:i:s');
+        $priceTo = $toDatetime->modify('+2 day')->format('Y-m-d H:i:s');
+
+        $product = $this->objectManager->create(Product::class);
+        $product->load(self::SPECIAL_PRICE_TEST_PRODUCT_ID);
+
+        $product->setCustomAttributes([
+            'special_price' => $specialPrice,
+            'special_from_date' => date($priceFrom),
+            'special_to_date' => date($priceTo),
+        ]);
+        $product->save();
+
+        $this->productIndexer->execute([self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
+        $this->algoliaHelper->waitLastTask();
+
+        $res = $this->algoliaHelper->getObjects(
+            $this->indexPrefix .
+            'default_products',
+            [(string) self::SPECIAL_PRICE_TEST_PRODUCT_ID]
+        );
+        $algoliaProduct = reset($res['results']);
+
+        $this->assertEquals($specialPrice, $algoliaProduct['price']['USD']['default']);
+        $this->assertEquals("$32.00", $algoliaProduct['price']['USD']['default_original_formated']);
+    }
+
+    protected function tearDown(): void
+    {
+        /** @var Product $product */
+        $product = $this->objectManager->create(Product::class);
+        $product->load(self::SPECIAL_PRICE_TEST_PRODUCT_ID);
+
+        $product->setCustomAttributes([
+            'special_price' => null,
+            'special_from_date' => null,
+            'special_to_date' => null,
+        ]);
+        $product->getResource()->saveAttribute($product, 'special_price');
+        $product->save();
+
+        parent::tearDown();
     }
 
 }

--- a/Test/Integration/Product/PricingTest.php
+++ b/Test/Integration/Product/PricingTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration\Product;
+
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
+use Algolia\AlgoliaSearch\Test\Integration\TestCase;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Indexer\IndexerRegistry;
+use function PHPUnit\Framework\assertTrue;
+
+/**
+ * @magentoDbIsolation disabled
+ * @magentoAppIsolation enabled
+ */
+class PricingTest extends TestCase
+{
+
+    /**
+     * @var int
+     */
+    protected const PRODUCT_ID_SIMPLE_STANDARD_PRICE = 1;
+    protected const PRODUCT_ID_CONFIGURABLE_STANDARD_PRICE = 62;
+    /**
+     * @var array<int, float>
+     */
+    protected const ASSERT_PRODUCT_PRICES = [
+        self::PRODUCT_ID_SIMPLE_STANDARD_PRICE => 34,
+        self::PRODUCT_ID_CONFIGURABLE_STANDARD_PRICE => 62
+    ];
+
+    protected ?ProductIndexer $productIndexer = null;
+    protected ?string $indexName = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->productIndexer = $this->objectManager->get(ProductIndexer::class);
+        $this->indexSuffix = 'products';
+        $this->indexName = $this->getIndexName('default');
+
+        $this->objectManager
+            ->get(IndexerRegistry::class)
+            ->get('catalog_product_price')
+            ->reindexAll();
+    }
+
+    /**
+     * @param int|int[] $productIds
+     * @return void
+     * @throws NoSuchEntityException
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     */
+    protected function indexProducts(int|array $productIds): void
+    {
+        if (!is_array($productIds)) {
+            $productIds = [$productIds];
+        }
+        $this->productIndexer->execute($productIds);
+        $this->algoliaHelper->waitLastTask();
+    }
+
+    protected function getAlgoliaObjectById(int $productId): ?array
+    {
+        $res = $this->algoliaHelper->getObjects(
+            $this->indexName,
+            [(string) $productId]
+        );
+        return reset($res['results']);
+    }
+
+    /**
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws NoSuchEntityException
+     */
+    public function testRegularPrice(): void
+    {
+        $productId = self::PRODUCT_ID_SIMPLE_STANDARD_PRICE;
+        $this->indexProducts($productId);
+        $algoliaProduct = $this->getAlgoliaObjectById($productId);
+        $this->assertNotNull($algoliaProduct, "Algolia product index was not successful.");
+        $this->assertEquals(self::ASSERT_PRODUCT_PRICES[$productId], $algoliaProduct['price']['USD']['default']);
+    }
+
+    // TODO: Add data provider
+    public function testProductAvailability(): void
+    {
+        /**
+         * @var \Magento\Catalog\Model\Product $product
+         */
+        $product = $this->objectManager->get('Magento\Catalog\Model\ProductRepository')->getById(self::PRODUCT_ID_SIMPLE_STANDARD_PRICE);
+        $this->assertTrue($product->isInStock(), "Product is not in stock");
+        $this->assertTrue($product->getIsSalable(), "Product is not salable");
+        $price = $product->getPrice();
+        $this->assertTrue($price > 0, "Product does not have a price");
+
+    }
+
+}

--- a/Test/Integration/Product/PricingTest.php
+++ b/Test/Integration/Product/PricingTest.php
@@ -4,10 +4,8 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Product;
 
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
-use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Indexer\IndexerRegistry;
 
 /**
  * @magentoDbIsolation disabled
@@ -15,7 +13,6 @@ use Magento\Framework\Indexer\IndexerRegistry;
  */
 class PricingTest extends ProductsIndexingTestCase
 {
-
     /**
      * @var int
      */
@@ -35,20 +32,14 @@ class PricingTest extends ProductsIndexingTestCase
         self::PRODUCT_ID_CONFIGURABLE_CATALOG_PRICE_RULE => 39.2
     ];
 
-    protected ?ProductIndexer $productIndexer = null;
     protected ?string $indexName = null;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->productIndexer = $this->objectManager->get(ProductIndexer::class);
+
         $this->indexSuffix = 'products';
         $this->indexName = $this->getIndexName('default');
-
-        $this->objectManager
-            ->get(IndexerRegistry::class)
-            ->get('catalog_product_price')
-            ->reindexAll();
     }
 
     /**
@@ -148,7 +139,7 @@ class PricingTest extends ProductsIndexingTestCase
         );
     }
 
-    public function testSpecialPrice()
+    public function testSpecialPrice(): void
     {
         $this->productIndexer->execute([self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
         $this->algoliaHelper->waitLastTask();

--- a/Test/Integration/Product/ProductsIndexingTest.php
+++ b/Test/Integration/Product/ProductsIndexingTest.php
@@ -5,9 +5,7 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Product;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
 use Magento\Catalog\Model\Product;
-use Magento\CatalogInventory\Model\StockRegistry;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Indexer\IndexerRegistry;
 
@@ -17,8 +15,6 @@ use Magento\Framework\Indexer\IndexerRegistry;
  */
 class ProductsIndexingTest extends ProductsIndexingTestCase
 {
-    /** @var ProductIndexer */
-    protected $productsIndexer;
 
     /*** @var IndexerRegistry */
     protected $indexerRegistry;
@@ -29,24 +25,13 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
 
     const OUT_OF_STOCK_PRODUCT_SKU = '24-MB01';
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->productsIndexer = $this->objectManager->get(ProductIndexer::class);
-        $this->indexerRegistry = $this->objectManager->get(IndexerRegistry::class);
-
-        $this->productPriceIndexer = $this->indexerRegistry->get('catalog_product_price');
-        $this->productPriceIndexer->reindexAll();
-    }
-
     public function testOnlyOnStockProducts()
     {
         $this->setConfig(ConfigHelper::SHOW_OUT_OF_STOCK, 0);
 
         $this->updateStockItem(self::OUT_OF_STOCK_PRODUCT_SKU, false);
 
-        $this->processTest($this->productsIndexer, 'products', $this->assertValues->productsOnStockCount);
+        $this->processTest($this->productIndexer, 'products', $this->assertValues->productsOnStockCount);
     }
 
     public function testIncludingOutOfStock()
@@ -55,7 +40,7 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
 
         $this->updateStockItem(self::OUT_OF_STOCK_PRODUCT_SKU, false);
 
-        $this->processTest($this->productsIndexer, 'products', $this->assertValues->productsOutOfStockCount);
+        $this->processTest($this->productIndexer, 'products', $this->assertValues->productsOutOfStockCount);
     }
 
     public function testDefaultIndexableAttributes()
@@ -67,7 +52,7 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
         $this->setConfig(ConfigHelper::SORTING_INDICES, $empty);
         $this->setConfig(ConfigHelper::PRODUCT_CUSTOM_RANKING, $empty);
 
-        $this->productsIndexer->executeRow($this->getValidTestProduct());
+        $this->productIndexer->executeRow($this->getValidTestProduct());
         $this->algoliaHelper->waitLastTask();
 
         $results = $this->algoliaHelper->getObjects($this->indexPrefix . 'default_products', [$this->getValidTestProduct()]);

--- a/Test/Integration/Product/ProductsIndexingTest.php
+++ b/Test/Integration/Product/ProductsIndexingTest.php
@@ -5,7 +5,6 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Product;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
 use Algolia\AlgoliaSearch\Test\Integration\IndexingTestCase;
-use Magento\Catalog\Api\Data\SpecialPriceInterfaceFactory;
 use Magento\Catalog\Model\Product;
 use Magento\CatalogInventory\Model\StockRegistry;
 use Magento\Framework\Indexer\IndexerRegistry;
@@ -176,7 +175,7 @@ class ProductsIndexingTest extends IndexingTestCase
         return $this->testProductId;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         /** @var Product $product */
         $product = $this->objectManager->create(\Magento\Catalog\Model\Product::class);

--- a/Test/Integration/Product/ProductsIndexingTest.php
+++ b/Test/Integration/Product/ProductsIndexingTest.php
@@ -24,7 +24,7 @@ class ProductsIndexingTest extends IndexingTestCase
 
     protected $testProductId;
 
-    public function setUp():void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Test/Integration/Product/ProductsIndexingTestCase.php
+++ b/Test/Integration/Product/ProductsIndexingTestCase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration\Product;
+
+use Algolia\AlgoliaSearch\Test\Integration\IndexingTestCase;
+use Magento\CatalogInventory\Model\StockRegistry;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+class ProductsIndexingTestCase extends IndexingTestCase
+{
+
+    protected ?StockRegistry $stockRegistry = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stockRegistry = $this->objectManager->get(StockRegistry::class);
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     */
+    protected function updateStockItem(string $sku, bool $isInStock): void
+    {
+        $stockItem = $this->stockRegistry->getStockItemBySku($sku);
+        $stockItem->setIsInStock($isInStock);
+        $this->stockRegistry->updateStockItemBySku($sku, $stockItem);
+    }
+}

--- a/Test/Integration/Product/ProductsIndexingTestCase.php
+++ b/Test/Integration/Product/ProductsIndexingTestCase.php
@@ -2,20 +2,29 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration\Product;
 
+use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
 use Algolia\AlgoliaSearch\Test\Integration\IndexingTestCase;
 use Magento\CatalogInventory\Model\StockRegistry;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Indexer\IndexerRegistry;
 
 class ProductsIndexingTestCase extends IndexingTestCase
 {
 
     protected ?StockRegistry $stockRegistry = null;
+    protected ?ProductIndexer $productIndexer = null;
 
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->productIndexer = $this->objectManager->get(ProductIndexer::class);
         $this->stockRegistry = $this->objectManager->get(StockRegistry::class);
+
+        $this->objectManager
+            ->get(IndexerRegistry::class)
+            ->get('catalog_product_price')
+            ->reindexAll();
     }
 
     /**

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -9,9 +9,9 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
-use Algolia\AlgoliaSearch\Test\Integration\IndexingTestCase;
+use Algolia\AlgoliaSearch\Test\Integration\TestCase;
 
-class ReplicaIndexingTest extends IndexingTestCase
+class ReplicaIndexingTest extends TestCase
 {
     protected ?ReplicaManagerInterface $replicaManager = null;
     protected ?ProductIndexer $productIndexer = null;
@@ -32,11 +32,6 @@ class ReplicaIndexingTest extends IndexingTestCase
     protected function getIndexName(string $storeIndexPart): string
     {
         return $this->indexPrefix . $storeIndexPart . $this->indexSuffix;
-    }
-
-    public function processFullReindexProducts(): void
-    {
-        $this->processFullReindex($this->productIndexer, $this->indexSuffix);
     }
 
     public function testReplicaLimits()

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -168,11 +168,13 @@ class ReplicaIndexingTest extends TestCase
         $this->algoliaHelper->waitLastTask();
 
         $rebuildCmd = $this->objectManager->get(\Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand::class);
-        $this->callReflectedMethod(
+        $this->invokeMethod(
             $rebuildCmd,
             'execute',
-            $this->createMock(\Symfony\Component\Console\Input\InputInterface::class),
-            $this->createMock(\Symfony\Component\Console\Output\OutputInterface::class)
+            [
+                $this->createMock(\Symfony\Component\Console\Input\InputInterface::class),
+                $this->createMock(\Symfony\Component\Console\Output\OutputInterface::class)
+            ]
         );
         $this->algoliaHelper->waitLastTask();
 

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -20,7 +20,7 @@ class ReplicaIndexingTest extends TestCase
 
     protected ?string $indexSuffix = null;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->productIndexer = $this->objectManager->get(ProductIndexer::class);

--- a/Test/Integration/Queue/QueueTest.php
+++ b/Test/Integration/Queue/QueueTest.php
@@ -25,7 +25,7 @@ class QueueTest extends TestCase
     /** @var Queue */
     private $queue;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -42,12 +42,12 @@ abstract class TestCase extends \TC
     /** @var Magento246|Magento247 */
     protected $assertValues;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->bootstrap();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->clearIndices();
         $this->algoliaHelper->waitLastTask();

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -165,26 +165,6 @@ abstract class TestCase extends \TC
         }
     }
 
-    /**
-     * @throws \ReflectionException
-     */
-    protected function mockProperty(object $object, string $propertyName, string $propertyClass): void
-    {
-        $mock = $this->createMock($propertyClass);
-        $reflection = new \ReflectionClass($object);
-        $property = $reflection->getProperty($propertyName);
-        $property->setValue($object, $mock);
-    }
-
-    /**
-     * @throws \ReflectionException
-     */
-    protected function callReflectedMethod(object $object, string $method, mixed ...$args): void
-    {
-        $reflection = new \ReflectionClass($object);
-        $reflection->getMethod($method)->invoke($object, ...$args);
-    }
-
     protected function clearIndices()
     {
         $indices = $this->algoliaHelper->listIndexes();
@@ -244,6 +224,18 @@ abstract class TestCase extends \TC
         $this->boostrapped = true;
     }
 
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function mockProperty(object $object, string $propertyName, string $propertyClass): void
+    {
+        $mock = $this->createMock($propertyClass);
+        $reflection = new \ReflectionClass($object);
+        $property = $reflection->getProperty($propertyName);
+        $property->setValue($object, $mock);
+    }
+
     /**
      * Call protected/private method of a class.
      *
@@ -255,13 +247,10 @@ abstract class TestCase extends \TC
      *
      * @return mixed method return
      */
-    protected function invokeMethod(&$object, $methodName, array $parameters = [])
+    protected function invokeMethod(object $object, string $methodName, array $parameters = [])
     {
         $reflection = new \ReflectionClass(get_class($object));
-        $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
-
-        return $method->invokeArgs($object, $parameters);
+        $reflection->getMethod($methodName)->invokeArgs($object, $parameters);
     }
 
     private function getMagentoVersion()

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Test\Integration;
 
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Setup\Patch\Schema\ConfigPatch;
@@ -42,16 +43,27 @@ abstract class TestCase extends \TC
     /** @var Magento246|Magento247 */
     protected $assertValues;
 
+    protected ?string $indexSuffix = null;
+
     protected function setUp(): void
     {
         $this->bootstrap();
     }
 
+    /**
+     * @throws ExceededRetriesException
+     * @throws AlgoliaException
+     */
     protected function tearDown(): void
     {
         $this->clearIndices();
         $this->algoliaHelper->waitLastTask();
         $this->clearIndices(); // Remaining replicas
+    }
+
+    protected function getIndexName(string $storeIndexPart): string
+    {
+        return $this->indexPrefix . $storeIndexPart . ($this->indexSuffix ? '_' . $this->indexSuffix : '');
     }
 
     protected function resetConfigs($configs = [])

--- a/Test/Unit/ConfigHelperTest.php
+++ b/Test/Unit/ConfigHelperTest.php
@@ -44,7 +44,7 @@ class ConfigHelperTest extends TestCase
     protected GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository;
     protected CookieHelper $cookieHelper;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configInterface = $this->createMock(ScopeConfigInterface::class);
         $this->configWriter = $this->createMock(WriterInterface::class);


### PR DESCRIPTION
This is a starter test class for pricing use cases. 

Includes:

- Simple product pricing
- Configurable product pricing
- Catalog price rule
- Special pricing (refactored from ProductsIndexingTest)
- Shared method refactoring
- Data providers for existing sample data fixtures

Follow up integration testing will be needed for:

- Customer group prices
- Tier prices

Not yet supported:

- Minimum advertised price
- VAT pricing
- Fixed product tax (FPT)

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/f3653e43-c650-4fac-b25d-571083968c02">

