### PR TITLE
MAGE-1228: updated changelog + pin PHP client version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fixed a bug where categories highlighting didn't work as expected on PLP powered by InstantSearch
 - Fixed a bug where excluded websites weren't taken into account while indexing customer prices on products. (thanks @kamilszewczyk)
 - Fixed a bug where full page cache (FPC) didn't work on category pages
+- Fixed a bug where credentials errors weren't gracefully handled on the SKU reindexing form
 
 ### Breaking Changes
 - If you have customized your front end implementation based on the `algoliaBundle` you may need to shim your application accordingly (Full details are shared in [our documentation](https://www.algolia.com/doc/integration/magento-2/troubleshooting/front-end-issues/))

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": "~8.1|~8.2|~8.3",
     "magento/framework": "~103.0",
-    "algolia/algoliasearch-client-php": "^4.0",
+    "algolia/algoliasearch-client-php": "4.18.3",
     "guzzlehttp/guzzle": "^6.3.3|^7.3.0",
     "ext-json": "*",
     "ext-PDO": "*",


### PR DESCRIPTION
This PR contains:
- updated changelog with the latest fix
- pinned PHP Client version to 4.18.3