### PR TITLE
MAGE-1134: AlgoliaHelper refactoring

### DIFF
--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -249,7 +249,8 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
             'indexName' => $coreHelper->getBaseIndexName(),
             'apiKey' => $algoliaHelper->generateSearchSecuredApiKey(
                 $config->getSearchOnlyAPIKey(),
-                $attributesToFilter
+                $attributesToFilter,
+                $this->getStoreId()
             ),
             'attributeFilter' => $attributesToFilter,
             'facets' => $facets,

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -14,20 +14,22 @@ class AlgoliaHelper
     /**
      * @var string Case-sensitive object ID key
      */
-    public const string ALGOLIA_API_OBJECT_ID = 'objectID';
+    public const ALGOLIA_API_OBJECT_ID = 'objectID';
+
     /**
      * @var string
      */
-    public const string ALGOLIA_API_INDEX_NAME = 'indexName';
+    public const ALGOLIA_API_INDEX_NAME = 'indexName';
+
     /**
      * @var string
      */
-    public const string ALGOLIA_API_TASK_ID = 'taskID';
+    public const ALGOLIA_API_TASK_ID = 'taskID';
 
     /**
      * @var int
      */
-    public const int ALGOLIA_DEFAULT_SCOPE = 0;
+    public const ALGOLIA_DEFAULT_SCOPE = 0;
 
     public function __construct(
         protected AlgoliaConnector $algoliaConnector

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -86,15 +86,6 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param int $storeId
-     * @return void
-     */
-//    public function setStoreId(int $storeId): void
-//    {
-//        $this->algoliaConnector->setStoreId($storeId);
-//    }
-
-    /**
      * @param int|null $storeId
      *
      * @return ListIndicesResponse|array<string,mixed>

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -12,28 +12,11 @@ use Exception;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\RequestInterface;
 
+/**
+ * @deprecated (will be removed in v3.16.0)
+ */
 class AlgoliaHelper extends AbstractHelper
 {
-    /**
-     * @var string Case-sensitive object ID key
-     */
-    public const ALGOLIA_API_OBJECT_ID = 'objectID';
-
-    /**
-     * @var string
-     */
-    public const ALGOLIA_API_INDEX_NAME = 'indexName';
-
-    /**
-     * @var string
-     */
-    public const ALGOLIA_API_TASK_ID = 'taskID';
-
-    /**
-     * @var int
-     */
-    public const ALGOLIA_DEFAULT_SCOPE = 0;
-
     public function __construct(
         Context $context,
         protected AlgoliaConnector $algoliaConnector
@@ -50,39 +33,13 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * Ensure AlgoliaConnector targets the application configured on a particular store
-     *
-     * @param int|null $storeId
-     * @return void
-     */
-    protected function handleStoreContext(int|null $storeId): void
-    {
-        if (!is_null($storeId)) {
-            $this->algoliaConnector->setStoreId($storeId);
-        }
-    }
-
-    /**
-     * Restore AlgoliaConnector default Scope
-     *
-     * @return void
-     */
-    protected function restoreDefaultScope(): void
-    {
-        $this->algoliaConnector->setStoreId(self::ALGOLIA_DEFAULT_SCOPE);
-    }
-
-    /**
      * @param int|null $storeId
      * @return SearchClient
      * @throws AlgoliaException
      */
-    public function getClient(int $storeId = null): SearchClient
+    public function getClient(?int $storeId = null): SearchClient
     {
-        $this->handleStoreContext($storeId);
-        $client = $this->algoliaConnector->getClient();
-        $this->restoreDefaultScope();
-        return $client;
+        return $this->algoliaConnector->getClient($storeId);
     }
 
     /**
@@ -91,12 +48,9 @@ class AlgoliaHelper extends AbstractHelper
      * @return ListIndicesResponse|array<string,mixed>
      * @throws AlgoliaException
      */
-    public function listIndexes(int $storeId = null)
+    public function listIndexes(?int $storeId = null)
     {
-        $this->handleStoreContext($storeId);
-        $indexes = $this->algoliaConnector->listIndexes();
-        $this->restoreDefaultScope();
-        return $indexes;
+        return $this->algoliaConnector->listIndexes($storeId);
     }
 
     /**
@@ -108,12 +62,9 @@ class AlgoliaHelper extends AbstractHelper
      * @throws AlgoliaException
      * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
      */
-    public function query(string $indexName, string $q, array $params, int $storeId = null): array
+    public function query(string $indexName, string $q, array $params, ?int $storeId = null): array
     {
-        $this->handleStoreContext($storeId);
-        $result = $this->algoliaConnector->query($indexName, $q, $params);
-        $this->restoreDefaultScope();
-        return $result;
+        return $this->algoliaConnector->query($indexName, $q, $params, $storeId);
     }
 
     /**
@@ -123,12 +74,9 @@ class AlgoliaHelper extends AbstractHelper
      * @return array<string, mixed>
      * @throws AlgoliaException
      */
-    public function getObjects(string $indexName, array $objectIds, int $storeId = null): array
+    public function getObjects(string $indexName, array $objectIds, ?int $storeId = null): array
     {
-        $this->handleStoreContext($storeId);
-        $result = $this->algoliaConnector->getObjects($indexName, $objectIds);
-        $this->restoreDefaultScope();
-        return $result;
+        return $this->algoliaConnector->getObjects($indexName, $objectIds, $storeId);
     }
 
     /**
@@ -146,17 +94,16 @@ class AlgoliaHelper extends AbstractHelper
         bool $forwardToReplicas = false,
         bool $mergeSettings = false,
         string $mergeSettingsFrom = '',
-        int $storeId = null
+        ?int $storeId = null
     ) {
-        $this->handleStoreContext($storeId);
         $this->algoliaConnector->setSettings(
             $indexName,
             $settings,
             $forwardToReplicas,
             $mergeSettings,
-            $mergeSettingsFrom
+            $mergeSettingsFrom,
+            $storeId
         );
-        $this->restoreDefaultScope();
     }
 
     /**
@@ -165,11 +112,9 @@ class AlgoliaHelper extends AbstractHelper
      * @return void
      * @throws AlgoliaException
      */
-    public function deleteIndex(string $indexName, int $storeId = null): void
+    public function deleteIndex(string $indexName, ?int $storeId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->deleteIndex($indexName);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->deleteIndex($indexName, $storeId);
     }
 
     /**
@@ -179,11 +124,9 @@ class AlgoliaHelper extends AbstractHelper
      * @return void
      * @throws AlgoliaException
      */
-    public function deleteObjects(array $ids, string $indexName, int $storeId = null): void
+    public function deleteObjects(array $ids, string $indexName, ?int $storeId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->deleteObjects($ids, $indexName);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->deleteObjects($ids, $indexName, $storeId);
     }
 
     /**
@@ -193,11 +136,9 @@ class AlgoliaHelper extends AbstractHelper
      * @return void
      * @throws AlgoliaException
      */
-    public function moveIndex(string $fromIndexName, string $toIndexName, int $storeId = null): void
+    public function moveIndex(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->moveIndex($fromIndexName, $toIndexName);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->moveIndex($fromIndexName, $toIndexName, $storeId);
     }
 
     /**
@@ -207,12 +148,9 @@ class AlgoliaHelper extends AbstractHelper
      * @return string
      * @throws AlgoliaException
      */
-    public function generateSearchSecuredApiKey(string $key, array $params = [], int $storeId = null): string
+    public function generateSearchSecuredApiKey(string $key, array $params = [], ?int $storeId = null): string
     {
-        $this->handleStoreContext($storeId);
-        $apiKey = $this->algoliaConnector->generateSearchSecuredApiKey($key, $params);
-        $this->restoreDefaultScope();
-        return $apiKey;
+        return $this->algoliaConnector->generateSearchSecuredApiKey($key, $params, $storeId);
     }
 
     /**
@@ -221,12 +159,9 @@ class AlgoliaHelper extends AbstractHelper
      * @return array<string, mixed>
      * @throws AlgoliaException
      */
-    public function getSettings(string $indexName, int $storeId = null): array
+    public function getSettings(string $indexName, ?int $storeId = null): array
     {
-        $this->handleStoreContext($storeId);
-        $settings = $this->algoliaConnector->getSettings($indexName);
-        $this->restoreDefaultScope();
-        return $settings;
+        return $this->algoliaConnector->getSettings($indexName, $storeId);
     }
 
     /**
@@ -238,39 +173,34 @@ class AlgoliaHelper extends AbstractHelper
      * @return void
      * @throws Exception
      */
-    public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false, int $storeId = null): void
+    public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false, ?int $storeId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->saveObjects($indexName, $objects, $isPartialUpdate);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->saveObjects($indexName, $objects, $isPartialUpdate, $storeId);
     }
 
     /**
      * @param array<string, mixed> $rule
      * @param string $indexName
      * @param bool $forwardToReplicas
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false, int $storeId = null): void
+    public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false, ?int $storeId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->saveRule($rule, $indexName, $forwardToReplicas);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->saveRule($rule, $indexName, $forwardToReplicas, $storeId);
     }
 
     /**
      * @param string $indexName
      * @param array $rules
      * @param bool $forwardToReplicas
-     * @param null $storeId
+     * @param int|null $storeId
      * @return void
      */
-    public function saveRules(string $indexName, array $rules, bool $forwardToReplicas = false, $storeId = null): void
+    public function saveRules(string $indexName, array $rules, bool $forwardToReplicas = false, ?int $storeId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->saveRules($indexName, $rules, $forwardToReplicas);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->saveRules($indexName, $rules, $forwardToReplicas, $storeId);
     }
 
     /**
@@ -285,12 +215,10 @@ class AlgoliaHelper extends AbstractHelper
         string $indexName,
         string $objectID,
         bool $forwardToReplicas = false,
-        int $storeId = null
+        ?int $storeId = null
     ) : void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->deleteRule($indexName, $objectID, $forwardToReplicas);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->deleteRule($indexName, $objectID, $forwardToReplicas, $storeId);
     }
 
     /**
@@ -301,11 +229,9 @@ class AlgoliaHelper extends AbstractHelper
      * @throws AlgoliaException
      * @throws ExceededRetriesException
      */
-    public function copySynonyms(string $fromIndexName, string $toIndexName, int $storeId = null): void
+    public function copySynonyms(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->copySynonyms($fromIndexName, $toIndexName);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->copySynonyms($fromIndexName, $toIndexName, $storeId);
     }
 
     /**
@@ -316,11 +242,9 @@ class AlgoliaHelper extends AbstractHelper
      * @throws AlgoliaException
      * @throws ExceededRetriesException
      */
-    public function copyQueryRules(string $fromIndexName, string $toIndexName, int $storeId = null): void
+    public function copyQueryRules(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->copyQueryRules($fromIndexName, $toIndexName);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->copyQueryRules($fromIndexName, $toIndexName, $storeId);
     }
 
     /**
@@ -331,22 +255,20 @@ class AlgoliaHelper extends AbstractHelper
      *
      * @throws AlgoliaException
      */
-    public function searchRules(string $indexName, array$searchRulesParams = null, int $storeId = null)
+    public function searchRules(string $indexName, array$searchRulesParams = null, ?int $storeId = null)
     {
-        $this->handleStoreContext($storeId);
-        $rules = $this->algoliaConnector->searchRules($indexName, $searchRulesParams);
-        $this->restoreDefaultScope();
-        return $rules;
+        return $this->algoliaConnector->searchRules($indexName, $searchRulesParams, $storeId);
     }
 
     /**
      * @param string $indexName
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    public function clearIndex(string $indexName): void
+    public function clearIndex(string $indexName, ?int $storeId = null): void
     {
-        $this->algoliaConnector->clearIndex($indexName);
+        $this->algoliaConnector->clearIndex($indexName, $storeId);
     }
 
     /**
@@ -357,11 +279,9 @@ class AlgoliaHelper extends AbstractHelper
      * @throws AlgoliaException
      * @throws ExceededRetriesException
      */
-    public function waitLastTask(int $storeId = null, string $lastUsedIndexName = null, int $lastTaskId = null): void
+    public function waitLastTask(?int $storeId = null, ?string $lastUsedIndexName = null, ?int $lastTaskId = null): void
     {
-        $this->handleStoreContext($storeId);
-        $this->algoliaConnector->waitLastTask($lastUsedIndexName, $lastTaskId);
-        $this->restoreDefaultScope();
+        $this->algoliaConnector->waitLastTask($storeId, $lastUsedIndexName, $lastTaskId);
     }
 
     /**
@@ -374,14 +294,10 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
-     * @param int|null $storeId
      * @return int
      */
-    public function getLastTaskId(int $storeId = null): int
+    public function getLastTaskId(): int
     {
-        $this->handleStoreContext($storeId);
-        $lastTaskId = $this->algoliaConnector->getLastTaskId();
-        $this->restoreDefaultScope();
-        return $lastTaskId;
+        return $this->algoliaConnector->getLastTaskId();
     }
 }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -34,54 +34,94 @@ class AlgoliaHelper
     ){}
 
     /**
+     * Ensure AlgoliaConnector targets the application configured on a particular store
+     *
+     * @param int|null $storeId
+     * @return void
+     */
+    protected function handleStoreContext(int|null $storeId): void
+    {
+        if (!is_null($storeId)) {
+            $this->algoliaConnector->setStoreId($storeId);
+        }
+    }
+
+    /**
+     * Restore AlgoliaConnector default Scope
+     *
+     * @return void
+     */
+    protected function restoreDefaultScope(): void
+    {
+        $this->algoliaConnector->setStoreId(self::ALGOLIA_DEFAULT_SCOPE);
+    }
+
+    /**
+     * @param int|null $storeId
      * @return SearchClient
      * @throws AlgoliaException
      */
-    public function getClient(): SearchClient
+    public function getClient(int $storeId = null): SearchClient
     {
-        return $this->algoliaConnector->getClient();
+        $this->handleStoreContext($storeId);
+        $client = $this->algoliaConnector->getClient();
+        $this->restoreDefaultScope();
+        return $client;
     }
 
     /**
      * @param int $storeId
      * @return void
      */
-    public function setStoreId(int $storeId): void
-    {
-        $this->algoliaConnector->setStoreId($storeId);
-    }
+//    public function setStoreId(int $storeId): void
+//    {
+//        $this->algoliaConnector->setStoreId($storeId);
+//    }
 
     /**
+     * @param int|null $storeId
+     *
      * @return ListIndicesResponse|array<string,mixed>
      * @throws AlgoliaException
      */
-    public function listIndexes()
+    public function listIndexes(int $storeId = null)
     {
-        return $this->algoliaConnector->listIndexes();
+        $this->handleStoreContext($storeId);
+        $indexes = $this->algoliaConnector->listIndexes();
+        $this->restoreDefaultScope();
+        return $indexes;
     }
 
     /**
      * @param string $indexName
      * @param string $q
      * @param array $params
+     * @param int|null $storeId
      * @return array<string, mixed>
      * @throws AlgoliaException
      * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
      */
-    public function query(string $indexName, string $q, array $params): array
+    public function query(string $indexName, string $q, array $params, int $storeId = null): array
     {
-        return $this->algoliaConnector->query($indexName, $q, $params);
+        $this->handleStoreContext($storeId);
+        $result = $this->algoliaConnector->query($indexName, $q, $params);
+        $this->restoreDefaultScope();
+        return $result;
     }
 
     /**
      * @param string $indexName
      * @param array $objectIds
+     * @param int|null $storeId
      * @return array<string, mixed>
      * @throws AlgoliaException
      */
-    public function getObjects(string $indexName, array $objectIds): array
+    public function getObjects(string $indexName, array $objectIds, int $storeId = null): array
     {
-        return $this->algoliaConnector->getObjects($indexName, $objectIds);
+        $this->handleStoreContext($storeId);
+        $result = $this->algoliaConnector->getObjects($indexName, $objectIds);
+        $this->restoreDefaultScope();
+        return $result;
     }
 
     /**
@@ -90,7 +130,7 @@ class AlgoliaHelper
      * @param bool $forwardToReplicas
      * @param bool $mergeSettings
      * @param string $mergeSettingsFrom
-     *
+     * @param int|null $storeId
      * @throws AlgoliaException
      */
     public function setSettings(
@@ -98,8 +138,10 @@ class AlgoliaHelper
         $settings,
         bool $forwardToReplicas = false,
         bool $mergeSettings = false,
-        string $mergeSettingsFrom = ''
+        string $mergeSettingsFrom = '',
+        int $storeId = null
     ) {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->setSettings(
             $indexName,
             $settings,
@@ -107,38 +149,48 @@ class AlgoliaHelper
             $mergeSettings,
             $mergeSettingsFrom
         );
+        $this->restoreDefaultScope();
     }
 
     /**
      * @param string $indexName
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    public function deleteIndex(string $indexName): void
+    public function deleteIndex(string $indexName, int $storeId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->deleteIndex($indexName);
+        $this->restoreDefaultScope();
     }
 
     /**
      * @param array $ids
      * @param string $indexName
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    public function deleteObjects(array $ids, string $indexName): void
+    public function deleteObjects(array $ids, string $indexName, int $storeId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->deleteObjects($ids, $indexName);
+        $this->restoreDefaultScope();
     }
 
     /**
      * @param string $fromIndexName
      * @param string $toIndexName
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    public function moveIndex(string $fromIndexName, string $toIndexName): void
+    public function moveIndex(string $fromIndexName, string $toIndexName, int $storeId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->moveIndex($fromIndexName, $toIndexName);
+        $this->restoreDefaultScope();
     }
 
     /**
@@ -154,12 +206,16 @@ class AlgoliaHelper
 
     /**
      * @param string $indexName
+     * @param int|null $storeId
      * @return array<string, mixed>
      * @throws AlgoliaException
      */
