### PR TITLE
MAGE-1228 Add proxies to constructor to defer store ops

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -185,6 +185,13 @@
         </arguments>
     </type>
 
+    <type name="Algolia\AlgoliaSearch\Console\Command\SynonymDeduplicateCommand">
+        <arguments>
+            <argument name="algoliaConnector" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaConnector\Proxy</argument>
+            <argument name="indexOptionsBuilder" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder\Proxy</argument>
+        </arguments>
+    </type>
+
     <virtualType name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger" type="Monolog\Logger">
         <arguments>
             <argument name="name" xsi:type="string">algolia</argument>


### PR DESCRIPTION
**Summary**

This addresses an install issue encountered on Community Edition when installing Algolia via Composer before Magento. It uses proxies to defer the dependency chain that attempts to access store config before it has been defined. 

The error resolved is: "In WebsiteRepository.php line 159:  The default website isn't defined. Set the website and try again."

**Result**

Before fix:

![image](https://github.com/user-attachments/assets/cb64278d-0531-460c-bf45-83b543371bde)

After fix:

![image](https://github.com/user-attachments/assets/fa0b89ff-014b-4a9a-9621-6781ffcb39c9)
