### PR TITLE
MAGE-1226: Update indexing integration tests

### DIFF
--- a/Test/Integration/Indexing/Category/CategoriesIndexingTest.php
+++ b/Test/Integration/Indexing/Category/CategoriesIndexingTest.php
@@ -2,16 +2,19 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Category;
 
-use Algolia\AlgoliaSearch\Model\Indexer\Category;
+use Algolia\AlgoliaSearch\Service\Category\BatchQueueProcessor as CategoryBatchQueueProcessor;
 use Algolia\AlgoliaSearch\Test\Integration\Indexing\IndexingTestCase;
 
 class CategoriesIndexingTest extends IndexingTestCase
 {
     public function testCategories()
     {
-        /** @var Category $categoriesIndexer */
-        $categoriesIndexer = $this->getObjectManager()->create(Category::class);
-        $this->processTest($categoriesIndexer, 'categories', $this->assertValues->expectedCategory);
+        $categoryBatchQueueProcessor = $this->objectManager->get(CategoryBatchQueueProcessor::class);
+        $this->processTest(
+            $categoryBatchQueueProcessor,
+            'categories',
+            $this->assertValues->expectedCategory
+        );
     }
 
     public function testDefaultIndexableAttributes()
@@ -21,10 +24,8 @@ class CategoriesIndexingTest extends IndexingTestCase
             $this->getSerializer()->serialize([])
         );
 
-        /** @var Category $categoriesIndexer */
-        $categoriesIndexer = $this->getObjectManager()->create(Category::class);
-        $categoriesIndexer->executeRow(3);
-
+        $categoryBatchQueueProcessor = $this->objectManager->get(CategoryBatchQueueProcessor::class);
+        $categoryBatchQueueProcessor->processBatch(1, [3]);
         $this->algoliaHelper->waitLastTask();
 
         $results = $this->algoliaHelper->getObjects($this->indexPrefix . 'default_categories', ['3']);

--- a/Test/Integration/Indexing/Category/MultiStoreCategoriesTest.php
+++ b/Test/Integration/Indexing/Category/MultiStoreCategoriesTest.php
@@ -40,16 +40,7 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
         $this->categoryCollectionFactory = $this->objectManager->get(CollectionFactory::class);
 
         $this->categoryBatchQueueProcessor = $this->objectManager->get(CategoryBatchQueueProcessor::class);
-        $this->reindexToAllStores();
-    }
-
-    protected function reindexToAllStores(array $categoryIds = null): void
-    {
-        // @todo factorize with BatchQueueProcessorInterface (see processTest)
-        foreach (array_keys($this->storeManager->getStores()) as $storeId) {
-            $this->categoryBatchQueueProcessor->processBatch($storeId, $categoryIds);
-            $this->algoliaHelper->waitLastTask($storeId);
-        }
+        $this->reindexToAllStores($this->categoryBatchQueueProcessor);
     }
 
     /**
@@ -87,7 +78,7 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
         $this->assertEquals(self::BAGS_CATEGORY_NAME, $bagsCategory->getName());
         $this->assertEquals(self::BAGS_CATEGORY_NAME_ALT, $bagsCategoryAlt->getName());
 
-        $this->reindexToAllStores([self::BAGS_CATEGORY_ID]);
+        $this->reindexToAllStores($this->categoryBatchQueueProcessor, [self::BAGS_CATEGORY_ID]);
 
         $this->assertAlgoliaRecordValues(
             $this->indexPrefix . 'default_categories',
@@ -110,7 +101,7 @@ class MultiStoreCategoriesTest extends MultiStoreTestCase
             ['is_active' => 0]
         );
 
-        $this->reindexToAllStores([self::BAGS_CATEGORY_ID]);
+        $this->reindexToAllStores($this->categoryBatchQueueProcessor, [self::BAGS_CATEGORY_ID]);
 
         $this->assertNbOfRecordsPerStore(
             $defaultStore->getCode(),

--- a/Test/Integration/Indexing/Config/ConfigTest.php
+++ b/Test/Integration/Indexing/Config/ConfigTest.php
@@ -58,64 +58,7 @@ class ConfigTest extends TestCase
 
     public function testAutomaticalSetOfCategoriesFacet()
     {
-        /** @var IndicesConfigurator $indicesConfigurator */
-        $indicesConfigurator = $this->getObjectManager()->create(IndicesConfigurator::class);
-
-        // Remove categories from facets
-        $facets = $this->configHelper->getFacets();
-        foreach ($facets as $key => $facet) {
-            if ($facet['attribute'] === 'categories') {
-                unset($facets[$key]);
-
-                break;
-            }
-        }
-
-        $this->setConfig('algoliasearch_instant/instant_facets/facets', $this->getSerializer()->serialize($facets));
-
-        // Set don't replace category pages with Algolia - categories attribute shouldn't be included in facets
-        $this->setConfig('algoliasearch_instant/instant/replace_categories', '0');
-
-        $indicesConfigurator->saveConfigurationToAlgolia(1);
-
-        $this->algoliaHelper->waitLastTask();
-
-        $indexSettings = $this->algoliaHelper->getSettings($this->indexPrefix . 'default_products');
-
-        $this->assertEquals($this->assertValues->automaticalSetOfCategoryAttributesForFaceting, count($indexSettings['attributesForFaceting']));
-
-        $categoriesAttributeIsIncluded = false;
-        foreach ($indexSettings['attributesForFaceting'] as $attribute) {
-            if ($attribute === 'categories') {
-                $categoriesAttributeIsIncluded = true;
-
-                break;
-            }
-        }
-
-        $this->assertFalse($categoriesAttributeIsIncluded, 'Categories attribute should not be included in facets, but it is');
-
-        // Set replace category pages with Algolia - categories attribute should be included in facets
-        $this->setConfig('algoliasearch_instant/instant/replace_categories', '1');
-
-        $indicesConfigurator->saveConfigurationToAlgolia(1);
-
-        $this->algoliaHelper->waitLastTask();
-
-        $indexSettings = $this->algoliaHelper->getSettings($this->indexPrefix . 'default_products');
-
-        $this->assertEquals($this->assertValues->automaticalSetOfCategoryAttributesForFaceting + 1, count($indexSettings['attributesForFaceting']));
-
-        $categoriesAttributeIsIncluded = false;
-        foreach ($indexSettings['attributesForFaceting'] as $attribute) {
-            if ($attribute === 'categories') {
-                $categoriesAttributeIsIncluded = true;
-
-                break;
-            }
-        }
-
-        $this->assertTrue($categoriesAttributeIsIncluded, 'Categories attribute should be included in facets, but it is not');
+        // Removed test, the addition/deletion of the "categories" attribute is now checked by the FacetBuilder unit test
     }
 
     public function testRetrievableAttributes()

