### PR TITLE
MAGE-1093: Fix NeuralSearch compatibility

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -361,6 +361,10 @@ class AlgoliaHelper extends AbstractHelper
 
         $removes = ['slaves', 'replicas', 'decompoundedAttributes'];
 
+        if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
+            $removes[] = 'mode';
+        }
+
         if (isset($settings['attributesToIndex'])) {
             $settings['searchableAttributes'] = $settings['attributesToIndex'];
             unset($settings['attributesToIndex']);


### PR DESCRIPTION
This PR contains:
- Removed `mode` during `setSettings` if index has NeuralSearch enabled to prevent crash during full reindexing with temporary index creation.