### PR TITLE
Add tax_class_id to mandatory attribute + extension point

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -33,7 +33,18 @@ use Magento\Store\Model\StoreManagerInterface;
 class ProductHelper extends AbstractEntityHelper
 {
     use EntityHelperTrait;
+
     public const INDEX_NAME_SUFFIX = '_products';
+
+    protected const MANDATORY_ATTRIBTES = [
+        'special_price',
+        'special_from_date',
+        'special_to_date',
+        'visibility',
+        'status',
+        'tax_class_id',
+    ];
+
     /**
      * @var AbstractType[]
      */
@@ -90,8 +101,10 @@ class ProductHelper extends AbstractEntityHelper
         protected ReplicaManagerInterface                 $replicaManager,
         protected ProductInterfaceFactory                 $productFactory,
         protected ProductRecordBuilder                    $productRecordBuilder,
+        protected array                                   $mandatoryAttributes = [],
     )
     {
+        $this->mandatoryAttributes = array_merge(self::MANDATORY_ATTRIBTES, $mandatoryAttributes);
         parent::__construct($indexNameFetcher);
     }
 
@@ -256,12 +269,7 @@ class ProductHelper extends AbstractEntityHelper
      */
     protected function addMandatoryAttributes(ProductCollection $products): void
     {
-        $products->addFinalPrice()
-            ->addAttributeToSelect('special_price')
-            ->addAttributeToSelect('special_from_date')
-            ->addAttributeToSelect('special_to_date')
-            ->addAttributeToSelect('visibility')
-            ->addAttributeToSelect('status');
+        $products->addFinalPrice()->addAttributeToSelect($this->mandatoryAttributes);
     }
 
     /**
@@ -286,6 +294,8 @@ class ProductHelper extends AbstractEntityHelper
         $customRanking = $this->getCustomRanking($storeId);
         $unretrievableAttributes = $this->getUnretrieveableAttributes($storeId);
         $attributesForFaceting = $this->getAttributesForFaceting($storeId);
+        $attributesForFaceting[] = 'searchable(categories.level0)';
+        $attributesForFaceting[] = 'searchable(categories)';
 
         $indexSettings = [
             'searchableAttributes'    => $searchableAttributes,

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -36,7 +36,7 @@ class ProductHelper extends AbstractEntityHelper
 
     public const INDEX_NAME_SUFFIX = '_products';
 
-    protected const MANDATORY_ATTRIBTES = [
+    protected const MANDATORY_ATTRIBUTES = [
         'special_price',
         'special_from_date',
         'special_to_date',
@@ -104,7 +104,7 @@ class ProductHelper extends AbstractEntityHelper
         protected array                                   $mandatoryAttributes = [],
     )
     {
-        $this->mandatoryAttributes = array_merge(self::MANDATORY_ATTRIBTES, $mandatoryAttributes);
+        $this->mandatoryAttributes = array_merge(self::MANDATORY_ATTRIBUTES, $mandatoryAttributes);
         parent::__construct($indexNameFetcher);
     }
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -294,8 +294,6 @@ class ProductHelper extends AbstractEntityHelper
         $customRanking = $this->getCustomRanking($storeId);
         $unretrievableAttributes = $this->getUnretrieveableAttributes($storeId);
         $attributesForFaceting = $this->getAttributesForFaceting($storeId);
-        $attributesForFaceting[] = 'searchable(categories.level0)';
-        $attributesForFaceting[] = 'searchable(categories)';
 
         $indexSettings = [
             'searchableAttributes'    => $searchableAttributes,


### PR DESCRIPTION
**Summary**

Indexation of prices when Excluding Tax is request fails because the tax_class_id is not indexed by default on product collection.
Add it and make it mandatory.
 