### PR TITLE
MAGE-1084: Multistore Replicas tests

### DIFF
--- a/Test/Integration/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Config/MultiStoreConfigTest.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Config;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Test\Integration\Config\Traits\ConfigAssertionsTrait;
 use Algolia\AlgoliaSearch\Test\Integration\MultiStoreTestCase;
 
 /**
@@ -12,6 +13,7 @@ use Algolia\AlgoliaSearch\Test\Integration\MultiStoreTestCase;
  */
 class MultiStoreConfigTest extends MultiStoreTestCase
 {
+    use ConfigAssertionsTrait;
 
     const ADDITIONAL_ATTRIBUTE = 'additional_attribute';
 
@@ -30,11 +32,13 @@ class MultiStoreConfigTest extends MultiStoreTestCase
 
         $defaultStore = $this->storeRepository->get('default');
         $fixtureSecondStore = $this->storeRepository->get('fixture_second_store');
+        $fixtureThirdStore = $this->storeRepository->get('fixture_third_store');
 
         $indicesCreatedByTest = 0;
 
-        $indicesCreatedByTest += $this->countStoreIndices($defaultStore->getId());
-        $indicesCreatedByTest += $this->countStoreIndices($fixtureSecondStore->getId());
+        $indicesCreatedByTest += $this->countStoreIndices($defaultStore);
+        $indicesCreatedByTest += $this->countStoreIndices($fixtureSecondStore);
+        $indicesCreatedByTest += $this->countStoreIndices($fixtureThirdStore);
 
         // Check that the configuration created the appropriate number of indices (7 (4 mains + 3 replicas per store => 3*7=21)
         $this->assertEquals(21, $indicesCreatedByTest);
@@ -119,28 +123,6 @@ class MultiStoreConfigTest extends MultiStoreTestCase
         // Check that the Rule has only been created for the fixture store
         $this->assertEquals(0, $defaultProductIndexRules['nbHits']);
         $this->assertEquals(1, $fixtureProductIndexRules['nbHits']);
-    }
-
-    /**
-     * @param int|null $storeId
-     * @return int
-     * @throws AlgoliaException
-     */
-    protected function countStoreIndices(int $storeId = null): int
-    {
-        $indices = $this->algoliaHelper->listIndexes($storeId);
-
-        $indicesCreatedByTest = 0;
-
-        foreach ($indices['items'] as $index) {
-            $name = $index['name'];
-
-            if (mb_strpos($name, $this->indexPrefix) === 0) {
-                $indicesCreatedByTest++;
-            }
-        }
-
-        return $indicesCreatedByTest;
     }
 
     protected function tearDown(): void

--- a/Test/Integration/Config/Traits/ConfigAssertionsTrait.php
+++ b/Test/Integration/Config/Traits/ConfigAssertionsTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration\Config\Traits;
+
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Magento\Store\Api\Data\StoreInterface;
+
+trait ConfigAssertionsTrait
+{
+    /**
+     * @param StoreInterface|null $store
+     * @return int
+     * @throws AlgoliaException
+     */
+    protected function countStoreIndices(StoreInterface $store = null): int
+    {
+        $indices = $this->algoliaHelper->listIndexes($store->getId());
+
+        $indicesCreatedByTest = 0;
+
+        foreach ($indices['items'] as $index) {
+            $name = $index['name'];
+
+            if (mb_strpos($name, $this->indexPrefix . $store->getCode()) === 0) {
+                $indicesCreatedByTest++;
+            }
+        }
+
+        return $indicesCreatedByTest;
+    }
+}

--- a/Test/Integration/Product/MultiStoreReplicaTest.php
+++ b/Test/Integration/Product/MultiStoreReplicaTest.php
@@ -61,8 +61,6 @@ class MultiStoreReplicaTest extends MultiStoreTestCase
         // Check replica config for color asc
         $this->checkReplicaIsStandard($defaultStore, self::COLOR_ATTR, self::ASC_DIR);
         $this->checkReplicaIsVirtual($fixtureSecondStore, self::COLOR_ATTR, self::ASC_DIR);
-
-        $this->resetAllSortings();
     }
 
     public function testCustomerGroupsConfig()
@@ -90,8 +88,6 @@ class MultiStoreReplicaTest extends MultiStoreTestCase
         // - 1 for suggestions
         // - 10 for products (1 main and 9 replicas (2 prices sortings * 4 customer groups + 1 other sorting (created_at))
         $this->assertEquals(13, $this->countStoreIndices($fixtureSecondStore));
