### PR TITLE
MAGE-1191 PHP 7 compatibility on last supported minor release

### DIFF
--- a/Model/Config/AutomaticPriceIndexingComment.php
+++ b/Model/Config/AutomaticPriceIndexingComment.php
@@ -7,9 +7,16 @@ use Magento\Framework\UrlInterface;
 
 class AutomaticPriceIndexingComment implements CommentInterface
 {
+    /**
+     * @var UrlInterface
+     */
+    protected $urlInterface;
+
     public function __construct(
-        protected UrlInterface $urlInterface
-    ) { }
+        UrlInterface $urlInterface
+    ) {
+        $this->urlInterface = $urlInterface;
+    }
 
     public function getCommentText($elementValue)
     {

--- a/Plugin/AddToCartRedirectForInsights.php
+++ b/Plugin/AddToCartRedirectForInsights.php
@@ -22,14 +22,51 @@ class AddToCartRedirectForInsights
      */
     private $requestInfoFilter;
 
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    protected $productRepository;
+
+    /**
+     * @var Session
+     */
+    protected $checkoutSession;
+
+    /**
+     * @var StockRegistryInterface
+     */
+    protected $stockRegistry;
+
+    /**
+     * @var ManagerInterface
+     */
+    protected ManagerInterface $eventManager;
+
+    /**
+     * @var ConfigHelper
+     */
+    protected ConfigHelper $configHelper;
+
     public function __construct(
-        protected StoreManagerInterface $storeManager,
-        protected ProductRepositoryInterface $productRepository,
-        protected Session $checkoutSession,
-        protected StockRegistryInterface $stockRegistry,
-        protected ManagerInterface $eventManager,
-        protected ConfigHelper $configHelper,
-    ) {}
+        StoreManagerInterface $storeManager,
+        ProductRepositoryInterface $productRepository,
+        Session $checkoutSession,
+        StockRegistryInterface $stockRegistry,
+        ManagerInterface $eventManager,
+        ConfigHelper $configHelper,
+    ) {
+        $this->storeManager = $storeManager;
+        $this->productRepository = $productRepository;
+        $this->checkoutSession = $checkoutSession;
+        $this->stockRegistry = $stockRegistry;
+        $this->eventManager = $eventManager;
+        $this->configHelper = $configHelper;
+    }
 
     /**
      * @param Cart $cartModel

--- a/Plugin/AddToCartRedirectForInsights.php
+++ b/Plugin/AddToCartRedirectForInsights.php
@@ -78,7 +78,7 @@ class AddToCartRedirectForInsights
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function beforeAddProduct(Cart $cartModel, int|Product $productInfo, array|int|DataObject $requestInfo = null)
+    public function beforeAddProduct(Cart $cartModel, $productInfo, $requestInfo = null)
     {
         // First, check is Insights are enabled
         if (!$this->configHelper->isClickConversionAnalyticsEnabled($this->storeManager->getStore()->getId())) {

--- a/Plugin/AddToCartRedirectForInsights.php
+++ b/Plugin/AddToCartRedirectForInsights.php
@@ -58,7 +58,7 @@ class AddToCartRedirectForInsights
         Session $checkoutSession,
         StockRegistryInterface $stockRegistry,
         ManagerInterface $eventManager,
-        ConfigHelper $configHelper,
+        ConfigHelper $configHelper
     ) {
         $this->storeManager = $storeManager;
         $this->productRepository = $productRepository;

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -56,7 +56,7 @@ class MissingPriceIndexHandler
      * @param string[]|ProductCollection $products
      * @return string[] Array of product IDs that were reindexed by this repair operation
      */
-    public function refreshPriceIndex(array|ProductCollection $products): array
+    public function refreshPriceIndex($products): array
     {
         $reindexIds = $this->getProductIdsToReindex($products);
         if (empty($reindexIds)) {
@@ -76,7 +76,7 @@ class MissingPriceIndexHandler
      * @param string[]|ProductCollection $products - either an explicit list of product ids or a product collection
      * @return string[] IDs of products that require price reindexing (will be empty if no indexing is required)
      */
-    protected function getProductIdsToReindex(array|ProductCollection $products): array
+    protected function getProductIdsToReindex($products): array
     {
         $productIds = $products instanceof ProductCollection
             ? $this->getProductIdsFromCollection($products)

--- a/Service/Product/MissingPriceIndexHandler.php
+++ b/Service/Product/MissingPriceIndexHandler.php
@@ -19,14 +19,36 @@ class MissingPriceIndexHandler
 
     protected array $_indexedProducts = [];
 
-    protected IndexerInterface $indexer;
+    /**
+     * @var CollectionFactory
+     */
+    protected $productCollectionFactory;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+
+    /**
+     * @var Logger
+     */
+    protected $logger;
+
+    /**
+     * @var IndexerInterface
+     */
+    protected $indexer;
+
     public function __construct(
-        protected CollectionFactory $productCollectionFactory,
-        protected ResourceConnection $resourceConnection,
-        protected Logger $logger,
+        CollectionFactory $productCollectionFactory,
+        ResourceConnection $resourceConnection,
+        Logger $logger,
         IndexerRegistry $indexerRegistry
     )
     {
+        $this->productCollectionFactory = $productCollectionFactory;
+        $this->resourceConnection = $resourceConnection;
+        $this->logger = $logger;
         $this->indexer = $indexerRegistry->get('catalog_product_price');
     }
 


### PR DESCRIPTION
Even though we do not officially support PHP 7 any longer (PHP 7.4 has not be supported since Magento 2.4.3 and support for that version [ended November 2022](https://experienceleague.adobe.com/en/docs/commerce-operations/release/versions#243)), version `3.13` of the Algolia extension has been compatible with PHP 7.4 to date. The recent release of `3.13.7` introduces newer PHP 8 syntax that could have an unintended impact to legacy installs. 

This PR reverts those constructs to preserve PHP 7 compatibility. 