### PR TITLE
MAGE-1170: Handle Index options with `IndexNameFetcher`

### DIFF
--- a/Api/Data/IndexOptionsInterface.php
+++ b/Api/Data/IndexOptionsInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api\Data;
+
+interface IndexOptionsInterface
+{
+    const STORE_ID = 'store_id';
+
+    const INDEX_SUFFIX = 'index_suffix';
+
+    const IS_TMP = 'is_tmp';
+
+    const ENFORCED_INDEX_NAME = 'enforced_index_name';
+
+    /**
+     * Get field: store_id
+     *
+     * @return int|null
+     */
+    public function getStoreId(): ?int;
+
+    /**
+     * Get field: index_suffix
+     *
+     * @return string|null
+     */
+    public function getIndexSuffix(): ?string;
+
+    /**
+     * Get field: is_tmp
+     *
+     * @return bool
+     */
+    public function isTmp(): bool;
+
+    /**
+     * Get field: enforced_index_name
+     *
+     * @return string|null
+     */
+    public function getEnforcedIndexName(): ?string;
+}

--- a/Api/Data/IndexOptionsInterface.php
+++ b/Api/Data/IndexOptionsInterface.php
@@ -31,7 +31,7 @@ interface IndexOptionsInterface
      *
      * @return bool
      */
-    public function isTmp(): bool;
+    public function isTemporaryIndex(): bool;
 
     /**
      * Get field: enforced_index_name

--- a/Api/Data/IndexOptionsInterface.php
+++ b/Api/Data/IndexOptionsInterface.php
@@ -10,7 +10,7 @@ interface IndexOptionsInterface
 
     const IS_TMP = 'is_tmp';
 
-    const ENFORCED_INDEX_NAME = 'enforced_index_name';
+    const INDEX_NAME = 'index_name';
 
     /**
      * Get field: store_id
@@ -34,9 +34,17 @@ interface IndexOptionsInterface
     public function isTemporaryIndex(): bool;
 
     /**
-     * Get field: enforced_index_name
+     * Get field: index_name
      *
      * @return string|null
      */
-    public function getEnforcedIndexName(): ?string;
+    public function getIndexName(): ?string;
+
+    /**
+     * Set field: index_name
+     *
+     * @param string $indexName
+     * @return void
+     */
+    public function setIndexName(string $indexName): void;
 }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -2,15 +2,18 @@
 
 namespace Algolia\AlgoliaSearch\Helper;
 
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
 use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Algolia\AlgoliaSearch\Model\IndexOptions;
 use Algolia\AlgoliaSearch\Model\Search\ListIndicesResponse;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Exception;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * @deprecated (will be removed in v3.16.0)
