### PR TITLE
MAGE-1122 Refactor intentional price indexing for 3.15

### DIFF
--- a/Controller/Adminhtml/Reindex/Save.php
+++ b/Controller/Adminhtml/Reindex/Save.php
@@ -13,6 +13,7 @@ use Algolia\AlgoliaSearch\Service\Product\IndexBuilder as ProductIndexBuilder;
 use Magento\Backend\App\Action\Context;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -110,6 +111,7 @@ class Save extends \Magento\Backend\App\Action
      * @param $stores
      * @return void
      * @throws NoSuchEntityException
+     * @throws LocalizedException
      */
     protected function checkAndReindex($product, $stores)
     {
@@ -199,7 +201,7 @@ class Save extends \Magento\Backend\App\Action
             $productIds = [$product->getId()];
             $productIds = array_merge($productIds, $this->productHelper->getParentProductIds($productIds));
 
-            $this->productIndexBuilder->rebuildEntityIds($storeId, $productIds);
+            $this->productIndexBuilder->buildIndexList($storeId, $productIds);
             $this->messageManager->addSuccessMessage(
                 __(
                     'The Product "%1" (%2) has been reindexed for store "%3 / %4 / %5".',

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -108,6 +108,7 @@ class ConfigHelper
     public const CONNECTION_TIMEOUT = 'algoliasearch_advanced/advanced/connection_timeout';
     public const READ_TIMEOUT = 'algoliasearch_advanced/advanced/read_timeout';
     public const WRITE_TIMEOUT = 'algoliasearch_advanced/advanced/write_timeout';
+    public const AUTO_PRICE_INDEXING_ENABLED = 'algoliasearch_advanced/advanced/auto_price_indexing';
 
     public const PROFILER_ENABLED = 'algoliasearch_advanced/advanced/enable_profiler';
 
@@ -1282,6 +1283,15 @@ class ConfigHelper
     public function getWriteTimeout($storeId = null)
     {
         return $this->configInterface->getValue(self::WRITE_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function isAutoPriceIndexingEnabled(?int $storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(
+            self::AUTO_PRICE_INDEXING_ENABLED,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 
     /**

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -1313,7 +1313,6 @@ class ProductHelper extends AbstractEntityHelper
      */
     public function canProductBeReindexed($product, $storeId, $isChildProduct = false)
     {
-        $this->logger->startProfiling(__METHOD__);
         if ($product->isDeleted() === true) {
             throw (new ProductDeletedException())
                 ->withProduct($product)
@@ -1347,7 +1346,6 @@ class ProductHelper extends AbstractEntityHelper
                 ->withStoreId($storeId);
         }
 
-        $this->logger->stopProfiling(__METHOD__);
         return true;
     }
 

--- a/Model/Config/AutomaticPriceIndexingComment.php
+++ b/Model/Config/AutomaticPriceIndexingComment.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Config;
+
+use Magento\Config\Model\Config\CommentInterface;
+use Magento\Framework\UrlInterface;
+
+class AutomaticPriceIndexingComment implements CommentInterface
+{
+    public function __construct(
+        protected UrlInterface $urlInterface
+    ) { }
+
+    public function getCommentText($elementValue)
+    {
+        $url = $this->urlInterface->getUrl('https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/#configure-the-queue');
+
+        $comment = array();
+        $comment[] = 'Algolia relies on the core Magento Product Price index when serializing product data. If the price index is not up to date, Algolia will not be able to accurately determine what should be included in the search index.';
+        $comment[] = 'If you are experiencing problems with products not syncing to Algolia due to this issue, enabling this setting will allow Algolia to automatically update the price index as needed.';
+        $comment[] = 'NOTE: This can introduce a marginal amount of overhead to the indexing process so only enable if necessary. Be sure to <a href="' . $url . '" target="_blank">optimize the indexing queue</a> based on the impact of this operation.';
+        return implode('<br><br>', $comment);
+    }
+}

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -26,15 +26,16 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
     protected IndexerInterface $priceIndexer;
 
     public function __construct(
-        protected ConfigHelper       $configHelper,
-        protected DiagnosticsLogger  $logger,
-        protected Emulation          $emulation,
-        protected ScopeCodeResolver  $scopeCodeResolver,
-        protected AlgoliaHelper      $algoliaHelper,
-        protected ProductHelper      $productHelper,
-        protected ResourceConnection $resource,
-        protected ManagerInterface   $eventManager,
-        IndexerRegistry              $indexerRegistry
+        protected ConfigHelper             $configHelper,
+        protected DiagnosticsLogger        $logger,
+        protected Emulation                $emulation,
+        protected ScopeCodeResolver        $scopeCodeResolver,
+        protected AlgoliaHelper            $algoliaHelper,
+        protected ProductHelper            $productHelper,
+        protected ResourceConnection       $resource,
+        protected ManagerInterface         $eventManager,
+        protected MissingPriceIndexHandler $missingPriceIndexHandler,
+        IndexerRegistry                    $indexerRegistry
     ){
         parent::__construct($configHelper, $logger, $emulation, $scopeCodeResolver, $algoliaHelper);
 
@@ -106,12 +107,6 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      */
     protected function rebuildEntityIds(int $storeId, array $productIds): void
     {
-        if ($this->isIndexingEnabled($storeId) === false) {
-            return;
-        }
-
-        $this->checkPriceIndex($productIds);
-
         $this->startEmulation($storeId);
         $this->logger->start('Indexing');
         try {
@@ -239,6 +234,11 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
                 'store'      => $storeId
             ]
         );
+
+        if ($this->configHelper->isAutoPriceIndexingEnabled($storeId)) {
+            $this->missingPriceIndexHandler->refreshPriceIndex($collection);
+        }
+
         $logMessage = 'LOADING: ' . $this->logger->getStoreName($storeId) . ',
             collection page: ' . $page . ',
             pageSize: ' . $pageSize;

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -327,10 +327,13 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             }
 
             try {
+                $this->logger->startProfiling("canProductBeReindexed");
                 $this->productHelper->canProductBeReindexed($product, $storeId);
             } catch (ProductReindexingException $e) {
                 $productsToRemove[$productId] = $productId;
                 continue;
+            } finally {
+                $this->logger->stopProfiling("canProductBeReindexed");
             }
 
             if (isset($salesData[$productId])) {

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -2,12 +2,19 @@
 
 namespace Algolia\AlgoliaSearch\Service\Product;
 
+use Magento\Framework\DB\Select;
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Indexer\IndexerInterface;
+use Zend_Db_Select;
 
 class MissingPriceIndexHandler
 {
+    public const PRICE_INDEX_TABLE = 'catalog_product_index_price';
+    public const PRICE_INDEX_TABLE_ALIAS = 'price_index';
+    public const MAIN_TABLE_ALIAS = 'e';
+
     protected IndexerInterface $indexer;
     public function __construct(
         protected CollectionFactory $productCollectionFactory,
@@ -18,12 +25,12 @@ class MissingPriceIndexHandler
     }
 
     /**
-     * @param array $productIds
-     * @return int[] Array of product IDs that were reindexed by this repair operation
+     * @param string[]|ProductCollection $products
+     * @return string[] Array of product IDs that were reindexed by this repair operation
      */
-    public function refreshPriceIndex(array $productIds): array
+    public function refreshPriceIndex(array|ProductCollection $products): array
     {
-        $reindexIds = $this->getProductIdsToReindex($productIds);
+        $reindexIds = $this->getProductIdsToReindex($products);
         if (empty($reindexIds)) {
             return [];
         }
@@ -34,16 +41,25 @@ class MissingPriceIndexHandler
     }
 
     /**
-     * @param int[] $productIds
-     * @return int[]
+     * @param string[]|ProductCollection $products
+     * @return string[]
      */
-    protected function getProductIdsToReindex(array $productIds): array
+    protected function getProductIdsToReindex(array|ProductCollection $products): array
     {
+        $productIds = $products instanceof ProductCollection
+            ? $this->getExpandedProductCollectionIds($products)
+            : $products;
+
         $state = $this->indexer->getState()->getStatus();
         if ($state === \Magento\Framework\Indexer\StateInterface::STATUS_INVALID) {
             return $productIds;
         }
 
+        return $this->filterProductIds($productIds);
+    }
+
+    protected function filterProductIds(array $productIds): array
+    {
         $collection = $this->productCollectionFactory->create();
 
         $collection->addAttributeToSelect(['name', 'price']);
@@ -56,8 +72,85 @@ class MissingPriceIndexHandler
 
         $collection->getSelect()
             ->where('price_index.entity_id IS NULL')
-            ->where('entity_id IN (?)', $productIds);
+            ->where('e.entity_id IN (?)', $productIds);
 
         return $collection->getAllIds();
+    }
+
+    protected function getExpandedProductCollectionIds(ProductCollection $collection): array
+    {
+        $expandedCollection = clone $collection;
+
+        $select = $expandedCollection->getSelect();
+
+        $joins = $select->getPart(Zend_Db_Select::FROM);
+
+        $priceIndexJoin = $this->getPriceIndexJoinAlias($joins);
+
+        if (!$priceIndexJoin) {
+            // nothing to do here - keep calm and carry on
+            return [];
+        }
+
+        $modifyJoin = &$joins[$priceIndexJoin];
+        $modifyJoin['joinType'] = Zend_Db_Select::LEFT_JOIN;
+
+        $this->rebuildJoins($select, $joins);
+
+        return $expandedCollection->getAllIds();
+    }
+
+    protected function rebuildJoins(Select $select, array $joins): void
+    {
+        $select->reset(Zend_Db_Select::FROM);
+        foreach ($joins as $alias => $joinData) {
+            if ($joinData['joinType'] === Zend_Db_Select::FROM) {
+                $select->from([$alias => $joinData['tableName']]);
+            } elseif ($joinData['joinType'] === Zend_Db_Select::LEFT_JOIN) {
+                $select->joinLeft(
+                    [$alias => $joinData['tableName']],
+                    $joinData['joinCondition'],
+                    [],
+                    $joinData['schema']
+                );
+            } else {
+                $select->join(
+                    [$alias => $joinData['tableName']],
+                    $joinData['joinCondition'],
+                    [],
+                    $joinData['schema']
+                );
+            }
+            $sql = $select->__toString();
+        }
+    }
+
+    private function inspectJoins(array $joins): void {
+        foreach ($joins as $alias => $joinData) {
+            echo "Table Alias: $alias\n";
+            echo "Table Name: {$joinData['tableName']}\n";
+            echo "Join Type: {$joinData['joinType']}\n";
+            echo "Join Condition: " . ($joinData['joinCondition'] ?? 'N/A') . "\n\n";
+        }
+    }
+
+    /**
+     * @param array<string, array> $joins
+     * @return string
+     */
+    protected function getPriceIndexJoinAlias(array $joins): string
+    {
+        if (isset($joins[self::PRICE_INDEX_TABLE_ALIAS])) {
+            return self::PRICE_INDEX_TABLE_ALIAS;
+        }
+        else {
+            foreach ($joins as $alias => $joinData) {
+                if ($joinData['tableName'] === self::PRICE_INDEX_TABLE) {
+                    return $alias;
+                }
+            }
+        }
+
+        return "";
     }
 }

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -65,14 +65,14 @@ class MissingPriceIndexHandler
         $collection->addAttributeToSelect(['name', 'price']);
 
         $collection->getSelect()->joinLeft(
-            ['price_index' => 'catalog_product_index_price'],
-            'e.entity_id = price_index.entity_id',
+            [self::PRICE_INDEX_TABLE_ALIAS => self::PRICE_INDEX_TABLE],
+            self::MAIN_TABLE_ALIAS . '.entity_id = ' . self::PRICE_INDEX_TABLE_ALIAS . '.entity_id',
             []
         );
 
         $collection->getSelect()
-            ->where('price_index.entity_id IS NULL')
-            ->where('e.entity_id IN (?)', $productIds);
+            ->where(self::PRICE_INDEX_TABLE_ALIAS . '.entity_id IS NULL')
+            ->where(self::MAIN_TABLE_ALIAS . '.entity_id IN (?)', $productIds);
 
         return $collection->getAllIds();
     }

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Product;
+
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Indexer\IndexerInterface;
+
+class MissingPriceIndexHandler
+{
+    protected IndexerInterface $indexer;
+    public function __construct(
+        protected CollectionFactory $productCollectionFactory,
+        IndexerRegistry $indexerRegistry
+    )
+    {
+        $this->indexer = $indexerRegistry->get('catalog_product_price');
+    }
+
+    /**
+     * @param array $productIds
+     * @return int[] Array of product IDs that were reindexed by this repair operation
+     */
+    public function refreshPriceIndex(array $productIds): array
+    {
+        $reindexIds = $this->getProductIdsToReindex($productIds);
+        if (empty($reindexIds)) {
+            return [];
+        }
+
+        $this->indexer->reindexList($reindexIds);
+
+        return $reindexIds;
+    }
+
+    /**
+     * @param int[] $productIds
+     * @return int[]
+     */
+    protected function getProductIdsToReindex(array $productIds): array
+    {
+        $state = $this->indexer->getState()->getStatus();
+        if ($state === \Magento\Framework\Indexer\StateInterface::STATUS_INVALID) {
+            return $productIds;
+        }
+
+        $collection = $this->productCollectionFactory->create();
+
+        $collection->addAttributeToSelect(['name', 'price']);
+
+        $collection->getSelect()->joinLeft(
+            ['price_index' => 'catalog_product_index_price'],
+            'e.entity_id = price_index.entity_id',
+            []
+        );
+
+        $collection->getSelect()
+            ->where('price_index.entity_id IS NULL')
+            ->where('entity_id IN (?)', $productIds);
+
+        return $collection->getAllIds();
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1337,6 +1337,16 @@
                 <field id="write_timeout" translate="label comment" type="text" sortOrder="110" showInDefault="1">
                     <label>Write Timeout (In Seconds)</label>
                 </field>
+                <field id="auto_price_indexing" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable automatic price indexing</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <model>Algolia\AlgoliaSearch\Model\Config\AutomaticPriceIndexingComment</model>
+                    </comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
                 <field id="enable_profiler" translate="label comment" type="select" sortOrder="130" showInDefault="1">
                     <label>Enable Profiler</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -94,6 +94,7 @@
                 <connection_timeout>2</connection_timeout>
                 <read_timeout>30</read_timeout>
                 <write_timeout>30</write_timeout>
+                <auto_price_indexing>0</auto_price_indexing>
                 <enable_profiler>0</enable_profiler>
             </advanced>
             <queue>

--- a/etc/indexer.xml
+++ b/etc/indexer.xml
@@ -5,9 +5,6 @@
         <description translate="true">
             Rebuild products index.
         </description>
-        <dependencies>
-            <indexer id="catalog_product_price" />
-        </dependencies>
     </indexer>
     <indexer id="algolia_categories" view_id="algolia_categories" class="Algolia\AlgoliaSearch\Model\Indexer\Category">
         <title translate="true">Algolia Search Categories</title>


### PR DESCRIPTION
Refactor of https://github.com/algolia/algoliasearch-magento-2/pull/1662 for 3.15 (with profiling)

Some results:

On an extra large fixture (1M products) processing a delta of a 100 products took an additional 19 ms with virtually no RAM consumption:
![image](https://github.com/user-attachments/assets/f2fcb7aa-f213-4645-baae-b9130a2e53f3)

Across a delta of 1000 products over 5 stores the process took 491 ms:
![image](https://github.com/user-attachments/assets/a1a33492-d1f2-414c-b02c-739a7b44156f)

On the same size catalog, where 2000 price index records were found missing across 5 stores (but the price index still appears to be valid), the extra reindexing repair operations (on the fly) took approximately 592 ms and ~2.1 MB of RAM. 

![image](https://github.com/user-attachments/assets/a7a35aa4-a061-4dce-892c-623c938937b2)

Performance impact appears to be super linear but sub quadratic - approx. O(n^1.41) observed - and the upper boundary can be contained by the number of records processed per job. 

Full details in Jira. 

