### PR TITLE
MAGE-1217: Fix excluded websites feature for price indexing

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
@@ -136,6 +136,7 @@ abstract class ProductWithoutChildren
             }
             if(count($excludedGroups) > 0) {
                 $this->groups->addFieldToFilter('main_table.customer_group_id', ["nin" => $excludedGroups]);
+                $this->groups->clear();
             }
         }
         // price/price_with_tax => true/false


### PR DESCRIPTION
Following the [PR](https://github.com/algolia/algoliasearch-magento-2/pull/1699) opened by @kamilszewczyk , we're adding the fix to the upcoming 3.15.0 minor version of the extension.

This contains:
- Fixed a bug where excluded websites weren't taken into account while indexing customer prices on products.