### PR TITLE
Release/3.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGE LOG
 
+## 3.14.4
+
+### Features
+- Added a feature to enable automatic price indexing on the Advanced section of the configuration (This feature should help alleviate issues where missing pricing records prevent Algolia from being able to index products.)
+
+### Updates
+- Updated `getCookie` method to make it more consistent
+- Removed dependency to `catalog_product_price` indexer
+
+### Bug Fixes
+- Fixed a bug where the Landing Page Builder was crashing on save with customer group pricing was enabled.
+- Fixed issue where Insights information wasn't kept on the url after clicking "add to cart" on PLP powered by InstantSearch
+- Fixed a bug where synonyms were unintentionally duplicated on the Algolia dashboard
+
 ## 3.14.3
 
 ### Updates

--- a/Controller/Adminhtml/Landingpage/Save.php
+++ b/Controller/Adminhtml/Landingpage/Save.php
@@ -107,13 +107,15 @@ class Save extends AbstractAction
                 $data['configuration'] = $data['algolia_configuration'];
                 if ($this->configHelper->isCustomerGroupsEnabled($data['store_id'])) {
                     $configuration = json_decode($data['algolia_configuration'], true);
-                    $priceConfig = $configuration['price'.$data['price_key']];
-                    $customerGroups = $this->customerGroupCollectionFactory->create();
-                    $store = $this->storeManager->getStore($data['store_id']);
-                    $baseCurrencyCode = $store->getBaseCurrencyCode();
-                    foreach ($customerGroups as $group) {
-                        $groupId = (int) $group->getData('customer_group_id');
-                        $configuration['price.'.$baseCurrencyCode.'.group_'.$groupId] = $priceConfig;
+                    if (isset($configuration['price'.$data['price_key']])) {
+                        $priceConfig = $configuration['price'.$data['price_key']];
+                        $customerGroups = $this->customerGroupCollectionFactory->create();
+                        $store = $this->storeManager->getStore($data['store_id']);
+                        $baseCurrencyCode = $store->getBaseCurrencyCode();
+                        foreach ($customerGroups as $group) {
+                            $groupId = (int) $group->getData('customer_group_id');
+                            $configuration['price.'.$baseCurrencyCode.'.group_'.$groupId] = $priceConfig;
+                        }
                     }
                     $data['configuration'] = json_encode($configuration);
                 }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -359,12 +359,6 @@ class AlgoliaHelper extends AbstractHelper
         } catch (\Exception $e) {
         }
 
-        $removes = ['slaves', 'replicas', 'decompoundedAttributes', 'synonyms'];
-
-        if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
-            $removes[] = 'mode';
-        }
-
         if (isset($settings['attributesToIndex'])) {
             $settings['searchableAttributes'] = $settings['attributesToIndex'];
             unset($settings['attributesToIndex']);
@@ -375,7 +369,7 @@ class AlgoliaHelper extends AbstractHelper
             unset($onlineSettings['attributesToIndex']);
         }
 