@@ -59,12 +62,14 @@ class AlgoliaHelper extends AbstractHelper
      * @param array $params
      * @param int|null $storeId
      * @return array<string, mixed>
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      * @internal This method is currently unstable and should not be used. It may be revisited ar fixed in a future version.
      */
     public function query(string $indexName, string $q, array $params, ?int $storeId = null): array
     {
-        return $this->algoliaConnector->query($indexName, $q, $params, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        return $this->algoliaConnector->query($indexOptions, $q, $params);
     }
 
     /**
@@ -72,11 +77,13 @@ class AlgoliaHelper extends AbstractHelper
      * @param array $objectIds
      * @param int|null $storeId
      * @return array<string, mixed>
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function getObjects(string $indexName, array $objectIds, ?int $storeId = null): array
     {
-        return $this->algoliaConnector->getObjects($indexName, $objectIds, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        return $this->algoliaConnector->getObjects($indexOptions, $objectIds);
     }
 
     /**
@@ -86,7 +93,7 @@ class AlgoliaHelper extends AbstractHelper
      * @param bool $mergeSettings
      * @param string $mergeSettingsFrom
      * @param int|null $storeId
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function setSettings(
         $indexName,
@@ -96,13 +103,14 @@ class AlgoliaHelper extends AbstractHelper
         string $mergeSettingsFrom = '',
         ?int $storeId = null
     ) {
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
         $this->algoliaConnector->setSettings(
-            $indexName,
+            $indexOptions,
             $settings,
             $forwardToReplicas,
             $mergeSettings,
-            $mergeSettingsFrom,
-            $storeId
+            $mergeSettingsFrom
         );
     }
 
@@ -110,11 +118,13 @@ class AlgoliaHelper extends AbstractHelper
      * @param string $indexName
      * @param int|null $storeId
      * @return void
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function deleteIndex(string $indexName, ?int $storeId = null): void
     {
-        $this->algoliaConnector->deleteIndex($indexName, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        $this->algoliaConnector->deleteIndex($indexOptions);
     }
 
     /**
@@ -126,7 +136,9 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function deleteObjects(array $ids, string $indexName, ?int $storeId = null): void
     {
-        $this->algoliaConnector->deleteObjects($ids, $indexName, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        $this->algoliaConnector->deleteObjects($ids, $indexOptions);
     }
 
     /**
@@ -134,11 +146,14 @@ class AlgoliaHelper extends AbstractHelper
      * @param string $toIndexName
      * @param int|null $storeId
      * @return void
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function moveIndex(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $this->algoliaConnector->moveIndex($fromIndexName, $toIndexName, $storeId);
+        $fromIndexOptions = $this->convertToIndexOptions($fromIndexName, $storeId);
+        $toIndexOptions = $this->convertToIndexOptions($toIndexName, $storeId);
+
+        $this->algoliaConnector->moveIndex($fromIndexOptions, $toIndexOptions);
     }
 
     /**
@@ -157,11 +172,13 @@ class AlgoliaHelper extends AbstractHelper
      * @param string $indexName
      * @param int|null $storeId
      * @return array<string, mixed>
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function getSettings(string $indexName, ?int $storeId = null): array
     {
-        return $this->algoliaConnector->getSettings($indexName, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        return $this->algoliaConnector->getSettings($indexOptions);
     }
 
     /**
@@ -175,7 +192,9 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false, ?int $storeId = null): void
     {
-        $this->algoliaConnector->saveObjects($indexName, $objects, $isPartialUpdate, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        $this->algoliaConnector->saveObjects($indexOptions, $objects, $isPartialUpdate);
     }
 
     /**
@@ -184,11 +203,13 @@ class AlgoliaHelper extends AbstractHelper
      * @param bool $forwardToReplicas
      * @param int|null $storeId
      * @return void
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false, ?int $storeId = null): void
     {
-        $this->algoliaConnector->saveRule($rule, $indexName, $forwardToReplicas, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        $this->algoliaConnector->saveRule($rule, $indexOptions, $forwardToReplicas);
     }
 
     /**
@@ -197,10 +218,14 @@ class AlgoliaHelper extends AbstractHelper
      * @param bool $forwardToReplicas
      * @param int|null $storeId
      * @return void
+     * @throws AlgoliaException
+     * @throws NoSuchEntityException
      */
     public function saveRules(string $indexName, array $rules, bool $forwardToReplicas = false, ?int $storeId = null): void
     {
-        $this->algoliaConnector->saveRules($indexName, $rules, $forwardToReplicas, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        $this->algoliaConnector->saveRules($indexOptions, $rules, $forwardToReplicas);
     }
 
     /**
@@ -209,7 +234,7 @@ class AlgoliaHelper extends AbstractHelper
      * @param bool $forwardToReplicas
      * @param int|null $storeId
      * @return void
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function deleteRule(
         string $indexName,
@@ -218,7 +243,9 @@ class AlgoliaHelper extends AbstractHelper
         ?int $storeId = null
     ) : void
     {
-        $this->algoliaConnector->deleteRule($indexName, $objectID, $forwardToReplicas, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        $this->algoliaConnector->deleteRule($indexOptions, $objectID, $forwardToReplicas);
     }
 
     /**
@@ -227,11 +254,14 @@ class AlgoliaHelper extends AbstractHelper
      * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
-     * @throws ExceededRetriesException
+     * @throws ExceededRetriesException|NoSuchEntityException
      */
     public function copySynonyms(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $this->algoliaConnector->copySynonyms($fromIndexName, $toIndexName, $storeId);
+        $fromIndexOptions = $this->convertToIndexOptions($fromIndexName, $storeId);
+        $toIndexOptions = $this->convertToIndexOptions($toIndexName, $storeId);
+
+        $this->algoliaConnector->copySynonyms($fromIndexOptions, $toIndexOptions);
     }
 
     /**
@@ -240,11 +270,14 @@ class AlgoliaHelper extends AbstractHelper
      * @param int|null $storeId
      * @return void
      * @throws AlgoliaException
-     * @throws ExceededRetriesException
+     * @throws ExceededRetriesException|NoSuchEntityException
      */
     public function copyQueryRules(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $this->algoliaConnector->copyQueryRules($fromIndexName, $toIndexName, $storeId);
+        $fromIndexOptions = $this->convertToIndexOptions($fromIndexName, $storeId);
+        $toIndexOptions = $this->convertToIndexOptions($toIndexName, $storeId);
+
+        $this->algoliaConnector->copyQueryRules($fromIndexOptions, $toIndexOptions);
     }
 
     /**
@@ -253,22 +286,26 @@ class AlgoliaHelper extends AbstractHelper
      * @param int|null $storeId
      * @return array
      *
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
-    public function searchRules(string $indexName, array$searchRulesParams = null, ?int $storeId = null)
+    public function searchRules(string $indexName, array $searchRulesParams = null, ?int $storeId = null)
     {
-        return $this->algoliaConnector->searchRules($indexName, $searchRulesParams, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        return $this->algoliaConnector->searchRules($indexOptions, $searchRulesParams);
     }
 
     /**
      * @param string $indexName
      * @param int|null $storeId
      * @return void
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function clearIndex(string $indexName, ?int $storeId = null): void
     {
-        $this->algoliaConnector->clearIndex($indexName, $storeId);
+        $indexOptions = $this->convertToIndexOptions($indexName, $storeId);
+
+        $this->algoliaConnector->clearIndex($indexOptions);
     }
 
     /**
@@ -300,5 +337,23 @@ class AlgoliaHelper extends AbstractHelper
     public function getLastTaskId(?int $storeId = null): int
     {
         return $this->algoliaConnector->getLastTaskId($storeId);
+    }
+
+    /**
+     * Automatically converts information related to an index into a IndexOptions objects
+     * This ensures compatibility of this deprecated class with the new method signatures of AlgoliaConnector
+     *
+     * @param string|null $indexName
+     * @param int|null $storeId
+     * @param bool|null $isTmp
+     * @return IndexOptions
+     */
+    protected function convertToIndexOptions(?string $indexName = null, ?int $storeId = null, ?bool $isTmp = false): IndexOptions
+    {
+        return new IndexOptions([
+            IndexOptionsInterface::ENFORCED_INDEX_NAME => $indexName,
+            IndexOptionsInterface::STORE_ID => $storeId,
+            IndexOptionsInterface::IS_TMP => $isTmp
+        ]);
     }
 }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -67,7 +67,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function query(string $indexName, string $q, array $params, ?int $storeId = null): array
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         return $this->algoliaConnector->query($indexOptions, $q, $params);
     }
