### PR TITLE
MAGE-1153 Synonym deduplicator

### DIFF
--- a/Console/Command/AbstractReplicaCommand.php
+++ b/Console/Command/AbstractReplicaCommand.php
@@ -2,37 +2,11 @@
 
 namespace Algolia\AlgoliaSearch\Console\Command;
 
-use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
-use Magento\Framework\App\Area;
-use Magento\Framework\App\State;
-use Magento\Framework\Exception\LocalizedException;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-abstract class AbstractReplicaCommand extends Command
+abstract class AbstractReplicaCommand extends AbstractStoreCommand
 {
-    protected const STORE_ARGUMENT = 'store';
-
-    protected ?OutputInterface $output = null;
-    protected ?InputInterface $input = null;
-
-    public function __construct(
-        protected State            $state,
-        protected StoreNameFetcher $storeNameFetcher,
-        ?string                    $name = null
-    )
-    {
-        parent::__construct($name);
-    }
-
-    abstract protected function getReplicaCommandName(): string;
-
     abstract protected function getCommandDescription(): string;
-
-    abstract protected function getStoreArgumentDescription(): string;
 
     abstract protected function getAdditionalDefinition(): array;
 
@@ -44,65 +18,16 @@ abstract class AbstractReplicaCommand extends Command
         $definition = [$this->getStoreArgumentDefinition()];
         $definition = array_merge($definition, $this->getAdditionalDefinition());
 
-        $this->setName($this->getCommandName())
+        $this->setName($this->getFullCommandName())
             ->setDescription($this->getCommandDescription())
             ->setDefinition($definition);
 
         parent::configure();
     }
 
-    protected function getStoreArgumentDefinition(): InputArgument {
-        return new InputArgument(
-            self::STORE_ARGUMENT,
-            InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-            $this->getStoreArgumentDescription()
-        );
-    }
-
-    public function getCommandName(): string
+    protected function getCommandPrefix(): string
     {
-        return 'algolia:replicas:' . $this->getReplicaCommandName();
-    }
-
-    protected function setAreaCode(): void
-    {
-        try {
-            $this->state->setAreaCode(Area::AREA_CRONTAB);
-        } catch (LocalizedException) {
-            // Area code is already set - nothing to do
-        }
-    }
-
-    /**
-     * @param InputInterface $input
-     * @return int[]
-     */
-    protected function getStoreIds(InputInterface $input): array
-    {
-        return (array) $input->getArgument(self::STORE_ARGUMENT);
-    }
-
-    /**
-     * @param int[] $storeIds
-     * @return string
-     */
-    protected function getOperationTargetLabel(array $storeIds): string
-    {
-        return ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
-    }
-
-    /**
-     * Generate a CLI operation announcement based on passed store arguments
-     * @param string $msg Use {{target} in message as a placeholder for inserting the generated target label
-     * @param int[] $storeIds
-     * @return string
-     */
-    protected function decorateOperationAnnouncementMessage(string $msg, array $storeIds): string
-    {
-        $msg = str_replace('{{target}}', $this->getOperationTargetLabel($storeIds), $msg);
-        return ($storeIds)
-            ? "<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>'
-            : "<info>$msg</info>";
+        return parent::getCommandPrefix() . 'replicas:';
     }
 
     protected function confirmOperation(string $okMessage = '', string $cancelMessage = 'Operation cancelled'): bool

--- a/Console/Command/AbstractReplicaCommand.php
+++ b/Console/Command/AbstractReplicaCommand.php
@@ -2,48 +2,11 @@
 
 namespace Algolia\AlgoliaSearch\Console\Command;
 
-use Symfony\Component\Console\Question\ConfirmationQuestion;
-
 abstract class AbstractReplicaCommand extends AbstractStoreCommand
 {
-    abstract protected function getCommandDescription(): string;
-
-    abstract protected function getAdditionalDefinition(): array;
-
-    /**
-     * @inheritDoc
-     */
-    protected function configure(): void
-    {
-        $definition = [$this->getStoreArgumentDefinition()];
-        $definition = array_merge($definition, $this->getAdditionalDefinition());
-
-        $this->setName($this->getFullCommandName())
-            ->setDescription($this->getCommandDescription())
-            ->setDefinition($definition);
-
-        parent::configure();
-    }
-
     protected function getCommandPrefix(): string
     {
         return parent::getCommandPrefix() . 'replicas:';
     }
 
-    protected function confirmOperation(string $okMessage = '', string $cancelMessage = 'Operation cancelled'): bool
-    {
-        $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion('<question>Are you sure wish to proceed? (y/n)</question> ', false);
-        if (!$helper->ask($this->input, $this->output, $question)) {
-            if ($cancelMessage) {
-                $this->output->writeln("<comment>$cancelMessage</comment>");
-            }
-            return false;
-        }
-
-        if ($okMessage) {
-            $this->output->writeln("<comment>$okMessage</comment>");
-        }
-        return true;
-    }
 }

