### PR TITLE
MAGE-1004 Babel transpiler fix

### DIFF
--- a/view/frontend/web/js/insights.js
+++ b/view/frontend/web/js/insights.js
@@ -6,7 +6,7 @@ define([
 ], function ($, algoliaAnalyticsWrapper, algoliaCommon) {
     const USE_GLOBALS = true;
 
-    algoliaAnalytics = algoliaAnalyticsWrapper.default;
+    const algoliaAnalytics = algoliaAnalyticsWrapper.default;
 
     const algoliaInsights = {
         config            : null,


### PR DESCRIPTION
This PR contains a small but necessary change from https://github.com/algolia/algoliasearch-magento-2/pull/1678 and is to be used in tandem with the Babel compilation steps from the companion PR outlined in Jira. 