@@ -77,11 +77,11 @@ class AlgoliaHelper extends AbstractHelper
      * @param array $objectIds
      * @param int|null $storeId
      * @return array<string, mixed>
-     * @throws AlgoliaException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     public function getObjects(string $indexName, array $objectIds, ?int $storeId = null): array
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         return $this->algoliaConnector->getObjects($indexOptions, $objectIds);
     }
@@ -103,7 +103,7 @@ class AlgoliaHelper extends AbstractHelper
         string $mergeSettingsFrom = '',
         ?int $storeId = null
     ) {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->algoliaConnector->setSettings(
             $indexOptions,
@@ -122,7 +122,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function deleteIndex(string $indexName, ?int $storeId = null): void
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->algoliaConnector->deleteIndex($indexOptions);
     }
@@ -136,7 +136,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function deleteObjects(array $ids, string $indexName, ?int $storeId = null): void
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->algoliaConnector->deleteObjects($ids, $indexOptions);
     }
@@ -150,8 +150,8 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function moveIndex(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $fromIndexOptions = $this->indexOptionsBuilder->convertToIndexOptions($fromIndexName, $storeId);
-        $toIndexOptions = $this->indexOptionsBuilder->convertToIndexOptions($toIndexName, $storeId);
+        $fromIndexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($fromIndexName, $storeId);
+        $toIndexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($toIndexName, $storeId);
 
         $this->algoliaConnector->moveIndex($fromIndexOptions, $toIndexOptions);
     }
@@ -176,7 +176,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function getSettings(string $indexName, ?int $storeId = null): array
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         return $this->algoliaConnector->getSettings($indexOptions);
     }
