### PR TITLE
MAGE-1247 Backport FPC fix

### DIFF
--- a/Test/Integration/Frontend/Category/CategoryCacheTest.php
+++ b/Test/Integration/Frontend/Category/CategoryCacheTest.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Integration\Frontend\Category;
+
+use Magento\Framework\App\Cache\Manager as CacheManager;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Response\Http as ResponseHttp;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Store\Model\ScopeInterface;
+use Magento\TestFramework\ObjectManager;
+use Magento\TestFramework\TestCase\AbstractController;
+
+class CategoryCacheTest extends AbstractController
+{
+    protected ?CacheManager $cacheManager;
+    protected ?ScopeConfigInterface $config;
+
+    protected static $cacheResets = [];
+
+    public const BASE_CATEGORY_URL = '/catalog/category/view/id/';
+    public const TEST_USER_AGENT = 'Foobot';
+
+    public static function getCategoryProvider(): array
+    {
+        return [
+            ['categoryId' => 20, 'name' => 'Women', 'hasProducts' => false],
+            ['categoryId' => 21, 'name' => 'Women > Tops', 'hasProducts' => true],
+            ['categoryId' => 22, 'name' => 'Women > Bottoms', 'hasProducts' => true],
+            ['categoryId' => 11, 'name' => 'Men', 'hasProducts' => false],
+            ['categoryId' => 12, 'name' => 'Men > Tops', 'hasProducts' => true],
+            ['categoryId' => 13, 'name' => 'Men > Bottoms', 'hasProducts' => true],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cacheManager = $this->_objectManager->get(CacheManager::class);
+        $this->config = $this->_objectManager->get(ScopeConfigInterface::class);
+
+        // Default user agent
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36';
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        self::reindexAll();
+    }
+
+    /** You must index to OpenSearch to get the default backend render  */
+    protected static function reindexAll(): void
+    {
+        $objectManager = ObjectManager::getInstance();
+        $indexerRegistry = $objectManager->get(IndexerRegistry::class);
+
+        $indexerCodes = [
+            'catalog_category_product',
+            'catalog_product_category',
+            'catalog_product_price',
+            'cataloginventory_stock',
+            'catalogsearch_fulltext'
+        ];
+
+        foreach ($indexerCodes as $indexerCode) {
+            $indexerRegistry->get($indexerCode)->reindexAll();
+        }
+    }
+
+    /**
+     * Selectively refresh the FPC cache (must be done at intervals)
+     * Warm the cache via MISS tests but only reset the cache once per MISS test
+     * Due to data provider test methods can be called multiple times
+     */
+    protected function resetCache(string $testMethod): void
+    {
+        if (!in_array($testMethod, self::$cacheResets)) {
+            $this->cacheManager->clean(['full_page']);
+            self::$cacheResets[] = $testMethod;
+        }
+    }
+
+    /**
+     * @dataProvider getCategoryProvider
+     * @depends      testFullPageCacheAvailable
+     * @magentoConfigFixture current_store system/full_page_cache/caching_application 1
+     * @magentoConfigFixture current_store algoliasearch_advanced/advanced/prevent_backend_rendering 0
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/replace_categories 1
+     * @magentoCache full_page enabled
+     */
+    public function testCategoryPlpMissBackendRenderOn(int $categoryId, string $name, bool $hasProducts): void
+    {
+        $this->assertReplaceCategories();
+
+        $this->resetCache(__METHOD__);
+        $this->dispatchCategoryPlpRequest($categoryId);
+        $response = $this->getResponse();
+        $this->assertEquals(200, $response->getHttpResponseCode(), 'Request failed');
+        $this->assertEquals(
+            'MISS',
+            $response->getHeader('X-Magento-Cache-Debug')->getFieldValue(),
+            "expected MISS on category {$name} id {$categoryId}"
+        );
+        $this->assertContains(
+            'FPC',
+            explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue()),
+            "expected FPC tag on category {$name} id {$categoryId}"
+        );
+
+        if ($hasProducts) {
+            $this->assertMatchesRegularExpression('/<div.*class=.*products-grid.*>/', $response->getContent(), 'Backend content was not rendered.');
+        }
+    }
+
+    /**
+     * @dataProvider getCategoryProvider
+     * @depends      testCategoryPlpMissBackendRenderOn
+     * @magentoConfigFixture current_store system/full_page_cache/caching_application 1
+     * @magentoConfigFixture current_store algoliasearch_advanced/advanced/prevent_backend_rendering 0
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/replace_categories 1
+     * @magentoCache full_page enabled
+     */
+    public function testCategoryPlpHitBackendRenderOn(int $categoryId, string $name): void
+    {
+        $this->assertReplaceCategories();
+
+        $this->registerPageHitSpy();
+
+        $this->dispatchCategoryPlpRequest($categoryId);
+        $response = $this->getResponse();
+        $this->assertEquals(200, $response->getHttpResponseCode(), 'Request failed');
+    }
+
+    /**
+     * @dataProvider getCategoryProvider
+     * @depends      testFullPageCacheAvailable
+     * @magentoConfigFixture current_store system/full_page_cache/caching_application 1
+     * @magentoConfigFixture current_store algoliasearch_advanced/advanced/prevent_backend_rendering 1
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/replace_categories 1
+     * @magentoCache full_page enabled
+     */
+    public function testCategoryPlpMissBackendRenderOff(int $categoryId, string $name, bool $hasProducts): void
+    {
+        $this->assertPreventBackend();
+
+        $this->resetCache(__METHOD__);
+        $this->dispatchCategoryPlpRequest($categoryId);
+        $response = $this->getResponse();
+        $this->assertEquals(200, $response->getHttpResponseCode(), 'Request failed');
+        $this->assertEquals(
+            'MISS',
+            $response->getHeader('X-Magento-Cache-Debug')->getFieldValue(),
+            "expected MISS on category {$name} id {$categoryId}"
+        );
+        $this->assertContains(
+            'FPC',
+            explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue()),
+            "expected FPC tag on category {$name} id {$categoryId}"
+        );
+
+        if ($hasProducts) {
+            $this->assertDoesNotMatchRegularExpression('/<div.*class=.*products-grid.*>/', $response->getContent(), 'Backend content was rendered.');
+        }
+    }
+
+    /**
+     * @dataProvider getCategoryProvider
+     * @depends      testCategoryPlpMissBackendRenderOff
+     * @magentoConfigFixture current_store system/full_page_cache/caching_application 1
+     * @magentoConfigFixture current_store algoliasearch_advanced/advanced/prevent_backend_rendering 1
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/replace_categories 1
+     * @magentoCache full_page enabled
+     */
+    public function testCategoryPlpHitBackendRenderOff(int $categoryId, string $name): void
+    {
+        $this->assertPreventBackend();
+
+        $this->registerPageHitSpy();
+
+        $this->dispatchCategoryPlpRequest($categoryId);
+        $response = $this->getResponse();
+
+        $this->assertEquals(200, $response->getHttpResponseCode(), 'Request failed');
+    }
+
+    /**
+     * @dataProvider getCategoryProvider
+     * @depends      testCategoryPlpHitBackendRenderOff
+     * @magentoConfigFixture current_store system/full_page_cache/caching_application 1
+     * @magentoConfigFixture current_store algoliasearch_advanced/advanced/prevent_backend_rendering 1
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/replace_categories 1
+     * @magentoDataFixture Algolia_AlgoliaSearch::Test/Integration/_files/backend_render_user_agents.php
+     * @magentoCache full_page enabled
+     */
+    public function testCategoryPlpMissBackendRenderWhiteList(int $categoryId, string $name, bool $hasProducts): void
+    {
+        $this->assertPreventBackend();
+
+        $this->setupUserAgent();
+
+        $this->dispatchCategoryPlpRequest($categoryId);
+
+        $response = $this->getResponse();
+        $this->assertEquals(200, $response->getHttpResponseCode(), 'Request failed');
+        $this->assertEquals(
+            'MISS',
+            $response->getHeader('X-Magento-Cache-Debug')->getFieldValue(),
+            "expected MISS on category {$name} id {$categoryId}"
+        );
+        $this->assertContains(
+            'FPC',
+            explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue()),
+            "expected FPC tag on category {$name} id {$categoryId}"
+        );
+
+        if ($hasProducts) {
+            $this->assertMatchesRegularExpression('/<div.*class=.*products-grid.*>/', $response->getContent(), 'Backend content was not rendered.');
+        }
+    }
+
+    /**
+     * @dataProvider getCategoryProvider
+     * @depends      testCategoryPlpMissBackendRenderOff
+     * @magentoConfigFixture current_store system/full_page_cache/caching_application 1
+     * @magentoConfigFixture current_store algoliasearch_advanced/advanced/prevent_backend_rendering 1
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/replace_categories 1
+     * @magentoDataFixture Algolia_AlgoliaSearch::Test/Integration/_files/backend_render_user_agents.php
+     * @magentoCache full_page enabled
+     */
+    public function testCategoryPlpHitBackendRenderWhiteList(int $categoryId, string $name): void
+    {
+        $this->assertPreventBackend();
+
+        $this->setupUserAgent();
+
+        $this->registerPageHitSpy();
+
+        $this->dispatchCategoryPlpRequest($categoryId);
+        $response = $this->getResponse();
+        $this->assertEquals(200, $response->getHttpResponseCode(), 'Request failed');
+    }
+
+    public function testFullPageCacheAvailable(): void
+    {
+        $types = $this->cacheManager->getAvailableTypes();
+        $this->assertContains('full_page', $types);
+    }
+
+
+    protected function assertConfig(string $path, string $expected, string $message): void
+    {
+        $this->assertEquals($expected, $this->config->getValue($path, ScopeInterface::SCOPE_STORE), $message);
+    }
+
+    protected function assertReplaceCategories(): void
+    {
+        $this->assertConfig(
+            'algoliasearch_instant/instant/replace_categories',
+            1,
+            "Replace categories must be enabled for this test."
+        );
+    }
+
+    protected function assertPreventBackend(): void
+    {
+        $this->assertConfig(
+            'algoliasearch_advanced/advanced/prevent_backend_rendering',
+            1,
+            "Prevent backend rendering must be enabled for this test."
+        );
+    }
+
+    protected function assertUserAgentAllowed(string $userAgent): void
+    {
+        $this->assertStringContainsString(
+            $userAgent,
+            $this->config->getValue('algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents', ScopeInterface::SCOPE_STORE),
+            "Allowed user agents for backend render must include $userAgent"
+        );
+    }
+
+    protected function setupUserAgent(): void
+    {
+        $testUserAgent = self::TEST_USER_AGENT;
+        $this->assertUserAgentAllowed($testUserAgent);
+        $_SERVER['HTTP_USER_AGENT'] = $testUserAgent;
+    }
+
+    /**
+     * The \Magento\TestFramework\TestCase\AbstractController::dispatch is flawed for this use case as it does not
+     * populate the URI which is used to build the cache key in \Magento\Framework\App\PageCache\Identifier::getValue
+     *
+     * This provides a workaround
+     *
+     * @param string $uri
+     * @return void
+     */
+    protected function dispatchHttpRequest(string $uri): void
+    {
+        $request = $this->_objectManager->get(\Magento\Framework\App\Request\Http::class);
+        $request->setDispatched(false);
+        $request->setUri($uri);
+        $request->setRequestUri($uri);
+        $this->_getBootstrap()->runApp();
+    }
+
+    /**
+     * It is imperative to always use the same URL format between MISS and HIT to ensure
+     * that the cache key is generated consistently
+     * @param int $categoryId
+     * @return string
+     */
+    protected function getCategoryUrl(int $categoryId): string
+    {
+        return self::BASE_CATEGORY_URL . $categoryId;
+    }
+
+    /**
+     * Dispatches a request using a properly formatted URL to ensure consistent cache key creation
+     */
+    protected function dispatchCategoryPlpRequest(int $categoryId): void
+    {
+        $this->dispatchHttpRequest($this->getCategoryUrl($categoryId));
+    }
+
+    /**
+     *  The response object is modified differently by the BuiltinPlugin which prevents anything useful
+     *  being returned by AbstractController::getResponse when a HIT is encountered
+     *
+     *  Therefore we apply a "spy" on the plugin via a mock to ensure that the proper header is added
+     *  when the cache has been warmed (by the first MISS)
+     *
+     * @return void
+     */
+    protected function registerPageHitSpy(): void
+    {
+        $mockedPluginClass = \Magento\PageCache\Model\App\FrontController\BuiltinPlugin::class;
+        $mockedPluginMethod = 'addDebugHeader';
+        $cachePluginMock = $this->getMockBuilder($mockedPluginClass)
+            ->setConstructorArgs([
+                $this->_objectManager->get(\Magento\PageCache\Model\Config::class),
+                $this->_objectManager->get(\Magento\Framework\App\PageCache\Version::class),
+                $this->_objectManager->get(\Magento\Framework\App\PageCache\Kernel::class),
+                $this->_objectManager->get(\Magento\Framework\App\State::class)
+            ])
+            ->onlyMethods([$mockedPluginMethod])
+            ->getMock();
+        $cachePluginMock
+            ->expects($this->once())
+            ->method($mockedPluginMethod)
+            ->with(
+                $this->isInstanceOf(ResponseHttp::class),
+                $this->equalTo("X-Magento-Cache-Debug"),
+                $this->equalTo("HIT"),
+                $this->isType('boolean')
+            )
+            ->willReturnCallback(
+                function (ResponseHttp $response, $name, $value, $replace)
+                use ($mockedPluginClass, $mockedPluginMethod, $cachePluginMock)
+                {
+                    $originalMethod = new \ReflectionMethod($mockedPluginClass, $mockedPluginMethod);
+                    return $originalMethod->invoke($cachePluginMock, $response, $name, $value, $replace);
+                }
+            );
+        $this->_objectManager->addSharedInstance(
+            $cachePluginMock,
+            $mockedPluginClass
+        );
+    }
+
+}

