### PR TITLE
MAGE-1228 Fix error on invalid creds when using manual SKU indexer

### DIFF
--- a/Controller/Adminhtml/Reindex/Save.php
+++ b/Controller/Adminhtml/Reindex/Save.php
@@ -100,6 +100,15 @@ class Save extends \Magento\Backend\App\Action
                         [$e->getProduct()->getName(), $e->getProduct()->getSku()]
                     )
                 );
+            } catch (\Exception $e) {
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __(
+                        'Unable to index product(s) due to the following error: %1',
+                        $e->getMessage()
+                    )
+                );
+                break;
             }
         }
 


### PR DESCRIPTION
**Summary**
 Fix for ugly error when creds aren't confgured.

**Result**
Before:
![2025-04-07_15-11-22](https://github.com/user-attachments/assets/e2ed613f-59e5-4b82-8a5a-2daa983fbd7b)
After:
![image](https://github.com/user-attachments/assets/774ea382-97ef-40fa-a95c-d2b9790c0e8e)
![image](https://github.com/user-attachments/assets/d1d96b55-3312-4e86-97ec-3d32038b2f46)
