### PR TITLE
MAGE-1218 Replica management enhancements - data patch fix / tests

### DIFF
--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -31,7 +31,7 @@ interface ReplicaManagerInterface
     /**
      * Delete the replica indices on a store index
      * @param int $storeId
-     * @param bool $unused Defaults to false - if true identifies any straggler indices and deletes those, otherwise deletes the replicas it knows aobut
+     * @param bool $unused Defaults to false - if true identifies any straggler indices and deletes those, otherwise deletes the replicas it knows about
      * @return void
      *
      * @throws LocalizedException

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -470,7 +470,7 @@ class ReplicaManager implements ReplicaManagerInterface
      */
     public function isReplicaSyncEnabled(int $storeId): bool
     {
-        return $this->configHelper->isInstantEnabled($storeId);
+        return $this->configHelper->isInstantEnabled($storeId) && $this->configHelper->isEnabledBackend($storeId);
     }
 
     /**

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -41,6 +41,7 @@ use Magento\Store\Model\StoreManagerInterface;
 class ReplicaManager implements ReplicaManagerInterface
 {
     public const ALGOLIA_SETTINGS_KEY_REPLICAS = 'replicas';
+    public const ALGOLIA_SETTINGS_KEY_PRIMARY = 'primary';
 
     protected const _DEBUG = true;
 
@@ -260,7 +261,7 @@ class ReplicaManager implements ReplicaManagerInterface
         $setReplicasTaskId = $this->algoliaHelper->getLastTaskId();
         $this->algoliaHelper->waitLastTask($indexName, $setReplicasTaskId);
         $this->clearAlgoliaReplicaSettingCache($indexName);
-        $this->deleteIndices($replicasToDelete);
+        $this->deleteReplicas($replicasToDelete);
 
         if (self::_DEBUG) {
             $this->logger->log(
@@ -354,19 +355,72 @@ class ReplicaManager implements ReplicaManagerInterface
     }
 
     /**
-     * @param array $replicasToDelete
-     * @param bool $waitLastTask
+     * Delete replica indices
+     *
+     * @param array $replicasToDelete - which replicas to delete
+     * @param bool $waitLastTask - wait until deleting next replica (default: false)
+     * @param bool $prevalidate - verify replica is not attached to a primary index before attempting to delete (default: false)
      * @return void
      * @throws AlgoliaException
+     * @throws ExceededRetriesException
      */