--- a/Test/Integration/_files/backend_render_user_agents.php
+++ b/Test/Integration/_files/backend_render_user_agents.php
@@ -1,0 +1,13 @@
+<?php
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\App\Config\MutableScopeConfigInterface;
+
+$objectManager = Bootstrap::getObjectManager();
+$scopeConfig = $objectManager->get(MutableScopeConfigInterface::class);
+
+// Set complex configuration value
+$scopeConfig->setValue(
+    'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents',
+    join("\n", ["Googlebot", "Bingbot", "Foobot"]),
+    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+);

--- a/Test/Unit/Helper/ConfigHelperTest.php
+++ b/Test/Unit/Helper/ConfigHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Test\Unit;
+namespace Algolia\AlgoliaSearch\Test\Unit\Helper;
 
 use Magento\Cookie\Helper\Cookie as CookieHelper;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;

--- a/Test/Unit/Helper/ConfigHelperTestable.php
+++ b/Test/Unit/Helper/ConfigHelperTestable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Test\Unit;
+namespace Algolia\AlgoliaSearch\Test\Unit\Helper;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 

--- a/Test/Unit/Plugin/RenderingCacheContextPluginTest.php
+++ b/Test/Unit/Plugin/RenderingCacheContextPluginTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Plugin;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Plugin\RenderingCacheContextPlugin;
+use Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Framework\App\Request\Http;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\UrlRewrite\Model\UrlFinderInterface;
+use PHPUnit\Framework\TestCase;
+
+class RenderingCacheContextPluginTest extends TestCase
+{
+    protected ?RenderingCacheContextPlugin $plugin;
+    protected ?ConfigHelper $configHelper;
+    protected ?StoreManagerInterface $storeManager;
+    protected ?Http $request;
+    protected ?UrlFinderInterface $urlFinder;
+
+    protected function setUp(): void
+    {
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->request = $this->createMock(Http::class);
+        $this->urlFinder = $this->createMock(UrlFinderInterface::class);
+
+        $this->plugin = new RenderingCacheContextPluginTestable(
+            $this->configHelper,
+            $this->storeManager,
+            $this->request,
+            $this->urlFinder
+        );
+    }
+
+    protected function getStoreMock(): StoreInterface
+    {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn(1);
+        return $store;
+    }
+
+    public function testAfterGetDataAddsRenderingContextNoBackendRender(): void
+    {
+        $this->configHelper->method('preventBackendRendering')->willReturn(true);
+        $this->storeManager->method('getStore')->willReturn($this->getStoreMock());
+
+        $this->request->method('getControllerName')->willReturn('category');
+        $this->configHelper->method('replaceCategories')->willReturn(true);
+
+        $result = $this->plugin->afterGetData(
+            $this->createMock(HttpContext::class),
+            []
+        );
+
+        $this->assertArrayHasKey(RenderingCacheContextPlugin::RENDERING_CONTEXT, $result);
+        $this->assertEquals(RenderingCacheContextPlugin::RENDERING_WITHOUT_BACKEND, $result[RenderingCacheContextPlugin::RENDERING_CONTEXT]);
+    }
+
+    public function testAfterGetDataAddsRenderingContextWithBackendRender(): void
+    {
+        $subject = $this->createMock(HttpContext::class);
+
+        $this->configHelper->method('preventBackendRendering')->willReturn(false);
+        $this->storeManager->method('getStore')->willReturn($this->getStoreMock());
+
+        $this->request->method('getControllerName')->willReturn('category');
+        $this->configHelper->method('replaceCategories')->willReturn(true);
+
+        $result = $this->plugin->afterGetData(
+            $this->createMock(HttpContext::class),
+            []
+        );
+
+        $this->assertArrayHasKey(RenderingCacheContextPlugin::RENDERING_CONTEXT, $result);
+        $this->assertEquals(RenderingCacheContextPlugin::RENDERING_WITH_BACKEND, $result[RenderingCacheContextPlugin::RENDERING_CONTEXT]);
+    }
+
+    public function testAfterGetDataDoesNotModifyDataIfNotApplicable(): void
+    {
+        $subject = $this->createMock(HttpContext::class);
+
+        $this->configHelper->method('preventBackendRendering')->willReturn(false);
+        $this->storeManager->method('getStore')->willReturn($this->getStoreMock());
+
+        $this->request->method('getControllerName')->willReturn('product');
+        $this->request->method('getRequestUri')->willReturn('some-product.html');
+        $this->configHelper->method('replaceCategories')->willReturn(false);
+
+        $data = ['existing_key' => 'existing_value'];
+        $result = $this->plugin->afterGetData($subject, $data);
+
+        $this->assertEquals($data, $result);
+    }
+
+    public function testIsCategoryRoute(): void
+    {
+        $this->assertTrue($this->plugin->isCategoryRoute('catalog/category/view'));
+        $this->assertFalse($this->plugin->isCategoryRoute('some/other/route'));
+    }
+
+    public function testGetOriginalRoute(): void
+    {
+        $storeId = 1;
+        $requestUri = '/some-path';
+        $targetPath = 'catalog/category/view/id/42';
+
+        $this->request->method('getRequestUri')->willReturn($requestUri);
+
+        $urlRewrite = $this->createMock(\Magento\UrlRewrite\Service\V1\Data\UrlRewrite::class);
+        $urlRewrite->method('getTargetPath')->willReturn($targetPath);
+
+        $this->urlFinder->method('findOneByData')->willReturn($urlRewrite);
+
+        $this->assertEquals($targetPath, $this->plugin->getOriginalRoute($storeId));
+    }
+
+    public function testShouldApplyCacheContext(): void
+    {
+        $this->storeManager->method('getStore')->willReturn($this->getStoreMock());
+
+        $this->request->method('getControllerName')->willReturn('category');
+        $this->configHelper->method('replaceCategories')->willReturn(true);
+
+        $this->assertTrue($this->plugin->shouldApplyCacheContext());
+    }
+}

--- a/Test/Unit/Plugin/RenderingCacheContextPluginTestable.php
+++ b/Test/Unit/Plugin/RenderingCacheContextPluginTestable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Plugin;
+
+use Algolia\AlgoliaSearch\Plugin\RenderingCacheContextPlugin;
+
+class RenderingCacheContextPluginTestable extends RenderingCacheContextPlugin
+{
+    public function isCategoryRoute(...$args): bool
+    {
+        return parent::isCategoryRoute(...$args);
+    }
+
+    public function getOriginalRoute(...$args): string
+    {
+        return parent::getOriginalRoute(...$args);
+    }
+
+    public function shouldApplyCacheContext(...$args): bool
+    {
+        return parent::shouldApplyCacheContext(...$args);
+    }
+}


### PR DESCRIPTION
**Summary**

This backports the FPC fix from 3.15.0 on PR https://github.com/algolia/algoliasearch-magento-2/pull/1712

**Result**

All tests pass on 3.14.5 running on Magento 2.4.7-p3.

Integration tests:
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/3aae19d9-e84c-46a5-a51e-aec31efac271" />

Unit tests:
<img width="1472" alt="image" src="https://github.com/user-attachments/assets/02b4a0c5-c0a0-47f1-9ba8-29271cee3938" />
