### PR TITLE
MAGE-1228 Fix unit tests for 3.15.0 release

### DIFF
--- a/Test/Unit/AlgoliaLoggerTest.php
+++ b/Test/Unit/AlgoliaLoggerTest.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Test\Unit;
+namespace Algolia\AlgoliaSearch\Test\Unit\Logger;
 
-use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler;
 use Algolia\AlgoliaSearch\Logger\Handler\SystemLoggerHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class AlgoliaLoggerTest extends TestCase
 {
-    protected AlgoliaLogger $algoliaLogger;
+    protected LoggerInterface $algoliaLogger;
     protected SystemLoggerHandler $systemLoggerHandler;
     protected AlgoliaLoggerHandler $algoliaLoggerHandler;
 
@@ -18,7 +19,7 @@ class AlgoliaLoggerTest extends TestCase
         $this->systemLoggerHandler = $this->createMock(SystemLoggerHandler::class);
         $this->algoliaLoggerHandler = $this->createMock(AlgoliaLoggerHandler::class);
 
-        $this->algoliaLogger = new AlgoliaLogger(
+        $this->algoliaLogger = new Logger(
             'algolia',
             [ $this->systemLoggerHandler, $this->algoliaLoggerHandler ]
         );


### PR DESCRIPTION
**Summary**

Switching to virtual types broke some unit tests. This fixes this issue. 

**Result**

Before:
![image](https://github.com/user-attachments/assets/82f4c939-a388-4c6a-90c8-20b2e3a28fb1)
After:
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/b2eb5cd2-82f0-4ee9-9277-08f620e573e4" />