@@ -192,7 +192,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function saveObjects(string $indexName, array $objects, bool $isPartialUpdate = false, ?int $storeId = null): void
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->algoliaConnector->saveObjects($indexOptions, $objects, $isPartialUpdate);
     }
@@ -207,7 +207,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function saveRule(array $rule, string $indexName, bool $forwardToReplicas = false, ?int $storeId = null): void
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->algoliaConnector->saveRule($rule, $indexOptions, $forwardToReplicas);
     }
@@ -223,7 +223,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function saveRules(string $indexName, array $rules, bool $forwardToReplicas = false, ?int $storeId = null): void
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->algoliaConnector->saveRules($indexOptions, $rules, $forwardToReplicas);
     }
@@ -243,7 +243,7 @@ class AlgoliaHelper extends AbstractHelper
         ?int $storeId = null
     ) : void
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->algoliaConnector->deleteRule($indexOptions, $objectID, $forwardToReplicas);
     }
@@ -258,8 +258,8 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function copySynonyms(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $fromIndexOptions = $this->indexOptionsBuilder->convertToIndexOptions($fromIndexName, $storeId);
-        $toIndexOptions = $this->indexOptionsBuilder->convertToIndexOptions($toIndexName, $storeId);
+        $fromIndexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($fromIndexName, $storeId);
+        $toIndexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($toIndexName, $storeId);
 
         $this->algoliaConnector->copySynonyms($fromIndexOptions, $toIndexOptions);
     }
@@ -274,8 +274,8 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function copyQueryRules(string $fromIndexName, string $toIndexName, ?int $storeId = null): void
     {
-        $fromIndexOptions = $this->indexOptionsBuilder->convertToIndexOptions($fromIndexName, $storeId);
-        $toIndexOptions = $this->indexOptionsBuilder->convertToIndexOptions($toIndexName, $storeId);
+        $fromIndexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($fromIndexName, $storeId);
+        $toIndexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($toIndexName, $storeId);
 
         $this->algoliaConnector->copyQueryRules($fromIndexOptions, $toIndexOptions);
     }
@@ -290,7 +290,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function searchRules(string $indexName, array $searchRulesParams = null, ?int $storeId = null)
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         return $this->algoliaConnector->searchRules($indexOptions, $searchRulesParams);
     }
@@ -303,7 +303,7 @@ class AlgoliaHelper extends AbstractHelper
      */
     public function clearIndex(string $indexName, ?int $storeId = null): void
     {
-        $indexOptions = $this->indexOptionsBuilder->convertToIndexOptions($indexName, $storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->algoliaConnector->clearIndex($indexOptions);
     }

--- a/Model/IndexOptions.php
+++ b/Model/IndexOptions.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Magento\Framework\DataObject;
+
+class IndexOptions extends DataObject implements IndexOptionsInterface
+{
+    public function getStoreId(): ?int
+    {
+        return $this->hasData(IndexOptionsInterface::STORE_ID) ?
+            (int) $this->getData(IndexOptionsInterface::STORE_ID) :
+            null;
+    }
+
+    public function getIndexSuffix(): ?string
+    {
+        return $this->hasData(IndexOptionsInterface::INDEX_SUFFIX) ?
+            (string) $this->getData(IndexOptionsInterface::INDEX_SUFFIX) :
+            null;
+    }
+
+    public function isTmp(): bool
+    {
+        return $this->hasData(IndexOptionsInterface::IS_TMP) ?
+            (string) $this->getData(IndexOptionsInterface::IS_TMP) :
+            false;
+    }
+
+    public function getEnforcedIndexName(): ?string
+    {
+        return $this->hasData(IndexOptionsInterface::ENFORCED_INDEX_NAME) ?
+            (string) $this->getData(IndexOptionsInterface::ENFORCED_INDEX_NAME) :
+            null;
+    }
+}

--- a/Model/IndexOptions.php
+++ b/Model/IndexOptions.php
@@ -41,15 +41,24 @@ class IndexOptions extends DataObject implements IndexOptionsInterface
         return $this->hasData(IndexOptionsInterface::IS_TMP) && $this->getData(IndexOptionsInterface::IS_TMP);
     }
 
+
     /**
-     * In case an enforced index name is used, this will override the index names fetched by the IndexNameFetcher service
+     * Returns the final index name computed by the IndexNameFetcher
      *
-     * @return string|null
+     * @return string
      */