-
-        $this->resetAllSortings();
     }
 
     public function testReplicaCommands()

--- a/Test/Integration/Product/MultiStoreReplicaTest.php
+++ b/Test/Integration/Product/MultiStoreReplicaTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration\Product;
+
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Test\Integration\MultiStoreTestCase;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Store\Api\Data\StoreInterface;
+
+/**
+ * @magentoDataFixture Magento/Store/_files/second_website_with_two_stores.php
+ */
+class MultiStoreReplicaTest extends MultiStoreTestCase
+{
+    use ReplicaAssertionsTrait;
+
+    const COLOR_ATTR = 'color';
+    const CREATED_AT_ATTR = 'created_at';
+    const ASC_DIR = 'asc';
+    const DESC_DIR = 'desc';
+
+    protected ?ReplicaManagerInterface $replicaManager = null;
+
+    protected ?SerializerInterface $serializer = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->replicaManager = $this->objectManager->get(ReplicaManagerInterface::class);
+        $this->serializer = $this->objectManager->get(SerializerInterface::class);
+
+        $stores = $this->storeManager->getStores();
+
+        foreach ($stores as $store) {
+            $this->setupStore($store, true);
+        }
+    }
+
+    public function testMultiStoreReplicaConfig()
+    {
+        $defaultStore = $this->storeRepository->get('default');
+        $fixtureSecondStore = $this->storeRepository->get('fixture_second_store');
+
+        // Check replica config for created_at desc
+        $this->checkReplicaIsStandard($defaultStore, self::CREATED_AT_ATTR, self::DESC_DIR);
+        $this->checkReplicaIsStandard($fixtureSecondStore, self::CREATED_AT_ATTR, self::DESC_DIR);
+
+        // add color asc sorting (virtual on a single store)
+        $this->addSortingByStore($defaultStore, self::COLOR_ATTR, self::ASC_DIR);
+        $this->addSortingByStore($fixtureSecondStore, self::COLOR_ATTR, self::ASC_DIR,true);
+
+        // Check replica config for color asc
+        $this->checkReplicaIsStandard($defaultStore, self::COLOR_ATTR, self::ASC_DIR);
+        $this->checkReplicaIsVirtual($fixtureSecondStore, self::COLOR_ATTR, self::ASC_DIR);
+    }
+
+    protected function checkReplicaIsStandard(StoreInterface $store, $sortAttr, $sortDir)
+    {
+        $this->checkReplicaConfigByStore($store, $sortAttr, $sortDir, 'standard');
+    }
+
+    protected function checkReplicaIsVirtual(StoreInterface $store, $sortAttr, $sortDir)
+    {
+        $this->checkReplicaConfigByStore($store, $sortAttr, $sortDir, 'virtual');
+    }
+
+    protected function checkReplicaConfigByStore(StoreInterface $store, $sortAttr, $sortDir, $type)
+    {
+        $indexName = $this->indexPrefix . $store->getCode() . '_products';
+
+        $settings = $this->algoliaHelper->getSettings($indexName, $store->getId());
+
+        $this->assertArrayHasKey('replicas', $settings);
+
+        $replicaIndexName = $indexName . '_' . $sortAttr . '_' . $sortDir;
+
+        $type === 'virtual' ?
+            $this->assertTrue($this->isVirtualReplica($settings['replicas'], $replicaIndexName)) :
+            $this->assertTrue($this->isStandardReplica($settings['replicas'], $replicaIndexName));
+
+        $replicaSettings = $this->assertReplicaIndexExists($indexName, $replicaIndexName, $store->getId());
+
+        $type === 'virtual' ?
+            $this->assertVirtualReplicaRanking($replicaSettings, "$sortDir($sortAttr)"):
+            $this->assertStandardReplicaRanking($replicaSettings, "$sortDir($sortAttr)");
+    }
+
+    protected function addSortingByStore(StoreInterface $store, $attr, $dir,  $isVirtual = false)
+    {
+        $sorting = $this->configHelper->getSorting($store->getId());
+        $newSorting = [
+            'attribute'      => $attr,
+            'sort'           => $dir,
+            'sortLabel'      => $attr,
+        ];
+
+        if ($isVirtual) {
+            $newSorting['virtualReplica'] = 1;
+        }
+
+        $sorting[] = $newSorting;
+
+        $this->setConfig(
+            ConfigHelper::SORTING_INDICES,
+            $this->serializer->serialize($sorting),
+            $store->getCode()
+        );
+
+        $this->assertSortingAttribute($attr, $dir);
+        $this->indicesConfigurator->saveConfigurationToAlgolia($store->getId());
+        $this->algoliaHelper->waitLastTask($store->getId());
+    }
+
+    protected function tearDown(): void
+    {
+        $stores = $this->storeManager->getStores();
+
+        foreach ($stores as $store) {
+            $this->setConfig(
+                ConfigHelper::SORTING_INDICES,
+                [
+                    [
+                        'attribute' => 'price',
+                        'sort' => 'asc',
+                        'sortLabel' => 'Lowest Price'
+                    ],
+                    [
+                        'attribute' => 'price',
+                        'sort' => 'desc',
+                        'sortLabel' => 'Highest Price'
+                    ],
+                    [
+                        'attribute' => 'created_at',
+                        'sort' => 'desc',
+                        'sortLabel' => 'Newest first'
+                    ]
+                ],
+                $store->getCode()
+            );
+        }
+
+        parent::tearDown();
+    }
+}

