### PR TITLE
MAGE-1122 intentional price indexing

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -108,6 +108,7 @@ class ConfigHelper
     public const CONNECTION_TIMEOUT = 'algoliasearch_advanced/advanced/connection_timeout';
     public const READ_TIMEOUT = 'algoliasearch_advanced/advanced/read_timeout';
     public const WRITE_TIMEOUT = 'algoliasearch_advanced/advanced/write_timeout';
+    public const AUTO_PRICE_INDEXING_ENABLED = 'algoliasearch_advanced/advanced/auto_price_indexing';
 
     public const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
 
@@ -1270,6 +1271,15 @@ class ConfigHelper
     public function getWriteTimeout($storeId = null)
     {
         return $this->configInterface->getValue(self::WRITE_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function isAutoPriceIndexingEnabled(?int $storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(
+            self::AUTO_PRICE_INDEXING_ENABLED,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -372,8 +372,6 @@ class Data
             return;
         }
 
-        $this->missingPriceIndexHandler->refreshPriceIndex($productIds);
-
         $this->startEmulation($storeId);
         $this->logger->start('Indexing');
         try {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -688,6 +688,7 @@ class Data
             page ' . $page . ',
             pageSize ' . $pageSize;
         $this->logger->start($wrapperLogMessage);
+
         if ($emulationInfo === null) {
             $this->startEmulation($storeId);
         }
@@ -713,6 +714,9 @@ class Data
                 'store'      => $storeId
             ]
         );
+
+        $this->missingPriceIndexHandler->refreshPriceIndex($collection);
+
         $logMessage = 'LOADING: ' . $this->logger->getStoreName($storeId) . ',
             collection page: ' . $page . ',
             pageSize: ' . $pageSize;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -713,7 +713,9 @@ class Data
             ]
         );
 
-        $this->missingPriceIndexHandler->refreshPriceIndex($collection);
+        if ($this->configHelper->isAutoPriceIndexingEnabled($storeId)) {
+            $this->missingPriceIndexHandler->refreshPriceIndex($collection);
+        }
 
         $logMessage = 'LOADING: ' . $this->logger->getStoreName($storeId) . ',
             collection page: ' . $page . ',

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -12,6 +12,7 @@ use Algolia\AlgoliaSearch\Helper\Entity\PageHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\SuggestionHelper;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Product\MissingPriceIndexHandler;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
@@ -35,21 +36,22 @@ class Data
     protected IndexerInterface $priceIndexer;
 
     public function __construct(
-        protected AlgoliaHelper           $algoliaHelper,
-        protected ConfigHelper            $configHelper,
-        protected ProductHelper           $productHelper,
-        protected CategoryHelper          $categoryHelper,
-        protected PageHelper              $pageHelper,
-        protected SuggestionHelper        $suggestionHelper,
-        protected AdditionalSectionHelper $additionalSectionHelper,
-        protected Emulation               $emulation,
-        protected Logger                  $logger,
-        protected ResourceConnection      $resource,
-        protected ManagerInterface        $eventManager,
-        protected ScopeCodeResolver       $scopeCodeResolver,
-        protected StoreManagerInterface   $storeManager,
-        protected IndexNameFetcher        $indexNameFetcher,
-        IndexerRegistry                   $indexerRegistry
+        protected AlgoliaHelper            $algoliaHelper,
+        protected ConfigHelper             $configHelper,
+        protected ProductHelper            $productHelper,
+        protected CategoryHelper           $categoryHelper,
+        protected PageHelper               $pageHelper,
+        protected SuggestionHelper         $suggestionHelper,
+        protected AdditionalSectionHelper  $additionalSectionHelper,
+        protected Emulation                $emulation,
+        protected Logger                   $logger,
+        protected ResourceConnection       $resource,
+        protected ManagerInterface         $eventManager,
+        protected ScopeCodeResolver        $scopeCodeResolver,
+        protected StoreManagerInterface    $storeManager,
+        protected IndexNameFetcher         $indexNameFetcher,
+        protected MissingPriceIndexHandler $missingPriceIndexHandler,
+        IndexerRegistry                    $indexerRegistry
     )
     {
         $this->priceIndexer = $indexerRegistry->get('catalog_product_price');
@@ -78,7 +80,7 @@ class Data
         $this->algoliaHelper->deleteObjects($ids, $indexName);
     }
 