--- a/Test/Integration/Indexing/IndexingTestCase.php
+++ b/Test/Integration/Indexing/IndexingTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing;
 
+use Algolia\AlgoliaSearch\Api\Processor\BatchQueueProcessorInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Test\Integration\TestCase;
 use Magento\Framework\Indexer\ActionInterface;
@@ -15,11 +16,14 @@ abstract class IndexingTestCase extends TestCase
         $this->setConfig('algoliasearch_queue/queue/active', '0');
     }
 
-    protected function processTest(ActionInterface $indexer, $indexSuffix, $expectedNbHits)
-    {
+    protected function processTest(
+        BatchQueueProcessorInterface $batchQueueProcessor,
+        $indexSuffix,
+        $expectedNbHits
+    ) {
         $this->algoliaHelper->clearIndex($this->indexPrefix . 'default_' . $indexSuffix);
 
-        $indexer->executeFull();
+        $batchQueueProcessor->processBatch(1);
 
         $this->algoliaHelper->waitLastTask();
 

--- a/Test/Integration/Indexing/IndexingTestCase.php
+++ b/Test/Integration/Indexing/IndexingTestCase.php
@@ -5,7 +5,6 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Indexing;
 use Algolia\AlgoliaSearch\Api\Processor\BatchQueueProcessorInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Test\Integration\TestCase;
-use Magento\Framework\Indexer\ActionInterface;
 
 abstract class IndexingTestCase extends TestCase
 {

--- a/Test/Integration/Indexing/MultiStoreTestCase.php
+++ b/Test/Integration/Indexing/MultiStoreTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing;
 
+use Algolia\AlgoliaSearch\Api\Processor\BatchQueueProcessorInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
@@ -38,6 +39,17 @@ abstract class MultiStoreTestCase extends IndexingTestCase
 
         foreach ($this->storeManager->getStores() as $store) {
             $this->setupStore($store);
+        }
+    }
+
+    protected function reindexToAllStores(
+        BatchQueueProcessorInterface $batchQueueProcessor,
+        array $categoryIds = null
+    ): void
+    {
+        foreach (array_keys($this->storeManager->getStores()) as $storeId) {
+            $batchQueueProcessor->processBatch($storeId, $categoryIds);
+            $this->algoliaHelper->waitLastTask($storeId);
         }
     }
 

--- a/Test/Integration/Indexing/Page/PagesIndexingTest.php
+++ b/Test/Integration/Indexing/Page/PagesIndexingTest.php
@@ -3,7 +3,7 @@
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Page;
 
 use Algolia\AlgoliaSearch\Helper\Entity\PageHelper;
-use Algolia\AlgoliaSearch\Model\Indexer\Page;
+use Algolia\AlgoliaSearch\Service\Page\BatchQueueProcessor as PageBatchQueueProcessor;
 use Algolia\AlgoliaSearch\Test\Integration\Indexing\IndexingTestCase;
 use Magento\Cms\Model\PageFactory;
 
@@ -16,10 +16,8 @@ class PagesIndexingTest extends IndexingTestCase
             $this->getSerializer()->serialize([])
         );
 
-        /** @var Page $indexer */
-        $indexer = $this->getObjectManager()->create(Page::class);
-
-        $this->processTest($indexer, 'pages', $this->assertValues->expectedPages);
+        $pageBatchQueueProcessor = $this->objectManager->get(PageBatchQueueProcessor::class);
+        $this->processTest($pageBatchQueueProcessor, 'pages', $this->assertValues->expectedPages);
     }
 
     public function testExcludedPages()
