### PR TITLE
MAGE-1179 Backport PHPCS fix to 3.13

### DIFF
--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -10,7 +10,6 @@ use Magento\Framework\DB\Select;
 use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Indexer\StateInterface;
-use Zend_Db_Select;
 
 class MissingPriceIndexHandler
 {
@@ -120,7 +119,7 @@ class MissingPriceIndexHandler
 
         $select = clone $collection->getSelect();
         try {
-            $joins = $select->getPart(Zend_Db_Select::FROM);
+            $joins = $select->getPart(Select::FROM);
         } catch (\Zend_Db_Select_Exception $e) {
             $this->logger->error("Unable to build query for missing product prices: " . $e->getMessage());
             return [];
@@ -142,20 +141,20 @@ class MissingPriceIndexHandler
     protected function expandPricingJoin(array &$joins, string $priceIndexJoin): void
     {
         $modifyJoin = &$joins[$priceIndexJoin];
-        $modifyJoin['joinType'] = Zend_Db_Select::LEFT_JOIN;
+        $modifyJoin['joinType'] = Select::LEFT_JOIN;
     }
 
     protected function rebuildJoins(Select $select, array $joins): void
     {
-        $select->reset(Zend_Db_Select::COLUMNS);
-        $select->reset(Zend_Db_Select::FROM);
+        $select->reset(Select::COLUMNS);
+        $select->reset(Select::FROM);
         foreach ($joins as $alias => $joinData) {
-            if ($joinData['joinType'] === Zend_Db_Select::FROM) {
+            if ($joinData['joinType'] === Select::FROM) {
                 $select->from(
                     [$alias => $joinData['tableName']],
                     'entity_id'
                 );
-            } elseif ($joinData['joinType'] === Zend_Db_Select::LEFT_JOIN) {
+            } elseif ($joinData['joinType'] === Select::LEFT_JOIN) {
                 $select->joinLeft(
                     [$alias => $joinData['tableName']],
                     $joinData['joinCondition'],


### PR DESCRIPTION
Addresses PHP complaint per [Magento Coding Standard](https://experienceleague.adobe.com/en/docs/commerce-operations/upgrade-guide/upgrade-compatibility-tool/reporting/error-messages) (backported for v3.13). 