-    /**
+    /**`
      * @param string $query
      * @param int $storeId
      * @param array|null $searchParams
@@ -370,7 +372,7 @@ class Data
             return;
         }
 
-        $this->checkPriceIndex($productIds);
+        $this->missingPriceIndexHandler->refreshPriceIndex($productIds);
 
         $this->startEmulation($storeId);
         $this->logger->start('Indexing');
@@ -936,18 +938,4 @@ class Data
         $idsToDeleteFromAlgolia = array_diff($objectIds, $dbIds);
         $this->algoliaHelper->deleteObjects($idsToDeleteFromAlgolia, $indexName);
     }
-
-    /**
-     * If the price index is stale
-     * @param array $productIds
-     * @return void
-     */
-    protected function checkPriceIndex(array $productIds): void
-    {
-        $state = $this->priceIndexer->getState()->getStatus();
-        if ($state === \Magento\Framework\Indexer\StateInterface::STATUS_INVALID) {
-            $this->priceIndexer->reindexList($productIds);
-        }
-    }
-
 }

--- a/Model/Config/AutomaticPriceIndexingComment.php
+++ b/Model/Config/AutomaticPriceIndexingComment.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Config;
+
+use Magento\Config\Model\Config\CommentInterface;
+use Magento\Framework\UrlInterface;
+
+class AutomaticPriceIndexingComment implements CommentInterface
+{
+    public function __construct(
+        protected UrlInterface $urlInterface
+    ) { }
+
+    public function getCommentText($elementValue)
+    {
+        $url = $this->urlInterface->getUrl('https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/#configure-the-queue');
+
+        $comment = array();
+        $comment[] = 'Algolia relies on the core Magento Product Price index when serializing product data. If the price index is not up to date, Algolia will not be able to accurately determine what should be included in the search index.';
+        $comment[] = 'If you are experiencing problems with products not syncing to Algolia due to this issue, enabling this setting will allow Algolia to automatically update the price index as needed.';
+        $comment[] = 'NOTE: This can introduce a marginal amount of overhead to the indexing process so only enable if necessary. Be sure to <a href="' . $url . '" target="_blank">optimize the indexing queue</a> based on the impact of this operation.';
+        return implode('<br><br>', $comment);
+    }
+}

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -2,12 +2,19 @@
 
 namespace Algolia\AlgoliaSearch\Service\Product;
 