-    public function getSettings(string $indexName): array
+    public function getSettings(string $indexName, int $storeId = null): array
     {
-        return $this->algoliaConnector->getSettings($indexName);
+        $this->handleStoreContext($storeId);
+        $settings = $this->algoliaConnector->getSettings($indexName);
+        $this->restoreDefaultScope();
+        return $settings;
     }
 
     /**
@@ -167,12 +223,15 @@ class AlgoliaHelper
      * @param string $indexName
      * @param array $objects
      * @param bool $isPartialUpdate
+     * @param int|null $storeId
      * @return void
      * @throws Exception
      */
-    public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false): void
+    public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false, int $storeId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->saveObjects($indexName, $objects, $isPartialUpdate);
+        $this->restoreDefaultScope();
     }
 
     /**
@@ -182,69 +241,91 @@ class AlgoliaHelper
      * @return void
      * @throws AlgoliaException
      */
-    public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false): void
+    public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false, int $storeId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->saveRule($rule, $indexName, $forwardToReplicas);
+        $this->restoreDefaultScope();
     }
 
     /**
      * @param string $indexName
      * @param array $rules
      * @param bool $forwardToReplicas
+     * @param null $storeId
      * @return void
      */
-    public function saveRules(string $indexName, array $rules, bool $forwardToReplicas = false): void
+    public function saveRules(string $indexName, array $rules, bool $forwardToReplicas = false, $storeId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->saveRules($indexName, $rules, $forwardToReplicas);
+        $this->restoreDefaultScope();
     }
 
     /**
      * @param string $indexName
      * @param string $objectID
      * @param bool $forwardToReplicas
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    public function deleteRule(string $indexName, string $objectID, bool $forwardToReplicas = false): void
+    public function deleteRule(
+        string $indexName,
+        string $objectID,
+        bool $forwardToReplicas = false,
+        int $storeId = null
+    ) : void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->deleteRule($indexName, $objectID, $forwardToReplicas);
+        $this->restoreDefaultScope();
     }
 
     /**
      * @param string $fromIndexName
      * @param string $toIndexName
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      * @throws ExceededRetriesException
      */
-    public function copySynonyms(string $fromIndexName, string $toIndexName): void
+    public function copySynonyms(string $fromIndexName, string $toIndexName, int $storeId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->copySynonyms($fromIndexName, $toIndexName);
+        $this->restoreDefaultScope();
     }
 
     /**
      * @param string $fromIndexName
      * @param string $toIndexName
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      * @throws ExceededRetriesException
      */
-    public function copyQueryRules(string $fromIndexName, string $toIndexName): void
+    public function copyQueryRules(string $fromIndexName, string $toIndexName, int $storeId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->copyQueryRules($fromIndexName, $toIndexName);
+        $this->restoreDefaultScope();
     }
 
     /**
      * @param string $indexName
      * @param array|null $searchRulesParams
-     *
+     * @param int|null $storeId
      * @return array
      *
      * @throws AlgoliaException
      */
-    public function searchRules(string $indexName, array$searchRulesParams = null)
+    public function searchRules(string $indexName, array$searchRulesParams = null, int $storeId = null)
     {
-        return $this->algoliaConnector->searchRules($indexName, $searchRulesParams);
+        $this->handleStoreContext($storeId);
+        $rules = $this->algoliaConnector->searchRules($indexName, $searchRulesParams);
+        $this->restoreDefaultScope();
+        return $rules;
     }
 
     /**
@@ -258,14 +339,18 @@ class AlgoliaHelper
     }
 
     /**
+     * @param int|null $storeId
      * @param string|null $lastUsedIndexName
      * @param int|null $lastTaskId
      * @return void
-     * @throws ExceededRetriesException|AlgoliaException
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
      */
-    public function waitLastTask(string $lastUsedIndexName = null, int $lastTaskId = null): void
+    public function waitLastTask(int $storeId = null, string $lastUsedIndexName = null, int $lastTaskId = null): void
     {
+        $this->handleStoreContext($storeId);
         $this->algoliaConnector->waitLastTask($lastUsedIndexName, $lastTaskId);
+        $this->restoreDefaultScope();
     }
 
     /**
@@ -278,10 +363,14 @@ class AlgoliaHelper
     }
 
     /**
+     * @param int|null $storeId
      * @return int
      */
-    public function getLastTaskId(): int
+    public function getLastTaskId(int $storeId = null): int
     {
-        return $this->algoliaConnector->getLastTaskId();
+        $this->handleStoreContext($storeId);
+        $lastTaskId = $this->algoliaConnector->getLastTaskId();
+        $this->restoreDefaultScope();
+        return $lastTaskId;
     }
 }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -196,12 +196,16 @@ class AlgoliaHelper
     /**
      * @param string $key
      * @param array $params
+     * @param int|null $storeId
      * @return string
      * @throws AlgoliaException
      */
-    public function generateSearchSecuredApiKey(string $key, array $params = []): string
+    public function generateSearchSecuredApiKey(string $key, array $params = [], int $storeId = null): string
     {
-        return $this->algoliaConnector->generateSearchSecuredApiKey($key, $params);
+        $this->handleStoreContext($storeId);
+        $apiKey = $this->algoliaConnector->generateSearchSecuredApiKey($key, $params);
+        $this->restoreDefaultScope();
+        return $apiKey;
     }
 
     /**

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -7,9 +7,12 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Model\Search\ListIndicesResponse;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Magento\Framework\App\Helper\AbstractHelper;
 use Exception;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\RequestInterface;
 
-class AlgoliaHelper
+class AlgoliaHelper extends AbstractHelper
 {
     /**
      * @var string Case-sensitive object ID key
@@ -32,8 +35,19 @@ class AlgoliaHelper
     public const ALGOLIA_DEFAULT_SCOPE = 0;
 
     public function __construct(
+        Context $context,
         protected AlgoliaConnector $algoliaConnector
-    ){}
+    ){
+        parent::__construct($context);
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    public function getRequest(): RequestInterface
+    {
+        return $this->_getRequest();
+    }
 
     /**
      * Ensure AlgoliaConnector targets the application configured on a particular store

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -294,10 +294,11 @@ class AlgoliaHelper extends AbstractHelper
     }
 
     /**
+     * @param int|null $storeId
      * @return int
      */
-    public function getLastTaskId(): int
+    public function getLastTaskId(?int $storeId = null): int
     {
-        return $this->algoliaConnector->getLastTaskId();
+        return $this->algoliaConnector->getLastTaskId($storeId);
     }
 }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -3,119 +3,35 @@
 namespace Algolia\AlgoliaSearch\Helper;
 
 use Algolia\AlgoliaSearch\Api\SearchClient;