--- a/Test/Integration/Product/MultiStoreReplicaTest.php
+++ b/Test/Integration/Product/MultiStoreReplicaTest.php
@@ -199,7 +199,7 @@ class MultiStoreReplicaTest extends MultiStoreTestCase
         foreach ($stores as $store) {
             $this->setConfig(
                 ConfigHelper::SORTING_INDICES,
-                [
+                $this->serializer->serialize([
                     [
                         'attribute' => 'price',
                         'sort' => 'asc',
@@ -215,7 +215,7 @@ class MultiStoreReplicaTest extends MultiStoreTestCase
                         'sort' => 'desc',
                         'sortLabel' => 'Newest first'
                     ]
-                ],
+                ]),
                 $store->getCode()
             );
         }

--- a/Test/Integration/Product/ReplicaAssertionsTrait.php
+++ b/Test/Integration/Product/ReplicaAssertionsTrait.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration\Product;
+
+trait ReplicaAssertionsTrait
+{
+    protected function assertSortToReplicaConfigParity(string $primaryIndexName, array $sorting, array $replicas): void
+    {
+        foreach ($sorting as $sortAttr) {
+            $replicaIndexName = $sortAttr['name'];
+            $isVirtual = array_key_exists('virtualReplica', $sortAttr) && $sortAttr['virtualReplica'];
+            $needle = $isVirtual
+                ? "virtual($replicaIndexName)"
+                : $replicaIndexName;
+            $this->assertContains($needle, $replicas);
+
+            $replicaSettings = $this->assertReplicaIndexExists($primaryIndexName, $replicaIndexName);
+            $sort = reset($sortAttr['ranking']);
+            if ($isVirtual) {
+                $this->assertVirtualReplicaRanking($replicaSettings, $sort);
+            } else {
+                $this->assertStandardReplicaRanking($replicaSettings, $sort);
+            }
+        }
+    }
+
+    protected function assertReplicaIndexExists(
+        string $primaryIndexName,
+        string $replicaIndexName,
+        ?int $storeId = null
+    ): array
+    {
+        $replicaSettings = $this->algoliaHelper->getSettings($replicaIndexName, $storeId);
+        $this->assertArrayHasKey('primary', $replicaSettings);
+        $this->assertEquals($primaryIndexName, $replicaSettings['primary']);
+        return $replicaSettings;
+    }
+
+    protected function assertReplicaRanking(array $replicaSettings, string $rankingKey, string $sort) {
+        $this->assertArrayHasKey($rankingKey, $replicaSettings);
+        $this->assertEquals($sort, reset($replicaSettings[$rankingKey]));
+    }
+
+    protected function assertStandardReplicaRanking(array $replicaSettings, string $sort): void
+    {
+        $this->assertReplicaRanking($replicaSettings, 'ranking', $sort);
+    }
+
+    protected function assertVirtualReplicaRanking(array $replicaSettings, string $sort): void
+    {
+        $this->assertReplicaRanking($replicaSettings, 'customRanking', $sort);
+    }
+
+    protected function assertStandardReplicaRankingOld(array $replicaSettings, string $sortAttr, string $sortDir): void
+    {
+        $this->assertArrayHasKey('ranking', $replicaSettings);
+        $this->assertEquals("$sortDir($sortAttr)", array_shift($replicaSettings['ranking']));
+    }
+
+    protected function assertVirtualReplicaRankingOld(array $replicaSettings, string $sortAttr, string $sortDir): void
+    {
+        $this->assertArrayHasKey('customRanking', $replicaSettings);
+        $this->assertEquals("$sortDir($sortAttr)", array_shift($replicaSettings['customRanking']));
+    }
+
+    /**
+     * @param string[] $replicaSetting
+     * @param string $replicaIndexName
+     * @return bool
+     */
+    protected function isVirtualReplica(array $replicaSetting, string $replicaIndexName): bool
+    {
+        return (bool) array_filter(
+            $replicaSetting,
+            function ($replica) use ($replicaIndexName) {
+                return str_contains($replica, "virtual($replicaIndexName)");
+            }
+        );
+    }
+
+    protected function isStandardReplica(array $replicaSetting, string $replicaIndexName): bool
+    {
+        return (bool) array_filter(
+            $replicaSetting,
+            function ($replica) use ($replicaIndexName) {
+                $regex = '/^' . preg_quote($replicaIndexName) . '$/';
+                return preg_match($regex, $replica);
+            }
+        );
+    }
+
+    protected function hasSortingAttribute($sortAttr, $sortDir): bool
+    {
+        $sorting = $this->configHelper->getSorting();
+        return (bool) array_filter(
+            $sorting,
+            function($sort) use ($sortAttr, $sortDir) {
+                return $sort['attribute'] == $sortAttr
+                    && $sort['sort'] == $sortDir;
+            }
+        );
+    }
+
+    protected function assertSortingAttribute($sortAttr, $sortDir): void
+    {
+        $this->assertTrue($this->hasSortingAttribute($sortAttr, $sortDir));
+    }
+
+    protected function assertNoSortingAttribute($sortAttr, $sortDir): void
+    {
+        $this->assertFalse($this->hasSortingAttribute($sortAttr, $sortDir));
+    }
+}

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -7,14 +7,14 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
-use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Test\Integration\TestCase;
 
 class ReplicaIndexingTest extends TestCase
 {
+    use ReplicaAssertionsTrait;
+
     protected ?ReplicaManagerInterface $replicaManager = null;
-    protected ?ProductIndexer $productIndexer = null;
 
     protected ?IndicesConfigurator $indicesConfigurator = null;
 
@@ -23,7 +23,6 @@ class ReplicaIndexingTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->productIndexer = $this->objectManager->get(ProductIndexer::class);
         $this->replicaManager = $this->objectManager->get(ReplicaManagerInterface::class);
         $this->indicesConfigurator = $this->objectManager->get(IndicesConfigurator::class);
         $this->indexSuffix = 'products';
@@ -214,109 +213,6 @@ class ReplicaIndexingTest extends TestCase
         $this->assertSortToReplicaConfigParity($primaryIndexName, $sorting, $replicas);
     }
 