-    public function getEnforcedIndexName(): ?string
+    public function getIndexName(): string
     {
-        return $this->hasData(IndexOptionsInterface::ENFORCED_INDEX_NAME) ?
-            (string) $this->getData(IndexOptionsInterface::ENFORCED_INDEX_NAME) :
-            null;
+        return $this->getData(IndexOptionsInterface::INDEX_NAME);
+    }
+
+    /**
+     * @param string $indexName
+     *
+     * @return void
+     */
+    public function setIndexName(string $indexName): void
+    {
+        $this->setData(IndexOptionsInterface::INDEX_NAME, $indexName);
     }
 }

--- a/Model/IndexOptions.php
+++ b/Model/IndexOptions.php
@@ -7,6 +7,11 @@ use Magento\Framework\DataObject;
 
 class IndexOptions extends DataObject implements IndexOptionsInterface
 {
+    /**
+     * Return the current store_id; if the method returns null, the Magento default store will be used
+     *
+     * @return int|null
+     */
     public function getStoreId(): ?int
     {
         return $this->hasData(IndexOptionsInterface::STORE_ID) ?
@@ -14,6 +19,11 @@ class IndexOptions extends DataObject implements IndexOptionsInterface
             null;
     }
 
+    /**
+     * Suffix usually refers to the entity to index (_products, _categories, _pages, ...)
+     *
+     * @return string|null
+     */
     public function getIndexSuffix(): ?string
     {
         return $this->hasData(IndexOptionsInterface::INDEX_SUFFIX) ?
@@ -21,13 +31,21 @@ class IndexOptions extends DataObject implements IndexOptionsInterface
             null;
     }
 
-    public function isTmp(): bool
+    /**
+     * Temporary indices can be used in case of full reindexing
+     *
+     * @return bool
+     */
+    public function isTemporaryIndex(): bool
     {
-        return $this->hasData(IndexOptionsInterface::IS_TMP) ?
-            (string) $this->getData(IndexOptionsInterface::IS_TMP) :
-            false;
+        return $this->hasData(IndexOptionsInterface::IS_TMP) && $this->getData(IndexOptionsInterface::IS_TMP);
     }
 
+    /**
+     * In case an enforced index name is used, this will override the index names fetched by the IndexNameFetcher service
+     *
+     * @return string|null
+     */
     public function getEnforcedIndexName(): ?string
     {
         return $this->hasData(IndexOptionsInterface::ENFORCED_INDEX_NAME) ?

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -308,6 +308,8 @@ class AlgoliaConnector
     }
 
     /**
+     * Warning: This method can't be performed across two different applications
+     *
      * @param IndexOptions $fromIndexOptions
      * @param IndexOptions $toIndexOptions
      * @return void
@@ -560,6 +562,8 @@ class AlgoliaConnector
     }
 
     /**
+     * Warning: This method can't be performed across two different applications
+     *
      * @param IndexOptionsInterface $fromIndexOptions
      * @param IndexOptionsInterface $toIndexOptions
      * @return void
@@ -583,6 +587,8 @@ class AlgoliaConnector
     }
 
     /**
+     * Warning: This method can't be performed across two different applications
+     *
      * @param IndexOptionsInterface $fromIndexOptions
      * @param IndexOptionsInterface $toIndexOptions
      * @return void
@@ -1062,6 +1068,7 @@ class AlgoliaConnector
      * @param IndexOptionsInterface $indexOptions
      * @return string|null
      * @throws NoSuchEntityException
+     * @throws AlgoliaException
      */
     protected function getIndexName(IndexOptionsInterface $indexOptions): ?string
     {
@@ -1070,13 +1077,13 @@ class AlgoliaConnector
         }
 
         if (is_null($indexOptions->getIndexSuffix())) {
-            return null;
+            throw new AlgoliaException('Index suffix is mandatory in case no enforced index name is specified.');
         }
 
         return $this->indexNameFetcher->getIndexName(
             $indexOptions->getIndexSuffix(),
             $indexOptions->getStoreId(),
-            $indexOptions->isTmp()
+            $indexOptions->isTemporaryIndex()
         );
     }
 }

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -78,7 +78,8 @@ class AlgoliaConnector
         protected ManagerInterface $messageManager,
         protected ConsoleOutput $consoleOutput,
         protected AlgoliaCredentialsManager $algoliaCredentialsManager,
