### PR TITLE
MAGE-1153: fix synonyms duplication after PHP v4 upgrade (3.14.4)

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -359,7 +359,7 @@ class AlgoliaHelper extends AbstractHelper
         } catch (\Exception $e) {
         }
 
-        $removes = ['slaves', 'replicas', 'decompoundedAttributes'];
+        $removes = ['slaves', 'replicas', 'decompoundedAttributes', 'synonyms'];
 
         if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
             $removes[] = 'mode';


### PR DESCRIPTION
This PR backport the fix contained in this PR : https://github.com/algolia/algoliasearch-magento-2/pull/1656

> Fix where synonyms were systematically re-added after an index setSettings() call. Before v3.14.x this was previously handled with the old PHP client v3 with a getVersion query parameter set to 2 . We now unset the synonyms attribute since it has to be handled in the Algolia dashboard anyway.