-    protected function assertSortToReplicaConfigParity(string $primaryIndexName, array $sorting, array $replicas): void
-    {
-        foreach ($sorting as $sortAttr) {
-            $replicaIndexName = $sortAttr['name'];
-            $isVirtual = array_key_exists('virtualReplica', $sortAttr) && $sortAttr['virtualReplica'];
-            $needle = $isVirtual
-                ? "virtual($replicaIndexName)"
-                : $replicaIndexName;
-            $this->assertContains($needle, $replicas);
-
-            $replicaSettings = $this->assertReplicaIndexExists($primaryIndexName, $replicaIndexName);
-            $sort = reset($sortAttr['ranking']);
-            if ($isVirtual) {
-                $this->assertVirtualReplicaRanking($replicaSettings, $sort);
-            } else {
-                $this->assertStandardReplicaRanking($replicaSettings, $sort);
-            }
-        }
-    }
-
-    protected function assertReplicaIndexExists(string $primaryIndexName, string $replicaIndexName): array
-    {
-        $replicaSettings = $this->algoliaHelper->getSettings($replicaIndexName);
-        $this->assertArrayHasKey('primary', $replicaSettings);
-        $this->assertEquals($primaryIndexName, $replicaSettings['primary']);
-        return $replicaSettings;
-    }
-
-    protected function assertReplicaRanking(array $replicaSettings, string $rankingKey, string $sort) {
-        $this->assertArrayHasKey($rankingKey, $replicaSettings);
-        $this->assertEquals($sort, reset($replicaSettings[$rankingKey]));
-    }
-
-    protected function assertStandardReplicaRanking(array $replicaSettings, string $sort): void
-    {
-        $this->assertReplicaRanking($replicaSettings, 'ranking', $sort);
-    }
-
-    protected function assertVirtualReplicaRanking(array $replicaSettings, string $sort): void
-    {
-        $this->assertReplicaRanking($replicaSettings, 'customRanking', $sort);
-    }
-
-    protected function assertStandardReplicaRankingOld(array $replicaSettings, string $sortAttr, string $sortDir): void
-    {
-        $this->assertArrayHasKey('ranking', $replicaSettings);
-        $this->assertEquals("$sortDir($sortAttr)", array_shift($replicaSettings['ranking']));
-    }
-
-    protected function assertVirtualReplicaRankingOld(array $replicaSettings, string $sortAttr, string $sortDir): void
-    {
-        $this->assertArrayHasKey('customRanking', $replicaSettings);
-        $this->assertEquals("$sortDir($sortAttr)", array_shift($replicaSettings['customRanking']));
-    }
-
-    /**
-     * @param string[] $replicaSetting
-     * @param string $replicaIndexName
-     * @return bool
-     */
-    protected function isVirtualReplica(array $replicaSetting, string $replicaIndexName): bool
-    {
-        return (bool) array_filter(
-            $replicaSetting,
-            function ($replica) use ($replicaIndexName) {
-                return str_contains($replica, "virtual($replicaIndexName)");
-            }
-        );
-    }
-
-    protected function isStandardReplica(array $replicaSetting, string $replicaIndexName): bool
-    {
-        return (bool) array_filter(
-            $replicaSetting,
-            function ($replica) use ($replicaIndexName) {
-                $regex = '/^' . preg_quote($replicaIndexName) . '$/';
-                return preg_match($regex, $replica);
-            }
-        );
-    }
-
-    protected function hasSortingAttribute($sortAttr, $sortDir): bool
-    {
-        $sorting = $this->configHelper->getSorting();
-        return (bool) array_filter(
-            $sorting,
-            function($sort) use ($sortAttr, $sortDir) {
-                return $sort['attribute'] == $sortAttr
-                    && $sort['sort'] == $sortDir;
-            }
-        );
-    }
-
-    protected function assertSortingAttribute($sortAttr, $sortDir): void
-    {
-        $this->assertTrue($this->hasSortingAttribute($sortAttr, $sortDir));
-    }
-
-    protected function assertNoSortingAttribute($sortAttr, $sortDir): void
-    {
-        $this->assertFalse($this->hasSortingAttribute($sortAttr, $sortDir));
-    }
-
     protected function tearDown(): void
     {
         parent::tearDown();
@@ -342,5 +238,4 @@ class ReplicaIndexingTest extends TestCase
             ]
         );
     }
