### PR TITLE
MAGE-1186: fix backward compatibility for old product jobs in queue

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -126,7 +126,7 @@ class Data
         $this->productIndexBuilder->buildIndexFull(
             $storeId,
             [
-                'productIds' => $productIds,
+                'entityIds' => $productIds,
                 'page' => $page,
                 'pageSize' => $pageSize,
                 'useTmpIndex' => $useTmpIndex


### PR DESCRIPTION
This PR contains:
- Fixed a bug where remaining old product jobs in the queue prior setup upgrade could cause the process to display unwanted warning.