### PR TITLE
MAGE-1244: Fix `$affectedProductIds` logic

### DIFF
--- a/Model/Indexer/Category.php
+++ b/Model/Indexer/Category.php
@@ -12,8 +12,6 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class Category implements \Magento\Framework\Indexer\ActionInterface, \Magento\Framework\Mview\ActionInterface
 {
-    public static $affectedProductIds = [];
-
     public function __construct(
         protected StoreManagerInterface $storeManager,
         protected ConfigHelper $configHelper,
@@ -43,9 +41,6 @@ class Category implements \Magento\Framework\Indexer\ActionInterface, \Magento\F
 
     public function executeRow($id)
     {
-        if (count(self::$affectedProductIds)) {
-            $this->categoryBatchQueueProcessor->setAffectedProductIds(self::$affectedProductIds);
-        }
         $this->execute([$id]);
     }
 }

--- a/Model/Indexer/Category.php
+++ b/Model/Indexer/Category.php
@@ -12,6 +12,8 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class Category implements \Magento\Framework\Indexer\ActionInterface, \Magento\Framework\Mview\ActionInterface
 {
+    public static $affectedProductIds = [];
+
     public function __construct(
         protected StoreManagerInterface $storeManager,
         protected ConfigHelper $configHelper,
@@ -41,6 +43,9 @@ class Category implements \Magento\Framework\Indexer\ActionInterface, \Magento\F
 
     public function executeRow($id)
     {
+        if (count(self::$affectedProductIds)) {
+            $this->categoryBatchQueueProcessor->setAffectedProductIds(self::$affectedProductIds);
+        }
         $this->execute([$id]);
     }
 }

--- a/Service/Category/BatchQueueProcessor.php
+++ b/Service/Category/BatchQueueProcessor.php
@@ -11,11 +11,12 @@ use Algolia\AlgoliaSearch\Model\Queue;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Service\Category\IndexBuilder as CategoryIndexBuilder;
 use Algolia\AlgoliaSearch\Service\Product\IndexBuilder as ProductIndexBuilder;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 class BatchQueueProcessor implements BatchQueueProcessorInterface
 {
-    public static $affectedProductIds = [];
+    public $affectedProductIds = [];
 
     public function __construct(
         protected Data $dataHelper,
@@ -29,7 +30,7 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
      * @param int $storeId
      * @param array|null $entityIds
      * @return void
-     * @throws NoSuchEntityException
+     * @throws NoSuchEntityException|LocalizedException
      */
     public function processBatch(int $storeId, ?array $entityIds = null): void
     {
@@ -43,7 +44,9 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
             return;
         }
 
-        $this->rebuildAffectedProducts($storeId);
+        if (count($this->affectedProductIds) > 0) {
+            $this->rebuildAffectedProducts($storeId);
+        }
 
         $categoriesPerPage = $this->configHelper->getNumberOfElementByPage();
 
@@ -59,14 +62,11 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
     /**
      * @param int $storeId
      */
-    protected function rebuildAffectedProducts($storeId)
+    protected function rebuildAffectedProducts(int $storeId): void
     {
-        $affectedProducts = self::$affectedProductIds;
-        $affectedProductsCount = count($affectedProducts);
-
-        if ($affectedProductsCount > 0 && $this->configHelper->indexProductOnCategoryProductsUpdate($storeId)) {
+        if ($this->configHelper->indexProductOnCategoryProductsUpdate($storeId)) {
             $productsPerPage = $this->configHelper->getNumberOfElementByPage();
-            foreach (array_chunk($affectedProducts, $productsPerPage) as $chunk) {
+            foreach (array_chunk($this->affectedProductIds, $productsPerPage) as $chunk) {
                 /** @uses ProductIndexBuilder::buildIndexList() */
                 $this->queue->addToQueue(
                     ProductIndexBuilder::class,
@@ -86,7 +86,7 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
      * @param int $categoriesPerPage
      * @param int $storeId
      */
-    protected function processSpecificCategories($categoryIds, $categoriesPerPage, $storeId)
+    protected function processSpecificCategories(array $categoryIds, int $categoriesPerPage, int $storeId): void
     {
         foreach (array_chunk($categoryIds, $categoriesPerPage) as $chunk) {
             /** @uses CategoryIndexBuilder::buildIndexList */
@@ -106,10 +106,10 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
      * @param int $storeId
      * @param int $categoriesPerPage
      *
-     * @throws Magento\Framework\Exception\LocalizedException
-     * @throws Magento\Framework\Exception\NoSuchEntityException
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
      */
-    protected function processFullReindex($storeId, $categoriesPerPage)
+    protected function processFullReindex(int $storeId, int $categoriesPerPage): void
     {
         /** @uses IndicesConfigurator::saveConfigurationToAlgolia() */
         $this->queue->addToQueue(IndicesConfigurator::class, 'saveConfigurationToAlgolia', ['storeId' => $storeId]);
@@ -137,5 +137,14 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
                 true
             );
         }
+    }
+
+    /**
+     * @param array $affectedProductIds
+     * @return void
+     */
+    public function setAffectedProductIds(array $affectedProductIds): void
+    {
+        $this->affectedProductIds = $affectedProductIds;
     }
 }


### PR DESCRIPTION
This PR contains:
- A fix to the way the Category indexer handles the products reindexing a category contains when the CategoryObserver is triggered (an issue was introduced with the refactoring of the indexers). 

Tests on the Category indexing will be part of an upcoming effort