### PR TITLE
Update changelog file for 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 ## Updates
 - Added support for Multi-Application IDs
 
+## 3.14.4
+
+### Features
+- Added a feature to enable automatic price indexing on the Advanced section of the configuration (This feature should help alleviate issues where missing pricing records prevent Algolia from being able to index products.)
+
+### Updates
+- Updated `getCookie` method to make it more consistent
+- Removed dependency to `catalog_product_price` indexer
+
+### Bug Fixes
+- Fixed a bug where the Landing Page Builder was crashing on save with customer group pricing was enabled.
+- Fixed issue where Insights information wasn't kept on the url after clicking "add to cart" on PLP powered by InstantSearch
+- Fixed a bug where synonyms were unintentionally duplicated on the Algolia dashboard
+
 ## 3.14.3
 
 ### Updates
@@ -102,6 +116,25 @@ If you have customized your Algolia implementation or are running on an older ve
 - Introduced PHP 8 constructor property promotion on affected classes
 - Added stronger typing to affected classes and methods
 - Added Looking Similar recommendations
+
+## 3.13.7
+
+### Features
+- Added a feature to enable automatic price indexing on the Advanced section of the configuration (This feature should help alleviate issues where missing pricing records prevent Algolia from being able to index products.)
+
+### Updates
+- Updated `getCookie` method to make it more consistent
+- Removed dependency to `catalog_product_price` indexer
+
+### Bug Fixes
+- Fixed a bug where the Landing Page Builder was crashing on save with customer group pricing was enabled.
+- Fixed issue where Insights information wasn't kept on the url after clicking "add to cart" on PLP powered by InstantSearch
+
+## 3.13.6
+
+### Bug Fixes
+- Improve handling of insights params for URLs that already have a query string
+- Improve query method for alternate root categories - Thank you @igorfigueiredogen
 
 ## 3.13.5
 


### PR DESCRIPTION
This PR updates the changelog for version `3.15.0` with all changes coming from `3.13.6`, `3.13.7` and `3.14.4` .