### PR TITLE
MAGE-1145: Fix Landing Page creation when customer groups are enabled

### DIFF
--- a/Controller/Adminhtml/Landingpage/Save.php
+++ b/Controller/Adminhtml/Landingpage/Save.php
@@ -107,13 +107,15 @@ class Save extends AbstractAction
                 $data['configuration'] = $data['algolia_configuration'];
                 if ($this->configHelper->isCustomerGroupsEnabled($data['store_id'])) {
                     $configuration = json_decode($data['algolia_configuration'], true);
-                    $priceConfig = $configuration['price'.$data['price_key']];
-                    $customerGroups = $this->customerGroupCollectionFactory->create();
-                    $store = $this->storeManager->getStore($data['store_id']);
-                    $baseCurrencyCode = $store->getBaseCurrencyCode();
-                    foreach ($customerGroups as $group) {
-                        $groupId = (int) $group->getData('customer_group_id');
-                        $configuration['price.'.$baseCurrencyCode.'.group_'.$groupId] = $priceConfig;
+                    if (isset($configuration['price'.$data['price_key']])) {
+                        $priceConfig = $configuration['price'.$data['price_key']];
+                        $customerGroups = $this->customerGroupCollectionFactory->create();
+                        $store = $this->storeManager->getStore($data['store_id']);
+                        $baseCurrencyCode = $store->getBaseCurrencyCode();
+                        foreach ($customerGroups as $group) {
+                            $groupId = (int) $group->getData('customer_group_id');
+                            $configuration['price.'.$baseCurrencyCode.'.group_'.$groupId] = $priceConfig;
+                        }
                     }
                     $data['configuration'] = json_encode($configuration);
                 }


### PR DESCRIPTION
Fixed a bug where Landing Page save action failed when : 
- Customer groups are activated
- "Merchandised products" section has been expanded
- No price configuration within Landing Page Builder has been selected 