-    protected function deleteIndices(array $replicasToDelete, bool $waitLastTask = false): void
+    protected function deleteReplicas(array $replicasToDelete, bool $waitLastTask = false, bool $prevalidate = false): void
     {
         foreach ($replicasToDelete as $deletedReplica) {
-            $this->algoliaHelper->deleteIndex($deletedReplica);
+            $this->deleteReplica($deletedReplica, $prevalidate);
             if ($waitLastTask) {
                 $this->algoliaHelper->waitLastTask($deletedReplica);
             }
         }
+    }
+
+    /**
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     */
+    protected function deleteReplica(string $replicaIndexName, bool $precheck = false): void
+    {
+        if ($precheck) {
+            $settings = $this->algoliaHelper->getSettings($replicaIndexName);
+            if (isset($settings[self::ALGOLIA_SETTINGS_KEY_PRIMARY])) {
+                $this->detachReplica($settings[self::ALGOLIA_SETTINGS_KEY_PRIMARY], $replicaIndexName);
+            }
+        }
+
+        $this->algoliaHelper->deleteIndex($replicaIndexName);
+    }
+
+    /**
+     * Detach a single replica from its primary index
+     *
+     * @throws ExceededRetriesException
+     * @throws AlgoliaException
+     */
+    protected function detachReplica(string $primaryIndexName, string $replicaIndexName): void
+    {
+        $settings = $this->algoliaHelper->getSettings($primaryIndexName);
+        if (!isset($settings[self::ALGOLIA_SETTINGS_KEY_REPLICAS])) {
+            return;
+        }
+        $newReplicas = $this->removeReplicaFromReplicaSetting($settings[self::ALGOLIA_SETTINGS_KEY_REPLICAS], $replicaIndexName);
+        $this->algoliaHelper->setSettings($primaryIndexName, [ self::ALGOLIA_SETTINGS_KEY_REPLICAS => $newReplicas]);
+        $this->algoliaHelper->waitLastTask($primaryIndexName);
+    }
+
+    /**
+     * Remove a single replica from the replica setting array
+     * (Can feature virtual or standard)
+     */
+    protected function removeReplicaFromReplicaSetting(array $replicaSetting, string $replicaToRemove): array
+    {
+        return array_filter(
+            $replicaSetting,
+            function ($replicaIndexSetting) use ($replicaToRemove) {
+                $escaped = preg_quote($replicaToRemove);
+                $regex = '/^' . $escaped . '|virtual\(' . $escaped . '\)$/';
+                return !preg_match($regex, $replicaToRemove);
+            }
+        );
     }
 
     /**
@@ -449,7 +503,7 @@ class ReplicaManager implements ReplicaManagerInterface
             $this->clearReplicasSettingInAlgolia($primaryIndexName);
         }
 
-        $this->deleteIndices($replicasToDelete);
+        $this->deleteReplicas($replicasToDelete, true, true);
 
         if ($unused) {
             $this->clearUnusedReplicaIndicesCache($storeId);

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -2,6 +2,8 @@
 
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Registry\ReplicaState;
@@ -9,6 +11,7 @@ use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State as AppState;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
@@ -66,17 +69,37 @@ class RebuildReplicasPatch implements DataPatchInterface
 
         $storeIds = array_keys($this->storeManager->getStores());
         // Delete all replicas before resyncing in case of incorrect replica assignments
-        foreach ($storeIds as $storeId) {
-            $this->replicaManager->deleteReplicasFromAlgolia($storeId);
-        }
 
-        foreach ($storeIds as $storeId) {
-            $this->replicaState->setChangeState(ReplicaState::REPLICA_STATE_CHANGED, $storeId); // avoids latency
-            $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
+        try {
+            foreach ($storeIds as $storeId) {
+                $this->retryDeleteReplica($storeId);
+            }
+
+            foreach ($storeIds as $storeId) {
+                $this->replicaState->setChangeState(ReplicaState::REPLICA_STATE_CHANGED, $storeId); // avoids latency
+                $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
+            }
+        }
+        catch (AlgoliaException $e) {
+            $this->logger->error("Could not rebuild replicas - a full reindex will be required.");
         }
 
         $this->moduleDataSetup->getConnection()->endSetup();
 
         return $this;
+    }
+
+    protected function retryDeleteReplica(int $storeId, int $maxRetries = 3, int $interval = 5)
+    {
+        for ($tries = $maxRetries - 1; $tries >= 0; $tries--) {
+            try {
+                $this->replicaManager->deleteReplicasFromAlgolia($storeId);
+                return;
+            } catch (AlgoliaException $e) {
+                $this->logger->warning(__("Unable to delete replicas, %1 tries remaining: %2", $tries, $e->getMessage()));
+                sleep($interval);
+            }
+        }
+        throw new ExceededRetriesException('Unable to delete old replica indices after $maxRetries retries.');
     }
 }

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -267,4 +267,22 @@ abstract class TestCase extends \TC
     {
         return $this->getObjectManager()->get(\Magento\Framework\Serialize\SerializerInterface::class);
     }
+
+    /**
+     * Run a callback once and only once
+     * @param callable $callback
+     * @param string|null $key - a unique key for this operation - if null a unique key will be derived
+     * @return mixed
+     */
+    function runOnce(callable $callback, string $key = null): mixed
+    {
+        static $executed = [];
+        $key ??= is_string($callback) ? $callback : spl_object_hash((object) $callback);
+        if (!isset($executed[$key])) {
+            $executed[$key] = true;
+            return $callback();
+        }
+
+        return null;
+    }
 }