-        protected IndexNameFetcher $indexNameFetcher
+        protected IndexNameFetcher $indexNameFetcher,
+        protected IndexOptionsBuilder $indexOptionsBuilder
     ) {
         // Merge non castable attributes set in config
         $this->nonCastableAttributes = array_merge(
@@ -182,7 +183,7 @@ class AlgoliaConnector
         //    return $this->searchWithDisjunctiveFaceting($indexName, $q, $params);
         //}
 
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $params = array_merge(
             [
@@ -202,11 +203,11 @@ class AlgoliaConnector
      * @param IndexOptionsInterface $indexOptions
      * @param array $objectIds
      * @return array<string, mixed>
-     * @throws AlgoliaException|NoSuchEntityException
+     * @throws AlgoliaException
      */
     public function getObjects(IndexOptionsInterface $indexOptions, array $objectIds): array
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $requests = array_values(
             array_map(
@@ -239,7 +240,7 @@ class AlgoliaConnector
         bool $mergeSettings = false,
         string $mergeSettingsFrom = ''
     ) {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         if ($mergeSettings === true) {
             $settings = $this->mergeSettings($indexName, $settings, $mergeSettingsFrom, $indexOptions->getStoreId());
@@ -259,7 +260,7 @@ class AlgoliaConnector
      */
     protected function performBatchOperation(IndexOptionsInterface $indexOptions, array $requests): array
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $response = $this->getClient($indexOptions->getStoreId())->batch($indexName, [ 'requests' => $requests ] );
 
@@ -275,7 +276,7 @@ class AlgoliaConnector
      */
     public function deleteIndex(IndexOptionsInterface $indexOptions): void
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $res = $this->getClient($indexOptions->getStoreId())->deleteIndex($indexName);
 
@@ -318,8 +319,8 @@ class AlgoliaConnector
      */
     public function moveIndex(IndexOptions $fromIndexOptions, IndexOptions $toIndexOptions): void
     {
-        $fromIndexName = $this->getIndexName($fromIndexOptions);
-        $toIndexName = $this->getIndexName($toIndexOptions);
+        $fromIndexName = $fromIndexOptions->getIndexName();
+        $toIndexName = $toIndexOptions->getIndexName();
 
         $response = $this->getClient($fromIndexOptions->getStoreId())->operationIndex(
             $fromIndexName,
@@ -357,7 +358,7 @@ class AlgoliaConnector
      */
     public function getSettings(IndexOptionsInterface $indexOptions): array
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         try {
             return $this->getClient($indexOptions->getStoreId())->getSettings($indexName);
@@ -457,7 +458,7 @@ class AlgoliaConnector
      */
     public function saveObjects(IndexOptionsInterface $indexOptions, array $objects, bool $isPartialUpdate = false): void
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $this->prepareRecords($objects, $indexName);
 
@@ -486,7 +487,7 @@ class AlgoliaConnector
      */
     protected function setLastOperationInfo(IndexOptionsInterface $indexOptions, array $response): void
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
         $storeId = $indexOptions->getStoreId();
 
         $this->lastUsedIndexName = $indexName;
@@ -510,7 +511,7 @@ class AlgoliaConnector
      */
     public function saveRule(array $rule, IndexOptionsInterface $indexOptions, bool $forwardToReplicas = false): void
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $res = $this->getClient($indexOptions->getStoreId())->saveRule(
             $indexName,
@@ -532,7 +533,7 @@ class AlgoliaConnector
      */
     public function saveRules(IndexOptionsInterface $indexOptions, array $rules, bool $forwardToReplicas = false): void
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $res = $this->getClient($indexOptions->getStoreId())->saveRules($indexName, $rules, $forwardToReplicas);
 
@@ -554,7 +555,7 @@ class AlgoliaConnector
         bool $forwardToReplicas = false
     ): void
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $res = $this->getClient($indexOptions->getStoreId())->deleteRule($indexName, $objectID, $forwardToReplicas);
 
@@ -572,8 +573,8 @@ class AlgoliaConnector
      */
     public function copySynonyms(IndexOptionsInterface $fromIndexOptions, IndexOptionsInterface $toIndexOptions): void
     {
-        $fromIndexName = $this->getIndexName($fromIndexOptions);
-        $toIndexName = $this->getIndexName($toIndexOptions);
+        $fromIndexName = $fromIndexOptions->getIndexName();
+        $toIndexName = $toIndexOptions->getIndexName();
 
         $response = $this->getClient($fromIndexOptions->getStoreId())->operationIndex(
             $fromIndexName,
@@ -597,8 +598,8 @@ class AlgoliaConnector
      */
     public function copyQueryRules(IndexOptionsInterface $fromIndexOptions, IndexOptionsInterface $toIndexOptions): void
     {
-        $fromIndexName = $this->getIndexName($fromIndexOptions);
-        $toIndexName = $this->getIndexName($toIndexOptions);
+        $fromIndexName = $fromIndexOptions->getIndexName();
+        $toIndexName = $toIndexOptions->getIndexName();
 
         $response = $this->getClient($fromIndexOptions->getStoreId())->operationIndex(
             $fromIndexName,
@@ -621,7 +622,7 @@ class AlgoliaConnector
      */
     public function searchRules(IndexOptionsInterface $indexOptions, array$searchRulesParams = null)
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         return $this->getClient($indexOptions->getStoreId())->searchRules($indexName, $searchRulesParams);
     }
@@ -634,7 +635,7 @@ class AlgoliaConnector
      */
     public function clearIndex(IndexOptionsInterface $indexOptions): void
     {
-        $indexName = $this->getIndexName($indexOptions);
+        $indexName = $indexOptions->getIndexName();
 
         $res = $this->getClient($indexOptions->getStoreId())->clearObjects($indexName);
 
@@ -1059,31 +1060,5 @@ class AlgoliaConnector
         }
 
         return $filters;
-    }
-
-    /**
-     * Determines the index name giving it suffix, store id and if it's temporary or not
-     * If an enforced index name has been set, it's automatically returned
-     *
-     * @param IndexOptionsInterface $indexOptions
-     * @return string|null
-     * @throws NoSuchEntityException
-     * @throws AlgoliaException
-     */
-    protected function getIndexName(IndexOptionsInterface $indexOptions): ?string
-    {
-        if (!is_null($indexOptions->getEnforcedIndexName())) {
-            return $indexOptions->getEnforcedIndexName();
-        }
-
-        if (is_null($indexOptions->getIndexSuffix())) {
-            throw new AlgoliaException('Index suffix is mandatory in case no enforced index name is specified.');
-        }
-
-        return $this->indexNameFetcher->getIndexName(
-            $indexOptions->getIndexSuffix(),
-            $indexOptions->getStoreId(),
-            $indexOptions->isTemporaryIndex()
-        );
     }
 }

--- a/Service/IndexNameFetcher.php
+++ b/Service/IndexNameFetcher.php
@@ -21,6 +21,8 @@ class IndexNameFetcher
     public const INDEX_QUERY_SUGGESTIONS_SUFFIX = '_query_suggestions';
 
     /**
+     * Ex: magento2_default_products
+     *
      * @param string $indexSuffix
      * @param int|null $storeId
      * @param bool $tmp
@@ -33,6 +35,8 @@ class IndexNameFetcher
     }
 
     /**
+     * Ex: magento2_default
+     *
      * @param int|null $storeId
      * @return string
      * @throws NoSuchEntityException

--- a/Service/IndexOptionsBuilder.php
+++ b/Service/IndexOptionsBuilder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Model\IndexOptions;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+class IndexOptionsBuilder
+{
+    public function __construct(
+        protected IndexNameFetcher $indexNameFetcher
+    ) {}
+
+    /**
+     * Automatically converts information related to an index into a IndexOptions objects
+     *
+     * @param string|null $indexSuffix
+     * @param int|null $storeId
+     * @param bool|null $isTmp
+     * @return IndexOptions
+     * @throws AlgoliaException
+     * @throws NoSuchEntityException
+     */
+    public function createIndexOptions(?string $indexSuffix = null, ?int $storeId = null, ?bool $isTmp = false): IndexOptions
+    {
+        $indexOptions =  new IndexOptions([
+            IndexOptionsInterface::STORE_ID => $storeId,
+            IndexOptionsInterface::INDEX_SUFFIX => $indexSuffix,
+            IndexOptionsInterface::IS_TMP => $isTmp
+        ]);
+
+        $indexOptions->setIndexName($this->computeIndexName($indexOptions));
+
+        return $indexOptions;
+    }
+
+    /**
+     * This method only ensures possibility to create IndexOptions with an enforced index name
+     *
+     * @param string|null $indexName
+     * @param int|null $storeId
+     * @return IndexOptions
+     */
+    public function convertToIndexOptions(?string $indexName = null, ?int $storeId = null): IndexOptions
+    {
+        return new IndexOptions([
+            IndexOptionsInterface::INDEX_NAME => $indexName,
+            IndexOptionsInterface::STORE_ID => $storeId
+        ]);
+    }
+
+    /**
+     * Determines the index name giving it suffix, store id and if it's temporary or not
+     *
+     * @param IndexOptionsInterface $indexOptions
+     * @return string|null
+     * @throws NoSuchEntityException
+     * @throws AlgoliaException
+     */
+    protected function computeIndexName(IndexOptionsInterface $indexOptions): ?string
+    {
+        if (is_null($indexOptions->getIndexSuffix())) {
+            throw new AlgoliaException('Index suffix is mandatory in case no enforced index name is specified.');
+        }
+
+        return $this->indexNameFetcher->getIndexName(
+            $indexOptions->getIndexSuffix(),
+            $indexOptions->getStoreId(),
+            $indexOptions->isTemporaryIndex()
+        );
+    }
+}

--- a/Service/IndexOptionsBuilder.php
+++ b/Service/IndexOptionsBuilder.php
@@ -23,7 +23,11 @@ class IndexOptionsBuilder
      * @throws AlgoliaException
      * @throws NoSuchEntityException
      */
-    public function createIndexOptions(?string $indexSuffix = null, ?int $storeId = null, ?bool $isTmp = false): IndexOptions
+    public function buildWithComputedIndex(
+        ?string $indexSuffix = null,
+        ?int $storeId = null,
+        ?bool $isTmp = false
+    ): IndexOptionsInterface
     {
         $indexOptions =  new IndexOptions([
             IndexOptionsInterface::STORE_ID => $storeId,
@@ -31,9 +35,7 @@ class IndexOptionsBuilder
             IndexOptionsInterface::IS_TMP => $isTmp
         ]);
 
-        $indexOptions->setIndexName($this->computeIndexName($indexOptions));
-
-        return $indexOptions;
+        return $this->build($indexOptions);
     }
 
     /**
@@ -42,13 +44,32 @@ class IndexOptionsBuilder
      * @param string|null $indexName
      * @param int|null $storeId
      * @return IndexOptions
+     * @throws AlgoliaException
+     * @throws NoSuchEntityException
      */
-    public function convertToIndexOptions(?string $indexName = null, ?int $storeId = null): IndexOptions
+    public function buildWithEnforcedIndex(?string $indexName = null, ?int $storeId = null): IndexOptionsInterface
     {
-        return new IndexOptions([
+        $indexOptions = new IndexOptions([
             IndexOptionsInterface::INDEX_NAME => $indexName,
             IndexOptionsInterface::STORE_ID => $storeId
         ]);
+
+        return $this->build($indexOptions);
+    }
+
+    /**
+     * Build IndexOptions object by setting its index name
+     *
+     * @param IndexOptionsInterface $indexOptions
+     * @return IndexOptionsInterface
+     * @throws AlgoliaException
+     * @throws NoSuchEntityException
+     */
+    protected function build(IndexOptionsInterface $indexOptions): IndexOptionsInterface
+    {
+        $indexOptions->setIndexName($this->computeIndexName($indexOptions));
+
+        return $indexOptions;
     }
 
     /**
@@ -61,6 +82,10 @@ class IndexOptionsBuilder
      */
     protected function computeIndexName(IndexOptionsInterface $indexOptions): ?string
     {
+        if (!is_null($indexOptions->getIndexName())) {
+            return $indexOptions->getIndexName();
+        }
+
         if (is_null($indexOptions->getIndexSuffix())) {
             throw new AlgoliaException('Index suffix is mandatory in case no enforced index name is specified.');
         }


### PR DESCRIPTION
This PR contains: 
- Added an `IndexOptions` model implementing `IndexOptionsInterface` which would be the component of every index operation coming to `AlgoliaConnector` in the future
- Updated the deprecated `AlgoliaHelper` class to convert all calls to the new format including `IndexOptions` model
- Updated the `AlgoliaConnector` class so it fetches all index names according to the `InderNameFetcher` service
- Removed all the static methods in `AlgoliaConnector` to be able to use the IndexNameFetcher everywhere, notably in the `setLastOperationInfo` methid