### PR TITLE
MAGE-1224: Add reindexing features in products and pages grid

### DIFF
--- a/Block/Adminhtml/Reindex/AbstractReindexAllButton.php
+++ b/Block/Adminhtml/Reindex/AbstractReindexAllButton.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Block\Adminhtml\Reindex;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Backend\Block\Widget\Context;
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+abstract class AbstractReindexAllButton implements ButtonProviderInterface
+{
+    protected string $entity;
+
+    protected string $redirectPath;
+
+    public function __construct(
+        protected Context $context,
+        protected ConfigHelper $configHelper
+    ) {}
+
+    /**
+     * @return string
+     */
+    protected function getEntity(): string
+    {
+        return $this->entity;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getRedirectPath(): string
+    {
+        return $this->redirectPath;
+    }
+
+    /**
+     * @return array
+     */
+    public function getButtonData(): array
+    {
+        $entity = $this->getEntity();
+        $redirectPath = $this->getRedirectPath();
+
+        $message = "Are you sure you want to reindex all $entity to Algolia ?";
+
+        if (!$this->configHelper->isQueueActive() && $entity === 'products') {
+            $message .= ' Warning : Your Indexing Queue is not activated. Depending on the size of the data you want to index, it may takes a lot of time and resources.';
+            $message .= 'We highly suggest to turn it on if you\'re performing a full product reindexing with a large catalog.';
+        }
+
+        $message = htmlentities(__($message));
+        $url = $this->context->getUrlBuilder()->getUrl('algolia_algoliasearch/indexingmanager/reindex');
+
+        return [
+            'label'      => __('Reindex All items to Algolia'),
+            'class'      => 'algolia_reindex_all',
+            'on_click'   => "deleteConfirm('{$message}', '{$url}', {data:{'entity':'{$entity}', 'redirect': '{$redirectPath}'}})",
+            'sort_order' => 5,
+        ];
+    }
+}

--- a/Block/Adminhtml/Reindex/AbstractReindexAllButton.php
+++ b/Block/Adminhtml/Reindex/AbstractReindexAllButton.php
@@ -52,7 +52,7 @@ abstract class AbstractReindexAllButton implements ButtonProviderInterface
         $url = $this->context->getUrlBuilder()->getUrl('algolia_algoliasearch/indexingmanager/reindex');
 
         return [
-            'label'      => __('Reindex All items to Algolia'),
+            'label'      => __('Reindex All ' . ucfirst($this->getEntity()) . ' to Algolia'),
             'class'      => 'algolia_reindex_all',
             'on_click'   => "deleteConfirm('{$message}', '{$url}', {data:{'entity':'{$entity}', 'redirect': '{$redirectPath}'}})",
             'sort_order' => 5,

--- a/Block/Adminhtml/Reindex/ReindexAll/Page.php
+++ b/Block/Adminhtml/Reindex/ReindexAll/Page.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Block\Adminhtml\Reindex\ReindexAll;
+
+use Algolia\AlgoliaSearch\Block\Adminhtml\Reindex\AbstractReindexAllButton;
+
+class Page extends AbstractReindexAllButton
+{
+    protected string $entity = "pages";
+
+    protected string $redirectPath = "cms/page/index";
+}

--- a/Block/Adminhtml/Reindex/ReindexAll/Product.php
+++ b/Block/Adminhtml/Reindex/ReindexAll/Product.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Block\Adminhtml\Reindex\ReindexAll;
+
+use Algolia\AlgoliaSearch\Block\Adminhtml\Reindex\AbstractReindexAllButton;
+
+class Product extends AbstractReindexAllButton
+{
+    protected string $entity = "products";
+
+    protected string $redirectPath = "catalog/product/index";
+}

--- a/Controller/Adminhtml/IndexingManager/Reindex.php
+++ b/Controller/Adminhtml/IndexingManager/Reindex.php
@@ -5,6 +5,9 @@ namespace Algolia\AlgoliaSearch\Controller\Adminhtml\IndexingManager;
 use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Redirect;
@@ -20,6 +23,9 @@ class Reindex extends Action
     public function __construct(
         Context $context,
         protected StoreManagerInterface $storeManager,
+        protected StoreNameFetcher $storeNameFetcher,
+        protected IndexNameFetcher $indexNameFetcher,
+        protected ConfigHelper $configHelper,
         protected ProductBatchQueueProcessor $productBatchQueueProcessor,
         protected CategoryBatchQueueProcessor $categoryBatchQueueProcessor,
         protected PageBatchQueueProcessor $pageBatchQueueProcessor,
@@ -34,30 +40,74 @@ class Reindex extends Action
      */
     public function execute()
     {
-        $storeIds = $this->getRequest()->getParam("store_id") === '0' ?
+        $storeIds = is_null($this->getRequest()->getParam("store_id")) ||  $this->getRequest()->getParam("store_id") === '0' ?
             array_keys($this->storeManager->getStores()) :
             [(int) $this->getRequest()->getParam("store_id")];
 
-        $entities = $this->getRequest()->getParam("entity") === 'all' ?
-            ['products', 'categories', 'pages'] :
-            [$this->getRequest()->getParam("entity")];
+        $entities = $this->defineEntitiesToIndex();
+        $entityIds = !is_null($this->getRequest()->getParam('selected')) ?
+            $this->getRequest()->getParam('selected') :
+            null;
 
-        $this->reindexEntities($entities, $storeIds);
+        $this->reindexEntities($entities, $storeIds, $entityIds);
 
         /** @var Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
 
-        return $resultRedirect->setPath('*/*/');
+        return $resultRedirect->setPath($this->defineRedirectPath());
+    }
+
+    /**
+     * @return array|string[]
+     */
+    protected function defineEntitiesToIndex(): array
+    {
+        $entities = [];
+        $params = $this->getRequest()->getParams();
+        if (isset($params["entity"])) {
+            $entities = $params["entity"] === 'all' ?
+                ['products', 'categories', 'pages'] :
+                [$params["entity"]];
+        } else if (isset($params["namespace"])) {
+            $entities = match ($params["namespace"]) {
+                'product_listing' => ['products'],
+                'cms_page_listing' => ['pages'],
+                default => []
+            };
+        }
+
+        return $entities;
+    }
+
+    /**
+     * @return string
+     */
+    protected function defineRedirectPath(): string
+    {
+        $redirect = '*/*/';
+
+        $params = $this->getRequest()->getParams();
+        if (isset($params["namespace"])) {
+            $redirect = match ($params["namespace"]) {
+                'product_listing' => 'catalog/product/index',
+                'cms_page_listing' => 'cms/page/index',
+                default => '*/*/'
+            };
+        }
+
+        return $redirect;
     }
 
     /**
      * @param array $entities
      * @param array|null $storeIds
+     * @param array|null $entityIds
      * @return void
      * @throws AlgoliaException
-     * @throws ExceededRetriesException|NoSuchEntityException|DiagnosticsException
+     * @throws DiagnosticsException
+     * @throws NoSuchEntityException
      */
-    protected function reindexEntities(array $entities, array $storeIds = null): void
+    protected function reindexEntities(array $entities, array $storeIds = null, array $entityIds = null): void
     {
         foreach ($entities as $entity) {
             $processor = match ($entity) {
@@ -68,10 +118,25 @@ class Reindex extends Action
             };
 
             foreach ($storeIds as $storeId) {
-                $processor->processBatch($storeId);
-                $this->messageManager->addSuccessMessage("Reindex successful (Store: $storeId, entities: $entity)");
+                $processor->processBatch($storeId, $entityIds);
+                $message = $this->storeNameFetcher->getStoreName($storeId) . " ";
+                $message .= "(" . $this->indexNameFetcher->getIndexName('_' . $entity, $storeId);
+
+                if (!is_null($entityIds)) {
+                    $recordLabel = count($entityIds) > 1 ? "records" : "record";
+                    $message .= " - " . count($entityIds) . " " . $recordLabel;
+                } else {
+                    $message .= " - full reindexing job";
+                }
+
+                if (!$this->configHelper->isQueueActive($storeId)) {
+                    $message .= " successfully processed)";
+                } else {
+                    $message .= " successfully added to the Algolia indexing queue)";
+                }
+
+                $this->messageManager->addSuccessMessage(htmlentities(__($message)));
             }
         }
     }
 }
-

--- a/Controller/Adminhtml/IndexingManager/Reindex.php
+++ b/Controller/Adminhtml/IndexingManager/Reindex.php
@@ -67,7 +67,7 @@ class Reindex extends Action
             $entities = $this->isFullIndex($params) ?
                 ['products', 'categories', 'pages'] :
                 [$params["entity"]];
-        } else if ($this->isComingFromGrid($params)) {
+        } else if ($this->isMassAction($params)) {
             $entities = match ($params["namespace"]) {
                 'product_listing' => ['products'],
                 'cms_page_listing' => ['pages'],
@@ -90,7 +90,7 @@ class Reindex extends Action
             return $params["redirect"];
         }
 
-        if ($this->isComingFromGrid($params)) {
+        if ($this->isMassAction($params)) {
             $redirect = match ($params["namespace"]) {
                 'product_listing' => 'catalog/product/index',
                 'cms_page_listing' => 'cms/page/index',
@@ -118,7 +118,7 @@ class Reindex extends Action
      * @param array $params
      * @return bool
      */
-    protected function isComingFromGrid(array $params): bool
+    protected function isMassAction(array $params): bool
     {
         return isset($params["namespace"]);
     }

--- a/view/adminhtml/ui_component/cms_page_listing.xml
+++ b/view/adminhtml/ui_component/cms_page_listing.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <settings>
+        <buttons>
+            <button class="Algolia\AlgoliaSearch\Block\Adminhtml\Reindex\ReindexAll\Page" name="algolia_reindex_all" />
+        </buttons>
+    </settings>
     <listingToolbar name="listing_top">
         <massaction name="listing_massaction">
             <action name="algolia_reindex">

--- a/view/adminhtml/ui_component/cms_page_listing.xml
+++ b/view/adminhtml/ui_component/cms_page_listing.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <listingToolbar name="listing_top">
+        <massaction name="listing_massaction">
+            <action name="algolia_reindex">
+                <settings>
+                    <confirm>
+                        <message translate="true">Are you sure you want to reindex the selected items to Algolia ?</message>
+                        <title translate="true">Reindex items</title>
+                    </confirm>
+                    <url path="algolia_algoliasearch/indexingmanager/reindex"/>
+                    <type>algolia_reindex</type>
+                    <label translate="true">Reindex to Algolia</label>
+                </settings>
+            </action>
+        </massaction>
+    </listingToolbar>
+</listing>

--- a/view/adminhtml/ui_component/product_listing.xml
+++ b/view/adminhtml/ui_component/product_listing.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <settings>
+        <buttons>
+            <button class="Algolia\AlgoliaSearch\Block\Adminhtml\Reindex\ReindexAll\Product" name="algolia_reindex_all" />
+        </buttons>
+    </settings>
     <listingToolbar name="listing_top">
         <massaction name="listing_massaction">
             <action name="algolia_reindex">

--- a/view/adminhtml/ui_component/product_listing.xml
+++ b/view/adminhtml/ui_component/product_listing.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <listingToolbar name="listing_top">
+        <massaction name="listing_massaction">
+            <action name="algolia_reindex">
+                <settings>
+                    <confirm>
+                        <message translate="true">Are you sure you want to reindex the selected items to Algolia ?</message>
+                        <title translate="true">Reindex items</title>
+                    </confirm>
+                    <url path="algolia_algoliasearch/indexingmanager/reindex"/>
+                    <type>algolia_reindex</type>
+                    <label translate="true">Reindex to Algolia</label>
+                </settings>
+            </action>
+        </massaction>
+    </listingToolbar>
+</listing>


### PR DESCRIPTION
This PR contains:

- Added a "Reindex to Algolia" option in the dropdown situated on top of the products and pages grid, which allows the user to select products/pages with the grid checkboxes and perform a reindex for the selected entities
- Added a "Reindex All Items" button on the top of the pages to perform a full reindex for those entities, reusing the `Reindex` controller introduced by the Indexing manager. 
- Introduced the possibility to set a redirect path after the reindexing
- Improved the success messages after a reindex (it now varies depending on if the queue is activated or not and displays the impacted number of entities if it's coming from the grid)