### PR TITLE
MAGE-1228 Fix error on invalid creds when using manual SKU indexer (3.14.x) 

### DIFF
--- a/Controller/Adminhtml/Reindex/Save.php
+++ b/Controller/Adminhtml/Reindex/Save.php
@@ -120,6 +120,15 @@ class Save extends \Magento\Backend\App\Action
                         [$e->getProduct()->getName(), $e->getProduct()->getSku()]
                     )
                 );
+            } catch (\Exception $e) {
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __(
+                        'Unable to index product(s) due to the following error: %1',
+                        $e->getMessage()
+                    )
+                );
+                break;
             }
         }
 


### PR DESCRIPTION
Backport fix from https://github.com/algolia/algoliasearch-magento-2/pull/1722 for v3.14.x. 