+use Magento\Framework\DB\Select;
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Indexer\IndexerInterface;
+use Zend_Db_Select;
 
 class MissingPriceIndexHandler
 {
+    public const PRICE_INDEX_TABLE = 'catalog_product_index_price';
+    public const PRICE_INDEX_TABLE_ALIAS = 'price_index';
+    public const MAIN_TABLE_ALIAS = 'e';
+
     protected IndexerInterface $indexer;
     public function __construct(
         protected CollectionFactory $productCollectionFactory,
@@ -18,12 +25,12 @@ class MissingPriceIndexHandler
     }
 
     /**
-     * @param array $productIds
-     * @return int[] Array of product IDs that were reindexed by this repair operation
+     * @param string[]|ProductCollection $products
+     * @return string[] Array of product IDs that were reindexed by this repair operation
      */
-    public function refreshPriceIndex(array $productIds): array
+    public function refreshPriceIndex(array|ProductCollection $products): array
     {
-        $reindexIds = $this->getProductIdsToReindex($productIds);
+        $reindexIds = $this->getProductIdsToReindex($products);
         if (empty($reindexIds)) {
             return [];
         }
@@ -34,16 +41,25 @@ class MissingPriceIndexHandler
     }
 
     /**
-     * @param int[] $productIds
-     * @return int[]
+     * @param string[]|ProductCollection $products
+     * @return string[]
      */
-    protected function getProductIdsToReindex(array $productIds): array
+    protected function getProductIdsToReindex(array|ProductCollection $products): array
     {
+        $productIds = $products instanceof ProductCollection
+            ? $this->getExpandedProductCollectionIds($products)
+            : $products;
+
         $state = $this->indexer->getState()->getStatus();
         if ($state === \Magento\Framework\Indexer\StateInterface::STATUS_INVALID) {
             return $productIds;
         }
 
+        return $this->filterProductIds($productIds);
+    }
+
+    protected function filterProductIds(array $productIds): array
+    {
         $collection = $this->productCollectionFactory->create();
 
         $collection->addAttributeToSelect(['name', 'price']);
@@ -56,8 +72,85 @@ class MissingPriceIndexHandler
 
         $collection->getSelect()
             ->where('price_index.entity_id IS NULL')
-            ->where('entity_id IN (?)', $productIds);
+            ->where('e.entity_id IN (?)', $productIds);
 
         return $collection->getAllIds();
+    }
+
+    protected function getExpandedProductCollectionIds(ProductCollection $collection): array
+    {
+        $expandedCollection = clone $collection;
+
+        $select = $expandedCollection->getSelect();
+
+        $joins = $select->getPart(Zend_Db_Select::FROM);
+
+        $priceIndexJoin = $this->getPriceIndexJoinAlias($joins);
+
+        if (!$priceIndexJoin) {
+            // nothing to do here - keep calm and carry on
+            return [];
+        }
+
+        $modifyJoin = &$joins[$priceIndexJoin];
+        $modifyJoin['joinType'] = Zend_Db_Select::LEFT_JOIN;
+
+        $this->rebuildJoins($select, $joins);
+
+        return $expandedCollection->getAllIds();
+    }
+
+    protected function rebuildJoins(Select $select, array $joins): void
+    {
+        $select->reset(Zend_Db_Select::FROM);
+        foreach ($joins as $alias => $joinData) {
+            if ($joinData['joinType'] === Zend_Db_Select::FROM) {
+                $select->from([$alias => $joinData['tableName']]);
+            } elseif ($joinData['joinType'] === Zend_Db_Select::LEFT_JOIN) {
+                $select->joinLeft(
+                    [$alias => $joinData['tableName']],
+                    $joinData['joinCondition'],
+                    [],
+                    $joinData['schema']
+                );
+            } else {
+                $select->join(
+                    [$alias => $joinData['tableName']],
+                    $joinData['joinCondition'],
+                    [],
+                    $joinData['schema']
+                );
+            }
+            $sql = $select->__toString();
+        }
+    }
+
+    private function inspectJoins(array $joins): void {
+        foreach ($joins as $alias => $joinData) {
+            echo "Table Alias: $alias\n";
+            echo "Table Name: {$joinData['tableName']}\n";
+            echo "Join Type: {$joinData['joinType']}\n";
+            echo "Join Condition: " . ($joinData['joinCondition'] ?? 'N/A') . "\n\n";
+        }
+    }
+
+    /**
+     * @param array<string, array> $joins
+     * @return string
+     */
+    protected function getPriceIndexJoinAlias(array $joins): string
+    {
+        if (isset($joins[self::PRICE_INDEX_TABLE_ALIAS])) {
+            return self::PRICE_INDEX_TABLE_ALIAS;
+        }
+        else {
+            foreach ($joins as $alias => $joinData) {
+                if ($joinData['tableName'] === self::PRICE_INDEX_TABLE) {
+                    return $alias;
+                }
+            }
+        }
+
+        return "";
     }
 }

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -65,14 +65,14 @@ class MissingPriceIndexHandler
         $collection->addAttributeToSelect(['name', 'price']);
 
         $collection->getSelect()->joinLeft(
-            ['price_index' => 'catalog_product_index_price'],
-            'e.entity_id = price_index.entity_id',
+            [self::PRICE_INDEX_TABLE_ALIAS => self::PRICE_INDEX_TABLE],
+            self::MAIN_TABLE_ALIAS . '.entity_id = ' . self::PRICE_INDEX_TABLE_ALIAS . '.entity_id',
             []
         );
 
         $collection->getSelect()
