### PR TITLE
MAGE-1153: fix synonyms duplication after PHP v4 upgrade

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -241,6 +241,11 @@ class AlgoliaHelper extends AbstractHelper
             $settings = $this->mergeSettings($indexName, $settings, $mergeSettingsFrom);
         }
 
+        // Removing synonyms from the settings to avoid duplication (synonyms must be managed within the algolia dashboard)
+        if (isset($settings['synonyms'])) {
+            unset($settings['synonyms']);
+        }
+
         $res = $this->getClient()->setSettings($indexName, $settings, $forwardToReplicas);
 
         self::setLastOperationInfo($indexName, $res);

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -241,11 +241,6 @@ class AlgoliaHelper extends AbstractHelper
             $settings = $this->mergeSettings($indexName, $settings, $mergeSettingsFrom);
         }
 
-        // Removing synonyms from the settings to avoid duplication (synonyms must be managed within the algolia dashboard)
-        if (isset($settings['synonyms'])) {
-            unset($settings['synonyms']);
-        }
-
         $res = $this->getClient()->setSettings($indexName, $settings, $forwardToReplicas);
 
         self::setLastOperationInfo($indexName, $res);
@@ -376,7 +371,7 @@ class AlgoliaHelper extends AbstractHelper
         } catch (Exception $e) {
         }
 
-        $removes = ['slaves', 'replicas', 'decompoundedAttributes'];
+        $removes = ['slaves', 'replicas', 'decompoundedAttributes', 'synonyms'];
 
         if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
             $removes[] = 'mode';


### PR DESCRIPTION
This PR contains:
- A fix where synonyms were systematically re-added after an index `setSettings()` call. Before v`3.14.x` this was previously handled with the old PHP client v3 with a `getVersion` query parameter set to `2` . We now unset the synonyms attribute since it has to be handled in the Algolia dashboard anyway.  