-
 }

--- a/Test/Integration/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Product/ReplicaIndexingTest.php
@@ -8,6 +8,7 @@ use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
+use Algolia\AlgoliaSearch\Test\Integration\Product\Traits\ReplicaAssertionsTrait;
 use Algolia\AlgoliaSearch\Test\Integration\TestCase;
 
 class ReplicaIndexingTest extends TestCase
@@ -116,35 +117,6 @@ class ReplicaIndexingTest extends TestCase
         // Restore prior state (for this test only)
         $this->configHelper->setSorting($ogSortingState);
         $this->setConfig(ConfigHelper::IS_INSTANT_ENABLED, 0);
-    }
-
-    /**
-     * ConfigHelper::setSorting uses WriterInterface which does not update unless DB isolation is disabled
-     * This provides a workaround to test using MutableScopeConfigInterface with DB isolation enabled
-     */
-    protected function mockSortUpdate(string $sortAttr, string $sortDir, array $attr): void
-    {
-        $sorting = $this->configHelper->getSorting();
-        $existing = array_filter($sorting, function ($item) use ($sortAttr, $sortDir) {
-           return $item['attribute'] === $sortAttr && $item['sort'] === $sortDir;
-        });
-
-
-        if ($existing) {
-            $idx = array_key_first($existing);
-            $sorting[$idx] = array_merge($existing[$idx], $attr);
-        }
-        else {
-            $sorting[] = array_merge(
-                [
-                    'attribute' => $sortAttr,
-                    'sort'       => $sortDir,
-                    'sortLabel'  => $sortAttr
-                ],
-                $attr
-            );
-        }
-        $this->setConfig(ConfigHelper::SORTING_INDICES, json_encode($sorting));
     }
 
     /**


### PR DESCRIPTION
This PR contains:
- Added tests for Replicas with multi stores/applications context
- Created a `ReplicaAssertionsTrait` class which contains all the methods to be used by the `ReplicaIndexingTest` class AND the newly created `MultiStoreReplicaTest` class.
- Updated some methods of the `ReplicaAssertionsTrait` class to handle store switching
- Added a test for customer groups replicas