### PR TITLE
MAGE-1259 Remove InstantSearch enablement dependency in Magento admin

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -362,9 +362,6 @@
                             DOM selector of block in which the search results page will be displayed using JavaScript.
                         ]]>
                     </comment>
-                    <depends>
-                        <field id="is_instant_enabled">1</field>
-                    </depends>
                 </field>
                 <field id="number_product_results" translate="label comment" type="text" sortOrder="5" showInDefault="1"
                        showInWebsite="1" showInStore="1">
@@ -375,9 +372,6 @@
                             The number of products displayed on the InstantSearch results page. Default value is 9.
                         ]]>
                     </comment>
-                    <depends>
-                        <field id="is_instant_enabled">1</field>
-                    </depends>
                 </field>
                 <field id="replace_categories" translate="label comment" type="select" sortOrder="40" showInDefault="1"
                        showInWebsite="1" showInStore="1">
@@ -388,9 +382,6 @@
                             Do you want to replace default Magento category pages (PLPs) with the InstantSearch results page?
                         ]]>
                     </comment>
-                    <depends>
-                        <field id="is_instant_enabled">1</field>
-                    </depends>
                 </field>
             </group>
             <group id="instant_facets" translate="label" type="text" sortOrder="10" showInDefault="1"
@@ -453,13 +444,7 @@
 
                         ]]>
                     </comment>
-                    <depends>
-                        <field id="is_instant_enabled">1</field>
-                    </depends>
                 </field>
-                <depends>
-                    <field id="algoliasearch_instant/instant/is_instant_enabled">1</field>
-                </depends>
             </group>
             <group id="instant_sorts" translate="label" type="text" sortOrder="10" showInDefault="1"
                    showInWebsite="1" showInStore="1">
@@ -483,9 +468,6 @@
                         ]]>
                     </comment>
                 </field>
-                <depends>
-                    <field id="algoliasearch_instant/instant/is_instant_enabled">1</field>
-                </depends>
             </group>
             <group id="instant_options" translate="label" type="text" sortOrder="10" showInDefault="1"
                    showInWebsite="1" showInStore="1">
@@ -540,9 +522,6 @@
                         ]]>
                     </comment>
                 </field>
-                <depends>
-                    <field id="algoliasearch_instant/instant/is_instant_enabled">1</field>
-                </depends>
             </group>
         </section>
         <section id="algoliasearch_products" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
**Summary**

In version 3.14, in an effort to enhance UX and make configuration impact clearer, we introduced Magento admin config dependencies on InstantSearch elements such as "Faceting" and "Sorting". A side effect of this change is the way Magento handles hidden elements that use the backend model: `\Magento\Config\Model\Config\Backend\Serialized`. If InstantSearch is disabled, complex configuration like Faceting and Sorting will be lost. This may be undesirable behavior when experimenting with Algolia admin configurations. For this reason we are removing all dependencies on `algoliasearch_instant/instant/is_instant_enabled` in version 3.16. 

**Result**
<img width="1379" alt="2025-04-15_11-05-44" src="https://github.com/user-attachments/assets/8b6e21f8-7387-4034-962d-892c84360afb" />