-use Algolia\AlgoliaSearch\Configuration\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Model\Search\ListIndicesResponse;
-use Algolia\AlgoliaSearch\Model\Search\SettingsResponse;
-use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
-use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Exception;
-use Magento\Framework\App\Helper\AbstractHelper;
-use Magento\Framework\App\Helper\Context;
-use Magento\Framework\Message\ManagerInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
-class AlgoliaHelper extends AbstractHelper
+class AlgoliaHelper
 {
     /**
      * @var string Case-sensitive object ID key
      */
-    public const ALGOLIA_API_OBJECT_ID = 'objectID';
+    public const string ALGOLIA_API_OBJECT_ID = 'objectID';
     /**
      * @var string
      */
-    public const ALGOLIA_API_INDEX_NAME = 'indexName';
+    public const string ALGOLIA_API_INDEX_NAME = 'indexName';
     /**
      * @var string
      */
-    public const ALGOLIA_API_TASK_ID = 'taskID';
+    public const string ALGOLIA_API_TASK_ID = 'taskID';
 
     /**
      * @var int
      */
-    public const ALGOLIA_DEFAULT_SCOPE = 0;
-
-    /** @var int This value should be configured based on system/full_page_cache/ttl
-     *           (which is by default 86400) and/or the configuration block TTL
-     */
-    protected const ALGOLIA_API_SECURED_KEY_TIMEOUT_SECONDS = 60 * 60 * 24; // TODO: Implement as config
-
-    /** @var SearchClient[] */
-    protected array $clients = [];
-
-    protected ?int $maxRecordSize = null;
-
-    /** @var string[] */
-    protected array $potentiallyLongAttributes = ['description', 'short_description', 'meta_description', 'content'];
-
-    /** @var string[] */
-    protected array $nonCastableAttributes = ['sku', 'name', 'description', 'query'];
-
-    /** @var int  */
-    protected int $storeId = self::ALGOLIA_DEFAULT_SCOPE;
-
-    /** @var bool */
-    protected bool $userAgentsAdded = false;
-
-    protected static ?string $lastUsedIndexName;
-
-    protected static ?int $lastTaskId;
+    public const int ALGOLIA_DEFAULT_SCOPE = 0;
 
     public function __construct(
-        Context $context,
-        protected ConfigHelper $config,
-        protected ManagerInterface $messageManager,
-        protected ConsoleOutput $consoleOutput,
-        protected AlgoliaCredentialsManager $algoliaCredentialsManager
-    ) {
-        parent::__construct($context);
-
-        // Merge non castable attributes set in config
-        $this->nonCastableAttributes = array_merge(
-            $this->nonCastableAttributes,
-            $this->config->getNonCastableAttributes()
-        );
-    }
-
-    /**
-     * @return void
-     * @throws AlgoliaException
-     */
-    protected function createClient(): void
-    {
-        $storeId = $this->getStoreId();
-        if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
-            throw new AlgoliaException('Client initialization could not be performed because Algolia credentials were not provided.');
-        }
-
-        $config = SearchConfig::create(
-            $this->config->getApplicationID($storeId),
-            $this->config->getAPIKey($storeId)
-        );
-        $config->setConnectTimeout($this->config->getConnectionTimeout($storeId));
-        $config->setReadTimeout($this->config->getReadTimeout($storeId));
-        $config->setWriteTimeout($this->config->getWriteTimeout($storeId));
-        $this->clients[$storeId] = SearchClient::createWithConfig($config);
-    }
-
-    /**
-     * @return void
-     * @throws AlgoliaException
-     */
-    protected function addAlgoliaUserAgent(): void
-    {
-        $clientName = $this->getClient()->getClientConfig()?->getClientName();
-
-        if ($clientName) {
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento2 integration', $this->config->getExtensionVersion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'PHP', phpversion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento', $this->config->getMagentoVersion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Edition', $this->config->getMagentoEdition());
-
-            $this->userAgentsAdded = true;
-        }
-    }
+        protected AlgoliaConnector $algoliaConnector
+    ){}
 
     /**
      * @return SearchClient
@@ -123,22 +39,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function getClient(): SearchClient
     {
-        if (!isset($this->clients[$this->getStoreId()])) {
-            $this->createClient();
-            if (!$this->userAgentsAdded) {
-                $this->addAlgoliaUserAgent();
-            }
-        }
-
-        return $this->clients[$this->getStoreId()];
-    }
-
-    /**
-     * @return int
-     */
-    public function getStoreId(): int
-    {
-        return $this->storeId;
+        return $this->algoliaConnector->getClient();
     }
 
     /**
@@ -147,17 +48,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function setStoreId(int $storeId): void
     {
-        $this->storeId = $storeId;
-    }
-
-    /**
-     * @param string $name
-     * @throws AlgoliaException
-     * @deprecated This method has been completely removed from the Algolia PHP connector version 4 and should not be used.
-     */
-    public function getIndex(string $name)
-    {
-        throw new AlgoliaException("This method is no longer supported for PHP client v4!");
+        $this->algoliaConnector->setStoreId($storeId);
     }
 
     /**
@@ -166,7 +57,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function listIndexes()
     {
-        return $this->getClient()->listIndices();
+        return $this->algoliaConnector->listIndexes();
     }
 
     /**
@@ -179,23 +70,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function query(string $indexName, string $q, array $params): array
     {
-        // TODO: Revisit - not compatible with PHP v4
-        // if (isset($params['disjunctiveFacets'])) {
-        //    return $this->searchWithDisjunctiveFaceting($indexName, $q, $params);
-        //}
-
-        $params = array_merge(
-            [
-                self::ALGOLIA_API_INDEX_NAME => $indexName,
-                'query' => $q
-            ],
-            $params
-        );
-
-        // TODO: Validate return value for integration tests
-        return $this->getClient()->search([
-            'requests' => [ $params ]
-        ]);
+        return $this->algoliaConnector->query($indexName, $q, $params);
     }
 
     /**
@@ -206,19 +81,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function getObjects(string $indexName, array $objectIds): array
     {
-        $requests = array_values(
-            array_map(
-                function($id) use ($indexName) {
-                    return [
-                        self::ALGOLIA_API_INDEX_NAME => $indexName,
-                        self::ALGOLIA_API_OBJECT_ID => $id
-                    ];
-                },
-                $objectIds
-            )
-        );
-
-        return $this->getClient()->getObjects([ 'requests' => $requests ]);
+        return $this->algoliaConnector->getObjects($indexName, $objectIds);
     }
 
     /**
@@ -237,28 +100,13 @@ class AlgoliaHelper extends AbstractHelper
         bool $mergeSettings = false,
         string $mergeSettingsFrom = ''
     ) {
-        if ($mergeSettings === true) {
-            $settings = $this->mergeSettings($indexName, $settings, $mergeSettingsFrom);
-        }
-
-        $res = $this->getClient()->setSettings($indexName, $settings, $forwardToReplicas);
-
-        self::setLastOperationInfo($indexName, $res);
-    }
-
-    /**
-     * @param string $indexName
-     * @param array $requests
-     * @return array<string, mixed>
-     * @throws AlgoliaException
-     */
-    protected function performBatchOperation(string $indexName, array $requests): array
-    {
-        $response = $this->getClient()->batch($indexName, [ 'requests' => $requests ] );
-
-        self::setLastOperationInfo($indexName, $response);
-
-        return $response;
+        $this->algoliaConnector->setSettings(
+            $indexName,
+            $settings,
+            $forwardToReplicas,
+            $mergeSettings,
+            $mergeSettingsFrom
+        );
     }
 
     /**
@@ -268,9 +116,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function deleteIndex(string $indexName): void
     {
-        $res = $this->getClient()->deleteIndex($indexName);
-
-        self::setLastOperationInfo($indexName, $res);
+        $this->algoliaConnector->deleteIndex($indexName);
     }
 
     /**
@@ -281,21 +127,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function deleteObjects(array $ids, string $indexName): void
     {
-        $requests = array_values(
-            array_map(
-                function ($id) {
-                    return [
-                        'action' => 'deleteObject',
-                        'body'   => [
-                            self::ALGOLIA_API_OBJECT_ID => $id
-                        ]
-                    ];
-                },
-                $ids
-            )
-        );
-
-        $this->performBatchOperation($indexName, $requests);
+        $this->algoliaConnector->deleteObjects($ids, $indexName);
     }
 
     /**
@@ -306,14 +138,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function moveIndex(string $fromIndexName, string $toIndexName): void
     {
-        $response = $this->getClient()->operationIndex(
-            $fromIndexName,
-            [
-                'operation'   => 'move',
-                'destination' => $toIndexName
-            ]
-        );
-        self::setLastOperationInfo($toIndexName, $response);
+        $this->algoliaConnector->moveIndex($fromIndexName, $toIndexName);
     }
 
     /**
@@ -324,14 +149,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function generateSearchSecuredApiKey(string $key, array $params = []): string
     {
-        // This is to handle a difference between API client v1 and v2.
-        if (! isset($params['tagFilters'])) {
-            $params['tagFilters'] = '';
-        }
-
-        $params['validUntil'] = time() + self::ALGOLIA_API_SECURED_KEY_TIMEOUT_SECONDS;
-
-        return $this->getClient()->generateSecuredApiKey($key, $params);
+        return $this->algoliaConnector->generateSearchSecuredApiKey($key, $params);
     }
 
     /**
@@ -341,75 +159,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function getSettings(string $indexName): array
     {
-        try {
-            return $this->getClient()->getSettings($indexName);
-        } catch (Exception $e) {
-            if ($e->getCode() !== 404) {
-                throw $e;
-            }
-            return [];
-        }
-    }
-
-    /**
-     * @param $indexName
-     * @param $settings
-     * @param string $mergeSettingsFrom
-     * @return SettingsResponse|array
-     */
-    public function mergeSettings($indexName, $settings, string $mergeSettingsFrom = ''): SettingsResponse|array
-    {
-        $onlineSettings = [];
-
-        try {
-            $sourceIndex = $indexName;
-            if ($mergeSettingsFrom !== '') {
-                $sourceIndex = $mergeSettingsFrom;
-            }
-
-            $onlineSettings = $this->getClient()->getSettings($sourceIndex);
-        } catch (Exception $e) {
-        }
-
-        $removes = ['slaves', 'replicas', 'decompoundedAttributes'];
-
-        if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
-            $removes[] = 'mode';
-        }
-
-        if (isset($settings['attributesToIndex'])) {
-            $settings['searchableAttributes'] = $settings['attributesToIndex'];
-            unset($settings['attributesToIndex']);
-        }
-
-        if (isset($onlineSettings['attributesToIndex'])) {
-            $onlineSettings['searchableAttributes'] = $onlineSettings['attributesToIndex'];
-            unset($onlineSettings['attributesToIndex']);
-        }
-
-        foreach ($removes as $remove) {
-            if (isset($onlineSettings[$remove])) {
-                unset($onlineSettings[$remove]);
-            }
-        }
-
-        foreach ($settings as $key => $value) {
-            $onlineSettings[$key] = $value;
-        }
-
-        return $onlineSettings;
-    }
-
-    /**
-     * Legacy function signature to add objects to Algolia
-     * @param array $objects
-     * @param string $indexName
-     * @return void
-     * @throws Exception
-     * @deprecated Do not use. This method has been replaced by saveObjects and may be removed in the future.
-     */
-    public function addObjects(array $objects, string $indexName): void {
-        $this->saveObjects($indexName, $objects, $this->config->isPartialUpdateEnabled());
+        return $this->algoliaConnector->getSettings($indexName);
     }
 
     /**
@@ -422,34 +172,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false): void
     {
-        $this->prepareRecords($objects, $indexName);
-
-        $action = $isPartialUpdate ? 'partialUpdateObject' : 'addObject';
-
-        $requests = array_values(
-            array_map(
-                function ($object) use ($action) {
-                    return [
-                        'action' => $action,
-                        'body'   => $object
-                    ];
-                },
-                $objects
-            )
-        );
-
-        $this->performBatchOperation($indexName, $requests);
-    }
-
-    /**
-     * @param string $indexName
-     * @param array $response
-     * @return void
-     */
-    protected static function setLastOperationInfo(string $indexName, array $response): void
-    {
-        self::$lastUsedIndexName = $indexName;
-        self::$lastTaskId = $response[self::ALGOLIA_API_TASK_ID] ?? null;
+        $this->algoliaConnector->saveObjects($indexName, $objects, $isPartialUpdate);
     }
 
     /**
@@ -461,14 +184,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false): void
     {
-        $res = $this->getClient()->saveRule(
-            $indexName,
-            $rule[AlgoliaHelper::ALGOLIA_API_OBJECT_ID],
-            $rule,
-            $forwardToReplicas
-        );
-
-        self::setLastOperationInfo($indexName, $res);
+        $this->algoliaConnector->saveRule($rule, $indexName, $forwardToReplicas);
     }
 
     /**
@@ -479,11 +195,8 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function saveRules(string $indexName, array $rules, bool $forwardToReplicas = false): void
     {
-        $res = $this->getClient()->saveRules($indexName, $rules, $forwardToReplicas);
-
-        self::setLastOperationInfo($indexName, $res);
+        $this->algoliaConnector->saveRules($indexName, $rules, $forwardToReplicas);
     }
-
 
     /**
      * @param string $indexName
@@ -494,21 +207,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function deleteRule(string $indexName, string $objectID, bool $forwardToReplicas = false): void
     {
-        $res = $this->getClient()->deleteRule($indexName, $objectID, $forwardToReplicas);
-
-        self::setLastOperationInfo($indexName, $res);
-    }
-
-    /**
-     * @param $indexName
-     * @param $synonyms
-     * @return void
-     * @throws AlgoliaException
-     * @deprecated Managing synonyms from Magento is no longer supported. Use the Algolia dashboard instead.
-     */
-    public function setSynonyms($indexName, $synonyms): void
-    {
-        throw new AlgoliaException("This method is no longer supported for PHP client v4!");
+        $this->algoliaConnector->deleteRule($indexName, $objectID, $forwardToReplicas);
     }
 
     /**
@@ -520,15 +219,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function copySynonyms(string $fromIndexName, string $toIndexName): void
     {
-        $response = $this->getClient()->operationIndex(
-            $fromIndexName,
-            [
-                'operation'   => 'copy',
-                'destination' => $toIndexName,
-                'scope'       => ['synonyms']
-            ]
-        );
-        self::setLastOperationInfo($fromIndexName, $response);
+        $this->algoliaConnector->copySynonyms($fromIndexName, $toIndexName);
     }
 
     /**
@@ -540,28 +231,20 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function copyQueryRules(string $fromIndexName, string $toIndexName): void
     {
-        $response = $this->getClient()->operationIndex(
-            $fromIndexName,
-            [
-                'operation'   => 'copy',
-                'destination' => $toIndexName,
-                'scope'       => ['rules']
-            ]
-        );
-        self::setLastOperationInfo($fromIndexName, $response);
+        $this->algoliaConnector->copyQueryRules($fromIndexName, $toIndexName);
     }
 
     /**
      * @param string $indexName
      * @param array|null $searchRulesParams
      *
-     * @return SearchRulesResponse|mixed[]
+     * @return array
      *
      * @throws AlgoliaException
      */
     public function searchRules(string $indexName, array$searchRulesParams = null)
     {
-        return $this->getClient()->searchRules($indexName, $searchRulesParams);
+        return $this->algoliaConnector->searchRules($indexName, $searchRulesParams);
     }
 
     /**
@@ -571,9 +254,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function clearIndex(string $indexName): void
     {
-        $res = $this->getClient()->clearObjects($indexName);
-
-        self::setLastOperationInfo($indexName, $res);
+        $this->algoliaConnector->clearIndex($indexName);
     }
 
     /**
@@ -584,159 +265,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function waitLastTask(string $lastUsedIndexName = null, int $lastTaskId = null): void
     {
-        if ($lastUsedIndexName === null && isset(self::$lastUsedIndexName)) {
-            $lastUsedIndexName = self::$lastUsedIndexName;
-        }
-
-        if ($lastTaskId === null && isset(self::$lastTaskId)) {
-            $lastTaskId = self::$lastTaskId;
-        }
-
-        if (!$lastUsedIndexName || !$lastTaskId) {
-            return;
-        }
-
-        $this->getClient()->waitForTask($lastUsedIndexName, $lastTaskId);
-    }
-
-    /**
-     * @param array $objects
-     * @param string $indexName
-     * @return void
-     * @throws Exception
-     */
-    protected function prepareRecords(array &$objects, string $indexName): void
-    {
-        $currentCET = strtotime('now');
-
-        $modifiedIds = [];
-        foreach ($objects as $key => &$object) {
-            $object['algoliaLastUpdateAtCET'] = $currentCET;
-            // Convert created_at to UTC timestamp
-            if (isset($object['created_at'])) {
-                $object['created_at'] = strtotime($object['created_at']);
-            }
-
-            $previousObject = $object;
-
-            $object = $this->handleTooBigRecord($object);
-
-            if ($object === false) {
-                $longestAttribute = $this->getLongestAttribute($previousObject);
-                $modifiedIds[] = $indexName . '
-                    - ID ' . $previousObject[self::ALGOLIA_API_OBJECT_ID] . ' - skipped - longest attribute: ' . $longestAttribute;
-
-                unset($objects[$key]);
-
-                continue;
-            } elseif ($previousObject !== $object) {
-                $modifiedIds[] = $indexName . ' - ID ' . $previousObject[self::ALGOLIA_API_OBJECT_ID] . ' - truncated';
-            }
-
-            $object = $this->castRecord($object);
-        }
-
-        if ($modifiedIds && $modifiedIds !== []) {
-            $separator = php_sapi_name() === 'cli' ? "\n" : '<br>';
-
-            $errorMessage = 'Algolia reindexing:
-                You have some records which are too big to be indexed in Algolia.
-                They have either been truncated
-                (removed attributes: ' . implode(', ', $this->potentiallyLongAttributes) . ')
-                or skipped completely: ' . $separator . implode($separator, $modifiedIds);
-
-            if (php_sapi_name() === 'cli') {
-                $this->consoleOutput->writeln($errorMessage);
-
-                return;
-            }
-
-            $this->messageManager->addErrorMessage($errorMessage);
-        }
-    }
-
-    /**
-     * @return int
-     */
-    protected function getMaxRecordSize(): int
-    {
-        if (!$this->maxRecordSize) {
-            $this->maxRecordSize = $this->config->getMaxRecordSizeLimit();
-        }
-
-        return $this->maxRecordSize;
-    }
-
-    /**
-     * @param $object
-     * @return false|mixed
-     */
-    protected function handleTooBigRecord($object): mixed
-    {
-        $size = $this->calculateObjectSize($object);
-
-        if ($size > $this->getMaxRecordSize()) {
-            foreach ($this->potentiallyLongAttributes as $attribute) {
-                if (isset($object[$attribute])) {
-                    unset($object[$attribute]);
-
-                    // Recalculate size and check if it fits in Algolia index
-                    $size = $this->calculateObjectSize($object);
-                    if ($size < $this->getMaxRecordSize()) {
-                        return $object;
-                    }
-                }
-            }
-
-            // If the SKU attribute is the longest, start popping off SKU's to make it fit
-            // This has the downside that some products cannot be found on some of its childrens' SKU's
-            // But at least the config product can be indexed
-            // Always keep the original SKU though
-            if ($this->getLongestAttribute($object) === 'sku' && is_array($object['sku'])) {
-                foreach ($object['sku'] as $sku) {
-                    if (count($object['sku']) === 1) {
-                        break;
-                    }
-
-                    array_pop($object['sku']);
-
-                    $size = $this->calculateObjectSize($object);
-                    if ($size < $this->getMaxRecordSize()) {
-                        return $object;
-                    }
-                }
-            }
-
-            // Recalculate size, if it still does not fit, let's skip it
-            $size = $this->calculateObjectSize($object);
-            if ($size > $this->getMaxRecordSize()) {
-                $object = false;
-            }
-        }
-
-        return $object;
-    }
-
-    /**
-     * @param $object
-     * @return int|string
-     */
-    protected function getLongestAttribute($object): int|string
-    {
-        $maxLength = 0;
-        $longestAttribute = '';
-
-        foreach ($object as $attribute => $value) {
-            $attributeLength = mb_strlen(json_encode($value));
-
-            if ($attributeLength > $maxLength) {
-                $longestAttribute = $attribute;
-
-                $maxLength = $attributeLength;
-            }
-        }
-
-        return $longestAttribute;
+        $this->algoliaConnector->waitLastTask($lastUsedIndexName, $lastTaskId);
     }
 
     /**
@@ -745,83 +274,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function castProductObject(&$productData): void
     {
-        foreach ($productData as $key => &$data) {
-            if (in_array($key, $this->nonCastableAttributes, true) === true) {
-                continue;
-            }
-
-            $data = $this->castAttribute($data);
-
-            if (is_array($data) === false) {
-                if ($data != null) {
-                    $data = explode('|', $data);
-                    if (count($data) === 1) {
-                        $data = $data[0];
-                        $data = $this->castAttribute($data);
-                    } else {
-                        foreach ($data as &$element) {
-                            $element = $this->castAttribute($element);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * @param $object
-     * @return mixed
-     */
-    protected function castRecord($object): mixed
-    {
-        foreach ($object as $key => &$value) {
-            if (in_array($key, $this->nonCastableAttributes, true) === true) {
-                continue;
-            }
-
-            $value = $this->castAttribute($value);
-        }
-
-        return $object;
-    }
-
-    /**
-     * This method serves to prevent parse of float values that exceed PHP_FLOAT_MAX as INF will break
-     * JSON encoding.
-     *
-     * To further customize the handling of values that may be incorrectly interpreted as numeric by
-     * PHP you can implement an "after" plugin on this method.
-     *
-     * @param $value - what PHP thinks is a floating point number
-     * @return bool
-     */
-    public function isValidFloat(string $value) : bool {
-        return floatval($value) !== INF;
-    }
-
-    /**
-     * @param $value
-     * @return mixed
-     */
-    protected function castAttribute($value): mixed
-    {
-        if (is_numeric($value) && floatval($value) === floatval((int) $value)) {
-            return (int) $value;
-        }
-
-        if (is_numeric($value) && $this->isValidFloat($value)) {
-            return floatval($value);
-        }
-
-        return $value;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLastIndexName(): string
-    {
-        return self::$lastUsedIndexName;
+        $this->algoliaConnector->castProductObject($productData);
     }
 
     /**
@@ -829,156 +282,6 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function getLastTaskId(): int
     {
-        return self::$lastTaskId;
-    }
-
-    /**
-     * @param $object
-     *
-     * @return int
-     */
-    protected function calculateObjectSize($object): int
-    {
-        return mb_strlen(json_encode($object));
-    }
-
-    /**
-     * @param $indexName
-     * @param $q
-     * @param $params
-     * @return mixed|null
-     * @throws AlgoliaException
-     * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
-     */
-    protected function searchWithDisjunctiveFaceting($indexName, $q, $params): mixed
-    {
-        throw new AlgoliaException("This function is not currently supported on PHP connector v4");
-
-        // TODO: Revisit this implementation for backend render
-        if (! is_array($params['disjunctiveFacets']) || count($params['disjunctiveFacets']) <= 0) {
-            throw new \InvalidArgumentException('disjunctiveFacets needs to be an non empty array');
-        }
-
-        if (isset($params['filters'])) {
-            throw new \InvalidArgumentException('You can not use disjunctive faceting and the filters parameter');
-        }
-
-        /**
-         * Prepare queries
-         */
-        // Get the list of disjunctive queries to do: 1 per disjunctive facet
-        $disjunctiveQueries = $this->getDisjunctiveQueries($params);
-
-        // Format disjunctive queries for multipleQueries call
-        foreach ($disjunctiveQueries as &$disjunctiveQuery) {
-            $disjunctiveQuery[self::ALGOLIA_API_INDEX_NAME] = $indexName;
-            $disjunctiveQuery['query'] = $q;
-            unset($disjunctiveQuery['disjunctiveFacets']);
-        }
-
-        // Merge facets and disjunctiveFacets for the hits query
-        $facets = $params['facets'] ?? [];
-        $facets = array_merge($facets, $params['disjunctiveFacets']);
-        unset($params['disjunctiveFacets']);
-
-        // format the hits query for multipleQueries call
-        $params['query'] = $q;
-        $params[self::ALGOLIA_API_INDEX_NAME] = $indexName;
-        $params['facets'] = $facets;
-
-        // Put the hit query first
-        array_unshift($disjunctiveQueries, $params);
-
-        /**
-         * Do all queries in one call
-         */
-        $results = $this->getClient()->multipleQueries(array_values($disjunctiveQueries));
-        $results = $results['results'];
-
-        /**
-         * Merge facets from disjunctive queries with facets from the hits query
-         */
-        // The first query is the hits query that the one we'll return to the user
-        $queryResults = array_shift($results);
-
-        // To be able to add facets from disjunctive query we create 'facets' key in case we only have disjunctive facets
-        if (false === isset($queryResults['facets'])) {
-            $queryResults['facets'] =[];
-        }
-
-        foreach ($results as $disjunctiveResults) {
-            if (isset($disjunctiveResults['facets'])) {
-                foreach ($disjunctiveResults['facets'] as $facetName => $facetValues) {
-                    $queryResults['facets'][$facetName] = $facetValues;
-                }
-            }
-        }
-
-        return $queryResults;
-    }
-
-    /**
-     * @param $queryParams
-     * @return array
-     */
-    protected function getDisjunctiveQueries($queryParams): array
-    {
-        $queriesParams = [];
-
-        foreach ($queryParams['disjunctiveFacets'] as $facetName) {
-            $params = $queryParams;
-            $params['facets'] = [$facetName];
-            $facetFilters = isset($params['facetFilters']) ? $params['facetFilters'] : [];
-            $numericFilters = isset($params['numericFilters']) ? $params['numericFilters'] : [];
-
-            $additionalParams = [
-                'hitsPerPage' => 1,
-                'page' => 0,
-                'attributesToRetrieve' => [],
-                'attributesToHighlight' => [],
-                'attributesToSnippet' => [],
-                'analytics' => false,
-            ];
-
-            $additionalParams['facetFilters'] =
-                $this->getAlgoliaFiltersArrayWithoutCurrentRefinement($facetFilters, $facetName . ':');
-            $additionalParams['numericFilters'] =
-                $this->getAlgoliaFiltersArrayWithoutCurrentRefinement($numericFilters, $facetName);
-
-            $queriesParams[$facetName] = array_merge($params, $additionalParams);
-        }
-
-        return $queriesParams;
-    }
-
-    /**
-     * @param $filters
-     * @param $needle
-     * @return array
-     */
-    protected function getAlgoliaFiltersArrayWithoutCurrentRefinement($filters, $needle): array
-    {
-        // iterate on each filters which can be string or array and filter out every refinement matching the needle
-        for ($i = 0; $i < count($filters); $i++) {
-            if (is_array($filters[$i])) {
-                foreach ($filters[$i] as $filter) {
-                    if (mb_substr($filter, 0, mb_strlen($needle)) === $needle) {
-                        unset($filters[$i]);
-                        $filters = array_values($filters);
-                        $i--;
-
-                        break;
-                    }
-                }
-            } else {
-                if (mb_substr($filters[$i], 0, mb_strlen($needle)) === $needle) {
-                    unset($filters[$i]);
-                    $filters = array_values($filters);
-                    $i--;
-                }
-            }
-        }
-
-        return $filters;
+        return $this->algoliaConnector->getLastTaskId();
     }
 }

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Helper;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Magento;
 use Magento\Cookie\Helper\Cookie as CookieHelper;
 use Magento\Directory\Model\Currency as DirCurrency;
