### PR TITLE
MAGE-1184: Entity Helpers refactoring

### DIFF
--- a/Api/RecordBuilder/RecordBuilderInterface.php
+++ b/Api/RecordBuilder/RecordBuilderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api\RecordBuilder;
+
+use Magento\Framework\DataObject;
+
+interface RecordBuilderInterface
+{
+    public function buildRecord(DataObject $entity): array;
+}

--- a/Helper/Entity/AbstractEntityHelper.php
+++ b/Helper/Entity/AbstractEntityHelper.php
@@ -18,6 +18,14 @@ abstract class AbstractEntityHelper
     abstract public function getIndexNameSuffix(): string;
 
     /**
+     * Get the settings related to an entity to index
+     *
+     * @param int|null $storeId
+     * @return array
+     */
+    abstract public function getIndexSettings(?int $storeId = null): array;
+
+    /**
      * For a given entity helper, return the Algolia index for the specified store
      * @param int $storeId The store index desired
      * @param bool $tmp (Optional) Specify whether to obtain the temp index

--- a/Helper/Entity/AdditionalSectionHelper.php
+++ b/Helper/Entity/AdditionalSectionHelper.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
-use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\AdditionalSection\RecordBuilder as AdditionalSectionRecordBuilder;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Eav\Model\Config;
@@ -15,16 +15,20 @@ class AdditionalSectionHelper extends AbstractEntityHelper
     public const INDEX_NAME_SUFFIX = '_section';
 
     public function __construct(
-        protected ManagerInterface  $eventManager,
-        protected CollectionFactory $collectionFactory,
-        protected Config            $eavConfig,
-        protected IndexNameFetcher  $indexNameFetcher,
-    )
-    {
+        protected ManagerInterface               $eventManager,
+        protected CollectionFactory              $collectionFactory,
+        protected Config                         $eavConfig,
+        protected AdditionalSectionRecordBuilder $additionalSectionRecordBuilder,
+        protected IndexNameFetcher               $indexNameFetcher,
+    ) {
         parent::__construct($indexNameFetcher);
     }
 
-    public function getIndexSettings($storeId): array
+    /**
+     * @param int|null $storeId
+     * @return array
+     */
+    public function getIndexSettings(?int $storeId = null): array
     {
         $indexSettings = [
             'searchableAttributes' => ['unordered(value)'],
@@ -68,23 +72,13 @@ class AdditionalSectionHelper extends AbstractEntityHelper
         }
 
         $values = array_map(function ($value) use ($section, $storeId) {
-            $record = [
-                AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $value,
-                'value'                                 => $value,
-            ];
+            $dataObject = new DataObject([
+                'value' => $value,
+                'section' => $section,
+                'store_id' => $storeId
+            ]);
 
-            $transport = new DataObject($record);
-            $this->eventManager->dispatch(
-                'algolia_additional_section_item_index_before',
-                ['section' => $section, 'record' => $transport, 'store_id' => $storeId]
-            );
-            $this->eventManager->dispatch(
-                'algolia_additional_section_items_before_index',
-                ['section' => $section, 'record' => $transport, 'store_id' => $storeId]
-            );
-            $record = $transport->getData();
-
-            return $record;
+            return $this->additionalSectionRecordBuilder->buildRecord($dataObject);
         }, $values);
 
         return $values;

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -5,56 +5,45 @@ namespace Algolia\AlgoliaSearch\Helper\Entity;
 use Algolia\AlgoliaSearch\Exception\CategoryEmptyException;
 use Algolia\AlgoliaSearch\Exception\CategoryNotActiveException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Algolia\AlgoliaSearch\Helper\Image;
-use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\Category\RecordBuilder as CategoryRecordBuilder;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Category as MagentoCategory;
 use Magento\Catalog\Model\CategoryRepository;
-use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
 use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollection;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
 use Magento\Eav\Model\Config;
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\Module\Manager;
-use Magento\Store\Model\Store;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Store\Model\StoreManagerInterface;
 
 class CategoryHelper extends AbstractEntityHelper
 {
     use EntityHelperTrait;
     public const INDEX_NAME_SUFFIX = '_categories';
-    protected $isCategoryVisibleInMenuCache;
-    protected $coreCategories;
-    protected $idColumn;
     protected $categoryAttributes;
     protected $rootCategoryId = -1;
-    protected $categoryNames;
 
     public function __construct(
         protected ManagerInterface          $eventManager,
         protected StoreManagerInterface     $storeManager,
-        protected ResourceConnection        $resourceConnection,
         protected Config                    $eavConfig,
         protected ConfigHelper              $configHelper,
         protected CategoryCollectionFactory $categoryCollectionFactory,
-        protected Image                     $imageHelper,
-        protected CategoryResource          $categoryResource,
         protected CategoryRepository        $categoryRepository,
-        protected Manager                   $moduleManager,
-        protected IndexNameFetcher          $indexNameFetcher
+        protected IndexNameFetcher          $indexNameFetcher,
+        protected CategoryRecordBuilder     $categoryRecordBuilder,
     )
     {
         parent::__construct($indexNameFetcher);
     }
 
     /**
-     * @param $storeId
-     * @return array|mixed|null
+     * @param int|null $storeId
+     * @return array
      */
-    public function getIndexSettings($storeId)
+    public function getIndexSettings(?int $storeId = null): array
     {
         $searchableAttributes = [];
         $unretrievableAttributes = [];
@@ -90,10 +79,7 @@ class CategoryHelper extends AbstractEntityHelper
 
         // Additional index settings from event observer
         $transport = new DataObject($indexSettings);
-        $this->eventManager->dispatch('algolia_index_settings_prepare', [ // Only for backward compatibility
-                'store_id'       => $storeId,
-                'index_settings' => $transport,
-            ]);
+        /** Removed legacy algolia_index_settings_prepare event on 3.15.0 */
         $this->eventManager->dispatch('algolia_categories_index_before_set_settings', [
                 'store_id'       => $storeId,
                 'index_settings' => $transport,
@@ -116,7 +102,7 @@ class CategoryHelper extends AbstractEntityHelper
      * @param $storeId
      * @param null $categoryIds
      *
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      *
      * @return CategoryCollection
@@ -176,7 +162,7 @@ class CategoryHelper extends AbstractEntityHelper
 
     /**
      * @return array
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function getAllAttributes()
     {
@@ -213,97 +199,18 @@ class CategoryHelper extends AbstractEntityHelper
     /**
      * @param MagentoCategory $category
      * @return array|mixed|null
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function getObject(Category $category)
     {
-        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection */
-        $productCollection = $category->getProductCollection();
-        $category->setProductCount($productCollection->getSize());
-
-        $transport = new DataObject();
-        $this->eventManager->dispatch(
-            'algolia_category_index_before',
-            ['category' => $category, 'custom_data' => $transport]
-        );
-        $customData = $transport->getData();
-
-        $storeId = $category->getStoreId();
-
-        /** @var \Magento\Framework\Url $urlInstance */
-        $urlInstance = $category->getUrlInstance();
-        $urlInstance->setData('store', $storeId);
-
-        $path = '';
-        foreach ($category->getPathIds() as $categoryId) {
-            if ($path !== '') {
-                $path .= ' / ';
-            }
-
-            $path .= $this->getCategoryName($categoryId, $storeId);
-        }
-
-        $imageUrl = null;
-
-        try {
-            $imageUrl = $category->getImageUrl();
-        } catch (\Exception $e) {
-            /* no image, no default: not fatal */
-        }
-
-        $data = [
-            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $category->getId(),
-            'name'                                  => $category->getName(),
-            'path'                                  => $path,
-            'level'                                 => $category->getLevel(),
-            'url'                                   => $this->getUrl($category),
-            'include_in_menu'                       => $category->getIncludeInMenu(),
-            '_tags'                                 => ['category'],
-            'popularity'                            => 1,
-            'product_count'                         => $category->getProductCount(),
-        ];
-
-        if (!empty($imageUrl)) {
-            $data['image_url'] = $imageUrl;
-        }
-
-        foreach ($this->configHelper->getCategoryAdditionalAttributes($storeId) as $attribute) {
-            $value = $category->getData($attribute['attribute']);
-
-            /** @var CategoryResource $resource */
-            $resource = $category->getResource();
-
-            $attributeResource = $resource->getAttribute($attribute['attribute']);
-            if ($attributeResource) {
-                $value = $attributeResource->getFrontend()->getValue($category);
-            }
-
-            if (isset($data[$attribute['attribute']])) {
-                $value = $data[$attribute['attribute']];
-            }
-
-            if ($value) {
-                $data[$attribute['attribute']] = $value;
-            }
-        }
-
-        $data = array_merge($data, $customData);
-
-        $transport = new DataObject($data);
-        $this->eventManager->dispatch(
-            'algolia_after_create_category_object',
-            ['category' => $category, 'categoryObject' => $transport]
-        );
-        $data = $transport->getData();
-
-        return $data;
+        return $this->categoryRecordBuilder->buildRecord($category);
     }
 
     /**
      * @return int|mixed
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
-    public function getRootCategoryId()
+    protected function getRootCategoryId()
     {
         if ($this->rootCategoryId !== -1) {
             return $this->rootCategoryId;
@@ -317,28 +224,6 @@ class CategoryHelper extends AbstractEntityHelper
         $this->rootCategoryId = $rootCategory->getId();
 
         return $this->rootCategoryId;
-    }
-
-    /**
-     * @param MagentoCategory $category
-     * @return array|string|string[]
-     */
-    private function getUrl(Category $category)
-    {
-        $categoryUrl = $category->getUrl();
-
-        if ($this->configHelper->useSecureUrlsInFrontend($category->getStoreId()) === false) {
-            return $categoryUrl;
-        }
-
-        $unsecureBaseUrl = $category->getUrlInstance()->getBaseUrl(['_secure' => false]);
-        $secureBaseUrl = $category->getUrlInstance()->getBaseUrl(['_secure' => true]);
-
-        if (mb_strpos($categoryUrl, $unsecureBaseUrl) === 0) {
-            return substr_replace($categoryUrl, $secureBaseUrl, 0, mb_strlen($unsecureBaseUrl));
-        }
-
-        return $categoryUrl;
     }
 
     /**
@@ -373,174 +258,17 @@ class CategoryHelper extends AbstractEntityHelper
      */
     public function getCategoryName($categoryId, $storeId = null)
     {
-        if ($categoryId instanceof MagentoCategory) {
-            $categoryId = $categoryId->getId();
-        }
-
-        if ($storeId instanceof Store) {
-            $storeId = $storeId->getId();
-        }
-
-        $categoryId = (int) $categoryId;
-        $storeId = (int) $storeId;
-        if (!isset($this->categoryNames)) {
-            $this->categoryNames = [];
-
-            /** @var CategoryResource $categoryModel */
-            $categoryModel = $this->categoryResource;
-
-            if ($attribute = $categoryModel->getAttribute('name')) {
-                $columnId = $this->getCorrectIdColumn();
-                $expression = new \Zend_Db_Expr("CONCAT(backend.store_id, '-', backend." . $columnId . ')');
-
-                $connection = $this->resourceConnection->getConnection();
-                $select = $connection->select()
-                                     ->from(
-                                         ['backend' => $attribute->getBackendTable()],
-                                         [$expression, 'backend.value']
-                                     )
-                                     ->join(
-                                         ['category' => $categoryModel->getTable('catalog_category_entity')],
-                                         'backend.' . $columnId . ' = category.' . $columnId,
-                                         []
-                                     )
-                                     ->where('backend.attribute_id = ?', $attribute->getAttributeId())
-                                     ->where('category.level > ?', 1);
-
-                $this->categoryNames = $connection->fetchPairs($select);
-            }
-        }
-
-        $categoryName = null;
-
-        $categoryKeyId = $this->getCategoryKeyId($categoryId, $storeId);
-
-        if ($categoryKeyId === null) {
-            return $categoryName;
-        }
-
-        $key = $storeId . '-' . $categoryKeyId;
-
-        if (isset($this->categoryNames[$key])) {
-            // Check whether the category name is present for the specified store
-            $categoryName = (string) $this->categoryNames[$key];
-        } elseif ($storeId !== 0) {
-            // Check whether the category name is present for the default store
-            $key = '0-' . $categoryKeyId;
-            if (isset($this->categoryNames[$key])) {
-                $categoryName = (string) $this->categoryNames[$key];
-            }
-        }
-
-        return $categoryName;
-    }
-
-    /**
-     * @param $categoryId
-     * @param $storeId
-     * @return mixed|null
-     */
-    private function getCategoryKeyId($categoryId, $storeId = null)
-    {
-        $categoryKeyId = $categoryId;
-
-        if ($this->getCorrectIdColumn() === 'row_id') {
-            $category = $this->getCategoryById($categoryId, $storeId);
-            return $category ? $category->getRowId() : null;
-        }
-
-        return $categoryKeyId;
-    }
-
-    /**
-     * @param $categoryId
-     * @param $storeId
-     * @return mixed|null
-     */
-    private function getCategoryById($categoryId, $storeId = null)
-    {
-        $categories = $this->getCoreCategories(false, $storeId);
-
-        return isset($categories[$categoryId]) ? $categories[$categoryId] : null;
-    }
-
-    /**
-     * @param $categoryId
-     * @param $storeId
-     * @return bool|mixed
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     */
-    public function isCategoryVisibleInMenu($categoryId, $storeId)
-    {
-        $key = $categoryId . '-' . $storeId;
-        if (isset($this->isCategoryVisibleInMenuCache[$key])) {
-            return $this->isCategoryVisibleInMenuCache[$key];
-        }
-
-        $categoryId = (int) $categoryId;
-
-        $category = $this->categoryRepository->get($categoryId, $storeId);
-
-        $this->isCategoryVisibleInMenuCache[$key] = (bool) $category->getIncludeInMenu();
-
-        return $this->isCategoryVisibleInMenuCache[$key];
+        return $this->categoryRecordBuilder->getCategoryName($categoryId, $storeId);
     }
 
     /**
      * @param $filterNotIncludedCategories
      * @param $storeId
      * @return array
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function getCoreCategories($filterNotIncludedCategories = true, $storeId = null)
     {
-        // Cache category look up by store scope
-        $key = ($filterNotIncludedCategories ? 'filtered' : 'non_filtered') . "-$storeId";
-
-        if (isset($this->coreCategories[$key])) {
-            return $this->coreCategories[$key];
-        }
-
-        $collection = $this->categoryCollectionFactory->create()
-            ->distinct(true)
-            ->setStoreId($storeId)
-            ->addNameToResult()
-            ->addIsActiveFilter()
-            ->addAttributeToSelect('name')
-            ->addAttributeToFilter('level', ['gt' => 1]);
-
-        if ($filterNotIncludedCategories) {
-            $collection->addAttributeToFilter('include_in_menu', '1');
-        }
-
-        $this->coreCategories[$key] = [];
-
-        /** @var \Magento\Catalog\Model\Category $category */
-        foreach ($collection as $category) {
-                $this->coreCategories[$key][$category->getId()] = $category;
-        }
-
-        return $this->coreCategories[$key];
-    }
-
-    /**
-     * @return string
-     */
-    private function getCorrectIdColumn()
-    {
-        if (isset($this->idColumn)) {
-            return $this->idColumn;
-        }
-
-        $this->idColumn = 'entity_id';
-
-        $edition = $this->configHelper->getMagentoEdition();
-        $version = $this->configHelper->getMagentoVersion();
-
-        if ($edition !== 'Community' && version_compare($version, '2.1.0', '>=') && $this->moduleManager->isEnabled('Magento_Staging')) {
-            $this->idColumn = 'row_id';
-        }
-
-        return $this->idColumn;
+        return $this->categoryRecordBuilder->getCoreCategories($filterNotIncludedCategories, $storeId);
     }
 }

--- a/Helper/Entity/CategoryHelper.php
+++ b/Helper/Entity/CategoryHelper.php
@@ -23,6 +23,7 @@ class CategoryHelper extends AbstractEntityHelper
     use EntityHelperTrait;
     public const INDEX_NAME_SUFFIX = '_categories';
     protected $categoryAttributes;
+
     protected $rootCategoryId = -1;
 
     public function __construct(
@@ -200,6 +201,8 @@ class CategoryHelper extends AbstractEntityHelper
      * @param MagentoCategory $category
      * @return array|mixed|null
      * @throws LocalizedException
+     *
+     * @deprecated (will be removed in v3.16.0)
      */
     public function getObject(Category $category)
     {
@@ -255,6 +258,8 @@ class CategoryHelper extends AbstractEntityHelper
      * @param null $storeId
      *
      * @return string|null
+     *
+     * @deprecated (will be removed in v3.16.0)
      */
     public function getCategoryName($categoryId, $storeId = null)
     {
@@ -266,6 +271,8 @@ class CategoryHelper extends AbstractEntityHelper
      * @param $storeId
      * @return array
      * @throws LocalizedException
+     *
+     * @deprecated (will be removed in v3.16.0)
      */
     public function getCoreCategories($filterNotIncludedCategories = true, $storeId = null)
     {

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -3,14 +3,12 @@
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Page\RecordBuilder as PageRecordBuilder;
 use Magento\Cms\Model\Page;
 use Magento\Cms\Model\ResourceModel\Page\CollectionFactory as PageCollectionFactory;
-use Magento\Cms\Model\Template\FilterProvider;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\UrlFactory;
 use Magento\Store\Model\StoreManagerInterface;
 
 class PageHelper extends AbstractEntityHelper
@@ -22,16 +20,18 @@ class PageHelper extends AbstractEntityHelper
         protected ManagerInterface      $eventManager,
         protected PageCollectionFactory $pageCollectionFactory,
         protected ConfigHelper          $configHelper,
-        protected FilterProvider        $filterProvider,
         protected StoreManagerInterface $storeManager,
-        protected UrlFactory            $frontendUrlFactory,
         protected IndexNameFetcher      $indexNameFetcher,
-    )
-    {
+        protected PageRecordBuilder     $pageRecordBuilder,
+    ) {
         parent::__construct($indexNameFetcher);
     }
 
-    public function getIndexSettings($storeId)
+    /**
+     * @param int|null $storeId
+     * @return array
+     */
+    public function getIndexSettings(?int $storeId = null): array
     {
         $indexSettings = [
             'searchableAttributes' => ['unordered(slug)', 'unordered(name)', 'unordered(content)'],
@@ -50,7 +50,6 @@ class PageHelper extends AbstractEntityHelper
 
     public function getPages($storeId, array $pageIds = null)
     {
-        /** @var \Magento\Cms\Model\ResourceModel\Page\Collection $magentoPages */
         $magentoPages = $this->pageCollectionFactory->create()
             ->addStoreFilter($storeId)
             ->addFieldToFilter('is_active', 1);
@@ -68,42 +67,15 @@ class PageHelper extends AbstractEntityHelper
 
         $pages = [];
 
-        $frontendUrlBuilder = $this->frontendUrlFactory->create()->setScope($storeId);
-
         /** @var Page $page */
         foreach ($magentoPages as $page) {
-            $pageObject = [];
-
-            $pageObject['slug'] = $page->getIdentifier();
-            $pageObject['name'] = $page->getTitle();
-
             $page->setData('store_id', $storeId);
 
             if (!$page->getId()) {
                 continue;
             }
 
-            $content = $page->getContent();
-            if ($this->configHelper->getRenderTemplateDirectives()) {
-                $content = $this->filterProvider->getPageFilter()->filter($content);
-            }
-
-            $pageObject[AlgoliaConnector::ALGOLIA_API_OBJECT_ID] = $page->getId();
-            $pageObject['url'] = $frontendUrlBuilder->getUrl(
-                null,
-                [
-                    '_direct' => $page->getIdentifier(),
-                    '_secure' => $this->configHelper->useSecureUrlsInFrontend($storeId),
-                ]
-            );
-            $pageObject['content'] = $this->strip($content, ['script', 'style']);
-
-            $transport = new DataObject($pageObject);
-            $this->eventManager->dispatch(
-                'algolia_after_create_page_object',
-                ['page' => $transport, 'pageObject' => $page]
-            );
-            $pageObject = $transport->getData();
+            $pageObject = $this->pageRecordBuilder->buildRecord($page);
 
             if (isset($pageIdsToRemove[$page->getId()])) {
                 unset($pageIdsToRemove[$page->getId()]);
@@ -146,42 +118,5 @@ class PageHelper extends AbstractEntityHelper
         }
 
         return $storeIds;
-    }
-
-    private function strip($s, $completeRemoveTags = [])
-    {
-        if ($completeRemoveTags && $completeRemoveTags !== [] && $s) {
-            $dom = new \DOMDocument();
-            libxml_use_internal_errors(true);
-            $encodedStr = mb_encode_numericentity($s, [0x80, 0x10fffff, 0, ~0]);
-            $dom->loadHTML($encodedStr);
-            libxml_use_internal_errors(false);
-
-            $toRemove = [];
-            foreach ($completeRemoveTags as $tag) {
-                $removeTags = $dom->getElementsByTagName($tag);
-
-                foreach ($removeTags as $item) {
-                    $toRemove[] = $item;
-                }
-            }
-
-            foreach ($toRemove as $item) {
-                $item->parentNode->removeChild($item);
-            }
-
-            $s = $dom->saveHTML();
-        }
-
-        $s = html_entity_decode($s, 0, 'UTF-8');
-
-        $s = trim(preg_replace('/\s+/', ' ', $s));
-        $s = preg_replace('/&nbsp;/', ' ', $s);
-        $s = preg_replace('!\s+!', ' ', $s);
-        $s = preg_replace('/\{\{[^}]+\}\}/', ' ', $s);
-        $s = strip_tags($s);
-        $s = trim($s);
-
-        return $s;
     }
 }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -3,7 +3,6 @@
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
-use Algolia\AlgoliaSearch\Exception\ProductReindexingException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
@@ -12,7 +11,6 @@ use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
-use Magento\Bundle\Model\Product\Type as BundleProductType;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -22,7 +20,6 @@ use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\CatalogInventory\Helper\Stock;
-use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
 use Magento\Directory\Model\Currency as CurrencyHelper;
@@ -159,6 +156,8 @@ class ProductHelper extends AbstractEntityHelper
      * @param $additionalAttributes
      * @param $attributeName
      * @return bool
+     *
+     * @deprecated (will be removed in v3.16.0)
      */
     public function isAttributeEnabled($additionalAttributes, $attributeName): bool
     {
@@ -268,6 +267,7 @@ class ProductHelper extends AbstractEntityHelper
     /**
      * @param int|null $storeId
      * @return array
+     *
      */
     protected function getAdditionalAttributes(?int $storeId = null): array
     {
@@ -390,51 +390,12 @@ class ProductHelper extends AbstractEntityHelper
      * @param Product $product
      * @return array|mixed|null
      * @throws \Exception
+     *
+     * @deprecated (will be removed in v3.16.0)
      */
     public function getObject(Product $product)
     {
         return $this->productRecordBuilder->buildRecord($product);
-    }
-
-    /**
-     * @param Product $product
-     * @return array|\Magento\Catalog\Api\Data\ProductInterface[]|DataObject[]
-     */
-    protected function getSubProducts(Product $product): array
-    {
-        $type = $product->getTypeId();
-
-        if (!in_array($type, ['bundle', 'grouped', 'configurable'], true)) {
-            return [];
-        }
-
-        $this->logger->startProfiling(__METHOD__);
-
-        $storeId = $product->getStoreId();
-        $typeInstance = $product->getTypeInstance();
-
-        if ($typeInstance instanceof Configurable) {
-            $subProducts = $typeInstance->getUsedProducts($product);
-        } elseif ($typeInstance instanceof BundleProductType) {
-            $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product)->getItems();
-        } else { // Grouped product
-            $subProducts = $typeInstance->getAssociatedProducts($product);
-        }
-
-        /**
-         * @var int $index
-         * @var Product $subProduct
-         */
-        foreach ($subProducts as $index => $subProduct) {
-            try {
-                $this->canProductBeReindexed($subProduct, $storeId, true);
-            } catch (ProductReindexingException) {
-                unset($subProducts[$index]);
-            }
-        }
-
-        $this->logger->stopProfiling(__METHOD__);
-        return $subProducts;
     }
 
     /**
@@ -481,6 +442,8 @@ class ProductHelper extends AbstractEntityHelper
      * @param $customData
      * @param Product $product
      * @return mixed
+     *
+     * @deprecated (will be removed in v3.16.0)
      */
     protected function addInStock($defaultData, $customData, Product $product)
     {
@@ -706,6 +669,8 @@ class ProductHelper extends AbstractEntityHelper
      * @param bool $isChildProduct
      *
      * @return bool
+     *
+     * @deprecated (will be removed in v3.16.0)
      */
     public function canProductBeReindexed($product, $storeId, $isChildProduct = false)
     {

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -684,6 +684,8 @@ class ProductHelper extends AbstractEntityHelper
      * @param int $storeId
      *
      * @return bool
+     *
+     * @deprecated (will be remove in a future version)
      */
     public function productIsInStock($product, $storeId): bool
     {

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -3,20 +3,15 @@
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
-use Algolia\AlgoliaSearch\Exception\ProductDeletedException;
-use Algolia\AlgoliaSearch\Exception\ProductDisabledException;
-use Algolia\AlgoliaSearch\Exception\ProductNotVisibleException;
-use Algolia\AlgoliaSearch\Exception\ProductOutOfStockException;
 use Algolia\AlgoliaSearch\Exception\ProductReindexingException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
-use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
 use Magento\Bundle\Model\Product\Type as BundleProductType;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
 use Magento\Catalog\Model\Product;
@@ -24,10 +19,8 @@ use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Type;
 use Magento\Catalog\Model\Product\Type\AbstractType;
 use Magento\Catalog\Model\Product\Visibility;
-use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeResource;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
-use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\CatalogInventory\Helper\Stock;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
@@ -38,7 +31,6 @@ use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 
 class ProductHelper extends AbstractEntityHelper
@@ -83,14 +75,6 @@ class ProductHelper extends AbstractEntityHelper
         'default_bundle_options',
     ];
 
-    /**
-     * @var string[]
-     */
-    protected array $attributesToIndexAsArray = [
-        'sku',
-        'color',
-    ];
-
     public function __construct(
         protected Config                                  $eavConfig,
         protected ConfigHelper                            $configHelper,
@@ -100,18 +84,15 @@ class ProductHelper extends AbstractEntityHelper
         protected ManagerInterface                        $eventManager,
         protected Visibility                              $visibility,
         protected Stock                                   $stockHelper,
-        protected StockRegistryInterface                  $stockRegistry,
         protected CurrencyHelper                          $currencyManager,
-        protected CategoryHelper                          $categoryHelper,
-        protected PriceManager                            $priceManager,
         protected Type                                    $productType,
         protected CollectionFactory                       $productCollectionFactory,
         protected GroupCollection                         $groupCollection,
         protected GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository,
-        protected ImageHelper                             $imageHelper,
         protected IndexNameFetcher                        $indexNameFetcher,
         protected ReplicaManagerInterface                 $replicaManager,
-        protected ProductInterfaceFactory                 $productFactory
+        protected ProductInterfaceFactory                 $productFactory,
+        protected ProductRecordBuilder                    $productRecordBuilder,
     )
     {
         parent::__construct($indexNameFetcher);
@@ -181,13 +162,7 @@ class ProductHelper extends AbstractEntityHelper
      */
     public function isAttributeEnabled($additionalAttributes, $attributeName): bool
     {
-        foreach ($additionalAttributes as $attr) {
-            if ($attr['attribute'] === $attributeName) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->productRecordBuilder->isAttributeEnabled($additionalAttributes, $attributeName);
     }
 
     /**
@@ -294,9 +269,9 @@ class ProductHelper extends AbstractEntityHelper
      * @param int|null $storeId
      * @return array
      */
-    public function getAdditionalAttributes(?int $storeId = null): array
+    protected function getAdditionalAttributes(?int $storeId = null): array
     {
-        return $this->configHelper->getProductAdditionalAttributes($storeId);
+        return $this->productRecordBuilder->getAdditionalAttributes($storeId);
     }
 
     /**
@@ -313,8 +288,8 @@ class ProductHelper extends AbstractEntityHelper
         $attributesForFaceting = $this->getAttributesForFaceting($storeId);
 
         $indexSettings = [
-            'searchableAttributes' => $searchableAttributes,
-            'customRanking' => $customRanking,
+            'searchableAttributes'    => $searchableAttributes,
+            'customRanking'           => $customRanking,
             'unretrievableAttributes' => $unretrievableAttributes,
             'attributesForFaceting'   => $attributesForFaceting,
             'maxValuesPerFacet'       => $this->configHelper->getMaxValuesPerFacet($storeId),
@@ -412,108 +387,13 @@ class ProductHelper extends AbstractEntityHelper
     }
 
     /**
-     * @param $categoryIds
-     * @param $storeId
-     * @return array
-     * @throws LocalizedException
-     */
-    public function getAllCategories($categoryIds, $storeId): array
-    {
-        $filterNotIncludedCategories = !$this->configHelper->showCatsNotIncludedInNavigation($storeId);
-        $categories = $this->categoryHelper->getCoreCategories($filterNotIncludedCategories, $storeId);
-
-        $selectedCategories = [];
-        foreach ($categoryIds as $id) {
-            if (isset($categories[$id])) {
-                $selectedCategories[] = $categories[$id];
-            }
-        }
-
-        return $selectedCategories;
-    }
-
-    /**
      * @param Product $product
      * @return array|mixed|null
      * @throws \Exception
      */
     public function getObject(Product $product)
     {
-        $storeId = $product->getStoreId();
-
-        $logEventName = 'CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId);
-        $this->logger->start($logEventName, true);
-        $defaultData = [];
-
-        $transport = new DataObject($defaultData);
-        $this->eventManager->dispatch(
-            'algolia_product_index_before',
-            ['product' => $product, 'custom_data' => $transport]
-        );
-
-        $defaultData = $transport->getData();
-
-        $visibility = $product->getVisibility();
-
-        $visibleInCatalog = $this->visibility->getVisibleInCatalogIds();
-        $visibleInSearch = $this->visibility->getVisibleInSearchIds();
-
-        $urlParams = [
-            '_secure' => $this->configHelper->useSecureUrlsInFrontend($product->getStoreId()),
-            '_nosid'  => true,
-        ];
-
-        $customData = [
-            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $product->getId(),
-            'name'                                  => $product->getName(),
-            'url'                                   => $product->getUrlModel()->getUrl($product, $urlParams),
-            'visibility_search'                     => (int) (in_array($visibility, $visibleInSearch)),
-            'visibility_catalog'                    => (int) (in_array($visibility, $visibleInCatalog)),
-            'type_id'                               => $product->getTypeId(),
-        ];
-
-        $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
-
-        $customData = $this->addAttribute('description', $defaultData, $customData, $additionalAttributes, $product);
-        $customData = $this->addAttribute('ordered_qty', $defaultData, $customData, $additionalAttributes, $product);
-        $customData = $this->addAttribute('total_ordered', $defaultData, $customData, $additionalAttributes, $product);
-        $customData = $this->addAttribute('rating_summary', $defaultData, $customData, $additionalAttributes, $product);
-        $customData = $this->addCategoryData($customData, $product);
-        $customData = $this->addImageData($customData, $product, $additionalAttributes);
-        $customData = $this->addInStock($defaultData, $customData, $product);
-        $customData = $this->addStockQty($defaultData, $customData, $additionalAttributes, $product);
-        if ($product->getTypeId() == "bundle") {
-            $customData = $this->addBundleProductDefaultOptions($customData, $product);
-        }
-        $subProducts = $this->getSubProducts($product);
-        $customData = $this->addAdditionalAttributes($customData, $additionalAttributes, $product, $subProducts);
-        $customData = $this->priceManager->addPriceDataByProductType($customData, $product, $subProducts);
-        $transport = new DataObject($customData);
-        $this->eventManager->dispatch(
-            'algolia_subproducts_index',
-            [
-                'custom_data'   => $transport,
-                'sub_products'  => $subProducts,
-                'productObject' => $product
-            ]
-        );
-        $customData = $transport->getData();
-        $customData = array_merge($customData, $defaultData);
-        $this->algoliaHelper->castProductObject($customData);
-        $transport = new DataObject($customData);
-        $this->eventManager->dispatch(
-            'algolia_after_create_product_object',
-            [
-                'custom_data'   => $transport,
-                'sub_products'  => $subProducts,
-                'productObject' => $product
-            ]
-        );
-        $customData = $transport->getData();
-
-        $this->logger->stop($logEventName, true);
-
-        return $customData;
+        return $this->productRecordBuilder->buildRecord($product);
     }
 
     /**
@@ -597,272 +477,6 @@ class ProductHelper extends AbstractEntityHelper
     }
 
     /**
-     * @param $attribute
-     * @param $defaultData
-     * @param $customData
-     * @param $additionalAttributes
-     * @param Product $product
-     * @return mixed
-     */
-    protected function addAttribute($attribute, $defaultData, $customData, $additionalAttributes, Product $product)
-    {
-        if (isset($defaultData[$attribute]) === false
-            && $this->isAttributeEnabled($additionalAttributes, $attribute)) {
-            $customData[$attribute] = $product->getData($attribute);
-        }
-
-        return $customData;
-    }
-
-    /**
-     * A category should only be indexed if in the path of the current store and has a valid name.
-     *
-     * @param $category
-     * @param $rootCat
-     * @param $storeId
-     * @return string|null
-     */
-    protected function getValidCategoryName($category, $rootCat, $storeId): ?string
-    {
-        $pathParts = explode('/', $category->getPath());
-        if (isset($pathParts[1]) && $pathParts[1] !== $rootCat) {
-            return null;
-        }
-
-        return $this->categoryHelper->getCategoryName($category->getId(), $storeId);
-
-    }
-
-    /**
-     * Filter out non unique category path entries.
-     *
-     * @param $paths
-     * @return array
-     */
-    protected function dedupePaths($paths): array
-    {
-        return array_values(
-            array_intersect_key(
-                $paths,
-                array_unique(array_map('serialize', $paths))
-            )
-        );
-    }
-
-    /**
-     * @param $customData
-     * @param Product $product
-     * @return mixed
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    protected function  addBundleProductDefaultOptions($customData, Product $product) {
-        $optionsCollection = $product->getTypeInstance()->getOptionsCollection($product);
-        $optionDetails = [];
-        foreach ($optionsCollection as $option){
-            $selections = $product->getTypeInstance()->getSelectionsCollection($option->getOptionId(),$product);
-            //selection details by optionids
-            foreach ($selections as $selection) {
-                if($selection->getIsDefault()){
-                    $optionDetails[$option->getOptionId()] = $selection->getSelectionId();
-                }
-            }
-        }
-        $customData['default_bundle_options'] = array_unique($optionDetails);
-        return $customData;
-    }
-
-    /**
-     * For a given product extract category data including category names, parent paths and all category tree IDs
-     *
-     * @param Product $product
-     * @return array|array[]
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    protected function buildCategoryData(Product $product): array
-    {
-        // Build within a single loop
-        // TODO: Profile for efficiency vs separate loops
-        $categoryData = [
-            'categoryNames'      => [],
-            'categoryIds'        => [],
-            'categoriesWithPath' => [],
-        ];
-
-        $storeId = $product->getStoreId();
-
-        $_categoryIds = $product->getCategoryIds();
-
-        if (is_array($_categoryIds) && count($_categoryIds)) {
-            $categoryCollection = $this->getAllCategories($_categoryIds, $storeId);
-
-            /** @var Store $store */
-            $store = $this->storeManager->getStore($product->getStoreId());
-            $rootCat = $store->getRootCategoryId();
-
-            foreach ($categoryCollection as $category) {
-                $categoryName = $this->getValidCategoryName($category, $rootCat, $storeId);
-                if (!$categoryName) {
-                    continue;
-                }
-                $categoryData['categoryNames'][] = $categoryName;
-
-                $category->getUrlInstance()->setStore($storeId);
-                $paths = [];
-
-                foreach ($category->getPathIds() as $treeCategoryId) {
-                    $name = $this->categoryHelper->getCategoryName($treeCategoryId, $storeId);
-                    if ($name) {
-                        $categoryData['categoryIds'][] = $treeCategoryId;
-                        $paths[] = $name;
-                    }
-                }
-
-                $categoryData['categoriesWithPath'][] = $paths;
-            }
-        }
-
-        // TODO: Evaluate use cases
-        // Based on old extraneous array manip logic (since removed) - is this still a likely scenario?
-        $categoryData['categoriesWithPath'] = $this->dedupePaths($categoryData['categoriesWithPath']);
-
-        return $categoryData;
-    }
-
-    /**
-     * Flatten non-hierarchical paths for merchandising
-     *
-     * @param array $paths
-     * @param int $storeId
-     * @return array
-     */
-    protected function flattenCategoryPaths(array $paths, int $storeId): array
-    {
-        return array_map(
-            function ($path) use ($storeId) { return implode($this->configHelper->getCategorySeparator($storeId), $path); },
-            $paths
-        );
-    }
-
-    /**
-     * Take an array of paths where each element is an array of parent-child hierarchies and
-     * append to the top level array each possible parent iteration.
-     * This serves to emulate anchoring in Magento in order to use category page id filtering
-     * without explicit category assignment.
-     *
-     * @param array $paths
-     * @return array
-     */
-    protected function autoAnchorParentCategories(array $paths): array {
-        foreach ($paths as $path) {
-            for ($i = count($path) - 1; $i > 0; $i--) {
-                $paths[] = array_slice($path,0, $i);
-            }
-        }
-        return $this->dedupePaths($paths);
-    }
-
-    /**
-     * @param array $algoliaData Data for product object to be serialized to Algolia index
-     * @param Product $product
-     * @return mixed
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    protected function addCategoryData(array $algoliaData, Product $product): array
-    {
-        $this->logger->startProfiling(__METHOD__);
-        $storeId = $product->getStoreId();
-
-        $categoryData = $this->buildCategoryData($product);
-        $hierarchicalCategories = $this->getHierarchicalCategories($categoryData['categoriesWithPath'], $storeId);
-        $algoliaData['categories'] = $hierarchicalCategories;
-        $algoliaData['categories_without_path'] = $categoryData['categoryNames'];
-        $algoliaData['categoryIds'] = array_values(array_unique($categoryData['categoryIds']));
-
-        if ($this->configHelper->isVisualMerchEnabled($storeId)) {
-            $autoAnchorPaths = $this->autoAnchorParentCategories($categoryData['categoriesWithPath']);
-            $algoliaData[$this->configHelper->getCategoryPageIdAttributeName($storeId)] = $this->flattenCategoryPaths($autoAnchorPaths, $storeId);
-        }
-
-        $this->logger->stopProfiling(__METHOD__);
-        return $algoliaData;
-    }
-
-    /**
-     * @param array $categoriesWithPath
-     * @param int $storeId
-     * @return array
-     */
-    protected function getHierarchicalCategories(array $categoriesWithPath, int $storeId): array
-    {
-        $hierarchicalCategories = [];
-
-        $levelName = 'level';
-
-        foreach ($categoriesWithPath as $category) {
-            $categoryCount = count($category);
-            for ($i = 0; $i < $categoryCount; $i++) {
-                if (isset($hierarchicalCategories[$levelName . $i]) === false) {
-                    $hierarchicalCategories[$levelName . $i] = [];
-                }
-
-                if ($category[$i] === null) {
-                    continue;
-                }
-
-                $hierarchicalCategories[$levelName . $i][] = implode($this->configHelper->getCategorySeparator($storeId), array_slice($category, 0, $i + 1));
-            }
-        }
-
-        // dedupe in case of multicategory assignment
-        foreach ($hierarchicalCategories as &$level) {
-            $level = array_values(array_unique($level));
-        }
-
-        return $hierarchicalCategories;
-    }
-
-    /**
-     * @param array $customData
-     * @param Product $product
-     * @param $additionalAttributes
-     * @return array
-     */
-    protected function addImageData(array $customData, Product $product, $additionalAttributes)
-    {
-        if (false === isset($customData['thumbnail_url'])) {
-            $customData['thumbnail_url'] = $this->imageHelper
-                ->init($product, 'product_thumbnail_image')
-                ->getUrl();
-        }
-
-        if (false === isset($customData['image_url'])) {
-            $this->imageHelper
-                ->init($product, $this->configHelper->getImageType())
-                ->resize($this->configHelper->getImageWidth(), $this->configHelper->getImageHeight());
-
-            $customData['image_url'] = $this->imageHelper->getUrl();
-
-            if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
-                $product->load($product->getId(), 'media_gallery');
-
-                $customData['media_gallery'] = [];
-
-                $images = $product->getMediaGalleryImages();
-                if ($images) {
-                    foreach ($images as $image) {
-                        $customData['media_gallery'][] = $image->getUrl();
-                    }
-                }
-            }
-        }
-
-        return $customData;
-    }
-
-    /**
      * @param $defaultData
      * @param $customData
      * @param Product $product
@@ -870,245 +484,7 @@ class ProductHelper extends AbstractEntityHelper
      */
     protected function addInStock($defaultData, $customData, Product $product)
     {
-        if (isset($defaultData['in_stock']) === false) {
-            $stockItem = $this->stockRegistry->getStockItem($product->getId());
-            $customData['in_stock'] = $product->isSaleable() && $stockItem->getIsInStock();
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $defaultData
-     * @param $customData
-     * @param $additionalAttributes
-     * @param Product $product
-     * @return mixed
-     */
-    protected function addStockQty($defaultData, $customData, $additionalAttributes, Product $product)
-    {
-        if (isset($defaultData['stock_qty']) === false
-            && $this->isAttributeEnabled($additionalAttributes, 'stock_qty')) {
-            $customData['stock_qty'] = 0;
-
-            $stockItem = $this->stockRegistry->getStockItem($product->getId());
-            if ($stockItem) {
-                $customData['stock_qty'] = (int)$stockItem->getQty();
-            }
-        }
-
-        return $customData;
-    }
-
-    /**
-     * @param $customData
-     * @param $additionalAttributes
-     * @param Product $product
-     * @param $subProducts
-     * @return mixed
-     * @throws LocalizedException
-     */
-    protected function addAdditionalAttributes($customData, $additionalAttributes, Product $product, $subProducts)
-    {
-        $this->logger->startProfiling(__METHOD__);
-        foreach ($additionalAttributes as $attribute) {
-            $attributeName = $attribute['attribute'];
-
-            if (isset($customData[$attributeName]) && $attributeName !== 'sku') {
-                continue;
-            }
-
-            /** @var \Magento\Catalog\Model\ResourceModel\Product $resource */
-            $resource = $product->getResource();
-
-            /** @var AttributeResource $attributeResource */
-            $attributeResource = $resource->getAttribute($attributeName);
-            if (!$attributeResource) {
-                continue;
-            }
-
-            $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
-
-            $value = $product->getData($attributeName);
-
-            if ($value !== null) {
-                $customData = $this->addNonNullValue($customData, $value, $product, $attribute, $attributeResource);
-
-                if (!in_array($attributeName, $this->attributesToIndexAsArray, true)) {
-                    continue;
-                }
-            }
-
-            $type = $product->getTypeId();
-            if ($type !== 'configurable' && $type !== 'grouped' && $type !== 'bundle') {
-                continue;
-            }
-
-            $customData = $this->addNullValue($customData, $subProducts, $attribute, $attributeResource);
-        }
-        $this->logger->stopProfiling(__METHOD__);
-
-        return $customData;
-    }
-
-    /**
-     * @param $customData
-     * @param $subProducts
-     * @param $attribute
-     * @param AttributeResource $attributeResource
-     * @return mixed
-     */
-    protected function addNullValue($customData, $subProducts, $attribute, AttributeResource $attributeResource)
-    {
-        $attributeName = $attribute['attribute'];
-
-        $values = [];
-        $subProductImages = [];
-
-        if (isset($customData[$attributeName])) {
-            $values[] = $customData[$attributeName];
-        }
-
-        /** @var Product $subProduct */
-        foreach ($subProducts as $subProduct) {
-            $value = $subProduct->getData($attributeName);
-            if ($value) {
-                /** @var string|array $valueText */
-                $valueText = $subProduct->getAttributeText($attributeName);
-
-                $values = array_merge($values, $this->getValues($valueText, $subProduct, $attributeResource));
-                if ($this->configHelper->useAdaptiveImage($attributeResource->getStoreId())) {
-                    $subProductImages = $this->addSubProductImage(
-                        $subProductImages,
-                        $attribute,
-                        $subProduct,
-                        $valueText
-                    );
-                }
-            }
-        }
-
-        if (is_array($values) && count($values) > 0) {
-            $customData[$attributeName] = $this->getSanitizedArrayValues($values, $attributeName);
-        }
-
-        if (count($subProductImages) > 0) {
-            $customData['images_data'] = $subProductImages;
-        }
-
-        return $customData;
-    }
-
-    /**
-     * By default Algolia will remove all redundant attribute values that are fetched from the child simple products.
-     *
-     * Overridable via Preference to allow implementer to enforce their own uniqueness rules while leveraging existing indexing code.
-     * e.g. $values = (in_array($attributeName, self::NON_UNIQUE_ATTRIBUTES)) ? $values : array_unique($values);
-     *
-     * @param array $values
-     * @param string $attributeName
-     * @return array
-     */
-    protected function getSanitizedArrayValues(array $values, string $attributeName): array
-    {
-        return array_values(array_unique($values));
-    }
-
-    /**
-     * @param string|array $valueText - bit of a misnomer - essentially the retrieved values to be indexed for a given product's attribute
-     * @param Product $subProduct - the simple product to index
-     * @param AttributeResource $attributeResource - the attribute being indexed
-     * @return array
-     */
-    protected function getValues($valueText, Product $subProduct, AttributeResource $attributeResource): array
-    {
-        $values = [];
-
-        if ($valueText) {
-            if (is_array($valueText)) {
-                foreach ($valueText as $valueText_elt) {
-                    $values[] = $valueText_elt;
-                }
-            } else {
-                $values[] = $valueText;
-            }
-        } else {
-            $values[] = $attributeResource->getFrontend()->getValue($subProduct);
-        }
-
-        return $values;
-    }
-
-    /**
-     * @param $subProductImages
-     * @param $attribute
-     * @param $subProduct
-     * @param $valueText
-     * @return mixed
-     */
-    protected function addSubProductImage($subProductImages, $attribute, $subProduct, $valueText)
-    {
-        if (mb_strtolower($attribute['attribute'], 'utf-8') !== 'color') {
-            return $subProductImages;
-        }
-
-        $image = $this->imageHelper
-            ->init($subProduct, $this->configHelper->getImageType())
-            ->resize(
-                $this->configHelper->getImageWidth(),
-                $this->configHelper->getImageHeight()
-            );
-
-        $subImage = $subProduct->getData($image->getType());
-        if (!$subImage || $subImage === 'no_selection') {
-            return $subProductImages;
-        }
-
-        try {
-            $textValueInLower = mb_strtolower($valueText, 'utf-8');
-            $subProductImages[$textValueInLower] = $image->getUrl();
-        } catch (\Exception $e) {
-            $this->logger->log($e->getMessage());
-            $this->logger->log($e->getTraceAsString());
-        }
-
-        return $subProductImages;
-    }
-
-    /**
-     * @param $customData
-     * @param $value
-     * @param Product $product
-     * @param $attribute
-     * @param AttributeResource $attributeResource
-     * @return mixed
-     */
-    protected function addNonNullValue(
-        $customData,
-        $value,
-        Product $product,
-        $attribute,
-        AttributeResource $attributeResource
-    )
-    {
-        $valueText = null;
-
-        if (!is_array($value) && $attributeResource->usesSource()) {
-            $valueText = $product->getAttributeText($attribute['attribute']);
-        }
-
-        if ($valueText) {
-            $value = $valueText;
-        } else {
-            $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
-            $value = $attributeResource->getFrontend()->getValue($product);
-        }
-
-        if ($value !== null) {
-            $customData[$attribute['attribute']] = $value;
-        }
-
-        return $customData;
+        return $this->productRecordBuilder->addInStock($defaultData, $customData, $product);
     }
 
     /**
@@ -1333,40 +709,7 @@ class ProductHelper extends AbstractEntityHelper
      */
     public function canProductBeReindexed($product, $storeId, $isChildProduct = false)
     {
-        if ($product->isDeleted() === true) {
-            throw (new ProductDeletedException())
-                ->withProduct($product)
-                ->withStoreId($storeId);
-        }
-
-        if ($product->getStatus() == Status::STATUS_DISABLED) {
-            throw (new ProductDisabledException())
-                ->withProduct($product)
-                ->withStoreId($storeId);
-        }
-
-        if ($isChildProduct === false && !in_array($product->getVisibility(), [
-                Visibility::VISIBILITY_BOTH,
-                Visibility::VISIBILITY_IN_SEARCH,
-                Visibility::VISIBILITY_IN_CATALOG,
-            ])) {
-            throw (new ProductNotVisibleException())
-                ->withProduct($product)
-                ->withStoreId($storeId);
-        }
-
-        $isInStock = true;
-        if (!$this->configHelper->getShowOutOfStock($storeId)) {
-            $isInStock = $this->productIsInStock($product, $storeId);
-        }
-
-        if (!$isInStock) {
-            throw (new ProductOutOfStockException())
-                ->withProduct($product)
-                ->withStoreId($storeId);
-        }
-
-        return true;
+        return $this->productRecordBuilder->canProductBeReindexed($product, $storeId, $isChildProduct);
     }
 
     /**
@@ -1379,9 +722,7 @@ class ProductHelper extends AbstractEntityHelper
      */
     public function productIsInStock($product, $storeId): bool
     {
-        $stockItem = $this->stockRegistry->getStockItem($product->getId());
-
-        return $product->isSaleable() && $stockItem->getIsInStock();
+        return $this->productRecordBuilder->productIsInStock($product, $storeId);
     }
 
     /**

--- a/Helper/Entity/SuggestionHelper.php
+++ b/Helper/Entity/SuggestionHelper.php
@@ -3,7 +3,7 @@
 namespace Algolia\AlgoliaSearch\Helper\Entity;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\Suggestion\RecordBuilder as SuggestionRecordBuilder;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Magento\Framework\App\Cache\Type\Config as ConfigCache;
 use Magento\Framework\DataObject;
@@ -24,22 +24,22 @@ class SuggestionHelper extends AbstractEntityHelper
     public const POPULAR_QUERIES_CACHE_TAG = 'algoliasearch_popular_queries_cache_tag';
 
     public function __construct(
-        protected ManagerInterface       $eventManager,
-        protected QueryCollectionFactory $queryCollectionFactory,
-        protected ConfigCache            $cache,
-        protected ConfigHelper           $configHelper,
-        protected SerializerInterface    $serializer,
-        protected IndexNameFetcher       $indexNameFetcher,
-    )
-    {
+        protected ManagerInterface        $eventManager,
+        protected QueryCollectionFactory  $queryCollectionFactory,
+        protected ConfigCache             $cache,
+        protected ConfigHelper            $configHelper,
+        protected SerializerInterface     $serializer,
+        protected SuggestionRecordBuilder $suggestionRecordBuilder,
+        protected IndexNameFetcher        $indexNameFetcher,
+    ) {
         parent::__construct($indexNameFetcher);
     }
 
     /**
-     * @param $storeId
-     * @return array|mixed|null
+     * @param int|null $storeId
+     * @return array
      */
-    public function getIndexSettings($storeId)
+    public function getIndexSettings(?int $storeId = null): array
     {
         $indexSettings = [
             'searchableAttributes' => ['query'],
@@ -58,24 +58,13 @@ class SuggestionHelper extends AbstractEntityHelper
 
     /**
      * @param Query $suggestion
-     * @return array|mixed|null
+     * @return array
+     *
+     * @deprecated (will be removed in v3.16.0)
      */
     public function getObject(Query $suggestion)
     {
-        $suggestionObject = [
-            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $suggestion->getData('query_id'),
-            'query'                                 => $suggestion->getData('query_text'),
-            'number_of_results'                     => (int) $suggestion->getData('num_results'),
-            'popularity'                            => (int) $suggestion->getData('popularity'),
-            'updated_at'                            => (int) strtotime($suggestion->getData('updated_at')),
-        ];
-
-        $transport = new DataObject($suggestionObject);
-        $this->eventManager->dispatch(
-            'algolia_after_create_suggestion_object',
-            ['suggestion' => $transport, 'suggestionObject' => $suggestion]
-        );
-        return $transport->getData();
+        return $this->suggestionRecordBuilder->buildRecord($suggestion);
     }
 
     /**

--- a/Service/AdditionalSection/RecordBuilder.php
+++ b/Service/AdditionalSection/RecordBuilder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\AdditionalSection;
+
+use Algolia\AlgoliaSearch\Api\RecordBuilder\RecordBuilderInterface;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface;
+
+class RecordBuilder implements RecordBuilderInterface
+{
+    public function __construct(
+        protected ManagerInterface $eventManager,
+    ){}
+
+    public function buildRecord(DataObject $entity): array
+    {
+        $record = [
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $entity->getData('value'),
+            'value'                                 => $entity->getData('value'),
+        ];
+
+        $transport = new DataObject($record);
+
+        /** Removed legacy algolia_additional_section_item_index_before event on 3.15.0 */
+        $this->eventManager->dispatch(
+            'algolia_additional_section_items_before_index',
+            [
+                'section' => $entity->getData('section'),
+                'record' => $transport,
+                'store_id' => $entity->getData('store_id')
+            ]
+        );
+
+        return $transport->getData();
+    }
+}

--- a/Service/AdditionalSection/RecordBuilder.php
+++ b/Service/AdditionalSection/RecordBuilder.php
@@ -13,6 +13,12 @@ class RecordBuilder implements RecordBuilderInterface
         protected ManagerInterface $eventManager,
     ){}
 
+    /**
+     * Builds a Section record
+     *
+     * @param DataObject $entity
+     * @return array
+     */
     public function buildRecord(DataObject $entity): array
     {
         $record = [

--- a/Service/Category/RecordBuilder.php
+++ b/Service/Category/RecordBuilder.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Category;
+
+use Algolia\AlgoliaSearch\Api\RecordBuilder\RecordBuilderInterface;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Category as MagentoCategory;
+use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Module\Manager;
+use Magento\Framework\Url;
+use Magento\Store\Model\Store;
+
+class RecordBuilder implements RecordBuilderInterface
+{
+    protected $categoryNames;
+    protected $idColumn;
+
+    public function __construct(
+        protected ManagerInterface          $eventManager,
+        protected ConfigHelper              $configHelper,
+        protected CategoryResource          $categoryResource,
+        protected CategoryCollectionFactory $categoryCollectionFactory,
+        protected ResourceConnection        $resourceConnection,
+        protected Manager                   $moduleManager,
+    ) {}
+
+    public function buildRecord(DataObject $entity): array
+    {
+        if (!$entity instanceof MagentoCategory) {
+            throw new AlgoliaException('Object must be a Category model');
+        }
+
+        /** @var Collection $productCollection */
+        $productCollection = $entity->getProductCollection();
+        $entity->setProductCount($productCollection->getSize());
+
+        $transport = new DataObject();
+        $this->eventManager->dispatch(
+            'algolia_category_index_before',
+            ['category' => $entity, 'custom_data' => $transport]
+        );
+        $customData = $transport->getData();
+
+        $storeId = $entity->getStoreId();
+
+        /** @var Url $urlInstance */
+        $urlInstance = $entity->getUrlInstance();
+        $urlInstance->setData('store', $storeId);
+
+        $path = '';
+        foreach ($entity->getPathIds() as $categoryId) {
+            if ($path !== '') {
+                $path .= ' / ';
+            }
+
+            $path .= $this->getCategoryName($categoryId, $storeId);
+        }
+
+        $imageUrl = null;
+
+        try {
+            $imageUrl = $entity->getImageUrl();
+        } catch (\Exception $e) {
+            /* no image, no default: not fatal */
+        }
+
+        $data = [
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $entity->getId(),
+            'name'                                  => $entity->getName(),
+            'path'                                  => $path,
+            'level'                                 => $entity->getLevel(),
+            'url'                                   => $this->getUrl($entity),
+            'include_in_menu'                       => $entity->getIncludeInMenu(),
+            '_tags'                                 => ['category'],
+            'popularity'                            => 1,
+            'product_count'                         => $entity->getProductCount(),
+        ];
+
+        if (!empty($imageUrl)) {
+            $data['image_url'] = $imageUrl;
+        }
+
+        foreach ($this->configHelper->getCategoryAdditionalAttributes($storeId) as $attribute) {
+            $value = $entity->getData($attribute['attribute']);
+
+            /** @var CategoryResource $resource */
+            $resource = $entity->getResource();
+
+            $attributeResource = $resource->getAttribute($attribute['attribute']);
+            if ($attributeResource) {
+                $value = $attributeResource->getFrontend()->getValue($entity);
+            }
+
+            if (isset($data[$attribute['attribute']])) {
+                $value = $data[$attribute['attribute']];
+            }
+
+            if ($value) {
+                $data[$attribute['attribute']] = $value;
+            }
+        }
+
+        $data = array_merge($data, $customData);
+
+        $transport = new DataObject($data);
+        $this->eventManager->dispatch(
+            'algolia_after_create_category_object',
+            ['category' => $entity, 'categoryObject' => $transport]
+        );
+
+        return $transport->getData();
+    }
+
+    /**
+     * @param MagentoCategory $category
+     * @return array|string|string[]
+     */
+    protected function getUrl(Category $category)
+    {
+        $categoryUrl = $category->getUrl();
+
+        if ($this->configHelper->useSecureUrlsInFrontend($category->getStoreId()) === false) {
+            return $categoryUrl;
+        }
+
+        $unsecureBaseUrl = $category->getUrlInstance()->getBaseUrl(['_secure' => false]);
+        $secureBaseUrl = $category->getUrlInstance()->getBaseUrl(['_secure' => true]);
+
+        if (mb_strpos($categoryUrl, $unsecureBaseUrl) === 0) {
+            return substr_replace($categoryUrl, $secureBaseUrl, 0, mb_strlen($unsecureBaseUrl));
+        }
+
+        return $categoryUrl;
+    }
+
+    /**
+     * @param int $categoryId
+     * @param null $storeId
+     *
+     * @return string|null
+     */
+    public function getCategoryName($categoryId, $storeId = null)
+    {
+        if ($categoryId instanceof MagentoCategory) {
+            $categoryId = $categoryId->getId();
+        }
+
+        if ($storeId instanceof Store) {
+            $storeId = $storeId->getId();
+        }
+
+        $categoryId = (int) $categoryId;
+        $storeId = (int) $storeId;
+        if (!isset($this->categoryNames)) {
+            $this->categoryNames = [];
+
+            $categoryModel = $this->categoryResource;
+
+            if ($attribute = $categoryModel->getAttribute('name')) {
+                $columnId = $this->getCorrectIdColumn();
+                $expression = new \Zend_Db_Expr("CONCAT(backend.store_id, '-', backend." . $columnId . ')');
+
+                $connection = $this->resourceConnection->getConnection();
+                $select = $connection->select()
+                    ->from(
+                        ['backend' => $attribute->getBackendTable()],
+                        [$expression, 'backend.value']
+                    )
+                    ->join(
+                        ['category' => $categoryModel->getTable('catalog_category_entity')],
+                        'backend.' . $columnId . ' = category.' . $columnId,
+                        []
+                    )
+                    ->where('backend.attribute_id = ?', $attribute->getAttributeId())
+                    ->where('category.level > ?', 1);
+
+                $this->categoryNames = $connection->fetchPairs($select);
+            }
+        }
+
+        $categoryName = null;
+
+        $categoryKeyId = $this->getCategoryKeyId($categoryId, $storeId);
+
+        if ($categoryKeyId === null) {
+            return $categoryName;
+        }
+
+        $key = $storeId . '-' . $categoryKeyId;
+
+        if (isset($this->categoryNames[$key])) {
+            // Check whether the category name is present for the specified store
+            $categoryName = (string) $this->categoryNames[$key];
+        } elseif ($storeId !== 0) {
+            // Check whether the category name is present for the default store
+            $key = '0-' . $categoryKeyId;
+            if (isset($this->categoryNames[$key])) {
+                $categoryName = (string) $this->categoryNames[$key];
+            }
+        }
+
+        return $categoryName;
+    }
+
+    /**
+     * @param $categoryId
+     * @param $storeId
+     * @return mixed|null
+     */
+    protected function getCategoryKeyId($categoryId, $storeId = null)
+    {
+        $categoryKeyId = $categoryId;
+
+        if ($this->getCorrectIdColumn() === 'row_id') {
+            $category = $this->getCategoryById($categoryId, $storeId);
+            return $category ? $category->getRowId() : null;
+        }
+
+        return $categoryKeyId;
+    }
+
+    /**
+     * @param $categoryId
+     * @param $storeId
+     * @return mixed|null
+     * @throws LocalizedException
+     */
+    protected function getCategoryById($categoryId, $storeId = null)
+    {
+        $categories = $this->getCoreCategories(false, $storeId);
+
+        return $categories[$categoryId] ?? null;
+    }
+
+    /**
+     * @param $filterNotIncludedCategories
+     * @param $storeId
+     * @return array
+     * @throws LocalizedException
+     */
+    public function getCoreCategories($filterNotIncludedCategories = true, $storeId = null)
+    {
+        // Cache category look up by store scope
+        $key = ($filterNotIncludedCategories ? 'filtered' : 'non_filtered') . "-$storeId";
+
+        if (isset($this->coreCategories[$key])) {
+            return $this->coreCategories[$key];
+        }
+
+        $collection = $this->categoryCollectionFactory->create()
+            ->distinct(true)
+            ->setStoreId($storeId)
+            ->addNameToResult()
+            ->addIsActiveFilter()
+            ->addAttributeToSelect('name')
+            ->addAttributeToFilter('level', ['gt' => 1]);
+
+        if ($filterNotIncludedCategories) {
+            $collection->addAttributeToFilter('include_in_menu', '1');
+        }
+
+        $this->coreCategories[$key] = [];
+
+        /** @var MagentoCategory $category */
+        foreach ($collection as $category) {
+            $this->coreCategories[$key][$category->getId()] = $category;
+        }
+
+        return $this->coreCategories[$key];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getCorrectIdColumn()
+    {
+        if (isset($this->idColumn)) {
+            return $this->idColumn;
+        }
+
+        $this->idColumn = 'entity_id';
+
+        $edition = $this->configHelper->getMagentoEdition();
+        $version = $this->configHelper->getMagentoVersion();
+
+        if ($edition !== 'Community' && version_compare($version, '2.1.0', '>=') && $this->moduleManager->isEnabled('Magento_Staging')) {
+            $this->idColumn = 'row_id';
+        }
+
+        return $this->idColumn;
+    }
+}

--- a/Service/Category/RecordBuilder.php
+++ b/Service/Category/RecordBuilder.php
@@ -23,6 +23,7 @@ class RecordBuilder implements RecordBuilderInterface
 {
     protected $categoryNames;
     protected $idColumn;
+    protected $coreCategories;
 
     public function __construct(
         protected ManagerInterface          $eventManager,

--- a/Service/Category/RecordBuilder.php
+++ b/Service/Category/RecordBuilder.php
@@ -34,6 +34,14 @@ class RecordBuilder implements RecordBuilderInterface
         protected Manager                   $moduleManager,
     ) {}
 
+    /**
+     * Builds a Category record
+     *
+     * @param DataObject $entity
+     * @return array
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     */
     public function buildRecord(DataObject $entity): array
     {
         if (!$entity instanceof MagentoCategory) {

--- a/Service/Page/RecordBuilder.php
+++ b/Service/Page/RecordBuilder.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Page;
+
+use Algolia\AlgoliaSearch\Api\RecordBuilder\RecordBuilderInterface;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Magento\Cms\Model\Page;
+use Magento\Cms\Model\Template\FilterProvider;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\UrlFactory;
+
+class RecordBuilder implements RecordBuilderInterface
+{
+    public function __construct(
+        protected ManagerInterface $eventManager,
+        protected ConfigHelper     $configHelper,
+        protected FilterProvider   $filterProvider,
+        protected UrlFactory       $frontendUrlFactory,
+    ){}
+
+    /**
+     * @throws AlgoliaException
+     */
+    public function buildRecord(DataObject $entity): array
+    {
+        if (!$entity instanceof Page) {
+            throw new AlgoliaException('Object must be a Page model');
+        }
+
+        $pageObject = [];
+        $pageObject['slug'] = $entity->getIdentifier();
+        $pageObject['name'] = $entity->getTitle();
+
+        $content = $entity->getContent();
+        if ($this->configHelper->getRenderTemplateDirectives()) {
+            $content = $this->filterProvider->getPageFilter()->filter($content);
+        }
+
+        $frontendUrlBuilder = $this->frontendUrlFactory->create()->setScope($entity->getData('store_id'));
+        $pageObject[AlgoliaConnector::ALGOLIA_API_OBJECT_ID] = $entity->getId();
+        $pageObject['url'] = $frontendUrlBuilder->getUrl(
+            null,
+            [
+                '_direct' => $entity->getIdentifier(),
+                '_secure' => $this->configHelper->useSecureUrlsInFrontend($entity->getData('store_id')),
+            ]
+        );
+        $pageObject['content'] = $this->strip($content, ['script', 'style']);
+
+        $transport = new DataObject($pageObject);
+        $this->eventManager->dispatch(
+            'algolia_after_create_page_object',
+            ['page' => $transport, 'pageObject' => $entity]
+        );
+
+        return $transport->getData();
+    }
+
+    protected function strip($s, $completeRemoveTags = [])
+    {
+        if ($completeRemoveTags && $completeRemoveTags !== [] && $s) {
+            $dom = new \DOMDocument();
+            libxml_use_internal_errors(true);
+            $encodedStr = mb_encode_numericentity($s, [0x80, 0x10fffff, 0, ~0]);
+            $dom->loadHTML($encodedStr);
+            libxml_use_internal_errors(false);
+
+            $toRemove = [];
+            foreach ($completeRemoveTags as $tag) {
+                $removeTags = $dom->getElementsByTagName($tag);
+
+                foreach ($removeTags as $item) {
+                    $toRemove[] = $item;
+                }
+            }
+
+            foreach ($toRemove as $item) {
+                $item->parentNode->removeChild($item);
+            }
+
+            $s = $dom->saveHTML();
+        }
+
+        $s = html_entity_decode($s, 0, 'UTF-8');
+
+        $s = trim(preg_replace('/\s+/', ' ', $s));
+        $s = preg_replace('/&nbsp;/', ' ', $s);
+        $s = preg_replace('!\s+!', ' ', $s);
+        $s = preg_replace('/\{\{[^}]+\}\}/', ' ', $s);
+        $s = strip_tags($s);
+        $s = trim($s);
+
+        return $s;
+    }
+}

--- a/Service/Page/RecordBuilder.php
+++ b/Service/Page/RecordBuilder.php
@@ -30,22 +30,24 @@ class RecordBuilder implements RecordBuilderInterface
             throw new AlgoliaException('Object must be a Page model');
         }
 
+        $page = $entity;
+
         $pageObject = [];
-        $pageObject['slug'] = $entity->getIdentifier();
-        $pageObject['name'] = $entity->getTitle();
+        $pageObject['slug'] = $page->getIdentifier();
+        $pageObject['name'] = $page->getTitle();
 
         $content = $entity->getContent();
         if ($this->configHelper->getRenderTemplateDirectives()) {
             $content = $this->filterProvider->getPageFilter()->filter($content);
         }
 
-        $frontendUrlBuilder = $this->frontendUrlFactory->create()->setScope($entity->getData('store_id'));
-        $pageObject[AlgoliaConnector::ALGOLIA_API_OBJECT_ID] = $entity->getId();
+        $frontendUrlBuilder = $this->frontendUrlFactory->create()->setScope($page->getData('store_id'));
+        $pageObject[AlgoliaConnector::ALGOLIA_API_OBJECT_ID] = $page->getId();
         $pageObject['url'] = $frontendUrlBuilder->getUrl(
             null,
             [
-                '_direct' => $entity->getIdentifier(),
-                '_secure' => $this->configHelper->useSecureUrlsInFrontend($entity->getData('store_id')),
+                '_direct' => $page->getIdentifier(),
+                '_secure' => $this->configHelper->useSecureUrlsInFrontend($page->getData('store_id')),
             ]
         );
         $pageObject['content'] = $this->strip($content, ['script', 'style']);
@@ -53,7 +55,7 @@ class RecordBuilder implements RecordBuilderInterface
         $transport = new DataObject($pageObject);
         $this->eventManager->dispatch(
             'algolia_after_create_page_object',
-            ['page' => $transport, 'pageObject' => $entity]
+            ['page' => $transport, 'pageObject' => $page]
         );
 
         return $transport->getData();

--- a/Service/Page/RecordBuilder.php
+++ b/Service/Page/RecordBuilder.php
@@ -22,6 +22,11 @@ class RecordBuilder implements RecordBuilderInterface
     ){}
 
     /**
+     * Builds a Page record
+     *
+     * @param DataObject $entity
+     * @return array
+     *
      * @throws AlgoliaException
      */
     public function buildRecord(DataObject $entity): array

--- a/Service/Product/RecordBuilder.php
+++ b/Service/Product/RecordBuilder.php
@@ -1,0 +1,804 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Product;
+
+use Algolia\AlgoliaSearch\Api\RecordBuilder\RecordBuilderInterface;
+use Algolia\AlgoliaSearch\Exception\ProductDeletedException;
+use Algolia\AlgoliaSearch\Exception\ProductDisabledException;
+use Algolia\AlgoliaSearch\Exception\ProductNotVisibleException;
+use Algolia\AlgoliaSearch\Exception\ProductOutOfStockException;
+use Algolia\AlgoliaSearch\Exception\ProductReindexingException;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
+use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
+use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Magento\Bundle\Model\Product\Type as BundleProductType;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeResource;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+
+class RecordBuilder implements RecordBuilderInterface
+{
+    /**
+     * @var string[]
+     */
+    protected array $attributesToIndexAsArray = [
+        'sku',
+        'color',
+    ];
+
+    public function __construct(
+        protected ManagerInterface       $eventManager,
+        protected DiagnosticsLogger      $logger,
+        protected Visibility             $visibility,
+        protected StoreManagerInterface  $storeManager,
+        protected ConfigHelper           $configHelper,
+        protected CategoryHelper         $categoryHelper,
+        protected AlgoliaHelper          $algoliaHelper,
+        protected ImageHelper            $imageHelper,
+        protected StockRegistryInterface $stockRegistry,
+        protected PriceManager           $priceManager,
+    ){}
+    public function buildRecord(DataObject $entity): array
+    {
+        if (!$entity instanceof Product) {
+            throw new AlgoliaException('Object must be a Product model');
+        }
+
+        $product = $entity;
+
+        $storeId = $product->getStoreId();
+
+        $logEventName = 'CREATE RECORD ' . $product->getId() . ' ' . $this->logger->getStoreName($storeId);
+        $this->logger->start($logEventName, true);
+        $defaultData = [];
+
+        $transport = new DataObject($defaultData);
+        $this->eventManager->dispatch(
+            'algolia_product_index_before',
+            ['product' => $product, 'custom_data' => $transport]
+        );
+
+        $defaultData = $transport->getData();
+
+        $visibility = $product->getVisibility();
+
+        $visibleInCatalog = $this->visibility->getVisibleInCatalogIds();
+        $visibleInSearch = $this->visibility->getVisibleInSearchIds();
+
+        $urlParams = [
+            '_secure' => $this->configHelper->useSecureUrlsInFrontend($product->getStoreId()),
+            '_nosid'  => true,
+        ];
+
+        $customData = [
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $product->getId(),
+            'name'                                  => $product->getName(),
+            'url'                                   => $product->getUrlModel()->getUrl($product, $urlParams),
+            'visibility_search'                     => (int) (in_array($visibility, $visibleInSearch)),
+            'visibility_catalog'                    => (int) (in_array($visibility, $visibleInCatalog)),
+            'type_id'                               => $product->getTypeId(),
+        ];
+
+        $additionalAttributes = $this->getAdditionalAttributes($product->getStoreId());
+
+        $customData = $this->addAttribute('description', $defaultData, $customData, $additionalAttributes, $product);
+        $customData = $this->addAttribute('ordered_qty', $defaultData, $customData, $additionalAttributes, $product);
+        $customData = $this->addAttribute('total_ordered', $defaultData, $customData, $additionalAttributes, $product);
+        $customData = $this->addAttribute('rating_summary', $defaultData, $customData, $additionalAttributes, $product);
+        $customData = $this->addCategoryData($customData, $product);
+        $customData = $this->addImageData($customData, $product, $additionalAttributes);
+        $customData = $this->addInStock($defaultData, $customData, $product);
+        $customData = $this->addStockQty($defaultData, $customData, $additionalAttributes, $product);
+        if ($product->getTypeId() == "bundle") {
+            $customData = $this->addBundleProductDefaultOptions($customData, $product);
+        }
+        $subProducts = $this->getSubProducts($product);
+        $customData = $this->addAdditionalAttributes($customData, $additionalAttributes, $product, $subProducts);
+        $customData = $this->priceManager->addPriceDataByProductType($customData, $product, $subProducts);
+        $transport = new DataObject($customData);
+        $this->eventManager->dispatch(
+            'algolia_subproducts_index',
+            [
+                'custom_data'   => $transport,
+                'sub_products'  => $subProducts,
+                'productObject' => $product
+            ]
+        );
+        $customData = $transport->getData();
+        $customData = array_merge($customData, $defaultData);
+        $this->algoliaHelper->castProductObject($customData);
+        $transport = new DataObject($customData);
+        $this->eventManager->dispatch(
+            'algolia_after_create_product_object',
+            [
+                'custom_data'   => $transport,
+                'sub_products'  => $subProducts,
+                'productObject' => $product
+            ]
+        );
+        $customData = $transport->getData();
+
+        $this->logger->stop($logEventName, true);
+
+        return $customData;
+    }
+
+    /**
+     * @param int|null $storeId
+     * @return array
+     */
+    public function getAdditionalAttributes(?int $storeId = null): array
+    {
+        return $this->configHelper->getProductAdditionalAttributes($storeId);
+    }
+
+    /**
+     * @param $attribute
+     * @param $defaultData
+     * @param $customData
+     * @param $additionalAttributes
+     * @param Product $product
+     * @return mixed
+     */
+    protected function addAttribute($attribute, $defaultData, $customData, $additionalAttributes, Product $product)
+    {
+        if (isset($defaultData[$attribute]) === false
+            && $this->isAttributeEnabled($additionalAttributes, $attribute)) {
+            $customData[$attribute] = $product->getData($attribute);
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $additionalAttributes
+     * @param $attributeName
+     * @return bool
+     */
+    public function isAttributeEnabled($additionalAttributes, $attributeName): bool
+    {
+        foreach ($additionalAttributes as $attr) {
+            if ($attr['attribute'] === $attributeName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array $algoliaData Data for product object to be serialized to Algolia index
+     * @param Product $product
+     * @return mixed
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    protected function addCategoryData(array $algoliaData, Product $product): array
+    {
+        $this->logger->startProfiling(__METHOD__);
+        $storeId = $product->getStoreId();
+
+        $categoryData = $this->buildCategoryData($product);
+        $hierarchicalCategories = $this->getHierarchicalCategories($categoryData['categoriesWithPath'], $storeId);
+        $algoliaData['categories'] = $hierarchicalCategories;
+        $algoliaData['categories_without_path'] = $categoryData['categoryNames'];
+        $algoliaData['categoryIds'] = array_values(array_unique($categoryData['categoryIds']));
+
+        if ($this->configHelper->isVisualMerchEnabled($storeId)) {
+            $autoAnchorPaths = $this->autoAnchorParentCategories($categoryData['categoriesWithPath']);
+            $algoliaData[$this->configHelper->getCategoryPageIdAttributeName($storeId)] = $this->flattenCategoryPaths($autoAnchorPaths, $storeId);
+        }
+
+        $this->logger->stopProfiling(__METHOD__);
+        return $algoliaData;
+    }
+
+    /**
+     * @param array $customData
+     * @param Product $product
+     * @param $additionalAttributes
+     * @return array
+     */
+    protected function addImageData(array $customData, Product $product, $additionalAttributes)
+    {
+        if (false === isset($customData['thumbnail_url'])) {
+            $customData['thumbnail_url'] = $this->imageHelper
+                ->init($product, 'product_thumbnail_image')
+                ->getUrl();
+        }
+
+        if (false === isset($customData['image_url'])) {
+            $this->imageHelper
+                ->init($product, $this->configHelper->getImageType())
+                ->resize($this->configHelper->getImageWidth(), $this->configHelper->getImageHeight());
+
+            $customData['image_url'] = $this->imageHelper->getUrl();
+
+            if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
+                $product->load($product->getId(), 'media_gallery');
+
+                $customData['media_gallery'] = [];
+
+                $images = $product->getMediaGalleryImages();
+                if ($images) {
+                    foreach ($images as $image) {
+                        $customData['media_gallery'][] = $image->getUrl();
+                    }
+                }
+            }
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $defaultData
+     * @param $customData
+     * @param Product $product
+     * @return mixed
+     */
+    public function addInStock($defaultData, $customData, Product $product)
+    {
+        if (isset($defaultData['in_stock']) === false) {
+            $stockItem = $this->stockRegistry->getStockItem($product->getId());
+            $customData['in_stock'] = $product->isSaleable() && $stockItem->getIsInStock();
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $defaultData
+     * @param $customData
+     * @param $additionalAttributes
+     * @param Product $product
+     * @return mixed
+     */
+    protected function addStockQty($defaultData, $customData, $additionalAttributes, Product $product)
+    {
+        if (isset($defaultData['stock_qty']) === false
+            && $this->isAttributeEnabled($additionalAttributes, 'stock_qty')) {
+            $customData['stock_qty'] = 0;
+
+            $stockItem = $this->stockRegistry->getStockItem($product->getId());
+            if ($stockItem) {
+                $customData['stock_qty'] = (int)$stockItem->getQty();
+            }
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $customData
+     * @param $additionalAttributes
+     * @param Product $product
+     * @param $subProducts
+     * @return mixed
+     * @throws LocalizedException
+     */
+    protected function addAdditionalAttributes($customData, $additionalAttributes, Product $product, $subProducts)
+    {
+        $this->logger->startProfiling(__METHOD__);
+        foreach ($additionalAttributes as $attribute) {
+            $attributeName = $attribute['attribute'];
+
+            if (isset($customData[$attributeName]) && $attributeName !== 'sku') {
+                continue;
+            }
+
+            /** @var \Magento\Catalog\Model\ResourceModel\Product $resource */
+            $resource = $product->getResource();
+
+            /** @var AttributeResource $attributeResource */
+            $attributeResource = $resource->getAttribute($attributeName);
+            if (!$attributeResource) {
+                continue;
+            }
+
+            $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
+
+            $value = $product->getData($attributeName);
+
+            if ($value !== null) {
+                $customData = $this->addNonNullValue($customData, $value, $product, $attribute, $attributeResource);
+
+                if (!in_array($attributeName, $this->attributesToIndexAsArray, true)) {
+                    continue;
+                }
+            }
+
+            $type = $product->getTypeId();
+            if ($type !== 'configurable' && $type !== 'grouped' && $type !== 'bundle') {
+                continue;
+            }
+
+            $customData = $this->addNullValue($customData, $subProducts, $attribute, $attributeResource);
+        }
+        $this->logger->stopProfiling(__METHOD__);
+
+        return $customData;
+    }
+
+    /**
+     * For a given product extract category data including category names, parent paths and all category tree IDs
+     *
+     * @param Product $product
+     * @return array|array[]
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    protected function buildCategoryData(Product $product): array
+    {
+        // Build within a single loop
+        // TODO: Profile for efficiency vs separate loops
+        $categoryData = [
+            'categoryNames'      => [],
+            'categoryIds'        => [],
+            'categoriesWithPath' => [],
+        ];
+
+        $storeId = $product->getStoreId();
+
+        $_categoryIds = $product->getCategoryIds();
+
+        if (is_array($_categoryIds) && count($_categoryIds)) {
+            $categoryCollection = $this->getAllCategories($_categoryIds, $storeId);
+
+            /** @var Store $store */
+            $store = $this->storeManager->getStore($product->getStoreId());
+            $rootCat = $store->getRootCategoryId();
+
+            foreach ($categoryCollection as $category) {
+                $categoryName = $this->getValidCategoryName($category, $rootCat, $storeId);
+                if (!$categoryName) {
+                    continue;
+                }
+                $categoryData['categoryNames'][] = $categoryName;
+
+                $category->getUrlInstance()->setStore($storeId);
+                $paths = [];
+
+                foreach ($category->getPathIds() as $treeCategoryId) {
+                    $name = $this->categoryHelper->getCategoryName($treeCategoryId, $storeId);
+                    if ($name) {
+                        $categoryData['categoryIds'][] = $treeCategoryId;
+                        $paths[] = $name;
+                    }
+                }
+
+                $categoryData['categoriesWithPath'][] = $paths;
+            }
+        }
+
+        // TODO: Evaluate use cases
+        // Based on old extraneous array manip logic (since removed) - is this still a likely scenario?
+        $categoryData['categoriesWithPath'] = $this->dedupePaths($categoryData['categoriesWithPath']);
+
+        return $categoryData;
+    }
+
+    /**
+     * @param $categoryIds
+     * @param $storeId
+     * @return array
+     * @throws LocalizedException
+     */
+    public function getAllCategories($categoryIds, $storeId): array
+    {
+        $filterNotIncludedCategories = !$this->configHelper->showCatsNotIncludedInNavigation($storeId);
+        $categories = $this->categoryHelper->getCoreCategories($filterNotIncludedCategories, $storeId);
+
+        $selectedCategories = [];
+        foreach ($categoryIds as $id) {
+            if (isset($categories[$id])) {
+                $selectedCategories[] = $categories[$id];
+            }
+        }
+
+        return $selectedCategories;
+    }
+
+    /**
+     * A category should only be indexed if in the path of the current store and has a valid name.
+     *
+     * @param $category
+     * @param $rootCat
+     * @param $storeId
+     * @return string|null
+     */
+    protected function getValidCategoryName($category, $rootCat, $storeId): ?string
+    {
+        $pathParts = explode('/', $category->getPath());
+        if (isset($pathParts[1]) && $pathParts[1] !== $rootCat) {
+            return null;
+        }
+
+        return $this->categoryHelper->getCategoryName($category->getId(), $storeId);
+    }
+
+    /**
+     * Filter out non unique category path entries.
+     *
+     * @param $paths
+     * @return array
+     */
+    protected function dedupePaths($paths): array
+    {
+        return array_values(
+            array_intersect_key(
+                $paths,
+                array_unique(array_map('serialize', $paths))
+            )
+        );
+    }
+
+    /**
+     * @param array $categoriesWithPath
+     * @param int $storeId
+     * @return array
+     */
+    protected function getHierarchicalCategories(array $categoriesWithPath, int $storeId): array
+    {
+        $hierarchicalCategories = [];
+
+        $levelName = 'level';
+
+        foreach ($categoriesWithPath as $category) {
+            $categoryCount = count($category);
+            for ($i = 0; $i < $categoryCount; $i++) {
+                if (isset($hierarchicalCategories[$levelName . $i]) === false) {
+                    $hierarchicalCategories[$levelName . $i] = [];
+                }
+
+                if ($category[$i] === null) {
+                    continue;
+                }
+
+                $hierarchicalCategories[$levelName . $i][] = implode($this->configHelper->getCategorySeparator($storeId), array_slice($category, 0, $i + 1));
+            }
+        }
+
+        // dedupe in case of multicategory assignment
+        foreach ($hierarchicalCategories as &$level) {
+            $level = array_values(array_unique($level));
+        }
+
+        return $hierarchicalCategories;
+    }
+
+    /**
+     * Take an array of paths where each element is an array of parent-child hierarchies and
+     * append to the top level array each possible parent iteration.
+     * This serves to emulate anchoring in Magento in order to use category page id filtering
+     * without explicit category assignment.
+     *
+     * @param array $paths
+     * @return array
+     */
+    protected function autoAnchorParentCategories(array $paths): array {
+        foreach ($paths as $path) {
+            for ($i = count($path) - 1; $i > 0; $i--) {
+                $paths[] = array_slice($path,0, $i);
+            }
+        }
+        return $this->dedupePaths($paths);
+    }
+
+    /**
+     * Flatten non-hierarchical paths for merchandising
+     *
+     * @param array $paths
+     * @param int $storeId
+     * @return array
+     */
+    protected function flattenCategoryPaths(array $paths, int $storeId): array
+    {
+        return array_map(
+            function ($path) use ($storeId) { return implode($this->configHelper->getCategorySeparator($storeId), $path); },
+            $paths
+        );
+    }
+
+    /**
+     * @param $customData
+     * @param Product $product
+     * @return mixed
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    protected function addBundleProductDefaultOptions($customData, Product $product) {
+        $optionsCollection = $product->getTypeInstance()->getOptionsCollection($product);
+        $optionDetails = [];
+        foreach ($optionsCollection as $option){
+            $selections = $product->getTypeInstance()->getSelectionsCollection($option->getOptionId(),$product);
+            //selection details by optionids
+            foreach ($selections as $selection) {
+                if($selection->getIsDefault()){
+                    $optionDetails[$option->getOptionId()] = $selection->getSelectionId();
+                }
+            }
+        }
+        $customData['default_bundle_options'] = array_unique($optionDetails);
+
+        return $customData;
+    }
+
+    /**
+     * @param Product $product
+     * @return array|ProductInterface[]|DataObject[]
+     */
+    protected function getSubProducts(Product $product): array
+    {
+        $type = $product->getTypeId();
+
+        if (!in_array($type, ['bundle', 'grouped', 'configurable'], true)) {
+            return [];
+        }
+
+        $this->logger->startProfiling(__METHOD__);
+
+        $storeId = $product->getStoreId();
+        $typeInstance = $product->getTypeInstance();
+
+        if ($typeInstance instanceof Configurable) {
+            $subProducts = $typeInstance->getUsedProducts($product);
+        } elseif ($typeInstance instanceof BundleProductType) {
+            $subProducts = $typeInstance->getSelectionsCollection($typeInstance->getOptionsIds($product), $product)->getItems();
+        } else { // Grouped product
+            $subProducts = $typeInstance->getAssociatedProducts($product);
+        }
+
+        /**
+         * @var int $index
+         * @var Product $subProduct
+         */
+        foreach ($subProducts as $index => $subProduct) {
+            try {
+                $this->canProductBeReindexed($subProduct, $storeId, true);
+            } catch (ProductReindexingException) {
+                unset($subProducts[$index]);
+            }
+        }
+
+        $this->logger->stopProfiling(__METHOD__);
+        return $subProducts;
+    }
+
+    /**
+     * Check if product can be index on Algolia
+     *
+     * @param Product $product
+     * @param int $storeId
+     * @param bool $isChildProduct
+     *
+     * @return bool
+     */
+    public function canProductBeReindexed($product, $storeId, $isChildProduct = false)
+    {
+        if ($product->isDeleted() === true) {
+            throw (new ProductDeletedException())
+                ->withProduct($product)
+                ->withStoreId($storeId);
+        }
+
+        if ($product->getStatus() == Status::STATUS_DISABLED) {
+            throw (new ProductDisabledException())
+                ->withProduct($product)
+                ->withStoreId($storeId);
+        }
+
+        if ($isChildProduct === false && !in_array($product->getVisibility(), [
+                Visibility::VISIBILITY_BOTH,
+                Visibility::VISIBILITY_IN_SEARCH,
+                Visibility::VISIBILITY_IN_CATALOG,
+            ])) {
+            throw (new ProductNotVisibleException())
+                ->withProduct($product)
+                ->withStoreId($storeId);
+        }
+
+        $isInStock = true;
+        if (!$this->configHelper->getShowOutOfStock($storeId)) {
+            $isInStock = $this->productIsInStock($product, $storeId);
+        }
+
+        if (!$isInStock) {
+            throw (new ProductOutOfStockException())
+                ->withProduct($product)
+                ->withStoreId($storeId);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param $customData
+     * @param $value
+     * @param Product $product
+     * @param $attribute
+     * @param AttributeResource $attributeResource
+     * @return mixed
+     */
+    protected function addNonNullValue(
+        $customData,
+        $value,
+        Product $product,
+        $attribute,
+        AttributeResource $attributeResource
+    )
+    {
+        $valueText = null;
+
+        if (!is_array($value) && $attributeResource->usesSource()) {
+            $valueText = $product->getAttributeText($attribute['attribute']);
+        }
+
+        if ($valueText) {
+            $value = $valueText;
+        } else {
+            $attributeResource = $attributeResource->setData('store_id', $product->getStoreId());
+            $value = $attributeResource->getFrontend()->getValue($product);
+        }
+
+        if ($value !== null) {
+            $customData[$attribute['attribute']] = $value;
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param $customData
+     * @param $subProducts
+     * @param $attribute
+     * @param AttributeResource $attributeResource
+     * @return mixed
+     */
+    protected function addNullValue($customData, $subProducts, $attribute, AttributeResource $attributeResource)
+    {
+        $attributeName = $attribute['attribute'];
+
+        $values = [];
+        $subProductImages = [];
+
+        if (isset($customData[$attributeName])) {
+            $values[] = $customData[$attributeName];
+        }
+
+        /** @var Product $subProduct */
+        foreach ($subProducts as $subProduct) {
+            $value = $subProduct->getData($attributeName);
+            if ($value) {
+                /** @var string|array $valueText */
+                $valueText = $subProduct->getAttributeText($attributeName);
+
+                $values = array_merge($values, $this->getValues($valueText, $subProduct, $attributeResource));
+                if ($this->configHelper->useAdaptiveImage($attributeResource->getStoreId())) {
+                    $subProductImages = $this->addSubProductImage(
+                        $subProductImages,
+                        $attribute,
+                        $subProduct,
+                        $valueText
+                    );
+                }
+            }
+        }
+
+        if (is_array($values) && count($values) > 0) {
+            $customData[$attributeName] = $this->getSanitizedArrayValues($values, $attributeName);
+        }
+
+        if (count($subProductImages) > 0) {
+            $customData['images_data'] = $subProductImages;
+        }
+
+        return $customData;
+    }
+
+    /**
+     * @param string|array $valueText - bit of a misnomer - essentially the retrieved values to be indexed for a given product's attribute
+     * @param Product $subProduct - the simple product to index
+     * @param AttributeResource $attributeResource - the attribute being indexed
+     * @return array
+     */
+    protected function getValues($valueText, Product $subProduct, AttributeResource $attributeResource): array
+    {
+        $values = [];
+
+        if ($valueText) {
+            if (is_array($valueText)) {
+                foreach ($valueText as $valueText_elt) {
+                    $values[] = $valueText_elt;
+                }
+            } else {
+                $values[] = $valueText;
+            }
+        } else {
+            $values[] = $attributeResource->getFrontend()->getValue($subProduct);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param $subProductImages
+     * @param $attribute
+     * @param $subProduct
+     * @param $valueText
+     * @return mixed
+     */
+    protected function addSubProductImage($subProductImages, $attribute, $subProduct, $valueText)
+    {
+        if (mb_strtolower($attribute['attribute'], 'utf-8') !== 'color') {
+            return $subProductImages;
+        }
+
+        $image = $this->imageHelper
+            ->init($subProduct, $this->configHelper->getImageType())
+            ->resize(
+                $this->configHelper->getImageWidth(),
+                $this->configHelper->getImageHeight()
+            );
+
+        $subImage = $subProduct->getData($image->getType());
+        if (!$subImage || $subImage === 'no_selection') {
+            return $subProductImages;
+        }
+
+        try {
+            $textValueInLower = mb_strtolower($valueText, 'utf-8');
+            $subProductImages[$textValueInLower] = $image->getUrl();
+        } catch (\Exception $e) {
+            $this->logger->log($e->getMessage());
+            $this->logger->log($e->getTraceAsString());
+        }
+
+        return $subProductImages;
+    }
+
+    /**
+     * By default Algolia will remove all redundant attribute values that are fetched from the child simple products.
+     *
+     * Overridable via Preference to allow implementer to enforce their own uniqueness rules while leveraging existing indexing code.
+     * e.g. $values = (in_array($attributeName, self::NON_UNIQUE_ATTRIBUTES)) ? $values : array_unique($values);
+     *
+     * @param array $values
+     * @param string $attributeName
+     * @return array
+     */
+    protected function getSanitizedArrayValues(array $values, string $attributeName): array
+    {
+        return array_values(array_unique($values));
+    }
+
+    /**
+     * Returns is product in stock
+     *
+     * @param Product $product
+     * @param int $storeId
+     *
+     * @return bool
+     */
+    public function productIsInStock($product, $storeId): bool
+    {
+        $stockItem = $this->stockRegistry->getStockItem($product->getId());
+
+        return $product->isSaleable() && $stockItem->getIsInStock();
+    }
+}

--- a/Service/Product/RecordBuilder.php
+++ b/Service/Product/RecordBuilder.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Service\Product;
 
 use Algolia\AlgoliaSearch\Api\RecordBuilder\RecordBuilderInterface;
+use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Algolia\AlgoliaSearch\Exception\ProductDeletedException;
 use Algolia\AlgoliaSearch\Exception\ProductDisabledException;
 use Algolia\AlgoliaSearch\Exception\ProductNotVisibleException;
@@ -53,6 +54,18 @@ class RecordBuilder implements RecordBuilderInterface
         protected StockRegistryInterface $stockRegistry,
         protected PriceManager           $priceManager,
     ){}
+
+    /**
+     * Builds a Product record
+     *
+     * @param DataObject $entity
+     * @return array
+     *
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     * @throws DiagnosticsException
+     */
     public function buildRecord(DataObject $entity): array
     {
         if (!$entity instanceof Product) {

--- a/Service/Suggestion/RecordBuilder.php
+++ b/Service/Suggestion/RecordBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Suggestion;
+
+use Algolia\AlgoliaSearch\Api\RecordBuilder\RecordBuilderInterface;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface;
+
+class RecordBuilder implements RecordBuilderInterface
+{
+    public function __construct(
+        protected ManagerInterface $eventManager,
+    ){}
+
+    public function buildRecord(DataObject $entity): array
+    {
+        $suggestionObject = [
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID => $entity->getData('query_id'),
+            'query'                                 => $entity->getData('query_text'),
+            'number_of_results'                     => (int) $entity->getData('num_results'),
+            'popularity'                            => (int) $entity->getData('popularity'),
+            'updated_at'                            => (int) strtotime($entity->getData('updated_at')),
+        ];
+
+        $transport = new DataObject($suggestionObject);
+        $this->eventManager->dispatch(
+            'algolia_after_create_suggestion_object',
+            ['suggestion' => $transport, 'suggestionObject' => $entity]
+        );
+
+        return $transport->getData();
+    }
+}

--- a/Service/Suggestion/RecordBuilder.php
+++ b/Service/Suggestion/RecordBuilder.php
@@ -13,6 +13,12 @@ class RecordBuilder implements RecordBuilderInterface
         protected ManagerInterface $eventManager,
     ){}
 
+    /**
+     * Builds a Suggestion record
+     *
+     * @param DataObject $entity
+     * @return array
+     */
     public function buildRecord(DataObject $entity): array
     {
         $suggestionObject = [


### PR DESCRIPTION
This PR contains:

- Updated `AbstractEntityHelper` with a new `getIndexSettings` method to implement
- Introduced `RecordBuilderInterface`
- Introduced a `RecordBuilder` per Entity which is now responsible for formatting any record sent to Algolia
- Updated each Entity Helpers which are now freed from such responsibility
- As a consequence, `getObject` methods from Entity Helpers are now deprecated and will be removed in version 3.16.0 in favour of `RecordBuilderInterface::buildRecord` which is much more self-explanatory