--- a/Console/Command/AbstractStoreCommand.php
+++ b/Console/Command/AbstractStoreCommand.php
@@ -72,10 +72,27 @@ abstract class AbstractStoreCommand extends Command
     /**
      * @param InputInterface $input
      * @return int[]
+     * @throws LocalizedException
      */
     protected function getStoreIds(InputInterface $input): array
     {
-        return (array) $input->getArgument(self::STORE_ARGUMENT);
+        return $this->validateStoreIds((array) $input->getArgument(self::STORE_ARGUMENT));
+    }
+
+    /**
+     * @param array $storeIds
+     * @return int[]
+     * @throws LocalizedException
+     */
+    protected function validateStoreIds(array $storeIds): array
+    {
+        foreach ($storeIds as $storeId) {
+            if (!ctype_digit($storeId) || (int) $storeId < 1) {
+                throw new LocalizedException(__("Store ID argument must be an integer"));
+            }
+        }
+
+        return array_map('intval', $storeIds);
     }
 
     protected function getStoreArgumentDefinition(): InputArgument {

--- a/Console/Command/AbstractStoreCommand.php
+++ b/Console/Command/AbstractStoreCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 abstract class AbstractStoreCommand extends Command
 {
-    protected const STORE_ARGUMENT = 'store';
+    protected const STORE_ARGUMENT = 'store_id';
 
     protected ?OutputInterface $output = null;
     protected ?InputInterface $input = null;
@@ -63,8 +63,9 @@ abstract class AbstractStoreCommand extends Command
     {
         try {
             $this->state->setAreaCode(Area::AREA_CRONTAB);
-        } catch (LocalizedException) {
-            // Area code is already set - nothing to do
+        } catch (LocalizedException $e) {
+            // Area code is already set - nothing to do - but report regardless
+            $this->output->writeln("Unable to set area code due to the following error: " . $e->getMessage());
         }
     }
 

--- a/Console/Command/AbstractStoreCommand.php
+++ b/Console/Command/AbstractStoreCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Command;
+
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractStoreCommand extends Command
+{
+    protected const STORE_ARGUMENT = 'store';
+
+    protected ?OutputInterface $output = null;
+    protected ?InputInterface $input = null;
+
+    abstract protected function getStoreArgumentDescription(): string;
+    abstract protected function getCommandName(): string;
+
+    public function __construct(
+        protected State            $state,
+        protected StoreNameFetcher $storeNameFetcher,
+        ?string                    $name = null
+    )
+    {
+        parent::__construct($name);
+    }
+
+    protected function getCommandPrefix(): string
+    {
+        return 'algolia:';
+    }
+
+    protected function getFullCommandName(): string
+    {
+        return $this->getCommandPrefix() . $this->getCommandName();
+    }
+
+    protected function setAreaCode(): void
+    {
+        try {
+            $this->state->setAreaCode(Area::AREA_CRONTAB);
+        } catch (LocalizedException) {
+            // Area code is already set - nothing to do
+        }
+    }
+
+    /**
+     * @param InputInterface $input
+     * @return int[]
+     */
+    protected function getStoreIds(InputInterface $input): array
+    {
+        return (array) $input->getArgument(self::STORE_ARGUMENT);
+    }
+
+    protected function getStoreArgumentDefinition(): InputArgument {
+        return new InputArgument(
+            self::STORE_ARGUMENT,
+            InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+            $this->getStoreArgumentDescription()
+        );
+    }
+
+    /**
+     * @param int[] $storeIds
+     * @return string
+     */
+    protected function getOperationTargetLabel(array $storeIds): string
+    {
+        return ($storeIds ? count($storeIds) : 'all') . ' store' . (!$storeIds || count($storeIds) > 1 ? 's' : '');
+    }
+
+    /**
+     * Generate a CLI operation announcement based on passed store arguments
+     * @param string $msg Use {{target} in message as a placeholder for inserting the generated target label
+     * @param int[] $storeIds
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    protected function decorateOperationAnnouncementMessage(string $msg, array $storeIds): string
+    {
+        $msg = str_replace('{{target}}', $this->getOperationTargetLabel($storeIds), $msg);
+        return ($storeIds)
+            ? "<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>'
+            : "<info>$msg</info>";
+    }
+}

--- a/Console/Command/ReplicaDeleteCommand.php
+++ b/Console/Command/ReplicaDeleteCommand.php
@@ -33,7 +33,7 @@ class ReplicaDeleteCommand extends AbstractReplicaCommand implements ReplicaDele
         parent::__construct($state, $storeNameFetcher, $name);
     }
 
-    protected function getReplicaCommandName(): string
+    protected function getCommandName(): string
     {
         return 'delete';
     }

--- a/Console/Command/ReplicaDisableVirtualCommand.php
+++ b/Console/Command/ReplicaDisableVirtualCommand.php
@@ -42,7 +42,7 @@ class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements Rep
         parent::__construct($state, $storeNameFetcher, $name);
     }
 
-    protected function getReplicaCommandName(): string
+    protected function getCommandName(): string
     {
         return 'disable-virtual-replicas';
     }

--- a/Console/Command/ReplicaRebuildCommand.php
+++ b/Console/Command/ReplicaRebuildCommand.php
@@ -38,7 +38,7 @@ class ReplicaRebuildCommand
         parent::__construct($appState, $storeNameFetcher, $name);
     }
 
-    protected function getReplicaCommandName(): string
+    protected function getCommandName(): string
     {
         return 'rebuild';
     }

--- a/Console/Command/ReplicaSyncCommand.php
+++ b/Console/Command/ReplicaSyncCommand.php
@@ -35,7 +35,7 @@ class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCo
         parent::__construct($appState, $storeNameFetcher, $name);
     }
 
-    protected function getReplicaCommandName(): string
+    protected function getCommandName(): string
     {
         return 'sync';
     }

--- a/Console/Command/SynonymDeduplicateCommand.php
+++ b/Console/Command/SynonymDeduplicateCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Command;
+
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SynonymDeduplicateCommand extends AbstractStoreCommand
+{
+    protected function getCommandPrefix(): string
+    {
+        return parent::getCommandPrefix() . 'synonyms:';
+    }
+
+    protected function getCommandName(): string
+    {
+        return 'deduplicate';
+    }
+
+    protected function getCommandDescription(): string
+    {
+        return "Identify and remove duplicate synonyms in Algolia";
+    }
+
+    protected function getStoreArgumentDescription(): string
+    {
+        return 'ID(s) for store(s) containing synonyms to deduplicate in Algolia (optional), if not specified, synonyms for all stores will be deduplicated';
+    }
+
+    protected function getAdditionalDefinition(): array
+    {
+        return [];
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->output = $output;
+        $this->setAreaCode();
+
+        $storeIds = $this->getStoreIds($input);
+
+        $output->writeln($this->decorateOperationAnnouncementMessage('Deduplicating synonyms for {{target}}', $storeIds));
+
+        try {
+            $this->dedupeSynonyms($storeIds);
+        } catch (\Exception $e) {
+            $this->output->writeln('<error>' . $e->getMessage() . '</error>');
+            return CLI::RETURN_FAILURE;
+        }
+
+        return Cli::RETURN_SUCCESS;
+    }
+
+    public function dedupeSynonyms(array $storeIds = []): void
+    {
+        if (count($storeIds)) {
+            foreach ($storeIds as $storeId) {
+                $this->dedupeSynonymsForStore($storeId);
+            }
+        } else {
+            // handle all
+        }
+    }
+
+    public function dedupeSynonymsForStore(int $storeId): void
+    {
+        $this->output->writeln('<info>Deduplicating synonyms for ' . $this->storeNameFetcher->getStoreName($storeId) . '...</info>');
+    }
+
+
+
+}

--- a/Console/Command/SynonymDeduplicateCommand.php
+++ b/Console/Command/SynonymDeduplicateCommand.php
@@ -37,12 +37,12 @@ class SynonymDeduplicateCommand extends AbstractStoreCommand
 
     protected function getCommandDescription(): string
     {
-        return "Identify and remove duplicate synonyms in Algolia for the following types: synonyms, placeholders and alternative corrections. \n  <fg=red>WARNING:</fg=red> If you use one-way synonyms, do not use this command as it will remove these from your index.";
+        return "Identify and remove duplicate synonyms in Algolia for the following types: synonyms, placeholders and alternative corrections \n  <fg=red>WARNING:</fg=red> If you use one-way synonyms, do not use this command as it will remove these from your index.";
     }
 
     protected function getStoreArgumentDescription(): string
     {
-        return 'ID(s) for store(s) containing synonyms to deduplicate in Algolia (optional), if not specified, synonyms for all stores will be deduplicated. Pass multiple store IDs as a list of integers separated by spaces. e.g.: bin/magento algolia:synonyms:deduplicate 1 2 3';
+        return 'ID(s) for store(s) containing synonyms to deduplicate in Algolia (optional), if not specified, synonyms for all stores will be deduplicated. Pass multiple store IDs as a list of integers separated by spaces. e.g.: <info>bin/magento algolia:synonyms:deduplicate 1 2 3</info>';
     }
 
     protected function getAdditionalDefinition(): array

--- a/Console/Command/SynonymDeduplicateCommand.php
+++ b/Console/Command/SynonymDeduplicateCommand.php
@@ -115,8 +115,10 @@ class SynonymDeduplicateCommand extends AbstractStoreCommand
         $settings = $this->algoliaHelper->getSettings($indexName);
         $deduped = $this->dedupeSpecificSettings(['synonyms', 'altCorrections'], $settings);
 
-        //bring over as is
-        $deduped['placeholders'] = $settings['placeholders'];
+        //bring over as is (no de-dupe necessary)
+        if (array_key_exists('placeholders', $settings)) {
+            $deduped['placeholders'] = $settings['placeholders'];
+        }
 
         // Updating the synonyms requires a separate endpoint which is not currently not exposed in the PHP API client
         // See https://www.algolia.com/doc/rest-api/search/#tag/Synonyms/operation/saveSynonyms

--- a/Console/Command/SynonymDeduplicateCommand.php
+++ b/Console/Command/SynonymDeduplicateCommand.php
@@ -37,12 +37,12 @@ class SynonymDeduplicateCommand extends AbstractStoreCommand
 
     protected function getCommandDescription(): string
     {
-        return "Identify and remove duplicate synonyms in Algolia";
+        return "Identify and remove duplicate synonyms in Algolia for the following types: synonyms, placeholders and alternative corrections. \n  <fg=red>WARNING:</fg=red> If you use one-way synonyms, do not use this command as it will remove these from your index.";
     }
 
     protected function getStoreArgumentDescription(): string
     {
-        return 'ID(s) for store(s) containing synonyms to deduplicate in Algolia (optional), if not specified, synonyms for all stores will be deduplicated';
+        return 'ID(s) for store(s) containing synonyms to deduplicate in Algolia (optional), if not specified, synonyms for all stores will be deduplicated. Pass multiple store IDs as a list of integers separated by spaces. e.g.: bin/magento algolia:synonyms:deduplicate 1 2 3';
     }
 
     protected function getAdditionalDefinition(): array
@@ -86,7 +86,7 @@ class SynonymDeduplicateCommand extends AbstractStoreCommand
      */
     protected function confirmDedupeOperation(): bool
     {
-        $this->output->writeln('<fg=red>This deduplicate process cannot handle one way synonyms and will remove them altogether!</fg=red>');
+        $this->output->writeln('<fg=red>WARNING:</fg=red> This deduplicate process cannot handle one way synonyms and will remove them altogether!');
         return $this->confirmOperation();
     }
 

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -519,6 +519,11 @@ class AlgoliaHelper extends AbstractHelper
         throw new AlgoliaException("This method is no longer supported for PHP client v4!");
     }
 
+    public function clearSynonyms(string $indexName, bool $forwardToReplicas = false): void
+    {
+        $this->client->clearSynonyms($indexName, $forwardToReplicas);
+    }
+
     /**
      * @param string $fromIndexName
      * @param string $toIndexName

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -152,6 +152,7 @@
                 <item name="replica_delete_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDeleteCommand</item>
                 <item name="replica_rebuild_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand</item>
                 <item name="replica_disable_virtual_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDisableVirtualCommand</item>
+                <item name="synonym_deduplicate_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\SynonymDeduplicateCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
This is an experimental synonym deduplicator that handles 3 of the 4 possible synonym types using the current PHP API client v4. Enhancement of the API will be necessary to support a more comprehensive solution. 