@@ -1482,7 +1483,7 @@ class ConfigHelper
             }
         }
         $attributes = array_merge($attributes, [
-            AlgoliaHelper::ALGOLIA_API_OBJECT_ID,
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID,
             'name',
             'url',
             'visibility_search',

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AdditionalSection\IndexBuilder as AdditionalSectionIndexBuilder;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\Category\IndexBuilder as CategoryIndexBuilder;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\Page\IndexBuilder as PageIndexBuilder;
@@ -224,7 +225,7 @@ class Data
     public function getIndexDataByStoreIds(): array
     {
         $indexNames = [];
-        $indexNames[AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE] = $this->buildIndexData();
+        $indexNames[AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE] = $this->buildIndexData();
         foreach ($this->storeManager->getStores() as $store) {
             $indexNames[$store->getId()] = $this->buildIndexData($store);
         }

--- a/Helper/Entity/AdditionalSectionHelper.php
+++ b/Helper/Entity/AdditionalSectionHelper.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
-use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Eav\Model\Config;
@@ -69,8 +69,8 @@ class AdditionalSectionHelper extends AbstractEntityHelper
 
         $values = array_map(function ($value) use ($section, $storeId) {
             $record = [
-                AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $value,
-                'value'                              => $value,
+                AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $value,
+                'value'                                 => $value,
             ];
 
             $transport = new DataObject($record);

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -4,9 +4,9 @@ namespace Algolia\AlgoliaSearch\Helper\Entity;
 
 use Algolia\AlgoliaSearch\Exception\CategoryEmptyException;
 use Algolia\AlgoliaSearch\Exception\CategoryNotActiveException;
-use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Image;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Category as MagentoCategory;
@@ -252,15 +252,15 @@ class CategoryHelper extends AbstractEntityHelper
         }
 
         $data = [
-            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $category->getId(),
-            'name'                               => $category->getName(),
-            'path'                               => $path,
-            'level'                              => $category->getLevel(),
-            'url'                                => $this->getUrl($category),
-            'include_in_menu'                    => $category->getIncludeInMenu(),
-            '_tags'                              => ['category'],
-            'popularity'                         => 1,
-            'product_count'                      => $category->getProductCount(),
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $category->getId(),
+            'name'                                  => $category->getName(),
+            'path'                                  => $path,
+            'level'                                 => $category->getLevel(),
+            'url'                                   => $this->getUrl($category),
+            'include_in_menu'                       => $category->getIncludeInMenu(),
+            '_tags'                                 => ['category'],
+            'popularity'                            => 1,
+            'product_count'                         => $category->getProductCount(),
         ];
 
         if (!empty($imageUrl)) {

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -2,8 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
-use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Cms\Model\Page;
 use Magento\Cms\Model\ResourceModel\Page\CollectionFactory as PageCollectionFactory;
@@ -88,7 +88,7 @@ class PageHelper extends AbstractEntityHelper
                 $content = $this->filterProvider->getPageFilter()->filter($content);
             }
 
-            $pageObject[AlgoliaHelper::ALGOLIA_API_OBJECT_ID] = $page->getId();
+            $pageObject[AlgoliaConnector::ALGOLIA_API_OBJECT_ID] = $page->getId();
             $pageObject['url'] = $frontendUrlBuilder->getUrl(
                 null,
                 [

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -15,6 +15,7 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
 use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Bundle\Model\Product\Type as BundleProductType;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
@@ -463,12 +464,12 @@ class ProductHelper extends AbstractEntityHelper
         ];
 
         $customData = [
-            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $product->getId(),
-            'name'                               => $product->getName(),
-            'url'                                => $product->getUrlModel()->getUrl($product, $urlParams),
-            'visibility_search'                  => (int) (in_array($visibility, $visibleInSearch)),
-            'visibility_catalog'                 => (int) (in_array($visibility, $visibleInCatalog)),
-            'type_id'                            => $product->getTypeId(),
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $product->getId(),
+            'name'                                  => $product->getName(),
+            'url'                                   => $product->getUrlModel()->getUrl($product, $urlParams),
+            'visibility_search'                     => (int) (in_array($visibility, $visibleInSearch)),
+            'visibility_catalog'                    => (int) (in_array($visibility, $visibleInCatalog)),
+            'type_id'                               => $product->getTypeId(),
         ];
 
         $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
@@ -1257,7 +1258,7 @@ class ProductHelper extends AbstractEntityHelper
             ];
 
             $rules[] = [
-                AlgoliaHelper::ALGOLIA_API_OBJECT_ID => 'filter_' . $attribute,
+                AlgoliaConnector::ALGOLIA_API_OBJECT_ID => 'filter_' . $attribute,
                 'description' => 'Filter facet "' . $attribute . '"',
                 'conditions' => [$condition],
                 'consequence' => [
@@ -1306,7 +1307,7 @@ class ProductHelper extends AbstractEntityHelper
                 foreach ($fetchedQueryRules['hits'] as $hit) {
                     $this->algoliaHelper->deleteRule(
                         $indexName,
-                        $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID],
+                        $hit[AlgoliaConnector::ALGOLIA_API_OBJECT_ID],
                         true,
                         $storeId
                     );

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -352,41 +352,53 @@ class ProductHelper extends AbstractEntityHelper
      */
     public function setSettings(string $indexName, string $indexNameTmp, int $storeId, bool $saveToTmpIndicesToo = false): void
     {
-        $this->algoliaHelper->setStoreId($storeId);
         $indexSettings = $this->getIndexSettings($storeId);
 
-        $this->algoliaHelper->setSettings($indexName, $indexSettings, false, true);
+        $this->algoliaHelper->setSettings(
+            $indexName,
+            $indexSettings,
+            false,
+            true,
+            '',
+            $storeId
+        );
         $this->logger->log('Settings: ' . json_encode($indexSettings));
         if ($saveToTmpIndicesToo) {
-            $this->algoliaHelper->setSettings($indexNameTmp, $indexSettings, false, true, $indexName);
+            $this->algoliaHelper->setSettings(
+                $indexNameTmp,
+                $indexSettings,
+                false,
+                true,
+                $indexName,
+                $storeId
+            );
             $this->logger->log('Pushing the same settings to TMP index as well');
         }
 
         $this->setFacetsQueryRules($indexName, $storeId);
-        $this->algoliaHelper->waitLastTask();
+        $this->algoliaHelper->waitLastTask($storeId);
 
         if ($saveToTmpIndicesToo) {
             $this->setFacetsQueryRules($indexNameTmp, $storeId);
-            $this->algoliaHelper->waitLastTask();
+            $this->algoliaHelper->waitLastTask($storeId);
         }
 
         $this->replicaManager->syncReplicasToAlgolia($storeId, $indexSettings);
 
         if ($saveToTmpIndicesToo) {
             try {
-                $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp);
-                $this->algoliaHelper->waitLastTask();
+                $this->algoliaHelper->copySynonyms($indexName, $indexNameTmp, $storeId);
+                $this->algoliaHelper->waitLastTask($storeId);
                 $this->logger->log('
                         Copying synonyms from production index to "' . $indexNameTmp . '" to not erase them with the index move.
                     ');
             } catch (AlgoliaException $e) {
                 $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
-                $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
             }
 
             try {
-                $this->algoliaHelper->copyQueryRules($indexName, $indexNameTmp);
-                $this->algoliaHelper->waitLastTask();
+                $this->algoliaHelper->copyQueryRules($indexName, $indexNameTmp, $storeId);
+                $this->algoliaHelper->waitLastTask($storeId);
                 $this->logger->log('
                         Copying query rules from production index to "' . $indexNameTmp . '" to not erase them with the index move.
                     ');
@@ -394,10 +406,8 @@ class ProductHelper extends AbstractEntityHelper
                 if ($e->getCode() !== 404) {
                     throw $e;
                 }
-                $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
             }
         }
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**
@@ -1229,7 +1239,7 @@ class ProductHelper extends AbstractEntityHelper
      */
     protected function setFacetsQueryRules(string $indexName, int $storeId = null)
     {
-        $this->clearFacetsQueryRules($indexName);
+        $this->clearFacetsQueryRules($indexName, $storeId);
 
         $rules = [];
         $facets = $this->configHelper->getFacets($storeId);
@@ -1263,34 +1273,43 @@ class ProductHelper extends AbstractEntityHelper
 
         if ($rules) {
             $this->logger->log('Setting facets query rules to "' . $indexName . '" index: ' . json_encode($rules));
-            $this->algoliaHelper->saveRules($indexName, $rules, true);
+            $this->algoliaHelper->saveRules($indexName, $rules, true, $storeId);
         }
     }
 
     /**
      * @param $indexName
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    protected function clearFacetsQueryRules($indexName): void
+    protected function clearFacetsQueryRules($indexName, int $storeId = null): void
     {
         try {
             $hitsPerPage = 100;
             $page = 0;
             do {
-                $fetchedQueryRules = $this->algoliaHelper->searchRules($indexName, [
-                    'context' => 'magento_filters',
-                    'page' => $page,
-                    'hitsPerPage' => $hitsPerPage,
-                ]);
-
+                $fetchedQueryRules = $this->algoliaHelper->searchRules(
+                    $indexName,
+                    [
+                        'context' => 'magento_filters',
+                        'page' => $page,
+                        'hitsPerPage' => $hitsPerPage,
+                    ],
+                    $storeId
+                );
 
                 if (!$fetchedQueryRules || !array_key_exists('hits', $fetchedQueryRules)) {
                     break;
                 }
 
                 foreach ($fetchedQueryRules['hits'] as $hit) {
-                    $this->algoliaHelper->deleteRule($indexName, $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID], true);
+                    $this->algoliaHelper->deleteRule(
+                        $indexName,
+                        $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID],
+                        true,
+                        $storeId
+                    );
                 }
 
                 $page++;
@@ -1422,7 +1441,7 @@ class ProductHelper extends AbstractEntityHelper
                     $replicasToDelete = array_diff($oldReplicas, $newReplicas);
                     $this->algoliaHelper->setSettings($indexName, ['replicas' => $newReplicas]);
                     $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
-                    $this->algoliaHelper->waitLastTask($indexName, $setReplicasTaskId);
+                    $this->algoliaHelper->waitLastTask($storeId, $indexName, $setReplicasTaskId);
                     if (count($replicasToDelete) > 0) {
                         foreach ($replicasToDelete as $deletedReplica) {
                             $this->algoliaHelper->deleteIndex($deletedReplica);

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1435,16 +1435,23 @@ class ProductHelper extends AbstractEntityHelper
             $newReplicas = $this->decorateReplicasSetting($sortingIndices);
 
             try {
-                $currentSettings = $this->algoliaHelper->getSettings($indexName);
+                $currentSettings = $this->algoliaHelper->getSettings($indexName, $storeId);
                 if (array_key_exists('replicas', $currentSettings)) {
                     $oldReplicas = $currentSettings['replicas'];
                     $replicasToDelete = array_diff($oldReplicas, $newReplicas);
-                    $this->algoliaHelper->setSettings($indexName, ['replicas' => $newReplicas]);
-                    $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
+                    $this->algoliaHelper->setSettings(
+                        $indexName,
+                        ['replicas' => $newReplicas],
+                        false,
+                        false,
+                        '',
+                        $storeId
+                    );
+                    $setReplicasTaskId = $this->algoliaHelper->getLastTaskId($storeId);
                     $this->algoliaHelper->waitLastTask($storeId, $indexName, $setReplicasTaskId);
                     if (count($replicasToDelete) > 0) {
                         foreach ($replicasToDelete as $deletedReplica) {
-                            $this->algoliaHelper->deleteIndex($deletedReplica);
+                            $this->algoliaHelper->deleteIndex($deletedReplica, $storeId);
                         }
                     }
                 }

--- a/Helper/Entity/SuggestionHelper.php
+++ b/Helper/Entity/SuggestionHelper.php
@@ -2,8 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
-use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Framework\App\Cache\Type\Config as ConfigCache;
 use Magento\Framework\DataObject;
@@ -63,11 +63,11 @@ class SuggestionHelper extends AbstractEntityHelper
     public function getObject(Query $suggestion)
     {
         $suggestionObject = [
-            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $suggestion->getData('query_id'),
-            'query'                              => $suggestion->getData('query_text'),
-            'number_of_results'                  => (int) $suggestion->getData('num_results'),
-            'popularity'                         => (int) $suggestion->getData('popularity'),
-            'updated_at'                         => (int) strtotime($suggestion->getData('updated_at')),
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $suggestion->getData('query_id'),
+            'query'                                 => $suggestion->getData('query_text'),
+            'number_of_results'                     => (int) $suggestion->getData('num_results'),
+            'popularity'                            => (int) $suggestion->getData('popularity'),
+            'updated_at'                            => (int) strtotime($suggestion->getData('updated_at')),
         ];
 
         $transport = new DataObject($suggestionObject);

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -85,9 +85,7 @@ class MerchandisingHelper
 
         // Not catching AlgoliaSearchException for disabled query rules on purpose
         // It displays correct error message and navigates user to pricing page
-        $this->algoliaHelper->setStoreId($storeId);
-        $this->algoliaHelper->saveRule($rule, $productsIndexName);
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
+        $this->algoliaHelper->saveRule($rule, $productsIndexName, false, $storeId);
     }
 
     /**
@@ -108,9 +106,7 @@ class MerchandisingHelper
 
         // Not catching AlgoliaSearchException for disabled query rules on purpose
         // It displays correct error message and navigates user to pricing page
-        $this->algoliaHelper->setStoreId($storeId);
-        $this->algoliaHelper->deleteRule($productsIndexName, $ruleId);
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
+        $this->algoliaHelper->deleteRule($productsIndexName, $ruleId, false, $storeId);
     }
 
     /**

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Helper;
 
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 
 class MerchandisingHelper
 {
@@ -57,7 +58,7 @@ class MerchandisingHelper
         ];
 
         $rule = [
-            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $this->getQueryRuleId($entityId, $entityType),
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $this->getQueryRuleId($entityId, $entityType),
             'description' => 'MagentoGeneratedQueryRule',
             'consequence' => [
                 'filterPromotes' => true,
@@ -119,7 +120,7 @@ class MerchandisingHelper
 
         foreach ($positions as $objectID => $position) {
             $transformedPositions[] = [
-                AlgoliaHelper::ALGOLIA_API_OBJECT_ID => (string) $objectID,
+                AlgoliaConnector::ALGOLIA_API_OBJECT_ID => (string) $objectID,
                 'position' => $position,
             ];
         }
@@ -160,7 +161,7 @@ class MerchandisingHelper
                     unset($hit['_highlightResult']);
 
                     $newContext = $this->getQueryRuleId($entityIdTo, $entityType);
-                    $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID] = $newContext;
+                    $hit[AlgoliaConnector::ALGOLIA_API_OBJECT_ID] = $newContext;
                     if (isset($hit['condition']['context']) && $hit['condition']['context'] == $context) {
                         $hit['condition']['context'] = $newContext;
                     }

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -138,7 +138,7 @@ class MerchandisingHelper
     public function copyQueryRules(int $storeId, int $entityIdFrom, int $entityIdTo, string $entityType): void
     {
         $productsIndexName = $this->productHelper->getIndexName($storeId);
-        $client = $this->algoliaHelper->getClient();
+        $client = $this->algoliaHelper->getClient($storeId);
         $context = $this->getQueryRuleId($entityIdFrom, $entityType);
         $queryRulesToSet = [];
 

--- a/Model/IndexMover.php
+++ b/Model/IndexMover.php
@@ -44,9 +44,7 @@ class IndexMover
             return;
         }
 
-        $this->algoliaHelper->setStoreId($storeId);
-        $this->algoliaHelper->moveIndex($tmpIndexName, $indexName);
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
+        $this->algoliaHelper->moveIndex($tmpIndexName, $indexName, $storeId);
     }
 
     /**

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -57,15 +57,13 @@ class IndicesConfigurator
             return;
         }
 
-        $this->algoliaHelper->setStoreId($storeId);
-
         $this->setCategoriesSettings($storeId);
-        $this->algoliaHelper->waitLastTask();
+        $this->algoliaHelper->waitLastTask($storeId);
 
-        /* heck if we want to index CMS pages */
+        /* Check if we want to index CMS pages */
         if ($this->configHelper->isPagesIndexEnabled($storeId)) {
             $this->setPagesSettings($storeId);
-            $this->algoliaHelper->waitLastTask();
+            $this->algoliaHelper->waitLastTask($storeId);
         } else {
             $this->logger->log('CMS Page Indexing is not enabled for the store.');
         }
@@ -73,19 +71,17 @@ class IndicesConfigurator
         //Check if we want to index Query Suggestions
         if ($this->configHelper->isQuerySuggestionsIndexEnabled($storeId)) {
             $this->setQuerySuggestionsSettings($storeId);
-            $this->algoliaHelper->waitLastTask();
+            $this->algoliaHelper->waitLastTask($storeId);
         } else {
             $this->logger->log('Query Suggestions Indexing is not enabled for the store.');
         }
 
         $this->setAdditionalSectionsSettings($storeId);
-        $this->algoliaHelper->waitLastTask();
+        $this->algoliaHelper->waitLastTask($storeId);
 
         $this->setProductsSettings($storeId, $useTmpIndex);
 
         $this->setExtraSettings($storeId, $useTmpIndex);
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
 
         $this->logger->stop($logEventName, true);
     }
@@ -103,7 +99,14 @@ class IndicesConfigurator
         $indexName = $this->categoryHelper->getIndexName($storeId);
         $settings = $this->categoryHelper->getIndexSettings($storeId);
 
-        $this->algoliaHelper->setSettings($indexName, $settings, false, true);
+        $this->algoliaHelper->setSettings(
+            $indexName,
+            $settings,
+            false,
+            true,
+            '',
+            $storeId
+        );
 
         $this->logger->log('Index name: ' . $indexName);
         $this->logger->log('Settings: ' . json_encode($settings));
@@ -123,7 +126,14 @@ class IndicesConfigurator
         $settings = $this->pageHelper->getIndexSettings($storeId);
         $indexName = $this->pageHelper->getIndexName($storeId);
 
-        $this->algoliaHelper->setSettings($indexName, $settings, false, true);
+        $this->algoliaHelper->setSettings(
+            $indexName,
+            $settings,
+            false,
+            true,
+            '',
+            $storeId
+        );
 
         $this->logger->log('Index name: ' . $indexName);
         $this->logger->log('Settings: ' . json_encode($settings));
@@ -143,7 +153,14 @@ class IndicesConfigurator
         $indexName = $this->suggestionHelper->getIndexName($storeId);
         $settings = $this->suggestionHelper->getIndexSettings($storeId);
 
-        $this->algoliaHelper->setSettings($indexName, $settings, false, true);
+        $this->algoliaHelper->setSettings(
+            $indexName,
+            $settings,
+            false,
+            true,
+            '',
+            $storeId
+        );
 
         $this->logger->log('Index name: ' . $indexName);
         $this->logger->log('Settings: ' . json_encode($settings));
@@ -171,7 +188,14 @@ class IndicesConfigurator
 
             $settings = $this->additionalSectionHelper->getIndexSettings($storeId);
 
-            $this->algoliaHelper->setSettings($indexName, $settings);
+            $this->algoliaHelper->setSettings(
+                $indexName,
+                $settings,
+                false,
+                false,
+                '',
+                $storeId
+            );
 
             $this->logger->log('Index name: ' . $indexName);
             $this->logger->log('Settings: ' . json_encode($settings));
@@ -235,15 +259,29 @@ class IndicesConfigurator
 
                     $this->logger->log('Index name: ' . $indexName);
                     $this->logger->log('Extra settings: ' . json_encode($extraSettings));
-                    $this->algoliaHelper->setSettings($indexName, $extraSettings, true);
-                    $this->algoliaHelper->waitLastTask();
+                    $this->algoliaHelper->setSettings(
+                        $indexName,
+                        $extraSettings,
+                        true,
+                        false,
+                        '',
+                        $storeId
+                    );
+                    $this->algoliaHelper->waitLastTask($storeId);
 
                     if ($section === 'products' && $saveToTmpIndicesToo) {
                         $tempIndexName = $indexName . IndexNameFetcher::INDEX_TEMP_SUFFIX;
                         $this->logger->log('Index name: ' . $tempIndexName);
                         $this->logger->log('Extra settings: ' . json_encode($extraSettings));
 
-                        $this->algoliaHelper->setSettings($tempIndexName, $extraSettings, true);
+                        $this->algoliaHelper->setSettings(
+                            $tempIndexName,
+                            $extraSettings,
+                            true,
+                            false,
+                            '',
+                            $storeId
+                        );
                     }
                 }
             } catch (AlgoliaException $e) {

--- a/Service/AbstractIndexBuilder.php
+++ b/Service/AbstractIndexBuilder.php
@@ -82,10 +82,11 @@ abstract class AbstractIndexBuilder
     /**
      * @param $indexName
      * @param $idsToRemove
+     * @param null $storeId
      * @return array|mixed
      * @throws AlgoliaException
      */
-    protected function getIdsToRealRemove($indexName, $idsToRemove)
+    protected function getIdsToRealRemove($indexName, $idsToRemove, $storeId = null)
     {
         if (count($idsToRemove) === 1) {
             return $idsToRemove;
@@ -94,7 +95,7 @@ abstract class AbstractIndexBuilder
         $toRealRemove = [];
         $idsToRemove = array_map('strval', $idsToRemove);
         foreach (array_chunk($idsToRemove, 1000) as $chunk) {
-            $objects = $this->algoliaHelper->getObjects($indexName, $chunk);
+            $objects = $this->algoliaHelper->getObjects($indexName, $chunk, $storeId);
             foreach ($objects['results'] as $object) {
                 if (isset($object[AlgoliaHelper::ALGOLIA_API_OBJECT_ID])) {
                     $toRealRemove[] = $object[AlgoliaHelper::ALGOLIA_API_OBJECT_ID];

--- a/Service/AbstractIndexBuilder.php
+++ b/Service/AbstractIndexBuilder.php
@@ -97,8 +97,8 @@ abstract class AbstractIndexBuilder
         foreach (array_chunk($idsToRemove, 1000) as $chunk) {
             $objects = $this->algoliaHelper->getObjects($indexName, $chunk, $storeId);
             foreach ($objects['results'] as $object) {
-                if (isset($object[AlgoliaHelper::ALGOLIA_API_OBJECT_ID])) {
-                    $toRealRemove[] = $object[AlgoliaHelper::ALGOLIA_API_OBJECT_ID];
+                if (isset($object[AlgoliaConnector::ALGOLIA_API_OBJECT_ID])) {
+                    $toRealRemove[] = $object[AlgoliaConnector::ALGOLIA_API_OBJECT_ID];
                 }
             }
         }

--- a/Service/AbstractIndexBuilder.php
+++ b/Service/AbstractIndexBuilder.php
@@ -70,12 +70,13 @@ abstract class AbstractIndexBuilder
     /**
      * @param array $objects
      * @param string $indexName
+     * @param int|null $storeId
      * @return void
      * @throws \Exception
      */
-    protected function saveObjects(array $objects, string $indexName): void
+    protected function saveObjects(array $objects, string $indexName, int $storeId = null): void
     {
-        $this->algoliaHelper->saveObjects($indexName, $objects, $this->configHelper->isPartialUpdateEnabled());
+        $this->algoliaHelper->saveObjects($indexName, $objects, $this->configHelper->isPartialUpdateEnabled(), $storeId);
     }
 
     /**

--- a/Service/AdditionalSection/IndexBuilder.php
+++ b/Service/AdditionalSection/IndexBuilder.php
@@ -56,8 +56,6 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             return;
         }
 
-        $this->algoliaHelper->setStoreId($storeId);
-
         $additionalSections = $this->configHelper->getAutocompleteSections();
 
         $protectedSections = ['products', 'categories', 'pages', 'suggestions'];
@@ -74,15 +72,20 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             $tempIndexName = $indexName . IndexNameFetcher::INDEX_TEMP_SUFFIX;
 
             foreach (array_chunk($attributeValues, 100) as $chunk) {
-                $this->saveObjects($chunk, $tempIndexName);
+                $this->saveObjects($chunk, $tempIndexName, $storeId);
             }
 
-            $this->algoliaHelper->copyQueryRules($indexName, $tempIndexName);
-            $this->algoliaHelper->moveIndex($tempIndexName, $indexName);
+            $this->algoliaHelper->copyQueryRules($indexName, $tempIndexName, $storeId);
+            $this->algoliaHelper->moveIndex($tempIndexName, $indexName, $storeId);
 
-            $this->algoliaHelper->setSettings($indexName, $this->additionalSectionHelper->getIndexSettings($storeId));
-
-            $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
+            $this->algoliaHelper->setSettings(
+                $indexName,
+                $this->additionalSectionHelper->getIndexSettings($storeId),
+                false,
+                false,
+                '',
+                $storeId
+            );
         }
     }
 }

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -349,12 +349,6 @@ class AlgoliaConnector
         } catch (Exception $e) {
         }
 
-        $removes = ['slaves', 'replicas', 'decompoundedAttributes'];
-
-        if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
-            $removes[] = 'mode';
-        }
-
         if (isset($settings['attributesToIndex'])) {
             $settings['searchableAttributes'] = $settings['attributesToIndex'];
             unset($settings['attributesToIndex']);
@@ -365,7 +359,7 @@ class AlgoliaConnector
             unset($onlineSettings['attributesToIndex']);
         }
 
-        foreach ($removes as $remove) {
+        foreach ($this->getSettingsToRemove($onlineSettings) as $remove) {
             if (isset($onlineSettings[$remove])) {
                 unset($onlineSettings[$remove]);
             }
@@ -376,6 +370,34 @@ class AlgoliaConnector
         }
 
         return $onlineSettings;
+    }
+
+    /**
+     * These settings are to be managed by other processes
+     * @param string[] $onlineSettings
+     * @return string[]
+     */
+    protected function getSettingsToRemove(array $onlineSettings): array
+    {
+        $removals = ['slaves', 'replicas', 'decompoundedAttributes'];
+
+        if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
+            $removals[] = 'mode';
+        }
+
+        return array_merge($removals, $this->getSynonymSettingNames());
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getSynonymSettingNames(): array
+    {
+        return [
+            'synonyms',
+            'altCorrections',
+            'placeholders'
+        ];
     }
 
     /**

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -1,0 +1,962 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Configuration\SearchConfig;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Model\Search\ListIndicesResponse;
+use Algolia\AlgoliaSearch\Model\Search\SettingsResponse;
+use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
+use Exception;
+use Magento\Framework\Message\ManagerInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class AlgoliaConnector
+{
+    /** @var int This value should be configured based on system/full_page_cache/ttl
+     *           (which is by default 86400) and/or the configuration block TTL
+     */
+    protected const ALGOLIA_API_SECURED_KEY_TIMEOUT_SECONDS = 60 * 60 * 24; // TODO: Implement as config
+
+    /** @var SearchClient[] */
+    protected array $clients = [];
+
+    protected ?int $maxRecordSize = null;
+
+    /** @var string[] */
+    protected array $potentiallyLongAttributes = ['description', 'short_description', 'meta_description', 'content'];
+
+    /** @var string[] */
+    protected array $nonCastableAttributes = ['sku', 'name', 'description', 'query'];
+
+    /** @var int  */
+    protected int $storeId = AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE;
+
+    /** @var bool */
+    protected bool $userAgentsAdded = false;
+
+    protected static ?string $lastUsedIndexName;
+
+    protected static ?int $lastTaskId;
+
+    public function __construct(
+        protected ConfigHelper $config,
+        protected ManagerInterface $messageManager,
+        protected ConsoleOutput $consoleOutput,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
+    ) {
+        // Merge non castable attributes set in config
+        $this->nonCastableAttributes = array_merge(
+            $this->nonCastableAttributes,
+            $this->config->getNonCastableAttributes()
+        );
+    }
+
+    /**
+     * @return void
+     * @throws AlgoliaException
+     */
+    protected function createClient(): void
+    {
+        $storeId = $this->getStoreId();
+        if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
+            throw new AlgoliaException('Client initialization could not be performed because Algolia credentials were not provided.');
+        }
+
+        $config = SearchConfig::create(
+            $this->config->getApplicationID($storeId),
+            $this->config->getAPIKey($storeId)
+        );
+        $config->setConnectTimeout($this->config->getConnectionTimeout($storeId));
+        $config->setReadTimeout($this->config->getReadTimeout($storeId));
+        $config->setWriteTimeout($this->config->getWriteTimeout($storeId));
+        $this->clients[$storeId] = SearchClient::createWithConfig($config);
+    }
+
+    /**
+     * @return void
+     * @throws AlgoliaException
+     */
+    protected function addAlgoliaUserAgent(): void
+    {
+        $clientName = $this->getClient()->getClientConfig()?->getClientName();
+
+        if ($clientName) {
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento2 integration', $this->config->getExtensionVersion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'PHP', phpversion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento', $this->config->getMagentoVersion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Edition', $this->config->getMagentoEdition());
+
+            $this->userAgentsAdded = true;
+        }
+    }
+
+    /**
+     * @return SearchClient
+     * @throws AlgoliaException
+     */
+    public function getClient(): SearchClient
+    {
+        if (!isset($this->clients[$this->getStoreId()])) {
+            $this->createClient();
+            if (!$this->userAgentsAdded) {
+                $this->addAlgoliaUserAgent();
+            }
+        }
+
+        return $this->clients[$this->getStoreId()];
+    }
+
+    /**
+     * @return int
+     */
+    public function getStoreId(): int
+    {
+        return $this->storeId;
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function setStoreId(int $storeId): void
+    {
+        $this->storeId = $storeId;
+    }
+
+    /**
+     * @param string $name
+     * @throws AlgoliaException
+     * @deprecated This method has been completely removed from the Algolia PHP connector version 4 and should not be used.
+     */
+    public function getIndex(string $name)
+    {
+        throw new AlgoliaException("This method is no longer supported for PHP client v4!");
+    }
+
+    /**
+     * @return ListIndicesResponse|array<string,mixed>
+     * @throws AlgoliaException
+     */
+    public function listIndexes()
+    {
+        return $this->getClient()->listIndices();
+    }
+
+    /**
+     * @param string $indexName
+     * @param string $q
+     * @param array $params
+     * @return array<string, mixed>
+     * @throws AlgoliaException
+     * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
+     */
+    public function query(string $indexName, string $q, array $params): array
+    {
+        // TODO: Revisit - not compatible with PHP v4
+        // if (isset($params['disjunctiveFacets'])) {
+        //    return $this->searchWithDisjunctiveFaceting($indexName, $q, $params);
+        //}
+
+        $params = array_merge(
+            [
+                AlgoliaHelper::ALGOLIA_API_INDEX_NAME => $indexName,
+                'query' => $q
+            ],
+            $params
+        );
+
+        // TODO: Validate return value for integration tests
+        return $this->getClient()->search([
+            'requests' => [ $params ]
+        ]);
+    }
+
+    /**
+     * @param string $indexName
+     * @param array $objectIds
+     * @return array<string, mixed>
+     * @throws AlgoliaException
+     */
+    public function getObjects(string $indexName, array $objectIds): array
+    {
+        $requests = array_values(
+            array_map(
+                function($id) use ($indexName) {
+                    return [
+                        AlgoliaHelper::ALGOLIA_API_INDEX_NAME => $indexName,
+                        AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $id
+                    ];
+                },
+                $objectIds
+            )
+        );
+
+        return $this->getClient()->getObjects([ 'requests' => $requests ]);
+    }
+
+    /**
+     * @param $indexName
+     * @param $settings
+     * @param bool $forwardToReplicas
+     * @param bool $mergeSettings
+     * @param string $mergeSettingsFrom
+     *
+     * @throws AlgoliaException
+     */
+    public function setSettings(
+        $indexName,
+        $settings,
+        bool $forwardToReplicas = false,
+        bool $mergeSettings = false,
+        string $mergeSettingsFrom = ''
+    ) {
+        if ($mergeSettings === true) {
+            $settings = $this->mergeSettings($indexName, $settings, $mergeSettingsFrom);
+        }
+
+        $res = $this->getClient()->setSettings($indexName, $settings, $forwardToReplicas);
+
+        self::setLastOperationInfo($indexName, $res);
+    }
+
+    /**
+     * @param string $indexName
+     * @param array $requests
+     * @return array<string, mixed>
+     * @throws AlgoliaException
+     */
+    protected function performBatchOperation(string $indexName, array $requests): array
+    {
+        $response = $this->getClient()->batch($indexName, [ 'requests' => $requests ] );
+
+        self::setLastOperationInfo($indexName, $response);
+
+        return $response;
+    }
+
+    /**
+     * @param string $indexName
+     * @return void
+     * @throws AlgoliaException
+     */
+    public function deleteIndex(string $indexName): void
+    {
+        $res = $this->getClient()->deleteIndex($indexName);
+
+        self::setLastOperationInfo($indexName, $res);
+    }
+
+    /**
+     * @param array $ids
+     * @param string $indexName
+     * @return void
+     * @throws AlgoliaException
+     */
+    public function deleteObjects(array $ids, string $indexName): void
+    {
+        $requests = array_values(
+            array_map(
+                function ($id) {
+                    return [
+                        'action' => 'deleteObject',
+                        'body'   => [
+                            AlgoliaHelper::ALGOLIA_API_OBJECT_ID => $id
+                        ]
+                    ];
+                },
+                $ids
+            )
+        );
+
+        $this->performBatchOperation($indexName, $requests);
+    }
+
+    /**
+     * @param string $fromIndexName
+     * @param string $toIndexName
+     * @return void
+     * @throws AlgoliaException
+     */
+    public function moveIndex(string $fromIndexName, string $toIndexName): void
+    {
+        $response = $this->getClient()->operationIndex(
+            $fromIndexName,
+            [
+                'operation'   => 'move',
+                'destination' => $toIndexName
+            ]
+        );
+        self::setLastOperationInfo($toIndexName, $response);
+    }
+
+    /**
+     * @param string $key
+     * @param array $params
+     * @return string
+     * @throws AlgoliaException
+     */
+    public function generateSearchSecuredApiKey(string $key, array $params = []): string
+    {
+        // This is to handle a difference between API client v1 and v2.
+        if (! isset($params['tagFilters'])) {
+            $params['tagFilters'] = '';
+        }
+
+        $params['validUntil'] = time() + self::ALGOLIA_API_SECURED_KEY_TIMEOUT_SECONDS;
+
+        return $this->getClient()->generateSecuredApiKey($key, $params);
+    }
+
+    /**
+     * @param string $indexName
+     * @return array<string, mixed>
+     * @throws AlgoliaException
+     */
+    public function getSettings(string $indexName): array
+    {
+        try {
+            return $this->getClient()->getSettings($indexName);
+        } catch (Exception $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+            return [];
+        }
+    }
+
+    /**
+     * @param $indexName
+     * @param $settings
+     * @param string $mergeSettingsFrom
+     * @return SettingsResponse|array
+     */
+    public function mergeSettings($indexName, $settings, string $mergeSettingsFrom = ''): SettingsResponse|array
+    {
+        $onlineSettings = [];
+
+        try {
+            $sourceIndex = $indexName;
+            if ($mergeSettingsFrom !== '') {
+                $sourceIndex = $mergeSettingsFrom;
+            }
+
+            $onlineSettings = $this->getClient()->getSettings($sourceIndex);
+        } catch (Exception $e) {
+        }
+
+        $removes = ['slaves', 'replicas', 'decompoundedAttributes'];
+
+        if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
+            $removes[] = 'mode';
+        }
+
+        if (isset($settings['attributesToIndex'])) {
+            $settings['searchableAttributes'] = $settings['attributesToIndex'];
+            unset($settings['attributesToIndex']);
+        }
+
+        if (isset($onlineSettings['attributesToIndex'])) {
+            $onlineSettings['searchableAttributes'] = $onlineSettings['attributesToIndex'];
+            unset($onlineSettings['attributesToIndex']);
+        }
+
+        foreach ($removes as $remove) {
+            if (isset($onlineSettings[$remove])) {
+                unset($onlineSettings[$remove]);
+            }
+        }
+
+        foreach ($settings as $key => $value) {
+            $onlineSettings[$key] = $value;
+        }
+
+        return $onlineSettings;
+    }
+
+    /**
+     * Legacy function signature to add objects to Algolia
+     * @param array $objects
+     * @param string $indexName
+     * @return void
+     * @throws Exception
+     * @deprecated Do not use. This method has been replaced by saveObjects and may be removed in the future.
+     */
+    public function addObjects(array $objects, string $indexName): void {
+        $this->saveObjects($indexName, $objects, $this->config->isPartialUpdateEnabled());
+    }
+
+    /**
+     * Save objects to index (upserts records)
+     * @param string $indexName
+     * @param array $objects
+     * @param bool $isPartialUpdate
+     * @return void
+     * @throws Exception
+     */
+    public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false): void
+    {
+        $this->prepareRecords($objects, $indexName);
+
+        $action = $isPartialUpdate ? 'partialUpdateObject' : 'addObject';
+
+        $requests = array_values(
+            array_map(
+                function ($object) use ($action) {
+                    return [
+                        'action' => $action,
+                        'body'   => $object
+                    ];
+                },
+                $objects
+            )
+        );
+
+        $this->performBatchOperation($indexName, $requests);
+    }
+
+    /**
+     * @param string $indexName
+     * @param array $response
+     * @return void
+     */
+    protected static function setLastOperationInfo(string $indexName, array $response): void
+    {
+        self::$lastUsedIndexName = $indexName;
+        self::$lastTaskId = $response[AlgoliaHelper::ALGOLIA_API_TASK_ID] ?? null;
+    }
+
+    /**
+     * @param array<string, mixed> $rule
+     * @param string $indexName
+     * @param bool $forwardToReplicas
+     * @return void
+     * @throws AlgoliaException
+     */
+    public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false): void
+    {
+        $res = $this->getClient()->saveRule(
+            $indexName,
+            $rule[AlgoliaHelper::ALGOLIA_API_OBJECT_ID],
+            $rule,
+            $forwardToReplicas
+        );
+
+        self::setLastOperationInfo($indexName, $res);
+    }
+
+    /**
+     * @param string $indexName
+     * @param array $rules
+     * @param bool $forwardToReplicas
+     * @return void
+     */
+    public function saveRules(string $indexName, array $rules, bool $forwardToReplicas = false): void
+    {
+        $res = $this->getClient()->saveRules($indexName, $rules, $forwardToReplicas);
+
+        self::setLastOperationInfo($indexName, $res);
+    }
+
+
+    /**
+     * @param string $indexName
+     * @param string $objectID
+     * @param bool $forwardToReplicas
+     * @return void
+     * @throws AlgoliaException
+     */
+    public function deleteRule(string $indexName, string $objectID, bool $forwardToReplicas = false): void
+    {
+        $res = $this->getClient()->deleteRule($indexName, $objectID, $forwardToReplicas);
+
+        self::setLastOperationInfo($indexName, $res);
+    }
+
+    /**
+     * @param $indexName
+     * @param $synonyms
+     * @return void
+     * @throws AlgoliaException
+     * @deprecated Managing synonyms from Magento is no longer supported. Use the Algolia dashboard instead.
+     */
+    public function setSynonyms($indexName, $synonyms): void
+    {
+        throw new AlgoliaException("This method is no longer supported for PHP client v4!");
+    }
+
+    /**
+     * @param string $fromIndexName
+     * @param string $toIndexName
+     * @return void
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     */
+    public function copySynonyms(string $fromIndexName, string $toIndexName): void
+    {
+        $response = $this->getClient()->operationIndex(
+            $fromIndexName,
+            [
+                'operation'   => 'copy',
+                'destination' => $toIndexName,
+                'scope'       => ['synonyms']
+            ]
+        );
+        self::setLastOperationInfo($fromIndexName, $response);
+    }
+
+    /**
+     * @param string $fromIndexName
+     * @param string $toIndexName
+     * @return void
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     */
+    public function copyQueryRules(string $fromIndexName, string $toIndexName): void
+    {
+        $response = $this->getClient()->operationIndex(
+            $fromIndexName,
+            [
+                'operation'   => 'copy',
+                'destination' => $toIndexName,
+                'scope'       => ['rules']
+            ]
+        );
+        self::setLastOperationInfo($fromIndexName, $response);
+    }
+
+    /**
+     * @param string $indexName
+     * @param array|null $searchRulesParams
+     *
+     * @return array
+     *
+     * @throws AlgoliaException
+     */
+    public function searchRules(string $indexName, array$searchRulesParams = null)
+    {
+        return $this->getClient()->searchRules($indexName, $searchRulesParams);
+    }
+
+    /**
+     * @param string $indexName
+     * @return void
+     * @throws AlgoliaException
+     */
+    public function clearIndex(string $indexName): void
+    {
+        $res = $this->getClient()->clearObjects($indexName);
+
+        self::setLastOperationInfo($indexName, $res);
+    }
+
+    /**
+     * @param string|null $lastUsedIndexName
+     * @param int|null $lastTaskId
+     * @return void
+     * @throws ExceededRetriesException|AlgoliaException
+     */
+    public function waitLastTask(string $lastUsedIndexName = null, int $lastTaskId = null): void
+    {
+        if ($lastUsedIndexName === null && isset(self::$lastUsedIndexName)) {
+            $lastUsedIndexName = self::$lastUsedIndexName;
+        }
+
+        if ($lastTaskId === null && isset(self::$lastTaskId)) {
+            $lastTaskId = self::$lastTaskId;
+        }
+
+        if (!$lastUsedIndexName || !$lastTaskId) {
+            return;
+        }
+
+        $this->getClient()->waitForTask($lastUsedIndexName, $lastTaskId);
+    }
+
+    /**
+     * @param array $objects
+     * @param string $indexName
+     * @return void
+     * @throws Exception
+     */
+    protected function prepareRecords(array &$objects, string $indexName): void
+    {
+        $currentCET = strtotime('now');
+
+        $modifiedIds = [];
+        foreach ($objects as $key => &$object) {
+            $object['algoliaLastUpdateAtCET'] = $currentCET;
+            // Convert created_at to UTC timestamp
+            if (isset($object['created_at'])) {
+                $object['created_at'] = strtotime($object['created_at']);
+            }
+
+            $previousObject = $object;
+
+            $object = $this->handleTooBigRecord($object);
+
+            if ($object === false) {
+                $longestAttribute = $this->getLongestAttribute($previousObject);
+                $modifiedIds[] = $indexName . '
+                    - ID ' . $previousObject[AlgoliaHelper::ALGOLIA_API_OBJECT_ID] . ' - skipped - longest attribute: ' . $longestAttribute;
+
+                unset($objects[$key]);
+
+                continue;
+            } elseif ($previousObject !== $object) {
+                $modifiedIds[] = $indexName . ' - ID ' . $previousObject[AlgoliaHelper::ALGOLIA_API_OBJECT_ID] . ' - truncated';
+            }
+
+            $object = $this->castRecord($object);
+        }
+
+        if ($modifiedIds && $modifiedIds !== []) {
+            $separator = php_sapi_name() === 'cli' ? "\n" : '<br>';
+
+            $errorMessage = 'Algolia reindexing:
+                You have some records which are too big to be indexed in Algolia.
+                They have either been truncated
+                (removed attributes: ' . implode(', ', $this->potentiallyLongAttributes) . ')
+                or skipped completely: ' . $separator . implode($separator, $modifiedIds);
+
+            if (php_sapi_name() === 'cli') {
+                $this->consoleOutput->writeln($errorMessage);
+
+                return;
+            }
+
+            $this->messageManager->addErrorMessage($errorMessage);
+        }
+    }
+
+    /**
+     * @return int
+     */
+    protected function getMaxRecordSize(): int
+    {
+        if (!$this->maxRecordSize) {
+            $this->maxRecordSize = $this->config->getMaxRecordSizeLimit();
+        }
+
+        return $this->maxRecordSize;
+    }
+
+    /**
+     * @param $object
+     * @return false|mixed
+     */
+    protected function handleTooBigRecord($object): mixed
+    {
+        $size = $this->calculateObjectSize($object);
+
+        if ($size > $this->getMaxRecordSize()) {
+            foreach ($this->potentiallyLongAttributes as $attribute) {
+                if (isset($object[$attribute])) {
+                    unset($object[$attribute]);
+
+                    // Recalculate size and check if it fits in Algolia index
+                    $size = $this->calculateObjectSize($object);
+                    if ($size < $this->getMaxRecordSize()) {
+                        return $object;
+                    }
+                }
+            }
+
+            // If the SKU attribute is the longest, start popping off SKU's to make it fit
+            // This has the downside that some products cannot be found on some of its childrens' SKU's
+            // But at least the config product can be indexed
+            // Always keep the original SKU though
+            if ($this->getLongestAttribute($object) === 'sku' && is_array($object['sku'])) {
+                foreach ($object['sku'] as $sku) {
+                    if (count($object['sku']) === 1) {
+                        break;
+                    }
+
+                    array_pop($object['sku']);
+
+                    $size = $this->calculateObjectSize($object);
+                    if ($size < $this->getMaxRecordSize()) {
+                        return $object;
+                    }
+                }
+            }
+
+            // Recalculate size, if it still does not fit, let's skip it
+            $size = $this->calculateObjectSize($object);
+            if ($size > $this->getMaxRecordSize()) {
+                $object = false;
+            }
+        }
+
+        return $object;
+    }
+
+    /**
+     * @param $object
+     * @return int|string
+     */
+    protected function getLongestAttribute($object): int|string
+    {
+        $maxLength = 0;
+        $longestAttribute = '';
+
+        foreach ($object as $attribute => $value) {
+            $attributeLength = mb_strlen(json_encode($value));
+
+            if ($attributeLength > $maxLength) {
+                $longestAttribute = $attribute;
+
+                $maxLength = $attributeLength;
+            }
+        }
+
+        return $longestAttribute;
+    }
+
+    /**
+     * @param $productData
+     * @return void
+     */
+    public function castProductObject(&$productData): void
+    {
+        foreach ($productData as $key => &$data) {
+            if (in_array($key, $this->nonCastableAttributes, true) === true) {
+                continue;
+            }
+
+            $data = $this->castAttribute($data);
+
+            if (is_array($data) === false) {
+                if ($data != null) {
+                    $data = explode('|', $data);
+                    if (count($data) === 1) {
+                        $data = $data[0];
+                        $data = $this->castAttribute($data);
+                    } else {
+                        foreach ($data as &$element) {
+                            $element = $this->castAttribute($element);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $object
+     * @return mixed
+     */
+    protected function castRecord($object): mixed
+    {
+        foreach ($object as $key => &$value) {
+            if (in_array($key, $this->nonCastableAttributes, true) === true) {
+                continue;
+            }
+
+            $value = $this->castAttribute($value);
+        }
+
+        return $object;
+    }
+
+    /**
+     * This method serves to prevent parse of float values that exceed PHP_FLOAT_MAX as INF will break
+     * JSON encoding.
+     *
+     * To further customize the handling of values that may be incorrectly interpreted as numeric by
+     * PHP you can implement an "after" plugin on this method.
+     *
+     * @param $value - what PHP thinks is a floating point number
+     * @return bool
+     */
+    public function isValidFloat(string $value) : bool {
+        return floatval($value) !== INF;
+    }
+
+    /**
+     * @param $value
+     * @return mixed
+     */
+    protected function castAttribute($value): mixed
+    {
+        if (is_numeric($value) && floatval($value) === floatval((int) $value)) {
+            return (int) $value;
+        }
+
+        if (is_numeric($value) && $this->isValidFloat($value)) {
+            return floatval($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastIndexName(): string
+    {
+        return self::$lastUsedIndexName;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastTaskId(): int
+    {
+        return self::$lastTaskId;
+    }
+
+    /**
+     * @param $object
+     *
+     * @return int
+     */
+    protected function calculateObjectSize($object): int
+    {
+        return mb_strlen(json_encode($object));
+    }
+
+    /**
+     * @param $indexName
+     * @param $q
+     * @param $params
+     * @return mixed|null
+     * @throws AlgoliaException
+     * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
+     */
+    protected function searchWithDisjunctiveFaceting($indexName, $q, $params): mixed
+    {
+        throw new AlgoliaException("This function is not currently supported on PHP connector v4");
+
+        // TODO: Revisit this implementation for backend render
+        if (! is_array($params['disjunctiveFacets']) || count($params['disjunctiveFacets']) <= 0) {
+            throw new \InvalidArgumentException('disjunctiveFacets needs to be an non empty array');
+        }
+
+        if (isset($params['filters'])) {
+            throw new \InvalidArgumentException('You can not use disjunctive faceting and the filters parameter');
+        }
+
+        /**
+         * Prepare queries
+         */
+        // Get the list of disjunctive queries to do: 1 per disjunctive facet
+        $disjunctiveQueries = $this->getDisjunctiveQueries($params);
+
+        // Format disjunctive queries for multipleQueries call
+        foreach ($disjunctiveQueries as &$disjunctiveQuery) {
+            $disjunctiveQuery[AlgoliaHelper::ALGOLIA_API_INDEX_NAME] = $indexName;
+            $disjunctiveQuery['query'] = $q;
+            unset($disjunctiveQuery['disjunctiveFacets']);
+        }
+
+        // Merge facets and disjunctiveFacets for the hits query
+        $facets = $params['facets'] ?? [];
+        $facets = array_merge($facets, $params['disjunctiveFacets']);
+        unset($params['disjunctiveFacets']);
+
+        // format the hits query for multipleQueries call
+        $params['query'] = $q;
+        $params[AlgoliaHelper::ALGOLIA_API_INDEX_NAME] = $indexName;
+        $params['facets'] = $facets;
+
+        // Put the hit query first
+        array_unshift($disjunctiveQueries, $params);
+
+        /**
+         * Do all queries in one call
+         */
+        $results = $this->getClient()->multipleQueries(array_values($disjunctiveQueries));
+        $results = $results['results'];
+
+        /**
+         * Merge facets from disjunctive queries with facets from the hits query
+         */
+        // The first query is the hits query that the one we'll return to the user
+        $queryResults = array_shift($results);
+
+        // To be able to add facets from disjunctive query we create 'facets' key in case we only have disjunctive facets
+        if (false === isset($queryResults['facets'])) {
+            $queryResults['facets'] =[];
+        }
+
+        foreach ($results as $disjunctiveResults) {
+            if (isset($disjunctiveResults['facets'])) {
+                foreach ($disjunctiveResults['facets'] as $facetName => $facetValues) {
+                    $queryResults['facets'][$facetName] = $facetValues;
+                }
+            }
+        }
+
+        return $queryResults;
+    }
+
+    /**
+     * @param $queryParams
+     * @return array
+     */
+    protected function getDisjunctiveQueries($queryParams): array
+    {
+        $queriesParams = [];
+
+        foreach ($queryParams['disjunctiveFacets'] as $facetName) {
+            $params = $queryParams;
+            $params['facets'] = [$facetName];
+            $facetFilters = isset($params['facetFilters']) ? $params['facetFilters'] : [];
+            $numericFilters = isset($params['numericFilters']) ? $params['numericFilters'] : [];
+
+            $additionalParams = [
+                'hitsPerPage' => 1,
+                'page' => 0,
+                'attributesToRetrieve' => [],
+                'attributesToHighlight' => [],
+                'attributesToSnippet' => [],
+                'analytics' => false,
+            ];
+
+            $additionalParams['facetFilters'] =
+                $this->getAlgoliaFiltersArrayWithoutCurrentRefinement($facetFilters, $facetName . ':');
+            $additionalParams['numericFilters'] =
+                $this->getAlgoliaFiltersArrayWithoutCurrentRefinement($numericFilters, $facetName);
+
+            $queriesParams[$facetName] = array_merge($params, $additionalParams);
+        }
+
+        return $queriesParams;
+    }
+
+    /**
+     * @param $filters
+     * @param $needle
+     * @return array
+     */
+    protected function getAlgoliaFiltersArrayWithoutCurrentRefinement($filters, $needle): array
+    {
+        // iterate on each filters which can be string or array and filter out every refinement matching the needle
+        for ($i = 0; $i < count($filters); $i++) {
+            if (is_array($filters[$i])) {
+                foreach ($filters[$i] as $filter) {
+                    if (mb_substr($filter, 0, mb_strlen($needle)) === $needle) {
+                        unset($filters[$i]);
+                        $filters = array_values($filters);
+                        $i--;
+
+                        break;
+                    }
+                }
+            } else {
+                if (mb_substr($filters[$i], 0, mb_strlen($needle)) === $needle) {
+                    unset($filters[$i]);
+                    $filters = array_values($filters);
+                    $i--;
+                }
+            }
+        }
+
+        return $filters;
+    }
+}

--- a/Service/Category/IndexBuilder.php
+++ b/Service/Category/IndexBuilder.php
@@ -150,7 +150,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         }
 
         if (!empty($indexData['toRemove'])) {
-            $toRealRemove = $this->getIdsToRealRemove($indexName, $indexData['toRemove']);
+            $toRealRemove = $this->getIdsToRealRemove($indexName, $indexData['toRemove'], $storeId);
             if (!empty($toRealRemove)) {
                 $this->logger->start('REMOVE FROM ALGOLIA');
                 $this->algoliaHelper->deleteObjects($toRealRemove, $indexName, $storeId);

--- a/Service/Category/IndexBuilder.php
+++ b/Service/Category/IndexBuilder.php
@@ -138,14 +138,13 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         if ($this->isIndexingEnabled($storeId) === false) {
             return;
         }
-        $this->algoliaHelper->setStoreId($storeId);
         $collection->setCurPage($page)->setPageSize($pageSize);
         $collection->load();
         $indexName = $this->categoryHelper->getIndexName($storeId);
         $indexData = $this->getCategoryRecords($storeId, $collection, $categoryIds);
         if (!empty($indexData['toIndex'])) {
             $this->logger->start('ADD/UPDATE TO ALGOLIA');
-            $this->saveObjects($indexData['toIndex'], $indexName);
+            $this->saveObjects($indexData['toIndex'], $indexName, $storeId);
             $this->logger->log('Product IDs: ' . implode(', ', array_keys($indexData['toIndex'])));
             $this->logger->stop('ADD/UPDATE TO ALGOLIA');
         }
@@ -154,7 +153,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             $toRealRemove = $this->getIdsToRealRemove($indexName, $indexData['toRemove']);
             if (!empty($toRealRemove)) {
                 $this->logger->start('REMOVE FROM ALGOLIA');
-                $this->algoliaHelper->deleteObjects($toRealRemove, $indexName);
+                $this->algoliaHelper->deleteObjects($toRealRemove, $indexName, $storeId);
                 $this->logger->log('Category IDs: ' . implode(', ', $toRealRemove));
                 $this->logger->stop('REMOVE FROM ALGOLIA');
             }
@@ -163,7 +162,6 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         $collection->walk('clearInstance');
         $collection->clear();
         unset($collection);
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**

--- a/Service/Page/IndexBuilder.php
+++ b/Service/Page/IndexBuilder.php
@@ -61,8 +61,6 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             return;
         }
 
-        $this->algoliaHelper->setStoreId($storeId);
-
         $indexName = $this->pageHelper->getIndexName($storeId);
 
         $this->startEmulation($storeId);
@@ -80,7 +78,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
 
             foreach (array_chunk($pagesToIndex, 100) as $chunk) {
                 try {
-                    $this->saveObjects($chunk, $toIndexName);
+                    $this->saveObjects($chunk, $toIndexName, $storeId);
                 } catch (\Exception $e) {
                     $this->logger->log($e->getMessage());
                     continue;
@@ -92,7 +90,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             $pagesToRemove = $pages['toRemove'];
             foreach (array_chunk($pagesToRemove, 100) as $chunk) {
                 try {
-                    $this->algoliaHelper->deleteObjects($chunk, $indexName);
+                    $this->algoliaHelper->deleteObjects($chunk, $indexName, $storeId);
                 } catch (\Exception $e) {
                     $this->logger->log($e->getMessage());
                     continue;
@@ -102,10 +100,16 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
 
         if ($isFullReindex) {
             $tempIndexName = $this->pageHelper->getTempIndexName($storeId);
-            $this->algoliaHelper->copyQueryRules($indexName, $tempIndexName);
-            $this->algoliaHelper->moveIndex($tempIndexName, $indexName);
+            $this->algoliaHelper->copyQueryRules($indexName, $tempIndexName, $storeId);
+            $this->algoliaHelper->moveIndex($tempIndexName, $indexName, $storeId);
         }
-        $this->algoliaHelper->setSettings($indexName, $this->pageHelper->getIndexSettings($storeId));
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
+        $this->algoliaHelper->setSettings(
+            $indexName,
+            $this->pageHelper->getIndexSettings($storeId),
+            false,
+            false,
+            '',
+            $storeId
+        );
     }
 }

--- a/Service/Product/BackendSearch.php
+++ b/Service/Product/BackendSearch.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 class BackendSearch
@@ -44,7 +45,7 @@ class BackendSearch
 
         $params = [
             'hitsPerPage'            => $numberOfResults, // retrieve all the hits (hard limit is 1000)
-            'attributesToRetrieve'   => AlgoliaHelper::ALGOLIA_API_OBJECT_ID,
+            'attributesToRetrieve'   => AlgoliaConnector::ALGOLIA_API_OBJECT_ID,
             'attributesToHighlight'  => '',
             'attributesToSnippet'    => '',
             'numericFilters'         => ['visibility_search=1'],
@@ -64,7 +65,7 @@ class BackendSearch
         $data = [];
 
         foreach ($answer['hits'] as $i => $hit) {
-            $productId = $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID];
+            $productId = $hit[AlgoliaConnector::ALGOLIA_API_OBJECT_ID];
 
             if ($productId) {
                 $data[$productId] = [

--- a/Service/Product/BackendSearch.php
+++ b/Service/Product/BackendSearch.php
@@ -58,7 +58,7 @@ class BackendSearch
             $params = array_merge($params, $searchParams);
         }
 
-        $response = $this->algoliaHelper->query($indexName, $query, $params);
+        $response = $this->algoliaHelper->query($indexName, $query, $params, $storeId);
         $answer = reset($response['results']);
 
         $data = [];

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -11,6 +11,7 @@ use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\ProductDataArray;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AbstractIndexBuilder;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\App\Config\ScopeCodeResolver;
 use Magento\Framework\App\ResourceConnection;
@@ -164,11 +165,11 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         $counter = 0;
         $browseOptions = [
             'query'                => '',
-            'attributesToRetrieve' => [AlgoliaHelper::ALGOLIA_API_OBJECT_ID],
+            'attributesToRetrieve' => [AlgoliaConnector::ALGOLIA_API_OBJECT_ID],
         ];
         $hits = $client->browseObjects($indexName, $browseOptions);
         foreach ($hits as $hit) {
-            $objectIds[] = $hit[AlgoliaHelper::ALGOLIA_API_OBJECT_ID];
+            $objectIds[] = $hit[AlgoliaConnector::ALGOLIA_API_OBJECT_ID];
             $counter++;
             if ($counter === 1000) {
                 $this->deleteInactiveIds($storeId, $objectIds, $indexName);

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -252,7 +252,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         }
 
         if (!empty($indexData['toRemove'])) {
-            $toRealRemove = $this->getIdsToRealRemove($indexName, $indexData['toRemove']);
+            $toRealRemove = $this->getIdsToRealRemove($indexName, $indexData['toRemove'], $storeId);
             if (!empty($toRealRemove)) {
                 $this->logger->start('REMOVE FROM ALGOLIA');
                 $this->algoliaHelper->deleteObjects($toRealRemove, $indexName, $storeId);

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -85,7 +85,7 @@ class ReplicaManager implements ReplicaManagerInterface
             case ReplicaState::REPLICA_STATE_UNKNOWN:
             default:
                 $primaryIndexName = $this->indexNameFetcher->getProductIndexName($storeId);
-                $old = $this->getMagentoReplicaConfigurationFromAlgolia($primaryIndexName);
+                $old = $this->getMagentoReplicaConfigurationFromAlgolia($primaryIndexName, $storeId);
                 $new = $this->sortingTransformer->transformSortingIndicesToReplicaSetting(
                     $this->sortingTransformer->getSortingIndices($storeId, null, null, true)
                 );
@@ -98,15 +98,16 @@ class ReplicaManager implements ReplicaManagerInterface
 
     /**
      * @param $primaryIndexName
+     * @param int|null $storeId
      * @param bool $refreshCache
      * @return string[]
      * @throws LocalizedException
      */
-    protected function getReplicaConfigurationFromAlgolia($primaryIndexName, bool $refreshCache = false): array
+    protected function getReplicaConfigurationFromAlgolia($primaryIndexName, int $storeId = null, bool $refreshCache = false): array
     {
         if ($refreshCache || !isset($this->_algoliaReplicaConfig[$primaryIndexName])) {
             try {
-                $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName);
+                $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName, $storeId);
                 $this->_algoliaReplicaConfig[$primaryIndexName] = array_key_exists(self::ALGOLIA_SETTINGS_KEY_REPLICAS, $currentSettings)
                     ? $currentSettings[self::ALGOLIA_SETTINGS_KEY_REPLICAS]
                     : [];
@@ -133,14 +134,19 @@ class ReplicaManager implements ReplicaManagerInterface
      * relevant to the Magento integration
      *
      * @param string $primaryIndexName
+     * @param int|null $storeId
      * @param bool $refreshCache
      * @return string[] Array of replica index names
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    protected function getMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName, bool $refreshCache = false): array
+    protected function getMagentoReplicaConfigurationFromAlgolia(
+        string $primaryIndexName,
+        int $storeId = null,
+        bool $refreshCache = false
+    ): array
     {
-        $algoliaReplicas = $this->getReplicaConfigurationFromAlgolia($primaryIndexName, $refreshCache);
+        $algoliaReplicas = $this->getReplicaConfigurationFromAlgolia($primaryIndexName, $storeId, $refreshCache);
         $magentoReplicas = $this->getMagentoReplicaSettings($primaryIndexName, $algoliaReplicas);
         return array_values(array_intersect($magentoReplicas, $algoliaReplicas));
     }
@@ -179,12 +185,14 @@ class ReplicaManager implements ReplicaManagerInterface
 
     /**
      * @param string $primaryIndexName
+     * @param int|null $storeId
      * @return array
      * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
-    protected function getNonMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName): array
+    protected function getNonMagentoReplicaConfigurationFromAlgolia(string $primaryIndexName, int $storeId = null): array
     {
-        $algoliaReplicas = $this->getReplicaConfigurationFromAlgolia($primaryIndexName);
+        $algoliaReplicas = $this->getReplicaConfigurationFromAlgolia($primaryIndexName, $storeId);
         $magentoReplicas = $this->getMagentoReplicaSettings($primaryIndexName, $algoliaReplicas);
         return array_diff($algoliaReplicas, $magentoReplicas);
     }
@@ -243,8 +251,8 @@ class ReplicaManager implements ReplicaManagerInterface
         $indexName = $this->indexNameFetcher->getProductIndexName($storeId);
         $sortingIndices = $this->sortingTransformer->getSortingIndices($storeId);
         $newMagentoReplicasSetting = $this->sortingTransformer->transformSortingIndicesToReplicaSetting($sortingIndices);
-        $oldMagentoReplicasSetting = $this->getMagentoReplicaConfigurationFromAlgolia($indexName, true);
-        $nonMagentoReplicasSetting = $this->getNonMagentoReplicaConfigurationFromAlgolia($indexName);
+        $oldMagentoReplicasSetting = $this->getMagentoReplicaConfigurationFromAlgolia($indexName, $storeId, true);
+        $nonMagentoReplicasSetting = $this->getNonMagentoReplicaConfigurationFromAlgolia($indexName, $storeId);
         $oldMagentoReplicaIndices = $this->getBareIndexNamesFromReplicaSetting($oldMagentoReplicasSetting);
         $newMagentoReplicaIndices = $this->getBareIndexNamesFromReplicaSetting($newMagentoReplicasSetting);
 
@@ -255,7 +263,11 @@ class ReplicaManager implements ReplicaManagerInterface
 
         $this->algoliaHelper->setSettings(
             $indexName,
-            [self::ALGOLIA_SETTINGS_KEY_REPLICAS => array_merge($newMagentoReplicasSetting, $nonMagentoReplicasSetting)]
+            [self::ALGOLIA_SETTINGS_KEY_REPLICAS => array_merge($newMagentoReplicasSetting, $nonMagentoReplicasSetting)],
+            false,
+            false,
+            '',
+            $storeId
         );
         $setReplicasTaskId = $this->algoliaHelper->getLastTaskId($storeId);
         $this->algoliaHelper->waitLastTask($storeId, $indexName, $setReplicasTaskId);
@@ -440,10 +452,18 @@ class ReplicaManager implements ReplicaManagerInterface
     /**
      * @throws AlgoliaException
      */
-    protected function clearReplicasSettingInAlgolia(string $primaryIndexName): void
+    protected function clearReplicasSettingInAlgolia(string $primaryIndexName, int $storeId): void
     {
-        $this->algoliaHelper->setSettings($primaryIndexName, [ self::ALGOLIA_SETTINGS_KEY_REPLICAS => []]);
-        $this->algoliaHelper->waitLastTask(null, $primaryIndexName);
+        $this->algoliaHelper->setSettings(
+            $primaryIndexName,
+            [ self::ALGOLIA_SETTINGS_KEY_REPLICAS => []],
+            false,
+            false,
+            '',
+            $storeId
+        )
+        ;
+        $this->algoliaHelper->waitLastTask($storeId, $primaryIndexName);
     }
 
     /**
@@ -456,7 +476,7 @@ class ReplicaManager implements ReplicaManagerInterface
         } else {
             $primaryIndexName = $this->indexNameFetcher->getProductIndexName($storeId);
             $replicasToDelete = $this->getMagentoReplicaIndicesFromAlgolia($primaryIndexName);
-            $this->clearReplicasSettingInAlgolia($primaryIndexName);
+            $this->clearReplicasSettingInAlgolia($primaryIndexName, $storeId);
         }
 
         $this->deleteIndices($replicasToDelete);
@@ -469,9 +489,9 @@ class ReplicaManager implements ReplicaManagerInterface
     /**
      * @throws LocalizedException
      */
-    protected function getMagentoReplicaIndicesFromAlgolia(string $primaryIndexName): array
+    protected function getMagentoReplicaIndicesFromAlgolia(string $primaryIndexName, $storeId = null): array
     {
-        return $this->getBareIndexNamesFromReplicaSetting($this->getMagentoReplicaConfigurationFromAlgolia($primaryIndexName));
+        return $this->getBareIndexNamesFromReplicaSetting($this->getMagentoReplicaConfigurationFromAlgolia($primaryIndexName, $storeId));
     }
 
     /**
@@ -483,7 +503,7 @@ class ReplicaManager implements ReplicaManagerInterface
         if (!isset($this->_unusedReplicaIndices[$storeId])) {
             $currentReplicas = $this->getMagentoReplicaIndicesFromAlgolia($primaryIndexName);
             $unusedReplicas = [];
-            $allIndices = $this->algoliaHelper->listIndexes();
+            $allIndices = $this->algoliaHelper->listIndexes($storeId);
 
             foreach ($allIndices['items'] as $indexInfo) {
                 $indexName = $indexInfo['name'];

--- a/Service/Suggestion/IndexBuilder.php
+++ b/Service/Suggestion/IndexBuilder.php
@@ -99,7 +99,6 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             return;
         }
 
-        $this->algoliaHelper->setStoreId($storeId);
         $collection = clone $collectionDefault;
         $collection->setCurPage($page)->setPageSize($pageSize);
         $collection->load();
@@ -115,13 +114,12 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             }
         }
         if (count($indexData) > 0) {
-            $this->saveObjects($indexData, $indexName);
+            $this->saveObjects($indexData, $indexName, $storeId);
         }
 
         unset($indexData);
         $collection->walk('clearInstance');
         $collection->clear();
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
         unset($collection);
     }
 
@@ -137,11 +135,9 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
         if ($this->isIndexingEnabled($storeId) === false) {
             return;
         }
-        $this->algoliaHelper->setStoreId($storeId);
         $tmpIndexName = $this->suggestionHelper->getTempIndexName($storeId);
         $indexName = $this->suggestionHelper->getIndexName($storeId);
-        $this->algoliaHelper->copyQueryRules($indexName, $tmpIndexName);
-        $this->algoliaHelper->moveIndex($tmpIndexName, $indexName);
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
+        $this->algoliaHelper->copyQueryRules($indexName, $tmpIndexName, $storeId);
+        $this->algoliaHelper->moveIndex($tmpIndexName, $indexName, $storeId);
     }
 }

--- a/Test/Integration/Category/MultiStoreCategoriesTest.php
+++ b/Test/Integration/Category/MultiStoreCategoriesTest.php
@@ -56,11 +56,13 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
     {
         // Check that every store has the right number of categories
         foreach ($this->storeManager->getStores() as $store) {
-            $this->algoliaHelper->setStoreId($store->getId());
-            $this->assertNbOfRecordsPerStore($store->getCode(), 'categories', $this->assertValues->expectedCategory);
+            $this->assertNbOfRecordsPerStore(
+                $store->getCode(),
+                'categories',
+                $this->assertValues->expectedCategory,
+                $store->getId()
+            );
         }
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
 
         $defaultStore = $this->storeRepository->get('default');
         $fixtureSecondStore = $this->storeRepository->get('fixture_second_store');
@@ -82,18 +84,18 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
         $this->categoriesIndexer->execute([self::BAGS_CATEGORY_ID]);
         $this->algoliaHelper->waitLastTask();
 
-        $this->algoliaHelper->setStoreId($defaultStore->getId());
         $this->assertAlgoliaRecordValues(
             $this->indexPrefix . 'default_categories',
             (string) self::BAGS_CATEGORY_ID,
-            ['name' => self::BAGS_CATEGORY_NAME]
+            ['name' => self::BAGS_CATEGORY_NAME],
+            $defaultStore->getId()
         );
 
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
         $this->assertAlgoliaRecordValues(
             $this->indexPrefix . 'fixture_second_store_categories',
             (string) self::BAGS_CATEGORY_ID,
-            ['name' => self::BAGS_CATEGORY_NAME_ALT]
+            ['name' => self::BAGS_CATEGORY_NAME_ALT],
+            $fixtureSecondStore->getId()
         );
 
         // Disable this category at store level
@@ -103,25 +105,22 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
             ['is_active' => 0]
         );
 
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
         $this->categoriesIndexer->execute([self::BAGS_CATEGORY_ID]);
         $this->algoliaHelper->waitLastTask();
 
-        $this->algoliaHelper->setStoreId($defaultStore->getId());
         $this->assertNbOfRecordsPerStore(
             $defaultStore->getCode(),
             'categories',
-            $this->assertValues->expectedCategory
+            $this->assertValues->expectedCategory,
+            $defaultStore->getId()
         );
 
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
         $this->assertNbOfRecordsPerStore(
             $fixtureSecondStore->getCode(),
             'categories',
-            $this->assertValues->expectedCategory - 1
+            $this->assertValues->expectedCategory - 1,
+            $fixtureSecondStore->getId()
         );
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**

--- a/Test/Integration/Category/MultiStoreCategoriesTest.php
+++ b/Test/Integration/Category/MultiStoreCategoriesTest.php
@@ -82,7 +82,9 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
         $this->assertEquals(self::BAGS_CATEGORY_NAME_ALT, $bagsCategoryAlt->getName());
 
         $this->categoriesIndexer->execute([self::BAGS_CATEGORY_ID]);
-        $this->algoliaHelper->waitLastTask();
+
+        $this->algoliaHelper->waitLastTask($defaultStore->getId());
+        $this->algoliaHelper->waitLastTask($fixtureSecondStore->getId());
 
         $this->assertAlgoliaRecordValues(
             $this->indexPrefix . 'default_categories',
@@ -106,7 +108,9 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
         );
 
         $this->categoriesIndexer->execute([self::BAGS_CATEGORY_ID]);
-        $this->algoliaHelper->waitLastTask();
+
+        $this->algoliaHelper->waitLastTask($defaultStore->getId());
+        $this->algoliaHelper->waitLastTask($fixtureSecondStore->getId());
 
         $this->assertNbOfRecordsPerStore(
             $defaultStore->getCode(),

--- a/Test/Integration/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Config/MultiStoreConfigTest.php
@@ -87,9 +87,7 @@ class MultiStoreConfigTest extends MultiStoreTestCase
             $fixtureSecondStore->getCode()
         );
 
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
         $this->indicesConfigurator->saveConfigurationToAlgolia($fixtureSecondStore->getId());
-        $this->algoliaHelper->waitLastTask();
 
         $this->algoliaHelper->setStoreId($defaultStore->getId());
         $defaultCategoryIndexSettings = $this->algoliaHelper->getSettings($this->indexPrefix . 'default_categories');

--- a/Test/Integration/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Config/MultiStoreConfigTest.php
@@ -33,11 +33,8 @@ class MultiStoreConfigTest extends MultiStoreTestCase
 
         $indicesCreatedByTest = 0;
 
-        $this->algoliaHelper->setStoreId($defaultStore->getId());
-        $indicesCreatedByTest += $this->countStoreIndices();
-
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
-        $indicesCreatedByTest += $this->countStoreIndices();
+        $indicesCreatedByTest += $this->countStoreIndices($defaultStore->getId());
+        $indicesCreatedByTest += $this->countStoreIndices($fixtureSecondStore->getId());
 
         // Check that the configuration created the appropriate number of indices (7 (4 mains + 3 replicas per store => 3*7=21)
         $this->assertEquals(21, $indicesCreatedByTest);
@@ -89,11 +86,15 @@ class MultiStoreConfigTest extends MultiStoreTestCase
 
         $this->indicesConfigurator->saveConfigurationToAlgolia($fixtureSecondStore->getId());
 
-        $this->algoliaHelper->setStoreId($defaultStore->getId());
-        $defaultCategoryIndexSettings = $this->algoliaHelper->getSettings($this->indexPrefix . 'default_categories');
+        $defaultCategoryIndexSettings = $this->algoliaHelper->getSettings(
+            $this->indexPrefix . 'default_categories',
+            $defaultStore->getId()
+        );
 
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
-        $fixtureCategoryIndexSettings = $this->algoliaHelper->getSettings($this->indexPrefix . 'fixture_second_store_categories');
+        $fixtureCategoryIndexSettings = $this->algoliaHelper->getSettings(
+            $this->indexPrefix . 'fixture_second_store_categories',
+            $fixtureSecondStore->getId()
+        );
 
         $attributeFromConfig = 'unordered(' . self::ADDITIONAL_ATTRIBUTE . ')';
         $this->assertNotContains($attributeFromConfig, $defaultCategoryIndexSettings['searchableAttributes']);
@@ -103,26 +104,31 @@ class MultiStoreConfigTest extends MultiStoreTestCase
         $this->assertNotContains($rankingFromConfig, $defaultCategoryIndexSettings['customRanking']);
         $this->assertContains($rankingFromConfig, $fixtureCategoryIndexSettings['customRanking']);
 
-        $this->algoliaHelper->setStoreId($defaultStore->getId());
-        $defaultProductIndexRules = $this->algoliaHelper->searchRules($this->indexPrefix . 'default_products');
+        $defaultProductIndexRules = $this->algoliaHelper->searchRules(
+            $this->indexPrefix . 'default_products',
+            null,
+            $defaultStore->getId()
+        );
 
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
-        $fixtureProductIndexRules = $this->algoliaHelper->searchRules($this->indexPrefix . 'fixture_second_store_products');
+        $fixtureProductIndexRules = $this->algoliaHelper->searchRules(
+            $this->indexPrefix . 'fixture_second_store_products',
+            null,
+            $fixtureSecondStore->getId()
+        );
 
         // Check that the Rule has only been created for the fixture store
         $this->assertEquals(0, $defaultProductIndexRules['nbHits']);
         $this->assertEquals(1, $fixtureProductIndexRules['nbHits']);
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**
+     * @param int|null $storeId
      * @return int
      * @throws AlgoliaException
      */
-    protected function countStoreIndices(): int
+    protected function countStoreIndices(int $storeId = null): int
     {
-        $indices = $this->algoliaHelper->listIndexes();
+        $indices = $this->algoliaHelper->listIndexes($storeId);
 
         $indicesCreatedByTest = 0;
 

--- a/Test/Integration/IndexingTestCase.php
+++ b/Test/Integration/IndexingTestCase.php
@@ -31,16 +31,17 @@ abstract class IndexingTestCase extends TestCase
      * @param string $indexName
      * @param string $recordId
      * @param array $expectedValues
-     *
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
     public function assertAlgoliaRecordValues(
         string $indexName,
         string $recordId,
-        array $expectedValues
+        array $expectedValues,
+        int $storeId = null
     ) : void {
-        $res = $this->algoliaHelper->getObjects($indexName, [$recordId]);
+        $res = $this->algoliaHelper->getObjects($indexName, [$recordId], $storeId);
         $record = reset($res['results']);
         foreach ($expectedValues as $attribute => $expectedValue) {
             $this->assertEquals($expectedValue, $record[$attribute]);

--- a/Test/Integration/MultiStoreTestCase.php
+++ b/Test/Integration/MultiStoreTestCase.php
@@ -99,10 +99,7 @@ abstract class MultiStoreTestCase extends IndexingTestCase
             $this->setConfig(ConfigHelper::IS_INSTANT_ENABLED, 1, $store->getCode());
         }
 
-        $this->algoliaHelper->setStoreId($store->getId());
         $this->indicesConfigurator->saveConfigurationToAlgolia($store->getId());
-        $this->algoliaHelper->waitLastTask();
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**

--- a/Test/Integration/MultiStoreTestCase.php
+++ b/Test/Integration/MultiStoreTestCase.php
@@ -46,13 +46,23 @@ abstract class MultiStoreTestCase extends IndexingTestCase
      * @param string $storeCode
      * @param string $entity
      * @param int $expectedNumber
-     *
+     * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
      */
-    protected function assertNbOfRecordsPerStore(string $storeCode, string $entity, int $expectedNumber): void
+    protected function assertNbOfRecordsPerStore(
+        string $storeCode,
+        string $entity,
+        int $expectedNumber,
+        int $storeId = null
+    ): void
     {
-        $resultsDefault = $this->algoliaHelper->query($this->indexPrefix .  $storeCode . '_' . $entity, '', []);
+        $resultsDefault = $this->algoliaHelper->query(
+            $this->indexPrefix .  $storeCode . '_' . $entity,
+            '',
+            [],
+            $storeId
+        );
 
         $this->assertEquals($expectedNumber, $resultsDefault['results'][0]['nbHits']);
     }
@@ -115,17 +125,16 @@ abstract class MultiStoreTestCase extends IndexingTestCase
     protected function clearStoresIndices($wait = false)
     {
         foreach ($this->storeManager->getStores() as $store) {
-            $this->algoliaHelper->setStoreId($store->getId());
             $deletedStoreIndices = 0;
 
-            $indices = $this->algoliaHelper->listIndexes();
+            $indices = $this->algoliaHelper->listIndexes($store->getId());
 
             foreach ($indices['items'] as $index) {
                 $name = $index['name'];
 
                 if (mb_strpos($name, $this->indexPrefix) === 0) {
                     try {
-                        $this->algoliaHelper->deleteIndex($name);
+                        $this->algoliaHelper->deleteIndex($name, $store->getId());
                         $deletedStoreIndices++;
                     } catch (AlgoliaException $e) {
                         // Might be a replica
@@ -134,10 +143,8 @@ abstract class MultiStoreTestCase extends IndexingTestCase
             }
 
             if ($deletedStoreIndices > 0 && $wait) {
-                $this->algoliaHelper->waitLastTask();
+                $this->algoliaHelper->waitLastTask($store->getId());
             }
         }
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 }

--- a/Test/Integration/Page/MultiStorePagesTest.php
+++ b/Test/Integration/Page/MultiStorePagesTest.php
@@ -80,7 +80,9 @@ class MultiStorePagesTest extends MultiStoreTestCase
         $this->pageRepository->save($homePage);
 
         $this->pagesIndexer->execute([self::HOME_PAGE_ID]);
-        $this->algoliaHelper->waitLastTask();
+
+        $this->algoliaHelper->waitLastTask($defaultStore->getId());
+        $this->algoliaHelper->waitLastTask($fixtureSecondStore->getId());
 
         $this->assertNbOfRecordsPerStore(
             $defaultStore->getCode(),

--- a/Test/Integration/Page/MultiStorePagesTest.php
+++ b/Test/Integration/Page/MultiStorePagesTest.php
@@ -56,17 +56,15 @@ class MultiStorePagesTest extends MultiStoreTestCase
     {
         // Check that every store has the right number of pages
         foreach ($this->storeManager->getStores() as $store) {
-            $this->algoliaHelper->setStoreId($store->getId());
             $this->assertNbOfRecordsPerStore(
                 $store->getCode(),
                 'pages',
                 $store->getCode() === 'fixture_second_store' ? // we excluded 2 pages on setupStore()
                     $this->assertValues->expectedExcludePages :
-                    $this->assertValues->expectedPages
+                    $this->assertValues->expectedPages,
+                $store->getId()
             );
         }
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
 
         $defaultStore = $this->storeRepository->get('default');
         $fixtureSecondStore = $this->storeRepository->get('fixture_second_store');
@@ -84,21 +82,19 @@ class MultiStorePagesTest extends MultiStoreTestCase
         $this->pagesIndexer->execute([self::ABOUT_US_PAGE_ID]);
         $this->algoliaHelper->waitLastTask();
 
-        $this->algoliaHelper->setStoreId($defaultStore->getId());
         $this->assertNbOfRecordsPerStore(
             $defaultStore->getCode(),
             'pages',
-            $this->assertValues->expectedPages
+            $this->assertValues->expectedPages,
+            $defaultStore->getId()
         );
 
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
         $this->assertNbOfRecordsPerStore(
             $fixtureSecondStore->getCode(),
             'pages',
-            $this->assertValues->expectedExcludePages - 1
+            $this->assertValues->expectedExcludePages - 1,
+            $fixtureSecondStore->getId()
         );
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**

--- a/Test/Integration/Page/MultiStorePagesTest.php
+++ b/Test/Integration/Page/MultiStorePagesTest.php
@@ -32,7 +32,7 @@ class MultiStorePagesTest extends MultiStoreTestCase
     /**  @var CollectionFactory */
     private $pageCollectionFactory;
 
-    const ABOUT_US_PAGE_ID = 7;
+    const HOME_PAGE_ID = 2;
 
     public function setUp():void
     {
@@ -70,16 +70,16 @@ class MultiStorePagesTest extends MultiStoreTestCase
         $fixtureSecondStore = $this->storeRepository->get('fixture_second_store');
 
         try {
-            $aboutUsPage = $this->loadPage(self::ABOUT_US_PAGE_ID);
+            $homePage = $this->loadPage(self::HOME_PAGE_ID);
         } catch (\Exception $e) {
             $this->markTestIncomplete('Page could not be found.');
         }
 
         // Setting the page only for default store
-        $aboutUsPage->setStores([$defaultStore->getId()]);
-        $this->pageRepository->save($aboutUsPage);
+        $homePage->setStores([$defaultStore->getId()]);
+        $this->pageRepository->save($homePage);
 
-        $this->pagesIndexer->execute([self::ABOUT_US_PAGE_ID]);
+        $this->pagesIndexer->execute([self::HOME_PAGE_ID]);
         $this->algoliaHelper->waitLastTask();
 
         $this->assertNbOfRecordsPerStore(
@@ -129,7 +129,7 @@ class MultiStorePagesTest extends MultiStoreTestCase
     {
         // Exclude 2 pages on second store
         $excludedPages = $store->getCode() === 'fixture_second_store' ?
-            [['attribute' => 'no-route'], ['attribute' => 'home']]:
+            [['attribute' => 'no-route'], ['attribute' => 'enable-cookies']]:
             [];
 
         $this->setConfig(
@@ -144,8 +144,8 @@ class MultiStorePagesTest extends MultiStoreTestCase
     public function tearDown(): void
     {
         // Restore page in case DB is not cleaned up
-        $aboutUsPage = $this->loadPage(self::ABOUT_US_PAGE_ID);
-        $this->resetPage($aboutUsPage);
+        $homePage = $this->loadPage(self::HOME_PAGE_ID);
+        $this->resetPage($homePage);
 
         parent::tearDown();
     }

--- a/Test/Integration/Product/MultiStoreProductsTest.php
+++ b/Test/Integration/Product/MultiStoreProductsTest.php
@@ -70,13 +70,13 @@ class MultiStoreProductsTest extends MultiStoreTestCase
     {
         // Check that every store has the right number of products
         foreach ($this->storeManager->getStores() as $store) {
-            $this->algoliaHelper->setStoreId($store->getId());
             $this->assertNbOfRecordsPerStore(
                 $store->getCode(),
                 'products',
                 $store->getCode() === 'default' ?
                     $this->assertValues->productsCountWithoutGiftcards :
-                    count(self::SKUS)
+                    count(self::SKUS),
+                $store->getId()
             );
         }
 
@@ -105,21 +105,19 @@ class MultiStoreProductsTest extends MultiStoreTestCase
         $this->productsIndexer->execute([self::VOYAGE_YOGA_BAG_ID]);
         $this->algoliaHelper->waitLastTask();
 
-        $this->algoliaHelper->setStoreId($defaultStore->getId());
         $this->assertAlgoliaRecordValues(
             $this->indexPrefix . 'default_products',
             (string) self::VOYAGE_YOGA_BAG_ID,
-            ['name' => self::VOYAGE_YOGA_BAG_NAME]
+            ['name' => self::VOYAGE_YOGA_BAG_NAME],
+            $defaultStore->getId()
         );
 
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
         $this->assertAlgoliaRecordValues(
             $this->indexPrefix . 'fixture_second_store_products',
             (string) self::VOYAGE_YOGA_BAG_ID,
-            ['name' => self::VOYAGE_YOGA_BAG_NAME_ALT]
+            ['name' => self::VOYAGE_YOGA_BAG_NAME_ALT],
+            $fixtureSecondStore->getId()
         );
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
 
         // Unassign product from a single website (removed from test website (second and third store))
         $baseWebsite = $this->websiteRepository->get('base');
@@ -134,29 +132,27 @@ class MultiStoreProductsTest extends MultiStoreTestCase
         $this->algoliaHelper->waitLastTask();
 
         // default store should have the same number of products
-        $this->algoliaHelper->setStoreId($defaultStore->getId());
         $this->assertNbOfRecordsPerStore(
             $defaultStore->getCode(),
             'products',
-            $this->assertValues->productsCountWithoutGiftcards
+            $this->assertValues->productsCountWithoutGiftcards,
+            $defaultStore->getId()
         );
 
         // Stores from test website must have one less product
-        $this->algoliaHelper->setStoreId($fixtureThirdStore->getId());
         $this->assertNbOfRecordsPerStore(
             $fixtureThirdStore->getCode(),
             'products',
-            count(self::SKUS) - 1
+            count(self::SKUS) - 1,
+            $fixtureThirdStore->getId()
         );
 
-        $this->algoliaHelper->setStoreId($fixtureSecondStore->getId());
         $this->assertNbOfRecordsPerStore(
             $fixtureSecondStore->getCode(),
             'products',
-            count(self::SKUS) - 1
+            count(self::SKUS) - 1,
+            $fixtureSecondStore->getId()
         );
-
-        $this->algoliaHelper->setStoreId(AlgoliaHelper::ALGOLIA_DEFAULT_SCOPE);
     }
 
     /**

--- a/Test/Integration/Product/MultiStoreProductsTest.php
+++ b/Test/Integration/Product/MultiStoreProductsTest.php
@@ -103,7 +103,10 @@ class MultiStoreProductsTest extends MultiStoreTestCase
         $this->assertEquals(self::VOYAGE_YOGA_BAG_NAME_ALT, $voyageYogaBagAlt->getName());
 
         $this->productsIndexer->execute([self::VOYAGE_YOGA_BAG_ID]);
-        $this->algoliaHelper->waitLastTask();
+
+        $this->algoliaHelper->waitLastTask($defaultStore->getId());
+        $this->algoliaHelper->waitLastTask($fixtureSecondStore->getId());
+        $this->algoliaHelper->waitLastTask($fixtureThirdStore->getId());
 
         $this->assertAlgoliaRecordValues(
             $this->indexPrefix . 'default_products',
@@ -129,7 +132,10 @@ class MultiStoreProductsTest extends MultiStoreTestCase
         $this->productPriceIndexer->reindexRow(self::VOYAGE_YOGA_BAG_ID);
 
         $this->productsIndexer->execute([self::VOYAGE_YOGA_BAG_ID]);
-        $this->algoliaHelper->waitLastTask();
+
+        $this->algoliaHelper->waitLastTask($defaultStore->getId());
+        $this->algoliaHelper->waitLastTask($fixtureSecondStore->getId());
+        $this->algoliaHelper->waitLastTask($fixtureThirdStore->getId());
 
         // default store should have the same number of products
         $this->assertNbOfRecordsPerStore(


### PR DESCRIPTION
This PR contains:
- Updated `AlgoliaHelper` by removing most of its logic. The main purpose of this class is now to handle the store context while communicating with the Algolia applications now that Multi-Application IDs has been introduced.
- Added `AlgoliaConnector` service which handles the logic previously handled by `AlgoliaHelper`
- Removed all the occurrences of `AlgoliaHelper::setStoreId() `all across the codebase (which was the main purpose of this refactoring)
- Updated all `AlgoliaHelper` methods which now include an optional `$storeId` parameter which ensure that the correct Algolia application is reached
- Fixed Page Tests for Magento 2.4.6