@@ -33,9 +31,8 @@ class PagesIndexingTest extends IndexingTestCase
             $this->getSerializer()->serialize($excludedPages)
         );
 
-        /** @var Page $indexer */
-        $indexer = $this->getObjectManager()->create(Page::class);
-        $this->processTest($indexer, 'pages', $this->assertValues->expectedExcludePages);
+        $pageBatchQueueProcessor = $this->objectManager->get(PageBatchQueueProcessor::class);
+        $this->processTest($pageBatchQueueProcessor, 'pages', $this->assertValues->expectedExcludePages);
 
         $response = $this->algoliaHelper->query($this->indexPrefix . 'default_pages', '', []);
         $hits = reset($response['results'])['hits'];
@@ -61,10 +58,8 @@ class PagesIndexingTest extends IndexingTestCase
 
     public function testDefaultIndexableAttributes()
     {
-        /** @var Page $indexer */
-        $indexer = $this->getObjectManager()->create(Page::class);
-        $indexer->executeFull();
-
+        $pageBatchQueueProcessor = $this->objectManager->get(PageBatchQueueProcessor::class);
+        $pageBatchQueueProcessor->processBatch(1);
         $this->algoliaHelper->waitLastTask();
 
         $response = $this->algoliaHelper->query($this->indexPrefix . 'default_pages', '', ['hitsPerPage' => 1]);

--- a/Test/Integration/Indexing/Product/PricingTest.php
+++ b/Test/Integration/Indexing/Product/PricingTest.php
@@ -54,7 +54,7 @@ class PricingTest extends ProductsIndexingTestCase
         if (!is_array($productIds)) {
             $productIds = [$productIds];
         }
-        $this->productIndexer->execute($productIds);
+        $this->productBatchQueueProcessor->processBatch(1, $productIds);
         $this->algoliaHelper->waitLastTask();
     }
 
