### PR TITLE
MAGE-1222 scoped currency codes

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1190,15 +1190,30 @@ class ConfigHelper
     }
 
     /**
-     * @param $storeId
-     * @return string
      * @throws Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getCurrencyCode($storeId = null)
+    public function getCurrencyCode(int $storeId = null): string
     {
         /** @var Magento\Store\Model\Store $store */
         $store = $this->storeManager->getStore($storeId);
         return $store->getCurrentCurrencyCode();
+    }
+
+    /**
+     * Obtain the store scoped currency configuration or fall back to all allowed currencies
+     * @return array
+     */
+    public function getAllowedCurrencies(?int $storeId = null): array
+    {
+        $configured = explode(
+            ',',
+            $this->configInterface->getValue(
+                DirCurrency::XML_PATH_CURRENCY_ALLOW,
+                ScopeInterface::SCOPE_STORE,
+                $storeId
+            ) ?? ''
+        );
+        return $configured ?: $this->dirCurrency->getConfigAllowCurrencies();
     }
 
     /**
@@ -1483,6 +1498,8 @@ class ConfigHelper
     }
 
     /**
+     * NOTE: This method is currently only used in integration tests and was removed from the general implementation
+     * TODO: Evaluate use cases with product permissions where we may need to restore this functionality
      * @param $groupId
      * @return array
      */

--- a/Service/Product/FacetBuilder.php
+++ b/Service/Product/FacetBuilder.php
@@ -5,7 +5,6 @@ namespace Algolia\AlgoliaSearch\Service\Product;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
-use Magento\Directory\Model\Currency as CurrencyHelper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
@@ -29,7 +28,6 @@ class FacetBuilder
     public function __construct(
         protected ConfigHelper                            $configHelper,
         protected StoreManagerInterface                   $storeManager,
-        protected CurrencyHelper                          $currencyManager,
         protected GroupCollection                         $groupCollection,
         protected GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository,
     )
@@ -196,7 +194,7 @@ class FacetBuilder
     protected function getPricingAttributes(int $storeId): array
     {
         $pricingAttributes = [];
-        $currencies = $this->currencyManager->getConfigAllowCurrencies();
+        $currencies = $this->configHelper->getAllowedCurrencies($storeId);
         foreach ($currencies as $currencyCode) {
             $pricingAttributes[] = self::FACET_ATTRIBUTE_PRICE . '.' . $currencyCode . '.default';
             $pricingAttributes = array_merge($pricingAttributes, $this->getGroupPricingAttributes($storeId, $currencyCode));

--- a/Test/Unit/Service/Product/FacetBuilderTest.php
+++ b/Test/Unit/Service/Product/FacetBuilderTest.php
@@ -9,7 +9,6 @@ use Algolia\AlgoliaSearch\Model\QuerySuggestions\Facet;
 use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
-use Magento\Directory\Model\Currency as CurrencyHelper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
@@ -20,7 +19,6 @@ class FacetBuilderTest extends TestCase
     protected FacetBuilder $facetBuilder;
     protected ConfigHelper $configHelper;
     protected StoreManagerInterface $storeManager;
-    protected CurrencyHelper $currencyManager;
     protected GroupCollection $groupCollection;
     protected GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository;
 
@@ -28,14 +26,12 @@ class FacetBuilderTest extends TestCase
     {
         $this->configHelper = $this->createMock(ConfigHelper::class);
         $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->currencyManager = $this->createMock(CurrencyHelper::class);
         $this->groupCollection = $this->createMock(GroupCollection::class);
         $this->groupExcludedWebsiteRepository = $this->createMock(GroupExcludedWebsiteRepositoryInterface::class);
 
         $this->facetBuilder = new FacetBuilderTestable(
             $this->configHelper,
             $this->storeManager,
-            $this->currencyManager,
             $this->groupCollection,
             $this->groupExcludedWebsiteRepository
         );
@@ -54,8 +50,8 @@ class FacetBuilderTest extends TestCase
 
     protected function mockStoreConfig($storeId, $websiteId): void
     {
-        $this->currencyManager
-            ->method('getConfigAllowCurrencies')
+        $this->configHelper
+            ->method('getAllowedCurrencies')
             ->willReturn(['EUR', 'USD']);
 
         $storeMock = $this->createMock(\Magento\Store\Api\Data\StoreInterface::class);

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.15.0",
+  "version": "3.16.0-dev",
   "require": {
     "php": "~8.1|~8.2|~8.3",
     "magento/framework": "~103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.15.0">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.16.0-dev">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
**Summary**

This PR adds scoped currency codes to the facet build operations. Previously we were relying on `Magento\Directory\Model\Currency::getConfigAllowCurrencies` which retrieves all currencies regardless of scope which unnecessarily inflates the facet configuration. 

**Result**

Before fix:
![image](https://github.com/user-attachments/assets/04d489ba-882f-47d3-9a2f-7b3a9307006c)

After fix:
![image](https://github.com/user-attachments/assets/35889c29-44dc-46d7-ad71-fa5ca53549bb)

Facet config shows only two currencies:
![image](https://github.com/user-attachments/assets/9143bea6-1a91-4c86-a9cc-9de6a8006a94)

Unit test results:
![image](https://github.com/user-attachments/assets/557b8052-b0ba-4da7-9b72-a6fea63bee99)
