### PR TITLE
MSI compatibility while being backward compatible

### DIFF
--- a/Service/Product/RecordBuilder.php
+++ b/Service/Product/RecordBuilder.php
@@ -268,8 +268,7 @@ class RecordBuilder implements RecordBuilderInterface
     public function addInStock($defaultData, $customData, Product $product)
     {
         if (isset($defaultData['in_stock']) === false) {
-            $stockItem = $this->stockRegistry->getStockItem($product->getId());
-            $customData['in_stock'] = $product->isSaleable() && $stockItem->getIsInStock();
+            $customData['in_stock'] = $this->productIsInStock($product, $product->getStoreId());
         }
 
         return $customData;
@@ -288,10 +287,8 @@ class RecordBuilder implements RecordBuilderInterface
             && $this->isAttributeEnabled($additionalAttributes, 'stock_qty')) {
             $customData['stock_qty'] = 0;
 
-            $stockItem = $this->stockRegistry->getStockItem($product->getId());
-            if ($stockItem) {
-                $customData['stock_qty'] = (int)$stockItem->getQty();
-            }
+            $stockStatus = $this->stockRegistry->getStockStatus($product->getId(), $product->getStore()->getWebsiteId());
+            $customData['stock_qty'] = (int)$stockStatus->getQty();
         }
 
         return $customData;
@@ -810,8 +807,6 @@ class RecordBuilder implements RecordBuilderInterface
      */
     public function productIsInStock($product, $storeId): bool
     {
-        $stockItem = $this->stockRegistry->getStockItem($product->getId());
-
-        return $product->isSaleable() && $stockItem->getIsInStock();
+        return $product->getIsSalable();
     }
 }


### PR DESCRIPTION
**Summary**

These changes fix the MSI compatibility. It also make this module unnecessary: https://github.com/algolia/algoliasearch-inventory-magento-2

algolia/algoliasearch-inventory-magento-2 is not really maintained anymore and many flaws exists as it does not really follow the changes introduced in the main module.
I've also noticed dead code.

The `$product->getIsSalable()` method use the alias added by MSI while it also fallback to simple inventory management when MSI is disabled.

I've also updated how the stock_qty is retrieved so it used the method that MSI have plugged, so if MSI is used, it's automatically compatible.