@@ -141,7 +141,7 @@ class PricingTest extends ProductsIndexingTestCase
 
     public function testSpecialPrice(): void
     {
-        $this->productIndexer->execute([self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
+        $this->productBatchQueueProcessor->processBatch(1, [self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
         $this->algoliaHelper->waitLastTask();
 
         $res = $this->algoliaHelper->getObjects(
@@ -175,7 +175,7 @@ class PricingTest extends ProductsIndexingTestCase
         ]);
         $product->save();
 
-        $this->productIndexer->execute([self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
+        $this->productBatchQueueProcessor->processBatch(1, [self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
         $this->algoliaHelper->waitLastTask();
 
         $res = $this->algoliaHelper->getObjects(

--- a/Test/Integration/Indexing/Product/ProductsIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ProductsIndexingTest.php
@@ -19,8 +19,6 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
     /*** @var IndexerRegistry */
     protected $indexerRegistry;
 
-    protected $productPriceIndexer;
-
     protected $testProductId;
 
     const OUT_OF_STOCK_PRODUCT_SKU = '24-MB01';
@@ -31,7 +29,7 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
 
         $this->updateStockItem(self::OUT_OF_STOCK_PRODUCT_SKU, false);
 
-        $this->processTest($this->productIndexer, 'products', $this->assertValues->productsOnStockCount);
+        $this->processTest($this->productBatchQueueProcessor, 'products', $this->assertValues->productsOnStockCount);
     }
 
     public function testIncludingOutOfStock()
@@ -40,7 +38,7 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
 
         $this->updateStockItem(self::OUT_OF_STOCK_PRODUCT_SKU, false);
 
-        $this->processTest($this->productIndexer, 'products', $this->assertValues->productsOutOfStockCount);
+        $this->processTest($this->productBatchQueueProcessor, 'products', $this->assertValues->productsOutOfStockCount);
     }
 
     public function testDefaultIndexableAttributes()
@@ -52,7 +50,7 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
         $this->setConfig(ConfigHelper::SORTING_INDICES, $empty);
         $this->setConfig(ConfigHelper::PRODUCT_CUSTOM_RANKING, $empty);
 
-        $this->productIndexer->executeRow($this->getValidTestProduct());
+        $this->productBatchQueueProcessor->processBatch(1, [$this->getValidTestProduct()]);
         $this->algoliaHelper->waitLastTask();
 
         $results = $this->algoliaHelper->getObjects($this->indexPrefix . 'default_products', [$this->getValidTestProduct()]);

--- a/Test/Integration/Indexing/Product/ProductsIndexingTestCase.php
+++ b/Test/Integration/Indexing/Product/ProductsIndexingTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Product;
 
-use Algolia\AlgoliaSearch\Model\Indexer\Product as ProductIndexer;
+use Algolia\AlgoliaSearch\Service\Product\BatchQueueProcessor as ProductBatchQueueProcessor;
 use Algolia\AlgoliaSearch\Test\Integration\Indexing\IndexingTestCase;
 use Magento\CatalogInventory\Model\StockRegistry;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -12,13 +12,13 @@ class ProductsIndexingTestCase extends IndexingTestCase
 {
 
     protected ?StockRegistry $stockRegistry = null;
-    protected ?ProductIndexer $productIndexer = null;
+    protected ?ProductBatchQueueProcessor $productBatchQueueProcessor = null;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->productIndexer = $this->objectManager->get(ProductIndexer::class);
+        $this->productBatchQueueProcessor = $this->objectManager->get(ProductBatchQueueProcessor::class);
         $this->stockRegistry = $this->objectManager->get(StockRegistry::class);
 
         $this->objectManager

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -201,6 +201,57 @@
         </arguments>
     </type>
 
+    <!-- custom indexers -->
+    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\IndexProductsCommand">
+        <arguments>
+            <argument name="productBatchQueueProcessor" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\BatchQueueProcessor\Proxy</argument>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\IndexCategoriesCommand">
+        <arguments>
+            <argument name="categoryBatchQueueProcessor" xsi:type="object">Algolia\AlgoliaSearch\Service\Category\BatchQueueProcessor\Proxy</argument>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\IndexPagesCommand">
+        <arguments>
+            <argument name="pageBatchQueueProcessor" xsi:type="object">Algolia\AlgoliaSearch\Service\Page\BatchQueueProcessor\Proxy</argument>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\IndexSuggestionsCommand">
+        <arguments>
+            <argument name="suggestionBatchQueueProcessor" xsi:type="object">Algolia\AlgoliaSearch\Service\Suggestion\BatchQueueProcessor\Proxy</argument>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\IndexAdditionalSectionsCommand">
+        <arguments>
+            <argument name="additionalSectionBatchQueueProcessorr" xsi:type="object">Algolia\AlgoliaSearch\Service\AdditionalSection\BatchQueueProcessor\Proxy</argument>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\DeleteProductsCommand">
+        <arguments>
+            <argument name="productBatchQueueProcessor" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\BatchQueueProcessor\Proxy</argument>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\ProcessQueueCommand">
+        <arguments>
+            <argument name="configHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\ConfigHelper\Proxy</argument>
+            <argument name="queue" xsi:type="object">Algolia\AlgoliaSearch\Model\Queue\Proxy</argument>
+            <argument name="algoliaCredentialsManager" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\IndexAllCommand">
+        <arguments>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
+    <!-- custom indexers END -->
+
     <virtualType name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger" type="Monolog\Logger">
         <arguments>
             <argument name="name" xsi:type="string">algolia</argument>


### PR DESCRIPTION
This PR contains:

- Added Proxy declaration in di.xml to avoid installation issue and provide ability to run the integration tests.
- Update all indexing integration tests so they use the introduced `BatchQueueProcessor` classes instead of the legacy indexers..
- Removed a test in the `ConfigTest` class which was testing the handling of the `categories` attribute. The newly created `FacetBuilder` class has now an applicative cache which can't be flushed, so changing the facets "on the fly" cannot be tested as before and resulted as an error. This could be removed because the `categories` attribute handling tests are now located in the `FacetBuilderTest` unit test. 
- All integration tests located in the `Test/Integration/Indexing` folder are now passing:
![image](https://github.com/user-attachments/assets/f50c2f17-6674-4cc6-ae67-95c317264875)
