### PR TITLE
Reset customer group collection after filtering

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
@@ -135,6 +135,7 @@ abstract class ProductWithoutChildren
             }
             if(count($excludedGroups) > 0) {
                 $this->groups->addFieldToFilter('main_table.customer_group_id', ["nin" => $excludedGroups]);
+                $this->groups->clear()
             }
         }
         // price/price_with_tax => true/false


### PR DESCRIPTION
Without clearing customer group collection, any loops on existing collection will not be filtered

**Summary**

Add field filtering without clearing the collection (or creating new instance of it) will not actually do anything. Excluding websites should speed up the process of indexing by not requiring retrieval of grouped prices in websites that are excluded.
Without this modification this code doesn't do anything.

**Result**

With Customer Group pricing option enabled, any runs of `foreach ($this->groups as $group)` for example in vendor/algolia/algoliasearch-magento-2/Helper/Entity/Product/PriceManager/ProductWithChildren.php::setFinalGroupPrices should only loop through customer groups that are NOT excluded in the current website scope.

Without the change:
![image](https://github.com/user-attachments/assets/b0a562f5-6d41-4535-8676-d98539139444)

After the change:
![image](https://github.com/user-attachments/assets/bbd9d101-c137-4d40-a9a9-be155a77e835)
