### PR TITLE
MAGE-1061 Adding support for additional IS mixins

### DIFF
--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -24,178 +24,38 @@ define([
             this.buildInstantSearch();
         },
 
+        isStarted: false,
+
+        /**
+         * Initialize search results using Algolia's InstantSearch.js library v4
+         * Docs: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/
+         */
         async buildInstantSearch() {
             const templateProcessor = await templateEngine.getSelectedEngineAdapter();
+
             const mockAlgoliaBundle = this.mockAlgoliaBundle();
 
-            /** We have nothing to do here if instantsearch is not enabled **/
-            if (
-                typeof algoliaConfig === 'undefined' ||
-                !algoliaConfig.instant.enabled ||
-                !(algoliaConfig.isSearchPage || !algoliaConfig.autocomplete.enabled)
-            ) {
-                return;
-            }
+            if (!this.checkInstantSearchEnablement()) return;
 
-            if ($(algoliaConfig.instant.selector).length <= 0) {
-                throw (
-                    '[Algolia] Invalid instant-search selector: ' +
-                    algoliaConfig.instant.selector
-                );
-            }
+            this.invokeLegacyHooks();
 
-            if (
-                algoliaConfig.autocomplete.enabled &&
-                $(algoliaConfig.instant.selector).find(
-                    algoliaConfig.autocomplete.selector
-                ).length > 0
-            ) {
-                throw (
-                    '[Algolia] You can\'t have a search input matching "' +
-                    algoliaConfig.autocomplete.selector +
-                    '" inside you instant selector "' +
-                    algoliaConfig.instant.selector +
-                    '"'
-                );
-            }
+            this.setupWrapper(templateProcessor);
 
-            var findAutocomplete =
-                algoliaConfig.autocomplete.enabled &&
-                $(algoliaConfig.instant.selector).find('#algolia-autocomplete-container')
-                    .length > 0;
-            if (findAutocomplete) {
-                $(algoliaConfig.instant.selector)
-                    .find('#algolia-autocomplete-container')
-                    .remove();
-            }
+            const indexName = algoliaConfig.indexName + '_products';
 
-            /** BC of old hooks **/
-            if (typeof algoliaHookBeforeInstantsearchInit === 'function') {
-                algoliaCommon.registerHook(
-                    'beforeInstantsearchInit',
-                    algoliaHookBeforeInstantsearchInit
-                );
-            }
-
-            if (typeof algoliaHookBeforeWidgetInitialization === 'function') {
-                algoliaCommon.registerHook(
-                    'beforeWidgetInitialization',
-                    algoliaHookBeforeWidgetInitialization
-                );
-            }
-
-            if (typeof algoliaHookBeforeInstantsearchStart === 'function') {
-                algoliaCommon.registerHook(
-                    'beforeInstantsearchStart',
-                    algoliaHookBeforeInstantsearchStart
-                );
-            }
-
-            if (typeof algoliaHookAfterInstantsearchStart === 'function') {
-                algoliaCommon.registerHook(
-                    'afterInstantsearchStart',
-                    algoliaHookAfterInstantsearchStart
-                );
-            }
-
-            /**
-             * Setup wrapper
-             *
-             * For templating is used Hogan library
-             * Docs: http://twitter.github.io/hogan.js/
-             *
-             * Alternatively use Mustache
-             * https://github.com/janl/mustache.js
-             **/
-            var instant_selector = '#instant-search-bar';
-
-            var div = document.createElement('div');
-            $(div).addClass('algolia-instant-results-wrapper');
-
-            $(algoliaConfig.instant.selector).addClass(
-                'algolia-instant-replaced-content'
-            );
-            $(algoliaConfig.instant.selector).wrap(div);
-
-            $('.algolia-instant-results-wrapper').append(
-                '<div class="algolia-instant-selector-results"></div>'
-            );
-
-            const template = $('#instant_wrapper_template').html();
-            const templateVars = {
-                second_bar      : algoliaConfig.instant.enabled,
-                findAutocomplete: findAutocomplete,
-                config          : algoliaConfig.instant,
-                translations    : algoliaConfig.translations,
-            };
-
-            const wrapperHtml = templateProcessor.process(template, templateVars);
-            $('.algolia-instant-selector-results').html(wrapperHtml).show();
-
-            /**
-             * Initialise instant search
-             * For rendering instant search page is used Algolia's instantsearch.js library
-             * Docs: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/
-             **/
-
-            var ruleContexts = ['magento_filters', '']; // Empty context to keep BC for already create rules in dashboard
-            if (algoliaConfig.request.categoryId.length > 0) {
-                ruleContexts.push('magento-category-' + algoliaConfig.request.categoryId);
-            }
-
-            if (algoliaConfig.request.landingPageId.length > 0) {
-                ruleContexts.push(
-                    'magento-landingpage-' + algoliaConfig.request.landingPageId
-                );
-            }
-
-            var searchClient = algoliasearch(
-                algoliaConfig.applicationId,
-                algoliaConfig.apiKey
-            );
-            var indexName = algoliaConfig.indexName + '_products';
-            var searchParameters = {
-                hitsPerPage : algoliaConfig.hitsPerPage,
-                ruleContexts: ruleContexts,
-            };
-            var instantsearchOptions = {
-                searchClient: searchClient,
-                indexName   : indexName,
-                routing     : algoliaCommon.routing,
-            };
-
-            if (
-                algoliaConfig.request.path.length > 0 &&
-                window.location.hash.indexOf('categories.level0') === -1
-            ) {
-                if (algoliaConfig.areCategoriesInFacets === false) {
-                    searchParameters['facetsRefinements'] = {};
-                    searchParameters['facetsRefinements'][
-                    'categories.level' + algoliaConfig.request.level
-                        ] = [algoliaConfig.request.path];
-                }
-            }
-
-            if (
-                algoliaConfig.instant.isVisualMerchEnabled &&
-                algoliaConfig.isCategoryPage
-            ) {
-                searchParameters.filters = `${
-                    algoliaConfig.instant.categoryPageIdAttribute
-                }:"${algoliaConfig.request.path.replace(/"/g, '\\"')}"`;
-            }
-
-            instantsearchOptions = algoliaCommon.triggerHooks(
+            const instantsearchOptions = algoliaCommon.triggerHooks(
                 'beforeInstantsearchInit',
-                instantsearchOptions,
+                {
+                    searchClient: algoliasearch(algoliaConfig.applicationId, algoliaConfig.apiKey),
+                    indexName   : indexName,
+                    routing     : algoliaCommon.routing,
+                },
                 mockAlgoliaBundle
             );
 
-            var search = instantsearch(instantsearchOptions);
+            const search = instantsearch(instantsearchOptions);
 
-            search.client.addAlgoliaAgent(
-                'Magento2 integration (' + algoliaConfig.extensionVersion + ')'
-            );
+            search.client.addAlgoliaAgent(this.getAlgoliaAgent());
 
             /** Prepare sorting indices data */
             algoliaConfig.sortingIndices.unshift({
@@ -203,29 +63,13 @@ define([
                 label: algoliaConfig.translations.relevance,
             });
 
-            /** Setup attributes for current refinements widget **/
-            var attributes = [];
-            $.each(algoliaConfig.facets, function (i, facet) {
-                var name = facet.attribute;
+            // TODO: Revisit use of closures
+            const currentRefinementsAttributes = this.getCurrentRefinementsAttributes();
 
-                if (name === 'categories') {
-                    name = 'categories.level0';
-                }
-
-                if (name === 'price') {
-                    name = facet.attribute + algoliaConfig.priceKey;
-                }
-
-                attributes.push({
-                    name : name,
-                    label: facet.label ? facet.label : facet.attribute,
-                });
-            });
-
-            var allWidgetConfiguration = {
+            let allWidgetConfiguration = {
                 infiniteHits: {},
                 hits        : {},
-                configure   : searchParameters,
+                configure   : this.getSearchParameters(),
                 custom      : [
                     /**
                      * Custom widget - this widget is used to refine results for search page or catalog page
@@ -402,7 +246,7 @@ define([
                     templates         : {
                         item: $('#current-refinements-template').html(),
                     },
-                    includedAttributes: attributes.map((attribute) => {
+                    includedAttributes: currentRefinementsAttributes.map((attribute) => {
                         if (
                             attribute.name.indexOf('categories') === -1 ||
                             !algoliaConfig.isCategoryPage
@@ -425,7 +269,7 @@ define([
                                     ); // do not expose the category root
                                 })
                                 .map((item) => {
-                                    const attribute = attributes.filter((_attribute) => {
+                                    const attribute = currentRefinementsAttributes.filter((_attribute) => {
                                         return item.attribute === _attribute.name;
                                     })[0];
                                     if (!attribute) return item;
@@ -455,7 +299,7 @@ define([
                     templates         : {
                         resetLabel: algoliaConfig.translations.clearAll,
                     },
-                    includedAttributes: attributes.map(function (attribute) {
+                    includedAttributes: currentRefinementsAttributes.map(function (attribute) {
                         if (
                             !(
                                 algoliaConfig.isCategoryPage &&
@@ -470,7 +314,7 @@ define([
                     },
                     transformItems    : function (items) {
                         return items.map(function (item) {
-                            var attribute = attributes.filter(function (_attribute) {
+                            var attribute = currentRefinementsAttributes.filter(function (_attribute) {
                                 return item.attribute === _attribute.name;
                             })[0];
                             if (!attribute) return item;
@@ -499,7 +343,7 @@ define([
                  * Docs: https://www.algolia.com/doc/api-reference/widgets/search-box/js/
                  **/
                 allWidgetConfiguration.searchBox = {
-                    container  : instant_selector,
+                    container  : '#instant-search-bar',
                     placeholder: algoliaConfig.translations.searchFor,
                     showSubmit : false,
                     queryHook  : (inputValue, search) => {
@@ -761,10 +605,201 @@ define([
             this.addMobileRefinementsToggle();
         },
 
-        isStarted: false,
+        /**
+         * @deprecated - these hooks will be removed in a future version
+         */
+        invokeLegacyHooks() {
+            if (typeof algoliaHookBeforeInstantsearchInit === 'function') {
+                algoliaCommon.registerHook(
+                    'beforeInstantsearchInit',
+                    algoliaHookBeforeInstantsearchInit
+                );
+            }
+
+            if (typeof algoliaHookBeforeWidgetInitialization === 'function') {
+                algoliaCommon.registerHook(
+                    'beforeWidgetInitialization',
+                    algoliaHookBeforeWidgetInitialization
+                );
+            }
+
+            if (typeof algoliaHookBeforeInstantsearchStart === 'function') {
+                algoliaCommon.registerHook(
+                    'beforeInstantsearchStart',
+                    algoliaHookBeforeInstantsearchStart
+                );
+            }
+
+            if (typeof algoliaHookAfterInstantsearchStart === 'function') {
+                algoliaCommon.registerHook(
+                    'afterInstantsearchStart',
+                    algoliaHookAfterInstantsearchStart
+                );
+            }
+        },
+
+        /**
+         * Pre-flight checks
+         *
+         * @returns {boolean} Returns true if InstantSearch is good to go
+         */
+        checkInstantSearchEnablement() {
+            if (
+                typeof algoliaConfig === 'undefined' ||
+                !algoliaConfig.instant.enabled ||
+                !algoliaConfig.isSearchPage
+            ) {
+                return false;
+            }
+
+            if (!$(algoliaConfig.instant.selector).length) {
+                throw new Error(
+                    `[Algolia] Invalid instant-search selector: ${algoliaConfig.instant.selector}`
+                );
+            }
+
+            if (
+                algoliaConfig.autocomplete.enabled &&
+                $(algoliaConfig.instant.selector).find(
+                    algoliaConfig.autocomplete.selector
+                ).length
+            ) {
+                throw new Error(
+                    `[Algolia] You can't have a search input matching "${algoliaConfig.autocomplete.selector}" ` +
+                    `inside your instant selector "${algoliaConfig.instant.selector}"`
+                );
+            }
+
+            return true;
+        },
+
+        /**
+         * Handle nested Autocomplete (legacy)
+         * @returns {boolean}
+         */
+        findAutocomplete() {
+            if (algoliaConfig.autocomplete.enabled) {
+                const $nestedAC = $(algoliaConfig.instant.selector).find('#algolia-autocomplete-container');
+                if ($nestedAC.length) {
+                    $nestedAC.remove();
+                    return true;
+                }
+            }
+            return false;
+        },
+
+        /**
+         * Build wrapper DOM object to contain InstantSearch
+         * @param templateProcessor
+         */
+        setupWrapper(templateProcessor) {
+            const div = document.createElement('div');
+            $(div).addClass('algolia-instant-results-wrapper');
+
+            $(algoliaConfig.instant.selector).addClass(
+                'algolia-instant-replaced-content'
+            );
+            $(algoliaConfig.instant.selector).wrap(div);
+
+            $('.algolia-instant-results-wrapper').append(
+                '<div class="algolia-instant-selector-results"></div>'
+            );
+
+            const template = $('#instant_wrapper_template').html();
+            const templateVars = {
+                second_bar      : algoliaConfig.instant.enabled,
+                findAutocomplete: this.findAutocomplete(),
+                config          : algoliaConfig.instant,
+                translations    : algoliaConfig.translations,
+            };
+
+            const wrapperHtml = templateProcessor.process(template, templateVars);
+            $('.algolia-instant-selector-results').html(wrapperHtml).show();
+        },
+
+        /**
+         * @returns {string[]}
+         */
+        getRuleContexts() {
+            const ruleContexts = ['magento_filters', '']; // Empty context to keep BC for already create rules in dashboard
+            if (algoliaConfig.request.categoryId.length) {
+                ruleContexts.push('magento-category-' + algoliaConfig.request.categoryId);
+            }
+
+            if (algoliaConfig.request.landingPageId.length) {
+                ruleContexts.push(
+                    'magento-landingpage-' + algoliaConfig.request.landingPageId
+                );
+            }
+            return ruleContexts;
+        },
+
+        /**
+         * @returns {*[]}
+         */
+        getSearchParameters() {
+            const searchParameters = {
+                hitsPerPage : algoliaConfig.hitsPerPage,
+                ruleContexts: this.getRuleContexts()
+            };
+
+            if (
+                algoliaConfig.request.path.length &&
+                window.location.hash.indexOf('categories.level0') === -1
+            ) {
+                if (!algoliaConfig.areCategoriesInFacets) {
+                    searchParameters['facetsRefinements'] = {};
+                    searchParameters['facetsRefinements'][
+                        'categories.level' + algoliaConfig.request.level
+                    ] = [algoliaConfig.request.path];
+                }
+            }
+
+            if (
+                algoliaConfig.instant.isVisualMerchEnabled &&
+                algoliaConfig.isCategoryPage
+            ) {
+                searchParameters.filters = `${
+                    algoliaConfig.instant.categoryPageIdAttribute
+                }:"${algoliaConfig.request.path.replace(/"/g, '\\"')}"`;
+            }
+
+            return searchParameters;
+        },
+
+        /**
+         * @returns {string}
+         */
+        getAlgoliaAgent() {
+            return 'Magento2 integration (' + algoliaConfig.extensionVersion + ')';
+        },
+
+        /**
+         * Setup attributes for current refinements widget
+         * @returns {*[]}
+         */
+        getCurrentRefinementsAttributes() {
+            const attributes = [];
+            $.each(algoliaConfig.facets, (i, facet) => {
+                let name = facet.attribute;
+
+                if (name === 'categories') {
+                    name = 'categories.level0';
+                }
+
+                if (name === 'price') {
+                    name = facet.attribute + algoliaConfig.priceKey;
+                }
+
+                attributes.push({
+                    name : name,
+                    label: facet.label ? facet.label : facet.attribute,
+                });
+            });
+            return attributes;
+        },
 
         startInstantSearch(search, mockAlgoliaBundle) {
-            console.log("IS started?:", this.isStarted);
             if (this.isStarted) {
                 return;
             }

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -10,7 +10,7 @@ define([
     'algoliaCommon',
     'algoliaBase64',
     'algoliaTemplateEngine',
-    
+
     // Magento core libs
     'Magento_Catalog/js/price-utils',
 
@@ -27,7 +27,7 @@ define([
         async buildInstantSearch() {
             const templateProcessor = await templateEngine.getSelectedEngineAdapter();
             const mockAlgoliaBundle = this.mockAlgoliaBundle();
-    
+
             /** We have nothing to do here if instantsearch is not enabled **/
             if (
                 typeof algoliaConfig === 'undefined' ||
@@ -36,14 +36,14 @@ define([
             ) {
                 return;
             }
-    
+
             if ($(algoliaConfig.instant.selector).length <= 0) {
                 throw (
                     '[Algolia] Invalid instant-search selector: ' +
                     algoliaConfig.instant.selector
                 );
             }
-    
+
             if (
                 algoliaConfig.autocomplete.enabled &&
                 $(algoliaConfig.instant.selector).find(
@@ -58,7 +58,7 @@ define([
                     '"'
                 );
             }
-    
+
             var findAutocomplete =
                 algoliaConfig.autocomplete.enabled &&
                 $(algoliaConfig.instant.selector).find('#algolia-autocomplete-container')
@@ -68,7 +68,7 @@ define([
                     .find('#algolia-autocomplete-container')
                     .remove();
             }
-    
+
             /** BC of old hooks **/
             if (typeof algoliaHookBeforeInstantsearchInit === 'function') {
                 algoliaCommon.registerHook(
@@ -76,51 +76,51 @@ define([
                     algoliaHookBeforeInstantsearchInit
                 );
             }
-    
+
             if (typeof algoliaHookBeforeWidgetInitialization === 'function') {
                 algoliaCommon.registerHook(
                     'beforeWidgetInitialization',
                     algoliaHookBeforeWidgetInitialization
                 );
             }
-    
+
             if (typeof algoliaHookBeforeInstantsearchStart === 'function') {
                 algoliaCommon.registerHook(
                     'beforeInstantsearchStart',
                     algoliaHookBeforeInstantsearchStart
                 );
             }
-    
+
             if (typeof algoliaHookAfterInstantsearchStart === 'function') {
                 algoliaCommon.registerHook(
                     'afterInstantsearchStart',
                     algoliaHookAfterInstantsearchStart
                 );
             }
-    
+
             /**
              * Setup wrapper
              *
              * For templating is used Hogan library
              * Docs: http://twitter.github.io/hogan.js/
-             * 
+             *
              * Alternatively use Mustache
              * https://github.com/janl/mustache.js
              **/
             var instant_selector = '#instant-search-bar';
-    
+
             var div = document.createElement('div');
             $(div).addClass('algolia-instant-results-wrapper');
-    
+
             $(algoliaConfig.instant.selector).addClass(
                 'algolia-instant-replaced-content'
             );
             $(algoliaConfig.instant.selector).wrap(div);
-    
+
             $('.algolia-instant-results-wrapper').append(
                 '<div class="algolia-instant-selector-results"></div>'
             );
-    
+
             const template = $('#instant_wrapper_template').html();
             const templateVars = {
                 second_bar      : algoliaConfig.instant.enabled,
@@ -128,27 +128,27 @@ define([
                 config          : algoliaConfig.instant,
                 translations    : algoliaConfig.translations,
             };
-    
+
             const wrapperHtml = templateProcessor.process(template, templateVars);
             $('.algolia-instant-selector-results').html(wrapperHtml).show();
-    
+
             /**
              * Initialise instant search
              * For rendering instant search page is used Algolia's instantsearch.js library
              * Docs: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/
              **/
-    
+
             var ruleContexts = ['magento_filters', '']; // Empty context to keep BC for already create rules in dashboard
             if (algoliaConfig.request.categoryId.length > 0) {
                 ruleContexts.push('magento-category-' + algoliaConfig.request.categoryId);
             }
-    
+
             if (algoliaConfig.request.landingPageId.length > 0) {
                 ruleContexts.push(
                     'magento-landingpage-' + algoliaConfig.request.landingPageId
                 );
             }
-    
+
             var searchClient = algoliasearch(
                 algoliaConfig.applicationId,
                 algoliaConfig.apiKey
@@ -163,7 +163,7 @@ define([
                 indexName   : indexName,
                 routing     : algoliaCommon.routing,
             };
-    
+
             if (
                 algoliaConfig.request.path.length > 0 &&
                 window.location.hash.indexOf('categories.level0') === -1
@@ -175,7 +175,7 @@ define([
                         ] = [algoliaConfig.request.path];
                 }
             }
-    
+
             if (
                 algoliaConfig.instant.isVisualMerchEnabled &&
                 algoliaConfig.isCategoryPage
@@ -184,44 +184,44 @@ define([
                     algoliaConfig.instant.categoryPageIdAttribute
                 }:"${algoliaConfig.request.path.replace(/"/g, '\\"')}"`;
             }
-    
+
             instantsearchOptions = algoliaCommon.triggerHooks(
                 'beforeInstantsearchInit',
                 instantsearchOptions,
                 mockAlgoliaBundle
             );
-    
+
             var search = instantsearch(instantsearchOptions);
-    
+
             search.client.addAlgoliaAgent(
                 'Magento2 integration (' + algoliaConfig.extensionVersion + ')'
             );
-    
+
             /** Prepare sorting indices data */
             algoliaConfig.sortingIndices.unshift({
                 name : indexName,
                 label: algoliaConfig.translations.relevance,
             });
-    
+
             /** Setup attributes for current refinements widget **/
             var attributes = [];
             $.each(algoliaConfig.facets, function (i, facet) {
                 var name = facet.attribute;
-    
+
                 if (name === 'categories') {
                     name = 'categories.level0';
                 }
-    
+
                 if (name === 'price') {
                     name = facet.attribute + algoliaConfig.priceKey;
                 }
-    
+
                 attributes.push({
                     name : name,
                     label: facet.label ? facet.label : facet.attribute,
                 });
             });
-    
+
             var allWidgetConfiguration = {
                 infiniteHits: {},
                 hits        : {},
@@ -245,20 +245,20 @@ define([
                         },
                         init                     : function (data) {
                             var page = data.helper.state.page;
-    
+
                             if (algoliaConfig.request.refinementKey.length > 0) {
                                 data.helper.toggleRefine(
                                     algoliaConfig.request.refinementKey,
                                     algoliaConfig.request.refinementValue
                                 );
                             }
-    
+
                             if (algoliaConfig.isCategoryPage) {
                                 data.helper.addNumericRefinement('visibility_catalog', '=', 1);
                             } else {
                                 data.helper.addNumericRefinement('visibility_search', '=', 1);
                             }
-    
+
                             data.helper.setPage(page);
                         },
                         render                   : function (data) {
@@ -316,7 +316,7 @@ define([
                                     $('<div>').text(data.results.query).html() +
                                     '</b>"</div>';
                                 content += '<div class="popular-searches">';
-    
+
                                 if (
                                     algoliaConfig.showSuggestionsOnNoResultsPage &&
                                     this.suggestions.length > 0
@@ -327,7 +327,7 @@ define([
                                         '</div>' +
                                         this.suggestions.join(', ');
                                 }
-    
+
                                 content += '</div>';
                                 content +=
                                     algoliaConfig.translations.or +
@@ -336,9 +336,9 @@ define([
                                     '/catalogsearch/result/?q=__empty__">' +
                                     algoliaConfig.translations.seeAll +
                                     '</a>';
-    
+
                                 content += '</div>';
-    
+
                                 $('#instant-empty-results-container').html(content);
                             } else {
                                 $('#instant-empty-results-container').html('');
@@ -361,7 +361,7 @@ define([
                             );
                             data.seconds = data.processingTimeMS / 1000;
                             data.translations = window.algoliaConfig.translations;
-    
+
                             // TODO: Revisit this injected jQuery logic
                             const searchParams = new URLSearchParams(window.location.search);
                             const searchQuery = searchParams.has('q') || '';
@@ -372,7 +372,7 @@ define([
                                 $('.algolia-instant-replaced-content').hide();
                                 $('.algolia-instant-selector-results').show();
                             }
-    
+
                             const template = $('#instant-stats-template').html();
                             return templateProcessor.process(template, data);
                         },
@@ -410,7 +410,7 @@ define([
                             // For category browse, requires a custom renderer to prevent removal of the root node from hierarchicalMenu widget
                             return attribute.name;
                     }),
-    
+
                     transformItems: (items) => {
                         return (
                             items
@@ -432,7 +432,7 @@ define([
                                     item.label = attribute.label;
                                     item.refinements.forEach(function (refinement) {
                                         if (refinement.type !== 'hierarchical') return refinement;
-    
+
                                         const levels = refinement.label.split(
                                             algoliaConfig.instant.categorySeparator
                                         );
@@ -444,7 +444,7 @@ define([
                         );
                     },
                 },
-    
+
                 /*
                  * clearRefinements
                  * Widget displays a button that lets the user clean every refinement applied to the search. You can control which attributes are impacted by the button with the options.
@@ -479,7 +479,7 @@ define([
                         });
                     },
                 },
-    
+
                 /*
                  * queryRuleCustomData
                  * The queryRuleCustomData widget displays custom data from Query Rules.
@@ -492,7 +492,7 @@ define([
                     },
                 },
             };
-    
+
             if (algoliaConfig.instant.isSearchBoxEnabled) {
                 /**
                  * searchBox
@@ -519,7 +519,7 @@ define([
                     },
                 };
             }
-    
+
             if (algoliaConfig.instant.infiniteScrollEnabled === true) {
                 /**
                  * infiniteHits
@@ -548,7 +548,7 @@ define([
                     showPrevious  : true,
                     escapeHits    : true,
                 };
-    
+
                 delete allWidgetConfiguration.hits;
             } else {
                 /**
@@ -584,7 +584,7 @@ define([
                         });
                     },
                 };
-    
+
                 /**
                  * pagination
                  * Docs: https://www.algolia.com/doc/api-reference/widgets/pagination/js/
@@ -601,10 +601,10 @@ define([
                         next    : algoliaConfig.translations.nextPage,
                     },
                 };
-    
+
                 delete allWidgetConfiguration.infiniteHits;
             }
-    
+
             /**
              * Here are specified custom attributes widgets which require special code to run properly
              * Custom widgets can be added to this object like [attribute]: function(facet, templates)
@@ -616,7 +616,7 @@ define([
                     for (let l = 0; l < 10; l++) {
                         hierarchical_levels.push('categories.level' + l.toString());
                     }
-    
+
                     const hierarchicalMenuParams = {
                         container      : facet.wrapper.appendChild(
                             algoliaCommon.createISWidgetContainer(facet.attribute)
@@ -642,7 +642,7 @@ define([
                                 : items;
                         },
                     };
-    
+
                     hierarchicalMenuParams.templates.item =
                         '' +
                         '<a class="{{cssClasses.link}} {{#isRefined}}{{cssClasses.link}}--selected{{/isRefined}}" href="{{categoryUrl}}">{{label}}' +
@@ -660,19 +660,19 @@ define([
                             return !items.length;
                         },
                     };
-    
+
                     return ['hierarchicalMenu', hierarchicalMenuParams];
                 },
             };
-    
+
             /** Add all facet widgets to instantsearch object **/
             var wrapper = document.getElementById('instant-search-facets-container');
             $.each(algoliaConfig.facets, (i, facet) => {
                 if (facet.attribute.indexOf('price') !== -1)
                     facet.attribute = facet.attribute + algoliaConfig.priceKey;
-    
+
                 facet.wrapper = wrapper;
-    
+
                 var templates = {
                     item: $('#refinements-lists-item-template').html(),
                 };
@@ -681,17 +681,17 @@ define([
                     customAttributeFacet[facet.attribute] !== undefined
                         ? customAttributeFacet[facet.attribute](facet, templates)
                         : this.getFacetWidget(facet, templates);
-    
+
                 var widgetType = widgetInfo[0],
                     widgetConfig = widgetInfo[1];
-    
+
                 if (typeof allWidgetConfiguration[widgetType] === 'undefined') {
                     allWidgetConfiguration[widgetType] = [widgetConfig];
                 } else {
                     allWidgetConfiguration[widgetType].push(widgetConfig);
                 }
             });
-    
+
             if (algoliaConfig.analytics.enabled) {
                 if (typeof algoliaAnalyticsPushFunction !== 'function') {
                     var algoliaAnalyticsPushFunction = function (
@@ -706,7 +706,7 @@ define([
                             formattedParameters +
                             '&numberOfHits=' +
                             results.nbHits;
-    
+
                         // Universal Analytics
                         if (typeof window.ga !== 'undefined') {
                             window.ga('set', 'page', trackedUrl);
@@ -714,7 +714,7 @@ define([
                         }
                     };
                 }
-    
+
                 allWidgetConfiguration['analytics'] = {
                     pushFunction          : algoliaAnalyticsPushFunction,
                     delay                 : algoliaConfig.analytics.delay,
@@ -722,13 +722,13 @@ define([
                     pushInitialSearch     : algoliaConfig.analytics.pushInitialSearch,
                 };
             }
-    
+
             allWidgetConfiguration = algoliaCommon.triggerHooks(
                 'beforeWidgetInitialization',
                 allWidgetConfiguration,
                 mockAlgoliaBundle
             );
-    
+
             $.each(allWidgetConfiguration, (widgetType, widgetConfig) => {
                 if (Array.isArray(widgetConfig) === true) {
                     $.each(widgetConfig, (i, widgetConfig) => {
@@ -738,7 +738,7 @@ define([
                     this.addWidget(search, widgetType, widgetConfig);
                 }
             });
-    
+
             // Capture active redirect URL with IS facet params for add to cart from PLP
             if (algoliaConfig.instant.isAddToCartEnabled) {
                 search.on('render', () => {
@@ -755,33 +755,31 @@ define([
                     });
                 });
             }
-    
-            var isStarted = false;
-    
-            function startInstantSearch() {
-                if (isStarted === true) {
-                    return;
-                }
-    
-                search = algoliaCommon.triggerHooks(
-                    'beforeInstantsearchStart',
-                    search,
-                    mockAlgoliaBundle
-                );
-                search.start();
-                search = algoliaCommon.triggerHooks(
-                    'afterInstantsearchStart',
-                    search,
-                    mockAlgoliaBundle
-                );
-    
-                isStarted = true;
-            }
-    
-            /** Initialise searching **/
-            startInstantSearch();
+
+            this.startInstantSearch(search, mockAlgoliaBundle);
 
             this.addMobileRefinementsToggle();
+        },
+
+        isStarted: false,
+
+        startInstantSearch(search, mockAlgoliaBundle) {
+            console.log("IS started?:", this.isStarted);
+            if (this.isStarted) {
+                return;
+            }
+            search = algoliaCommon.triggerHooks(
+                'beforeInstantsearchStart',
+                search,
+                mockAlgoliaBundle
+            );
+            search.start();
+            search = algoliaCommon.triggerHooks(
+                'afterInstantsearchStart',
+                search,
+                mockAlgoliaBundle
+            );
+            this.isStarted = true;
         },
 
         getFacetWidget(facet, templates) {
@@ -947,7 +945,7 @@ define([
                 );
                 delete config.panelOptions;
             }
-    
+
             search.addWidgets([widget(config)]);
         },
 
@@ -963,7 +961,7 @@ define([
                     algoliaConfig.translations.noResults +
                     '</div>';
             }
-    
+
             return options;
         },
 
@@ -978,7 +976,7 @@ define([
         },
 
         /**
-         * @deprecated algoliaBundle is going away! 
+         * @deprecated algoliaBundle is going away!
          * This mock only includes libraries available to this module
          * The following have been removed:
          *  - Hogan
@@ -991,7 +989,6 @@ define([
          * However if you've used or require any of these additional libs in your customizations,
          * you can either augment this mock as you need or include the global dependency in your module
          * and make it available to your hook.
-         * TODO: Mixin and documentation to come on how to do this...
          */
         mockAlgoliaBundle() {
             return {

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -735,6 +735,8 @@ define([
         },
 
         /**
+         * Get raw search parameters for configure widget
+         * See https://www.algolia.com/doc/api-reference/widgets/configure/js/
          * @returns {*[]}
          */
         getSearchParameters() {

--- a/view/frontend/web/js/internals/template-engine.js
+++ b/view/frontend/web/js/internals/template-engine.js
@@ -1,3 +1,11 @@
+/**
+ * For templating the Mustache library is used by default
+ * Docs: https://github.com/janl/mustache.js
+ *
+ * Alternatively you can also use Hogan
+ * Docs:http://twitter.github.io/hogan.js/
+ **/
+
 define([], function () {
   const ENGINE_TYPE_HOGAN = 'hogan';
   const ENGINE_TYPE_MUSTACHE = 'mustache';
@@ -30,7 +38,7 @@ define([], function () {
     // Convenience method
     processTemplate: async function (template, data, measure = false) {
       const adapter = await this.getSelectedEngineAdapter();
-      return (measure) 
+      return (measure)
         ? adapter.processAndMeasure(template, data)
         : adapter.process(template, data);
     },


### PR DESCRIPTION
While [supplying updates](https://github.com/algolia/algoliasearch-custom-algolia-magento-2/pull/15) to our `CustomAlgolia` module to demonstrate the ability to use mixins with the updated `3.15.0` libraries I decide to refactor a few more bits of functionality on InstantSearch to expose setup functions without getting too ambitious. 

There's more work that needs to be done here as the legacy code makes heavy use of closures in what is presently contained in a pretty monolithic `buildInstantSearch` method. I realize we expose `allWidgetConfiguration` for modification through our hooks, but I feel it would also be very convenient to be able to granularly override things through a simple mixin. Future updates here can expose more internals in these JavaScript files to customization without overrides. 