-            ->where('price_index.entity_id IS NULL')
-            ->where('e.entity_id IN (?)', $productIds);
+            ->where(self::PRICE_INDEX_TABLE_ALIAS . '.entity_id IS NULL')
+            ->where(self::MAIN_TABLE_ALIAS . '.entity_id IN (?)', $productIds);
 
         return $collection->getAllIds();
     }

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Product;
+
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Indexer\IndexerInterface;
+
+class MissingPriceIndexHandler
+{
+    protected IndexerInterface $indexer;
+    public function __construct(
+        protected CollectionFactory $productCollectionFactory,
+        IndexerRegistry $indexerRegistry
+    )
+    {
+        $this->indexer = $indexerRegistry->get('catalog_product_price');
+    }
+
+    /**
+     * @param array $productIds
+     * @return int[] Array of product IDs that were reindexed by this repair operation
+     */
+    public function refreshPriceIndex(array $productIds): array
+    {
+        $reindexIds = $this->getProductIdsToReindex($productIds);
+        if (empty($reindexIds)) {
+            return [];
+        }
+
+        $this->indexer->reindexList($reindexIds);
+
+        return $reindexIds;
+    }
+
+    /**
+     * @param int[] $productIds
+     * @return int[]
+     */
+    protected function getProductIdsToReindex(array $productIds): array
+    {
+        $state = $this->indexer->getState()->getStatus();
+        if ($state === \Magento\Framework\Indexer\StateInterface::STATUS_INVALID) {
+            return $productIds;
+        }
+
+        $collection = $this->productCollectionFactory->create();
+
+        $collection->addAttributeToSelect(['name', 'price']);
+
+        $collection->getSelect()->joinLeft(
+            ['price_index' => 'catalog_product_index_price'],
+            'e.entity_id = price_index.entity_id',
+            []
+        );
+
+        $collection->getSelect()
+            ->where('price_index.entity_id IS NULL')
+            ->where('entity_id IN (?)', $productIds);
+
+        return $collection->getAllIds();
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1337,6 +1337,16 @@
                 <field id="write_timeout" translate="label comment" type="text" sortOrder="110" showInDefault="1">
                     <label>Write Timeout (In Seconds)</label>
                 </field>
+                <field id="auto_price_indexing" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable automatic price indexing</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <model>Algolia\AlgoliaSearch\Model\Config\AutomaticPriceIndexingComment</model>
+                    </comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="queue" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Indexing Queue</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -94,6 +94,7 @@
                 <connection_timeout>2</connection_timeout>
                 <read_timeout>30</read_timeout>
                 <write_timeout>30</write_timeout>
+                <auto_price_indexing>0</auto_price_indexing>
             </advanced>
             <queue>
                 <number_of_element_by_page>300</number_of_element_by_page>

--- a/etc/indexer.xml
+++ b/etc/indexer.xml
@@ -5,9 +5,6 @@
         <description translate="true">
             Rebuild products index.
         </description>
-        <dependencies>
-            <indexer id="catalog_product_price" />
-        </dependencies>
     </indexer>
     <indexer id="algolia_categories" view_id="algolia_categories" class="Algolia\AlgoliaSearch\Model\Indexer\Category">
         <title translate="true">Algolia Search Categories</title>


### PR DESCRIPTION
This will need rebasing against `release/3.14.4-dev` (to be discussed) but this PR provides a feature flagged auto price indexer to address missing pricing record dependencies at time of index.

Introduces injectable service `MissingPriceIndexHandler`.

Tested successfully against 3 major scenarios: 

1. Valid product record missing from price index BUT price index is not marked as invalid by Magento (product should NOT be removed from Algolia search index)
2. Price index is invalid (Price records should be reverified prior to search indexing)
3. Invalid product record  (out of stock etc) missing from price index (product SHOULD be removed from Algolia search index)

As price indexing is entity ID driven / store agnostic and indexing process is called for each store view, a caching associative array is used to track already reindexed records for a single process to avoid redundant indexing. 