--- a/Test/Unit/Service/ReplicaManagerTest.php
+++ b/Test/Unit/Service/ReplicaManagerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Logger;
+use Algolia\AlgoliaSearch\Registry\ReplicaState;
+use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
+use Algolia\AlgoliaSearch\Service\Product\SortingTransformer;
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Algolia\AlgoliaSearch\Validator\VirtualReplicaValidatorFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class ReplicaManagerTest extends TestCase
+{
+    protected ?ReplicaManager $replicaManager;
+
+    public function setUp(): void
+    {
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $algoliaHelper = $this->createMock(AlgoliaHelper::class);
+        $replicaState = $this->createMock(ReplicaState::class);
+        $virtualReplicaValidatorFactory = $this->createMock(VirtualReplicaValidatorFactory::class);
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $storeNameFetcher = $this->createMock(StoreNameFetcher::class);
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $logger = $this->createMock(Logger::class);
+
+        $this->replicaManager = new ReplicaManagerTestable(
+            $configHelper,
+            $algoliaHelper,
+            $replicaState,
+            $virtualReplicaValidatorFactory,
+            $indexNameFetcher,
+            $storeNameFetcher,
+            $sortingTransformer,
+            $storeManager,
+            $logger
+        );
+    }
+
+    public function testVirtualReplicaSettingRemove(): void
+    {
+        $replicaSetting = [
+            'virtual(replica1)',
+            'virtual(replica2)',
+            'virtual(replica3)'
+        ];
+        $replicaToRemove = 'replica2';
+
+        $newReplicas = $this->replicaManager->removeReplicaFromReplicaSetting($replicaSetting, $replicaToRemove);
+
+        $this->assertNotContains($replicaToRemove, $newReplicas);
+    }
+
+    public function testStandardReplicaSettingRemove(): void
+    {
+        $replicaSetting = [
+            'replica1',
+            'replica2',
+            'replica3'
+        ];
+        $replicaToRemove = 'replica2';
+
+        $newReplicas = $this->replicaManager->removeReplicaFromReplicaSetting($replicaSetting, $replicaToRemove);
+
+        $this->assertNotContains($replicaToRemove, $newReplicas);
+    }
+}

--- a/Test/Unit/Service/ReplicaManagerTestable.php
+++ b/Test/Unit/Service/ReplicaManagerTestable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
+
+class ReplicaManagerTestable extends ReplicaManager
+{
+    public function removeReplicaFromReplicaSetting(...$params): array
+    {
+        return parent::removeReplicaFromReplicaSetting(...$params);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -185,4 +185,10 @@
         </arguments>
     </type>
 
+    <type name="Algolia\AlgoliaSearch\Console\Command\SynonymDeduplicateCommand">
+        <arguments>
+            <argument name="algoliaHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\AlgoliaHelper\Proxy</argument>
+            <argument name="indexNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\IndexNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
**Summary**

The PR aims to add robustness to handling replica operations when the API behaves unexpectedly. 

- Added replica specific delete method to `ReplicaManager` with an optional pre-validation step to ensure indices are not still in an attached state before attempting deletion
- Enforced additional pre validation for data patch calls to delete operations
- Refactored patch to be non blocking to CI/CD
- Added a retry mechanism to the data patch to address potential latency and/or accuracy issues with underlying PHP API client `waitForTask` operations
- Revised enablement logic to take into account stores without backend render active but still using InstantSearch 
- Added unit tests to ReplicaManager
- Added new and refactored existing integration tests for applying data patches for replicas and verifying edge cases
- Implemented mock `ReplicaManager` objects for simulating failed operations 
- Added DI proxies to address occasional integration test setup failures

**Result**

Integration test results:
<img width="1473" alt="image" src="https://github.com/user-attachments/assets/a042ddf0-892f-4e65-95ff-5231b2bd8aaa" />

Unit test results:
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/78448294-fe43-4b14-b769-72487c91e341" />