-        foreach ($removes as $remove) {
+        foreach ($this->getSettingsToRemove($onlineSettings) as $remove) {
             if (isset($onlineSettings[$remove])) {
                 unset($onlineSettings[$remove]);
             }
@@ -386,6 +380,34 @@ class AlgoliaHelper extends AbstractHelper
         }
 
         return $onlineSettings;
+    }
+
+    /**
+     * These settings are to be managed by other processes
+     * @param string[] $onlineSettings
+     * @return string[]
+     */
+    protected function getSettingsToRemove(array $onlineSettings): array
+    {
+        $removals = ['slaves', 'replicas', 'decompoundedAttributes'];
+
+        if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
+            $removals[] = 'mode';
+        }
+
+        return array_merge($removals, $this->getSynonymSettingNames());
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getSynonymSettingNames(): array
+    {
+        return [
+            'synonyms',
+            'altCorrections',
+            'placeholders'
+        ];
     }
 
     /**

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -359,7 +359,7 @@ class AlgoliaHelper extends AbstractHelper
         } catch (\Exception $e) {
         }
 
-        $removes = ['slaves', 'replicas', 'decompoundedAttributes'];
+        $removes = ['slaves', 'replicas', 'decompoundedAttributes', 'synonyms'];
 
         if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
             $removes[] = 'mode';

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -108,6 +108,7 @@ class ConfigHelper
     public const CONNECTION_TIMEOUT = 'algoliasearch_advanced/advanced/connection_timeout';
     public const READ_TIMEOUT = 'algoliasearch_advanced/advanced/read_timeout';
     public const WRITE_TIMEOUT = 'algoliasearch_advanced/advanced/write_timeout';
+    public const AUTO_PRICE_INDEXING_ENABLED = 'algoliasearch_advanced/advanced/auto_price_indexing';
 
     public const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
 
@@ -1270,6 +1271,15 @@ class ConfigHelper
     public function getWriteTimeout($storeId = null)
     {
         return $this->configInterface->getValue(self::WRITE_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function isAutoPriceIndexingEnabled(?int $storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(
+            self::AUTO_PRICE_INDEXING_ENABLED,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 
     /**

--- a/Model/Config/AutomaticPriceIndexingComment.php
+++ b/Model/Config/AutomaticPriceIndexingComment.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Model\Config;
+
+use Magento\Config\Model\Config\CommentInterface;
+use Magento\Framework\UrlInterface;
+
+class AutomaticPriceIndexingComment implements CommentInterface
+{
+    public function __construct(
+        protected UrlInterface $urlInterface
+    ) { }
+
+    public function getCommentText($elementValue)
+    {
+        $url = $this->urlInterface->getUrl('https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/#configure-the-queue');
+
+        $comment = array();
+        $comment[] = 'Algolia relies on the core Magento Product Price index when serializing product data. If the price index is not up to date, Algolia will not be able to accurately determine what should be included in the search index.';
+        $comment[] = 'If you are experiencing problems with products not syncing to Algolia due to this issue, enabling this setting will allow Algolia to automatically update the price index as needed.';
+        $comment[] = 'NOTE: This can introduce a marginal amount of overhead to the indexing process so only enable if necessary. Be sure to <a href="' . $url . '" target="_blank">optimize the indexing queue</a> based on the impact of this operation.';
+        return implode('<br><br>', $comment);
+    }
+}

--- a/Plugin/AddToCartRedirectForInsights.php
+++ b/Plugin/AddToCartRedirectForInsights.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Plugin;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\Checkout\Model\Cart;
+use Magento\Checkout\Model\Cart\RequestInfoFilterInterface;
+use Magento\Checkout\Model\Session;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+
+class AddToCartRedirectForInsights
+{
+    /**
+     * @var RequestInfoFilterInterface
+     */
+    private $requestInfoFilter;
+
+    public function __construct(
+        protected StoreManagerInterface $storeManager,
+        protected ProductRepositoryInterface $productRepository,
+        protected Session $checkoutSession,
+        protected StockRegistryInterface $stockRegistry,
+        protected ManagerInterface $eventManager,
+        protected ConfigHelper $configHelper,
+    ) {}
+
+    /**
+     * @param Cart $cartModel
+     * @param int|Product $productInfo
+     * @param array|int|DataObject|null $requestInfo
+     *
+     * @return null
+     *
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function beforeAddProduct(Cart $cartModel, int|Product $productInfo, array|int|DataObject $requestInfo = null)
+    {
+        // First, check is Insights are enabled
+        if (!$this->configHelper->isClickConversionAnalyticsEnabled($this->storeManager->getStore()->getId())) {
+            return;
+        }
+
+        // If the request doesn't have any insights info, no need to handle it
+        if (!isset($requestInfo['referer']) || !isset($requestInfo['queryID']) || !isset($requestInfo['indexName'])) {
+            return;
+        }
+
+        // Check if the request comes from the PLP handled by InstantSearch
+        if ($requestInfo['referer'] != 'instantsearch') {
+            return;
+        }
+
+        $product = $this->getProduct($productInfo);
+        $productId = $product->getId();
+
+        if ($productId) {
+            $request = $this->getQtyRequest($product, $requestInfo);
+
+            try {
+                $result = $product->getTypeInstance()->prepareForCartAdvanced($request, $product);
+            } catch (LocalizedException $e) {
+                $this->checkoutSession->setUseNotice(false);
+                $result = $e->getMessage();
+            }
+
+            // if the result is a string, this mean that the product can't be added to the cart
+            // see Magento\Quote\Model\Quote::addProduct()
+            // Here we need to add the insights information to the redirect
+            if (is_string($result)) {
+                $redirectUrl = $product->getUrlModel()->getUrl(
+                    $product,
+                    [
+                        '_query' => [
+                            'objectID' => $product->getId(),
+                            'queryID' => $requestInfo['queryID'],
+                            'indexName' => $requestInfo['indexName']
+                        ]
+                    ]
+                );
+
+                $this->checkoutSession->setRedirectUrl($redirectUrl);
+                if ($this->checkoutSession->getUseNotice() === null) {
+                    $this->checkoutSession->setUseNotice(true);
+                }
+                throw new LocalizedException(__($result));
+            }
+        }
+    }
+
+    /**
+     * @param $productInfo
+     *
+     * @return Product
+     *
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    protected function getProduct($productInfo): Product
+    {
+        $product = null;
+        if ($productInfo instanceof Product) {
+            $product = $productInfo;
+            if (!$product->getId()) {
+                throw new LocalizedException(
+                    __("The product wasn't found. Verify the product and try again.")
+                );
+            }
+        } elseif (is_int($productInfo) || is_string($productInfo)) {
+            $storeId = $this->storeManager->getStore()->getId();
+            try {
+                $product = $this->productRepository->getById($productInfo, false, $storeId);
+            } catch (NoSuchEntityException $e) {
+                throw new LocalizedException(
+                    __("The product wasn't found. Verify the product and try again."),
+                    $e
+                );
+            }
+        } else {
+            throw new LocalizedException(
+                __("The product wasn't found. Verify the product and try again.")
+            );
+        }
+        $currentWebsiteId = $this->storeManager->getStore()->getWebsiteId();
+        if (!is_array($product->getWebsiteIds()) || !in_array($currentWebsiteId, $product->getWebsiteIds())) {
+            throw new LocalizedException(
+                __("The product wasn't found. Verify the product and try again.")
+            );
+        }
+        return $product;
+    }
+
+    /**
+     * Get request quantity
+     *
+     * @param Product $product
+     * @param DataObject|int|array $request
+     * @return int|DataObject
+     */
+    protected function getQtyRequest($product, $request = 0)
+    {
+        $request = $this->getProductRequest($request);
+        $stockItem = $this->stockRegistry->getStockItem($product->getId(), $product->getStore()->getWebsiteId());
+        $minimumQty = $stockItem->getMinSaleQty();
+        //If product quantity is not specified in request and there is set minimal qty for it
+        if ($minimumQty
+            && $minimumQty > 0
+            && !$request->getQty()
+        ) {
+            $request->setQty($minimumQty);
+        }
+
+        return $request;
+    }
+
+    /**
+     * Get request for product add to cart procedure
+     *
+     * @param DataObject|int|array $requestInfo
+     * @return DataObject
+     * @throws LocalizedException
+     */
+    protected function getProductRequest($requestInfo)
+    {
+        if ($requestInfo instanceof DataObject) {
+            $request = $requestInfo;
+        } elseif (is_numeric($requestInfo)) {
+            $request = new DataObject(['qty' => $requestInfo]);
+        } elseif (is_array($requestInfo)) {
+            $request = new DataObject($requestInfo);
+        } else {
+            throw new LocalizedException(
+                __('We found an invalid request for adding product to quote.')
+            );
+        }
+        $this->getRequestInfoFilter()->filter($request);
+
+        return $request;
+    }
+
+    /**
+     * Getter for RequestInfoFilter
+     *
+     * @return RequestInfoFilterInterface
+     */
+    protected function getRequestInfoFilter()
+    {
+        if ($this->requestInfoFilter === null) {
+            $this->requestInfoFilter = \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(RequestInfoFilterInterface::class);
+        }
+        return $this->requestInfoFilter;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Algolia Search & Discovery extension for Magento 2
 ==================================================
 
-![Latest version](https://img.shields.io/badge/latest-3.14.3-green)
+![Latest version](https://img.shields.io/badge/latest-3.14.4-green)
 ![Magento 2](https://img.shields.io/badge/Magento-2.4.x-orange)
 
 ![PHP](https://img.shields.io/badge/PHP-8.1%2C8.2%2C8.3-blue)

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -10,7 +10,6 @@ use Magento\Framework\DB\Select;
 use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Indexer\StateInterface;
-use Zend_Db_Select;
 
 class MissingPriceIndexHandler
 {
@@ -120,7 +119,7 @@ class MissingPriceIndexHandler
 
         $select = clone $collection->getSelect();
         try {
-            $joins = $select->getPart(Zend_Db_Select::FROM);
+            $joins = $select->getPart(Select::FROM);
         } catch (\Zend_Db_Select_Exception $e) {
             $this->logger->error("Unable to build query for missing product prices: " . $e->getMessage());
             return [];
@@ -142,20 +141,20 @@ class MissingPriceIndexHandler
     protected function expandPricingJoin(array &$joins, string $priceIndexJoin): void
     {
         $modifyJoin = &$joins[$priceIndexJoin];
-        $modifyJoin['joinType'] = Zend_Db_Select::LEFT_JOIN;
+        $modifyJoin['joinType'] = Select::LEFT_JOIN;
     }
 
     protected function rebuildJoins(Select $select, array $joins): void
     {
-        $select->reset(Zend_Db_Select::COLUMNS);
-        $select->reset(Zend_Db_Select::FROM);
+        $select->reset(Select::COLUMNS);
+        $select->reset(Select::FROM);
         foreach ($joins as $alias => $joinData) {
-            if ($joinData['joinType'] === Zend_Db_Select::FROM) {
+            if ($joinData['joinType'] === Select::FROM) {
                 $select->from(
                     [$alias => $joinData['tableName']],
                     'entity_id'
                 );
-            } elseif ($joinData['joinType'] === Zend_Db_Select::LEFT_JOIN) {
+            } elseif ($joinData['joinType'] === Select::LEFT_JOIN) {
                 $select->joinLeft(
                     [$alias => $joinData['tableName']],
                     $joinData['joinCondition'],

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Product;
+
+use Algolia\AlgoliaSearch\Helper\Logger;
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Indexer\StateInterface;
+use Zend_Db_Select;
+
+class MissingPriceIndexHandler
+{
+    public const PRICE_INDEX_TABLE = 'catalog_product_index_price';
+    public const PRICE_INDEX_TABLE_ALIAS = 'price_index';
+    public const MAIN_TABLE_ALIAS = 'e';
+
+    protected array $_indexedProducts = [];
+
+    protected IndexerInterface $indexer;
+    public function __construct(
+        protected CollectionFactory $productCollectionFactory,
+        protected ResourceConnection $resourceConnection,
+        protected Logger $logger,
+        IndexerRegistry $indexerRegistry
+    )
+    {
+        $this->indexer = $indexerRegistry->get('catalog_product_price');
+    }
+
+    /**
+     * @param string[]|ProductCollection $products
+     * @return string[] Array of product IDs that were reindexed by this repair operation
+     */
+    public function refreshPriceIndex(array|ProductCollection $products): array
+    {
+        $reindexIds = $this->getProductIdsToReindex($products);
+        if (empty($reindexIds)) {
+            return [];
+        }
+
+        $this->logger->log(__("Pricing records missing or invalid for %1 product(s)", count($reindexIds)));
+        $this->logger->log(__("Reindexing product ID(s): %1", implode(', ', $reindexIds)));
+
+        $this->indexer->reindexList($reindexIds);
+
+        return $reindexIds;
+    }
+
+    /**
+     * Analyzes a product collection and determines which (if any) records should have their prices reindexed
+     * @param string[]|ProductCollection $products - either an explicit list of product ids or a product collection
+     * @return string[] IDs of products that require price reindexing (will be empty if no indexing is required)
+     */
+    protected function getProductIdsToReindex(array|ProductCollection $products): array
+    {
+        $productIds = $products instanceof ProductCollection
+            ? $this->getProductIdsFromCollection($products)
+            : $products;
+
+        if (empty($productIds)) {
+            return [];
+        }
+
+        $state = $this->indexer->getState()->getStatus();
+        if ($state === StateInterface::STATUS_INVALID) {
+            return $this->filterProductIdsNotYetProcessed($productIds);
+        }
+
+        $productIds = $this->filterProductIdsMissingPricing($productIds);
+        if (empty($productIds)) {
+            return [];
+        }
+
+        return $this->filterProductIdsNotYetProcessed($productIds);
+    }
+
+    protected function filterProductIdsMissingPricing(array $productIds): array
+    {
+        $collection = $this->productCollectionFactory->create();
+
+        $collection->addAttributeToSelect(['name', 'price']);
+
+        $collection->getSelect()->joinLeft(
+            [self::PRICE_INDEX_TABLE_ALIAS => self::PRICE_INDEX_TABLE],
+            self::MAIN_TABLE_ALIAS . '.entity_id = ' . self::PRICE_INDEX_TABLE_ALIAS . '.entity_id',
+            []
+        );
+
+        $collection->getSelect()
+            ->where(self::PRICE_INDEX_TABLE_ALIAS . '.entity_id IS NULL')
+            ->where(self::MAIN_TABLE_ALIAS . '.entity_id IN (?)', $productIds);
+
+        return $collection->getAllIds();
+    }
+
+    protected function filterProductIdsNotYetProcessed(array $productIds): array {
+        $pendingProcessing = array_fill_keys($productIds, true);
+
+        $notProcessed = array_diff_key($pendingProcessing, $this->_indexedProducts);
+
+        if (empty($notProcessed)) {
+            return [];
+        }
+
+        $this->_indexedProducts += $notProcessed;
+
+        return array_keys($notProcessed);
+    }
+
+    /**
+     * Expand the query for product ids from the collection regardless of price index status
+     * @return string[] An array of indices to be evaluated - array will be empty if no price index join found
+     */
+    protected function getProductIdsFromCollection(ProductCollection $collection): array
+    {
+
+        $select = clone $collection->getSelect();
+        try {
+            $joins = $select->getPart(Zend_Db_Select::FROM);
+        } catch (\Zend_Db_Select_Exception $e) {
+            $this->logger->error("Unable to build query for missing product prices: " . $e->getMessage());
+            return [];
+        }
+
+        $priceIndexJoin = $this->getPriceIndexJoinAlias($joins);
+
+        if (!$priceIndexJoin) {
+            // no price index on query - keep calm and carry on
+            return [];
+        }
+
+        $this->expandPricingJoin($joins, $priceIndexJoin);
+        $this->rebuildJoins($select, $joins);
+
+        return $this->resourceConnection->getConnection()->fetchCol($select);
+    }
+
+    protected function expandPricingJoin(array &$joins, string $priceIndexJoin): void
+    {
+        $modifyJoin = &$joins[$priceIndexJoin];
+        $modifyJoin['joinType'] = Zend_Db_Select::LEFT_JOIN;
+    }
+
+    protected function rebuildJoins(Select $select, array $joins): void
+    {
+        $select->reset(Zend_Db_Select::COLUMNS);
+        $select->reset(Zend_Db_Select::FROM);
+        foreach ($joins as $alias => $joinData) {
+            if ($joinData['joinType'] === Zend_Db_Select::FROM) {
+                $select->from(
+                    [$alias => $joinData['tableName']],
+                    'entity_id'
+                );
+            } elseif ($joinData['joinType'] === Zend_Db_Select::LEFT_JOIN) {
+                $select->joinLeft(
+                    [$alias => $joinData['tableName']],
+                    $joinData['joinCondition'],
+                    [],
+                    $joinData['schema']
+                );
+            } else {
+                $select->join(
+                    [$alias => $joinData['tableName']],
+                    $joinData['joinCondition'],
+                    [],
+                    $joinData['schema']
+                );
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array> $joins
+     * @return string
+     */
+    protected function getPriceIndexJoinAlias(array $joins): string
+    {
+        if (isset($joins[self::PRICE_INDEX_TABLE_ALIAS])) {
+            return self::PRICE_INDEX_TABLE_ALIAS;
+        }
+        else {
+            foreach ($joins as $alias => $joinData) {
+                if ($joinData['tableName'] === self::PRICE_INDEX_TABLE) {
+                    return $alias;
+                }
+            }
+        }
+
+        return "";
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.14.3",
+  "version": "3.14.4",
   "require": {
     "php": "~8.1|~8.2|~8.3",
     "magento/framework": "~103.0",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1337,6 +1337,16 @@
                 <field id="write_timeout" translate="label comment" type="text" sortOrder="110" showInDefault="1">
                     <label>Write Timeout (In Seconds)</label>
                 </field>
+                <field id="auto_price_indexing" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable automatic price indexing</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <model>Algolia\AlgoliaSearch\Model\Config\AutomaticPriceIndexingComment</model>
+                    </comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="queue" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Indexing Queue</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -94,6 +94,7 @@
                 <connection_timeout>2</connection_timeout>
                 <read_timeout>30</read_timeout>
                 <write_timeout>30</write_timeout>
+                <auto_price_indexing>0</auto_price_indexing>
             </advanced>
             <queue>
                 <number_of_element_by_page>300</number_of_element_by_page>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -20,4 +20,8 @@
     <type name="Magento\Framework\View\Element\AbstractBlock">
         <plugin name="remove_related_upsell_block" type="Algolia\AlgoliaSearch\Plugin\RemovePdpProductsBlock" />
     </type>
+
+    <type name="Magento\Checkout\Model\Cart">
+        <plugin name="handle_redirect_for_insights" type="Algolia\AlgoliaSearch\Plugin\AddToCartRedirectForInsights" />
+    </type>
 </config>

--- a/etc/indexer.xml
+++ b/etc/indexer.xml
@@ -5,9 +5,6 @@
         <description translate="true">
             Rebuild products index.
         </description>
-        <dependencies>
-            <indexer id="catalog_product_price" />
-        </dependencies>
     </indexer>
     <indexer id="algolia_categories" view_id="algolia_categories" class="Algolia\AlgoliaSearch\Model\Indexer\Category">
         <title translate="true">Algolia Search Categories</title>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.14.3">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.14.4">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>

--- a/view/frontend/templates/instant/hit.phtml
+++ b/view/frontend/templates/instant/hit.phtml
@@ -85,6 +85,8 @@ $origFormatedVar = $block->escapeHtml('price' . $priceKey . '_original_formated'
                         <form data-role="tocart-form" action="{{ addToCart.action }}" method="post">
                             <input type="hidden" name="queryID" value="{{__queryID}}">
                             <input type="hidden" name="product" value="{{objectID}}">
+                            <input type="hidden" name="indexName" value="{{__indexName}}">
+                            <input type="hidden" name="referer" value="instantsearch">
                             {{#_highlightResult.default_bundle_options}}<input type="hidden" name="bundle_option[{{ optionId }}]" value="{{selectionId}}">{{/_highlightResult.default_bundle_options}}
                             <input type="hidden" name="{{ addToCart.redirectUrlParam }}" value="{{ addToCart.uenc }}">
                             <input name="form_key" type="hidden" value="{{ addToCart.formKey }}">

--- a/view/frontend/web/js/internals/common.js
+++ b/view/frontend/web/js/internals/common.js
@@ -1,4 +1,5 @@
-define(['jquery', 'algoliaBundle'], function ($, algoliaBundle) {
+define(
+    ['jquery', 'algoliaBundle', 'Magento_PageCache/js/form-key-provider',], function ($, algoliaBundle, formKeyInit) {
     // Character maps supplied for more performant Regex ops
     const SPECIAL_CHAR_ENCODE_MAP = {
         '&': '&amp;',
@@ -98,15 +99,26 @@ define(['jquery', 'algoliaBundle'], function ($, algoliaBundle) {
         return check;
     };
 
-    window.getCookie = function (name) {
-        var value = "; " + document.cookie;
-        var parts = value.split("; " + name + "=");
-        if (parts.length == 2) {
-            return parts.pop().split(";").shift();
+    window.getCookie = function(name) {
+        let cookie, i;
+
+        const cookieName = name + "=",
+            cookieArr = document.cookie.split(';');
+
+        for (i = 0; i < cookieArr.length; i++) {
+            cookie = cookieArr[i];
+
+            while (cookie.charAt(0) === ' ') {
+                cookie = cookie.substring(1, cookie.length);
+            }
+
+            if (cookie.indexOf(cookieName) === 0) {
+                return cookie.substring(cookieName.length, cookie.length);
+            }
         }
 
         return "";
-    };
+    }
 
     window.transformHit = function (hit, price_key, helper) {
         if (Array.isArray(hit.categories))


### PR DESCRIPTION
Release 3.14.4 includes the following:

### Features
- Added a feature to enable automatic price indexing on the Advanced section of the configuration (This feature should help alleviate issues where missing pricing records prevent Algolia from being able to index products.)

### Updates
- Updated `getCookie` method to make it more consistent
- Removed dependency to `catalog_product_price` indexer

### Bug Fixes
- Fixed a bug where the Landing Page Builder was crashing on save with customer group pricing was enabled.
- Fixed issue where Insights information wasn't kept on the url after clicking "add to cart" on PLP powered by InstantSearch
- Fixed a bug where synonyms were unintentionally duplicated on the Algolia dashboard

