### PR TITLE
MAGE-973 Default renderingContent

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -10,6 +10,7 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
 use Magento\Catalog\Model\Product;
@@ -21,7 +22,6 @@ use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\CatalogInventory\Helper\Stock;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
-use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
 use Magento\Directory\Model\Currency as CurrencyHelper;
 use Magento\Eav\Model\Config;
 use Magento\Framework\DataObject;
@@ -73,23 +73,21 @@ class ProductHelper extends AbstractEntityHelper
     ];
 
     public function __construct(
-        protected Config                                  $eavConfig,
-        protected ConfigHelper                            $configHelper,
-        protected AlgoliaHelper                           $algoliaHelper,
-        protected DiagnosticsLogger                       $logger,
-        protected StoreManagerInterface                   $storeManager,
-        protected ManagerInterface                        $eventManager,
-        protected Visibility                              $visibility,
-        protected Stock                                   $stockHelper,
-        protected CurrencyHelper                          $currencyManager,
-        protected Type                                    $productType,
-        protected CollectionFactory                       $productCollectionFactory,
-        protected GroupCollection                         $groupCollection,
-        protected GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository,
-        protected IndexNameFetcher                        $indexNameFetcher,
-        protected ReplicaManagerInterface                 $replicaManager,
-        protected ProductInterfaceFactory                 $productFactory,
-        protected ProductRecordBuilder                    $productRecordBuilder,
+        protected Config                  $eavConfig,
+        protected ConfigHelper            $configHelper,
+        protected AlgoliaHelper           $algoliaHelper,
+        protected DiagnosticsLogger       $logger,
+        protected StoreManagerInterface   $storeManager,
+        protected ManagerInterface        $eventManager,
+        protected Visibility              $visibility,
+        protected Stock                   $stockHelper,
+        protected Type                    $productType,
+        protected CollectionFactory       $productCollectionFactory,
+        protected IndexNameFetcher        $indexNameFetcher,
+        protected ReplicaManagerInterface $replicaManager,
+        protected ProductInterfaceFactory $productFactory,
+        protected ProductRecordBuilder    $productRecordBuilder,
+        protected FacetBuilder            $facetBuilder,
     )
     {
         parent::__construct($indexNameFetcher);
@@ -282,16 +280,12 @@ class ProductHelper extends AbstractEntityHelper
      */
     public function getIndexSettings(?int $storeId = null): array
     {
-        $searchableAttributes = $this->getSearchableAttributes($storeId);
-        $customRanking = $this->getCustomRanking($storeId);
-        $unretrievableAttributes = $this->getUnretrieveableAttributes($storeId);
-        $attributesForFaceting = $this->getAttributesForFaceting($storeId);
-
         $indexSettings = [
-            'searchableAttributes'    => $searchableAttributes,
-            'customRanking'           => $customRanking,
-            'unretrievableAttributes' => $unretrievableAttributes,
-            'attributesForFaceting'   => $attributesForFaceting,
+            'searchableAttributes'    => $this->getSearchableAttributes($storeId),
+            'customRanking'           => $this->getCustomRanking($storeId),
+            'unretrievableAttributes' => $this->getUnretrieveableAttributes($storeId),
+            'attributesForFaceting'   => $this->facetBuilder->getAttributesForFaceting($storeId),
+            'renderingContent'        => $this->facetBuilder->getRenderingContent($storeId),
             'maxValuesPerFacet'       => $this->configHelper->getMaxValuesPerFacet($storeId),
             'removeWordsIfNoResults'  => $this->configHelper->getRemoveWordsIfNoResult($storeId),
         ];
@@ -509,66 +503,6 @@ class ProductHelper extends AbstractEntityHelper
         }
 
         return $unretrievableAttributes;
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    protected function getAttributesForFaceting($storeId)
-    {
-        $attributesForFaceting = [];
-
-        $currencies = $this->currencyManager->getConfigAllowCurrencies();
-
-        $facets = $this->configHelper->getFacets($storeId);
-        $websiteId = (int)$this->storeManager->getStore($storeId)->getWebsiteId();
-        foreach ($facets as $facet) {
-            if ($facet['attribute'] === 'price') {
-                foreach ($currencies as $currency_code) {
-                    $facet['attribute'] = 'price.' . $currency_code . '.default';
-
-                    if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
-                        foreach ($this->groupCollection as $group) {
-                            $groupId = (int)$group->getData('customer_group_id');
-                            $excludedWebsites = $this->groupExcludedWebsiteRepository->getCustomerGroupExcludedWebsites($groupId);
-                            if (in_array($websiteId, $excludedWebsites)) {
-                                continue;
-                            }
-                            $attributesForFaceting[] = 'price.' . $currency_code . '.group_' . $groupId;
-                        }
-                    }
-
-                    $attributesForFaceting[] = $facet['attribute'];
-                }
-            } else {
-                $attribute = $facet['attribute'];
-                if (array_key_exists('searchable', $facet)) {
-                    if ($facet['searchable'] === '1') {
-                        $attribute = 'searchable(' . $attribute . ')';
-                    } elseif ($facet['searchable'] === '3') {
-                        $attribute = 'filterOnly(' . $attribute . ')';
-                    }
-                }
-
-                $attributesForFaceting[] = $attribute;
-            }
-        }
-
-        if ($this->configHelper->replaceCategories($storeId) && !in_array('categories', $attributesForFaceting, true)) {
-            $attributesForFaceting[] = 'categories';
-        }
-
-        // Used for merchandising
-        $attributesForFaceting[] = 'categoryIds';
-
-        if ($this->configHelper->isVisualMerchEnabled($storeId)) {
-            $attributesForFaceting[] = 'searchable(' . $this->configHelper->getCategoryPageIdAttributeName($storeId) . ')';
-        }
-
-        return $attributesForFaceting;
     }
 
     /**

--- a/Model/Source/Facets.php
+++ b/Model/Source/Facets.php
@@ -2,6 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Model\Source;
 
+use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
+
 class Facets extends AbstractTable
 {
     protected function getTableData()
@@ -37,7 +39,11 @@ class Facets extends AbstractTable
             ],
             'searchable' => [
                 'label'  => 'Options',
-                'values' => ['1' => 'Searchable', '2' => 'Not Searchable', '3' => 'Filter Only'],
+                'values' => [
+                    FacetBuilder::FACET_SEARCHABLE_SEARCHABLE     => 'Searchable',
+                    FacetBuilder::FACET_SEARCHABLE_NOT_SEARCHABLE => 'Not Searchable',
+                    FacetBuilder::FACET_SEARCHABLE_FILTER_ONLY    => 'Filter Only'
+                ],
             ],
         ];
 

--- a/Service/Product/FacetBuilder.php
+++ b/Service/Product/FacetBuilder.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Product;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
+use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
+use Magento\Directory\Model\Currency as CurrencyHelper;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+
+class FacetBuilder
+{
+    public function __construct(
+        protected ConfigHelper                            $configHelper,
+        protected StoreManagerInterface                   $storeManager,
+        protected CurrencyHelper                          $currencyManager,
+        protected GroupCollection                         $groupCollection,
+        protected GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository,
+    )
+    {}
+
+    /**
+     * @param int $storeId
+     * @return array<string, array>|null
+     */
+    public function getRenderingContent(int $storeId): ?array
+    {
+        return null;
+    }
+
+    /**
+     * @param int $storeId
+     * @return string[]
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function getAttributesForFaceting(int $storeId): array
+    {
+        $attributesForFaceting = [];
+
+        $currencies = $this->currencyManager->getConfigAllowCurrencies();
+
+        $facets = $this->configHelper->getFacets($storeId);
+        $websiteId = (int)$this->storeManager->getStore($storeId)->getWebsiteId();
+        foreach ($facets as $facet) {
+            if ($facet['attribute'] === 'price') {
+                foreach ($currencies as $currency_code) {
+                    $facet['attribute'] = 'price.' . $currency_code . '.default';
+
+                    if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
+                        foreach ($this->groupCollection as $group) {
+                            $groupId = (int)$group->getData('customer_group_id');
+                            $excludedWebsites = $this->groupExcludedWebsiteRepository->getCustomerGroupExcludedWebsites($groupId);
+                            if (in_array($websiteId, $excludedWebsites)) {
+                                continue;
+                            }
+                            $attributesForFaceting[] = 'price.' . $currency_code . '.group_' . $groupId;
+                        }
+                    }
+
+                    $attributesForFaceting[] = $facet['attribute'];
+                }
+            } else {
+                $attribute = $facet['attribute'];
+                if (array_key_exists('searchable', $facet)) {
+                    if ($facet['searchable'] === '1') {
+                        $attribute = 'searchable(' . $attribute . ')';
+                    } elseif ($facet['searchable'] === '3') {
+                        $attribute = 'filterOnly(' . $attribute . ')';
+                    }
+                }
+
+                $attributesForFaceting[] = $attribute;
+            }
+        }
+
+        if ($this->configHelper->replaceCategories($storeId) && !in_array('categories', $attributesForFaceting, true)) {
+            $attributesForFaceting[] = 'categories';
+        }
+
+        // Added for legacy merchandising features
+        $attributesForFaceting[] = 'categoryIds';
+
+        if ($this->configHelper->isVisualMerchEnabled($storeId)) {
+            $attributesForFaceting[] = 'searchable(' . $this->configHelper->getCategoryPageIdAttributeName($storeId) . ')';
+        }
+
+        return $attributesForFaceting;
+    }
+}

--- a/Service/Product/FacetBuilder.php
+++ b/Service/Product/FacetBuilder.php
@@ -13,6 +13,14 @@ use Magento\Store\Model\StoreManagerInterface;
 class FacetBuilder
 {
     public const FACET_ATTRIBUTE_PRICE = 'price';
+    public const FACET_ATTRIBUTE_CATEGORIES = 'categories';
+    public const FACET_ATTRIBUTES_CATEGORY_ID = 'categoryIds';
+
+    public const FACET_KEY_ATTRIBUTE_NAME = 'attribute';
+    public const FACET_KEY_SEARCHABLE = 'searchable';
+
+    // Local raw facet cache, indexed by $storeId
+    protected array $facets = [];
 
     public function __construct(
         protected ConfigHelper                            $configHelper,
@@ -26,11 +34,130 @@ class FacetBuilder
     /**
      * @param int $storeId
      * @return array<string, array>|null
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
     public function getRenderingContent(int $storeId): ?array
     {
-        return null;
+        $facets = $this->getRawFacets($storeId);
+        if (empty($facets)) {
+            return null;
+        }
+        $attributes = $this->extractFacetAttributeNames($facets);
+        return [
+            'facetOrdering' => [
+                'facets' => [
+                    'order' => $attributes
+                ],
+                'values' => $this->getRenderingContentValues($attributes)
+            ],
+        ];
     }
+
+    /**
+     * @param array<array<string, mixed>> $facets
+     * @return string[]
+     */
+    protected function extractFacetAttributeNames(array $facets): array
+    {
+        return array_map(
+            function($facet) {
+                return $facet[self::FACET_KEY_ATTRIBUTE_NAME];
+            },
+            $facets
+        );
+    }
+
+    /**
+     * @param string[] $facets
+     * @return array<string, array>
+     */
+    protected function getRenderingContentValues(array $facets): array
+    {
+        return array_combine(
+            array_map(
+                function(string $attribute) {
+                    if ($attribute === self::FACET_ATTRIBUTE_CATEGORIES) {
+                        $attribute = self::FACET_ATTRIBUTE_CATEGORIES . '.level0';
+                    }
+                    return $attribute;
+                },
+                $facets
+            ),
+            array_fill(0, count($facets), [ 'sortRemainingBy' => 'alpha' ])
+        );
+    }
+
+    /**
+     * @param string $attribute
+     * @param bool $searchable
+     * @return array<string, string|int>
+     */
+    protected function getRawFacet(string $attribute, bool $searchable = false): array
+    {
+        return [
+            self::FACET_KEY_ATTRIBUTE_NAME => $attribute,
+            self::FACET_KEY_SEARCHABLE => $searchable ? 1 : 0,
+        ];
+    }
+
+    /**
+     * Generates common data to be used for both attributesForFaceting and renderingContent
+     * @return array<array<string, mixed>>
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    protected function getRawFacets(int $storeId): array
+    {
+        if (isset($this->facets[$storeId])) {
+            return $this->facets[$storeId];
+        }
+
+        $rawFacets = [];
+        $configFacets = $this->configHelper->getFacets($storeId);
+        foreach ($configFacets as $configFacet) {
+            if ($configFacet[self::FACET_KEY_ATTRIBUTE_NAME] === self::FACET_ATTRIBUTE_PRICE) {
+                $rawFacets = array_merge($rawFacets, array_map(
+                    function(string $attribute) {
+                        return $this->getRawFacet($attribute);
+                    },
+                    $this->getPricingAttributes($storeId)
+                ));
+            } else {
+                $rawFacets[] = $configFacet;
+            }
+        }
+
+        $this->facets[$storeId] = $this->addCategoryFacets($storeId, $rawFacets);
+        return $this->facets[$storeId];
+    }
+
+    /**
+     * @param int $storeId
+     * @param array<array<string, mixed>> $facets
+     * @return array<array<string, mixed>>
+     */
+    protected function addCategoryFacets(int $storeId, array $facets): array
+    {
+        if ($this->configHelper->replaceCategories($storeId)
+            && !array_filter($facets, function($facet) {
+                return $facet['attribute'] === self::FACET_ATTRIBUTE_CATEGORIES;
+            })
+        ) {
+            $facets[] = $this->getRawFacet(self::FACET_ATTRIBUTE_CATEGORIES);
+        }
+
+        // Added for legacy merchandising features
+        $facets[] = $this->getRawFacet(self::FACET_ATTRIBUTES_CATEGORY_ID);
+
+        if ($this->configHelper->isVisualMerchEnabled($storeId)) {
+            // Must be searchable per https://www.algolia.com/doc/guides/solutions/ecommerce/browse/tutorials/category-pages/#configure-your-index
+            $facets[] = $this->getRawFacet($this->configHelper->getCategoryPageIdAttributeName($storeId), true);
+        }
+
+        return $facets;
+    }
+
 
     /**
      * @param int $storeId
@@ -40,17 +167,14 @@ class FacetBuilder
      */
     public function getAttributesForFaceting(int $storeId): array
     {
+
         $attributesForFaceting = [];
-        $facets = $this->configHelper->getFacets($storeId);
+        $facets = $this->getRawFacets($storeId);
         foreach ($facets as $facet) {
-            if ($facet['attribute'] === self::FACET_ATTRIBUTE_PRICE) {
-                $attributesForFaceting = array_merge($attributesForFaceting, $this->getPricingAttributes($storeId));
-            } else {
-                $attributesForFaceting[] = $this->decorateAttributeForFaceting($facet);
-            }
+            $attributesForFaceting[] = $this->decorateAttributeForFaceting($facet);
         }
 
-        return $this->addCategoryAttributes($storeId, $attributesForFaceting);
+        return $attributesForFaceting;
     }
 
     /**
@@ -64,7 +188,7 @@ class FacetBuilder
         $pricingAttributes = [];
         $currencies = $this->currencyManager->getConfigAllowCurrencies();
         foreach ($currencies as $currencyCode) {
-            $pricingAttributes[] = 'price.' . $currencyCode . '.default';
+            $pricingAttributes[] = self::FACET_ATTRIBUTE_PRICE . '.' . $currencyCode . '.default';
             $pricingAttributes = array_merge($pricingAttributes, $this->getGroupPricingAttributes($storeId, $currencyCode));
         }
 
@@ -89,7 +213,7 @@ class FacetBuilder
                 if (in_array($websiteId, $excludedWebsites)) {
                     continue;
                 }
-                $groupPricingAttributes[] = 'price.' . $currencyCode . '.group_' . $groupId;
+                $groupPricingAttributes[] = self::FACET_ATTRIBUTE_PRICE . '.' . $currencyCode . '.group_' . $groupId;
             }
         }
         return $groupPricingAttributes;
@@ -97,15 +221,15 @@ class FacetBuilder
 
 
     /**
-     * @param array $facet
+     * @param array<string, string|int> $facet
      * @return string
      */
     protected function decorateAttributeForFaceting(array $facet): string {
-        $attribute = $facet['attribute'];
-        if (array_key_exists('searchable', $facet)) {
-            if ($facet['searchable'] === '1') {
+        $attribute = $facet[self::FACET_KEY_ATTRIBUTE_NAME];
+        if (array_key_exists(self::FACET_KEY_SEARCHABLE, $facet)) {
+            if ($facet[self::FACET_KEY_SEARCHABLE] === '1') {
                 $attribute = 'searchable(' . $attribute . ')';
-            } elseif ($facet['searchable'] === '3') {
+            } elseif ($facet[self::FACET_KEY_SEARCHABLE] === '3') {
                 $attribute = 'filterOnly(' . $attribute . ')';
             }
         }
@@ -120,7 +244,7 @@ class FacetBuilder
     protected function addCategoryAttributes(int $storeId, array $attributesForFaceting): array
     {
         if ($this->configHelper->replaceCategories($storeId) && !in_array('categories', $attributesForFaceting, true)) {
-            $attributesForFaceting[] = 'categories';
+            $attributesForFaceting[] = self::FACET_ATTRIBUTE_CATEGORIES;
         }
 
         // Added for legacy merchandising features

--- a/Service/Product/FacetBuilder.php
+++ b/Service/Product/FacetBuilder.php
@@ -207,9 +207,10 @@ class FacetBuilder
     {
         $groupPricingAttributes = [];
         $websiteId = (int) $this->storeManager->getStore($storeId)->getWebsiteId();
+
         if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
             foreach ($this->groupCollection as $group) {
-                $groupId = (int)$group->getData('customer_group_id');
+                $groupId = (int) $group->getData('customer_group_id');
                 $excludedWebsites = $this->groupExcludedWebsiteRepository->getCustomerGroupExcludedWebsites($groupId);
                 if (in_array($websiteId, $excludedWebsites)) {
                     continue;
@@ -225,7 +226,8 @@ class FacetBuilder
      * @param array<string, string|int> $facet
      * @return string
      */
-    protected function decorateAttributeForFaceting(array $facet): string {
+    protected function decorateAttributeForFaceting(array $facet): string
+    {
         $attribute = $facet[self::FACET_KEY_ATTRIBUTE_NAME];
         if (array_key_exists(self::FACET_KEY_SEARCHABLE, $facet)) {
             if ($facet[self::FACET_KEY_SEARCHABLE] == self::FACET_SEARCHABLE_SEARCHABLE) {

--- a/Service/Product/FacetBuilder.php
+++ b/Service/Product/FacetBuilder.php
@@ -47,7 +47,7 @@ class FacetBuilder
         foreach ($facets as $facet) {
             if ($facet['attribute'] === 'price') {
                 foreach ($currencies as $currency_code) {
-                    $facet['attribute'] = 'price.' . $currency_code . '.default';
+                    $attributesForFaceting[] = 'price.' . $currency_code . '.default';
 
                     if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
                         foreach ($this->groupCollection as $group) {
@@ -59,23 +59,29 @@ class FacetBuilder
                             $attributesForFaceting[] = 'price.' . $currency_code . '.group_' . $groupId;
                         }
                     }
-
-                    $attributesForFaceting[] = $facet['attribute'];
                 }
             } else {
-                $attribute = $facet['attribute'];
-                if (array_key_exists('searchable', $facet)) {
-                    if ($facet['searchable'] === '1') {
-                        $attribute = 'searchable(' . $attribute . ')';
-                    } elseif ($facet['searchable'] === '3') {
-                        $attribute = 'filterOnly(' . $attribute . ')';
-                    }
-                }
-
-                $attributesForFaceting[] = $attribute;
+                $attributesForFaceting[] = $this->decorateAttributeForFaceting($facet);
             }
         }
 
+        return $this->addCategoryAttributes($storeId, $attributesForFaceting);
+    }
+
+    protected function decorateAttributeForFaceting($facet): string {
+        $attribute = $facet['attribute'];
+        if (array_key_exists('searchable', $facet)) {
+            if ($facet['searchable'] === '1') {
+                $attribute = 'searchable(' . $attribute . ')';
+            } elseif ($facet['searchable'] === '3') {
+                $attribute = 'filterOnly(' . $attribute . ')';
+            }
+        }
+        return $attribute;
+    }
+
+    protected function addCategoryAttributes(int $storeId, array $attributesForFaceting): array
+    {
         if ($this->configHelper->replaceCategories($storeId) && !in_array('categories', $attributesForFaceting, true)) {
             $attributesForFaceting[] = 'categories';
         }
@@ -89,4 +95,5 @@ class FacetBuilder
 
         return $attributesForFaceting;
     }
+
 }

--- a/Service/Product/FacetBuilder.php
+++ b/Service/Product/FacetBuilder.php
@@ -63,7 +63,7 @@ class FacetBuilder
         if (empty($facets)) {
             return null;
         }
-        $attributes = $this->extractFacetAttributeNames($facets);
+        $attributes = $this->getRenderingContentAttributes($this->extractFacetAttributeNames($facets));
         return [
             'facetOrdering' => [
                 'facets' => [
@@ -89,22 +89,31 @@ class FacetBuilder
     }
 
     /**
-     * @param string[] $facets
+     * @param string[] $attributes
      * @return array<string, array>
      */
-    protected function getRenderingContentValues(array $facets): array
+    protected function getRenderingContentValues(array $attributes): array
     {
         return array_combine(
-            array_map(
-                function(string $attribute) {
-                    if ($attribute === self::FACET_ATTRIBUTE_CATEGORIES) {
-                        $attribute = self::FACET_ATTRIBUTE_CATEGORIES . '.level0';
-                    }
-                    return $attribute;
-                },
-                $facets
-            ),
-            array_fill(0, count($facets), [ 'sortRemainingBy' => 'alpha' ])
+            $attributes,
+            array_fill(0, count($attributes), [ 'sortRemainingBy' => 'alpha' ])
+        );
+    }
+
+    /**
+     * @param string[] $facets
+     * @return string[]
+     */
+    protected function getRenderingContentAttributes(array $facets): array
+    {
+        return array_map(
+            function(string $attribute) {
+                if ($attribute === self::FACET_ATTRIBUTE_CATEGORIES) {
+                    $attribute = self::FACET_ATTRIBUTE_CATEGORIES . '.level0';
+                }
+                return $attribute;
+            },
+            $facets
         );
     }
 
@@ -206,9 +215,8 @@ class FacetBuilder
     protected function getGroupPricingAttributes(int $storeId, string $currencyCode): array
     {
         $groupPricingAttributes = [];
-        $websiteId = (int) $this->storeManager->getStore($storeId)->getWebsiteId();
-
         if ($this->configHelper->isCustomerGroupsEnabled($storeId)) {
+            $websiteId = (int) $this->storeManager->getStore($storeId)->getWebsiteId();
             foreach ($this->groupCollection as $group) {
                 $groupId = (int) $group->getData('customer_group_id');
                 $excludedWebsites = $this->groupExcludedWebsiteRepository->getCustomerGroupExcludedWebsites($groupId);

--- a/Test/Unit/AlgoliaLoggerTest.php
+++ b/Test/Unit/AlgoliaLoggerTest.php
@@ -2,14 +2,15 @@
 
 namespace Algolia\AlgoliaSearch\Test\Unit;
 
-use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler;
 use Algolia\AlgoliaSearch\Logger\Handler\SystemLoggerHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class AlgoliaLoggerTest extends TestCase
 {
-    protected AlgoliaLogger $algoliaLogger;
+    protected LoggerInterface $algoliaLogger;
     protected SystemLoggerHandler $systemLoggerHandler;
     protected AlgoliaLoggerHandler $algoliaLoggerHandler;
 
@@ -18,7 +19,7 @@ class AlgoliaLoggerTest extends TestCase
         $this->systemLoggerHandler = $this->createMock(SystemLoggerHandler::class);
         $this->algoliaLoggerHandler = $this->createMock(AlgoliaLoggerHandler::class);
 
-        $this->algoliaLogger = new AlgoliaLogger(
+        $this->algoliaLogger = new Logger(
             'algolia',
             [ $this->systemLoggerHandler, $this->algoliaLoggerHandler ]
         );

--- a/Test/Unit/Helper/ConfigHelperTest.php
+++ b/Test/Unit/Helper/ConfigHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Test\Unit;
+namespace Algolia\AlgoliaSearch\Test\Unit\Helper;
 
 use Magento\Cookie\Helper\Cookie as CookieHelper;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;

--- a/Test/Unit/Helper/ConfigHelperTestable.php
+++ b/Test/Unit/Helper/ConfigHelperTestable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Test\Unit;
+namespace Algolia\AlgoliaSearch\Test\Unit\Helper;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 

--- a/Test/Unit/Logger/AlgoliaLoggerTest.php
+++ b/Test/Unit/Logger/AlgoliaLoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Test\Unit;
+namespace Algolia\AlgoliaSearch\Test\Unit\Logger;
 
 use Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler;
 use Algolia\AlgoliaSearch\Logger\Handler\SystemLoggerHandler;

--- a/Test/Unit/Logger/DiagnosticLoggerTest.php
+++ b/Test/Unit/Logger/DiagnosticLoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Test\Unit;
+namespace Algolia\AlgoliaSearch\Test\Unit\Logger;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;

--- a/Test/Unit/Service/Product/FacetBuilderTest.php
+++ b/Test/Unit/Service/Product/FacetBuilderTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service\Product;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Model\QuerySuggestions\Facet;
+use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
+use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
+use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
+use Magento\Directory\Model\Currency as CurrencyHelper;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class FacetBuilderTest extends TestCase
+{
+    protected FacetBuilder $facetBuilder;
+    protected ConfigHelper $configHelper;
+    protected StoreManagerInterface $storeManager;
+    protected CurrencyHelper $currencyManager;
+    protected GroupCollection $groupCollection;
+    protected GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository;
+
+    protected function setUp(): void
+    {
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->currencyManager = $this->createMock(CurrencyHelper::class);
+        $this->groupCollection = $this->createMock(GroupCollection::class);
+        $this->groupExcludedWebsiteRepository = $this->createMock(GroupExcludedWebsiteRepositoryInterface::class);
+
+        $this->facetBuilder = new FacetBuilderTestable(
+            $this->configHelper,
+            $this->storeManager,
+            $this->currencyManager,
+            $this->groupCollection,
+            $this->groupExcludedWebsiteRepository
+        );
+    }
+
+    protected function mockFacets(): void
+    {
+        $this->configHelper
+            ->method('getFacets')
+            ->willReturn([
+                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'brand', FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_NOT_SEARCHABLE],
+                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'color', FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_SEARCHABLE],
+                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => FacetBuilder::FACET_ATTRIBUTE_PRICE]
+            ]);
+    }
+
+    protected function mockStoreConfig($storeId, $websiteId): void
+    {
+        $this->currencyManager
+            ->method('getConfigAllowCurrencies')
+            ->willReturn(['EUR', 'USD']);
+
+        $storeMock = $this->createMock(\Magento\Store\Api\Data\StoreInterface::class);
+        $storeMock->method('getWebsiteId')->willReturn($websiteId);
+        $this->storeManager->method('getStore')->with($storeId)->willReturn($storeMock);
+    }
+
+    protected function mockGroups(): void
+    {
+        $groupMock1 = $this->createMock(\Magento\Customer\Model\Group::class);
+        $groupMock1->method('getData')->with('customer_group_id')->willReturn(1);
+
+        $groupMock2 = $this->createMock(\Magento\Customer\Model\Group::class);
+        $groupMock2->method('getData')->with('customer_group_id')->willReturn(2);
+
+        $this->groupCollection->method('getIterator')->willReturn(new \ArrayIterator([$groupMock1, $groupMock2]));
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function testGetAttributesForFacetingReturnsCorrectFacets(): void
+    {
+        $storeId = 1;
+        $websiteId = 2;
+
+        $this->mockFacets();
+        $this->mockGroups();
+
+        $this->mockStoreConfig($storeId, $websiteId);
+
+        $this->configHelper
+            ->method('isCustomerGroupsEnabled')
+            ->with($storeId)
+            ->willReturn(true);
+
+        $this->groupExcludedWebsiteRepository
+            ->method('getCustomerGroupExcludedWebsites')
+            ->willReturn([]);
+
+        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+
+        $this->assertContains('brand', $result);
+        $this->assertContains('searchable(color)', $result);
+        $this->assertContains('price.EUR.group_1', $result);
+        $this->assertContains('price.USD.group_2', $result);
+    }
+
+    public function testGetAttributesForFacetingRespectsGroupPriceSetting(): void
+    {
+        $storeId = 1;
+        $websiteId = 2;
+
+        $this->mockFacets();
+        $this->mockGroups();
+
+        $this->mockStoreConfig($storeId, $websiteId);
+
+        $this->configHelper
+            ->method('isCustomerGroupsEnabled')
+            ->with($storeId)
+            ->willReturn(false);
+
+        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+
+        $this->assertContains('brand', $result);
+        $this->assertContains('searchable(color)', $result);
+        $this->assertNotContains('price.EUR.group_1', $result);
+        $this->assertNotContains('price.USD.group_2', $result);
+    }
+
+    public function testGetAttributesForFacetingExcludesWebsites(): void
+    {
+        $storeId = 1;
+        $websiteId = 2;
+
+        $this->mockFacets();
+        $this->mockGroups();
+
+        $this->mockStoreConfig($storeId, $websiteId);
+
+        $this->configHelper
+            ->method('isCustomerGroupsEnabled')
+            ->with($storeId)
+            ->willReturn(true);
+
+        $this->groupExcludedWebsiteRepository
+            ->method('getCustomerGroupExcludedWebsites')
+            ->willReturn([$websiteId]);
+
+        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+
+        $this->assertContains('brand', $result);
+        $this->assertContains('searchable(color)', $result);
+        $this->assertNotContains('price.EUR.group_1', $result);
+        $this->assertNotContains('price.USD.group_2', $result);
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function testGetRenderingContentReturnsExpectedFormat(): void
+    {
+        $storeId = 1;
+        $websiteId = 2;
+        $this->mockFacets();
+        $this->mockGroups();
+        $this->mockStoreConfig($storeId, $websiteId);
+
+        $this->configHelper
+            ->method('isCustomerGroupsEnabled')
+            ->with($storeId)
+            ->willReturn(true);
+
+        $this->groupExcludedWebsiteRepository
+            ->method('getCustomerGroupExcludedWebsites')
+            ->willReturn([]);
+
+        $result = $this->facetBuilder->getRenderingContent($storeId);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('facetOrdering', $result);
+        $this->assertArrayHasKey('facets', $result['facetOrdering']);
+        $this->assertArrayHasKey('order', $result['facetOrdering']['facets']);
+        $this->assertArrayHasKey('values', $result['facetOrdering']);
+        $this->assertArrayHasKey('brand', $result['facetOrdering']['values']);
+        $this->assertArrayHasKey('sortRemainingBy', $result['facetOrdering']['values']['brand']);
+        $this->assertContains('brand', $result['facetOrdering']['facets']['order']);
+        $this->assertContains('price.EUR.group_1', $result['facetOrdering']['facets']['order']);
+        $this->assertContains('price.USD.group_2', $result['facetOrdering']['facets']['order']);
+        $this->assertEquals(count($result['facetOrdering']['facets']['order']), count($result['facetOrdering']['values']));
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function testGetRawFacetsReturnsCorrectStructure(): void
+    {
+        $storeId = 1;
+        $websiteId = 2;
+
+        $this->configHelper
+            ->method('getFacets')
+            ->willReturn([
+                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size'],
+                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => FacetBuilder::FACET_ATTRIBUTE_PRICE]
+            ]);
+
+        $this->mockStoreConfig($storeId, $websiteId);
+
+        $result = $this->facetBuilder->getRawFacets($storeId);
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+        $this->assertEquals('size', $result[0][FacetBuilder::FACET_KEY_ATTRIBUTE_NAME]);
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function testGetPricingAttributesReturnsCorrectValues(): void
+    {
+        $storeId = 1;
+        $websiteId = 2;
+
+        $this->mockStoreConfig($storeId, $websiteId);
+
+        $result = $this->facetBuilder->getPricingAttributes($storeId);
+        $this->assertContains('price.USD.default', $result);
+        $this->assertContains('price.EUR.default', $result);
+    }
+
+    public function testDecorateAttributeForFacetingHandlesSearchableCorrectly(): void
+    {
+        $facet = [
+            FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'brand',
+            FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_SEARCHABLE
+        ];
+        $result = $this->facetBuilder->decorateAttributeForFaceting($facet);
+        $this->assertEquals('searchable(brand)', $result);
+    }
+
+    public function testDecorateAttributeForFacetingHandlesFilterOnlyCorrectly(): void
+    {
+        $facet = [
+            FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size',
+            FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_FILTER_ONLY
+        ];
+        $result = $this->facetBuilder->decorateAttributeForFaceting($facet);
+        $this->assertEquals('filterOnly(size)', $result);
+    }
+}

--- a/Test/Unit/Service/Product/FacetBuilderTest.php
+++ b/Test/Unit/Service/Product/FacetBuilderTest.php
@@ -195,6 +195,35 @@ class FacetBuilderTest extends TestCase
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
+    public function testRenderingContentsFormatsCategoriesAttribute(): void
+    {
+        $storeId = 1;
+        $websiteId = 2;
+        $this->configHelper
+            ->method('getFacets')
+            ->willReturn([
+                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'color'],
+                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size']
+            ]);
+
+        $this->mockGroups();
+        $this->mockStoreConfig($storeId, $websiteId);
+
+        $this->configHelper
+            ->method('replaceCategories')
+            ->with($storeId)
+            ->willReturn(true);
+
+        $result = $this->facetBuilder->getRenderingContent($storeId);
+
+        $this->assertContains('categories.level0', $result['facetOrdering']['facets']['order']);
+        $this->assertArrayHasKey('categories.level0', $result['facetOrdering']['values']);
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
     public function testGetRawFacetsReturnsCorrectStructure(): void
     {
         $storeId = 1;

--- a/Test/Unit/Service/Product/FacetBuilderTestable.php
+++ b/Test/Unit/Service/Product/FacetBuilderTestable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service\Product;
+
+use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
+
+class FacetBuilderTestable extends FacetBuilder
+{
+    public function getRawFacets(int $storeId): array
+    {
+        return parent::getRawFacets($storeId);
+    }
+
+    public function getPricingAttributes(int $storeId): array
+    {
+        return parent::getPricingAttributes($storeId);
+    }
+
+    public function decorateAttributeForFaceting(array $facet): string
+    {
+        return parent::decorateAttributeForFaceting($facet);
+    }
+
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -580,13 +580,6 @@
                         ]]>
                     </comment>
                 </field>
-                <field id="include_non_visible_products_in_index" translate="label comment" type="select" sortOrder="55" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Include non visible products in index</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>
-                        Include non visible products in index. Default value is <strong>No</strong>
-                    </comment>
-                </field>
                 <field id="category_page_id_attribute_name" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Category page ID attribute</label>
                     <comment>
@@ -598,6 +591,13 @@
                     <depends>
                         <field id="enable_visual_merchandising">1</field>
                     </depends>
+                </field>
+                <field id="include_non_visible_products_in_index" translate="label comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Include non visible products in index</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        Include non visible products in index. Default value is <strong>No</strong>
+                    </comment>
                 </field>
             </group>
         </section>


### PR DESCRIPTION
**Summary**

This primary of objective of this PR is introduce default `renderingContent` that will help power `dynamicWidgets`. It also includes some refactoring:

- New `FacetBuilder` service
- Shared `rawFacets` between `renderingContent` and `attributesForFaceting`
- Separating logic into functions by area of concern: groups, categories,
- Introducing constants for Magento integration specific key conventions
- Added unit tests and reorganized existing

During implementation it was observed that our currency handling is flawed as it does not handle scoped currency config by store but this PR does not address that issue. That will be addressed in a separate ticket. 

**Result**

`renderingContent` persisted as Facet Display in Dashboard:
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/c9647328-c471-4d12-93d4-c70be6150ccb" />


All tests passed (including reorganized tests)
<img width="1486" alt="image" src="https://github.com/user-attachments/assets/5a301470-c9c7-4ff6-87e5-c930f2c75159" />
