### PR TITLE
MAGE-1078: Fix phpcs error

### DIFF
--- a/Test/Unit/ConfigHelperTest.php
+++ b/Test/Unit/ConfigHelperTest.php
@@ -2,7 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Test\Unit;
 
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Cookie\Helper\Cookie as CookieHelper;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
@@ -17,15 +16,6 @@ use Magento\Framework\Module\ResourceInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\TestCase;
-
-class ConfigHelperTestable extends ConfigHelper
-{
-    /** expose protected methods for unit testing */
-    public function serialize(array $value): string
-    {
-        return parent::serialize($value);
-    }
-}
 
 class ConfigHelperTest extends TestCase
 {

--- a/Test/Unit/ConfigHelperTestable.php
+++ b/Test/Unit/ConfigHelperTestable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+
+class ConfigHelperTestable extends ConfigHelper
+{
+    /** expose protected methods for unit testing */
+    public function serialize(array $value): string
+    {
+        return parent::serialize($value);
+    }
+}


### PR DESCRIPTION
This PR contains:
- Fixed the following error coming from PHPCS

```
FILE: ...var/www/html/app/code/Algolia/AlgoliaSearch/Test/Unit/ConfigHelperTest.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 30 | ERROR | Each class must be in a file by itself
--------------------------------------------------------------------------------
```