### PR TITLE
MAGE-1074: Add documentation link on the queue archive page

### DIFF
--- a/view/adminhtml/layout/algolia_algoliasearch_queuearchive_index.xml
+++ b/view/adminhtml/layout/algolia_algoliasearch_queuearchive_index.xml
@@ -1,7 +1,14 @@
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="styles"/>
     <body>
         <referenceContainer name="content">
+            <block
+                class="Magento\Backend\Block\Template"
+                name="queuearchive_links"
+                template="Algolia_AlgoliaSearch::queuearchive/links.phtml"
+            />
             <uiComponent name="algolia_algoliasearch_queuearchive_listing"/>
         </referenceContainer>
     </body>

--- a/view/adminhtml/templates/queuearchive/links.phtml
+++ b/view/adminhtml/templates/queuearchive/links.phtml
@@ -1,0 +1,15 @@
+<?php
+/** @var \Magento\Backend\Block\Template $block */
+?>
+<div class="algolia-admin-content">
+    <div class="algolia-admin-content-wrapper">
+        <div class="algolia-admin-content-links">
+            <p>
+                <span>
+                    <img src="<?php echo $block->escapeUrl($block->getViewFileUrl('Algolia_AlgoliaSearch::images/icon-docs.svg')) ?>">
+                    <a target="_blank" href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/#indexing-queue-archives"><?php echo $block->escapeHtml(__('Indexing queue archives documentation')) ?></a>
+                </span>
+            </p>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This PR contains:
- Added documentation link on the queue archive page