### PR TITLE
MAGE-1251 Fix replica detach operation for 3.14

### DIFF
--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -413,13 +413,16 @@ class ReplicaManager implements ReplicaManagerInterface
      */
     protected function removeReplicaFromReplicaSetting(array $replicaSetting, string $replicaToRemove): array
     {
-        return array_filter(
-            $replicaSetting,
-            function ($replicaIndexSetting) use ($replicaToRemove) {
-                $escaped = preg_quote($replicaToRemove);
-                $regex = '/^' . $escaped . '|virtual\(' . $escaped . '\)$/';
-                return !preg_match($regex, $replicaToRemove);
-            }
+        $escaped = preg_quote($replicaToRemove);
+        $regex = '/^' . $escaped . '|virtual\(' . $escaped . '\)$/';
+
+        return array_values(
+            array_filter(
+                $replicaSetting,
+                function ($replicaIndexSetting) use ($regex) {
+                    return !preg_match($regex, $replicaIndexSetting);
+                }
+            )
         );
     }
 

--- a/Test/Unit/Service/ReplicaManagerTest.php
+++ b/Test/Unit/Service/ReplicaManagerTest.php
@@ -54,7 +54,9 @@ class ReplicaManagerTest extends TestCase
 
         $newReplicas = $this->replicaManager->removeReplicaFromReplicaSetting($replicaSetting, $replicaToRemove);
 
-        $this->assertNotContains($replicaToRemove, $newReplicas);
+        $this->assertNotContains("virtual($replicaToRemove)", $newReplicas);
+        $this->assertContains('virtual(replica1)', $newReplicas);
+        $this->assertContains('virtual(replica3)', $newReplicas);
     }
 
     public function testStandardReplicaSettingRemove(): void
@@ -69,5 +71,8 @@ class ReplicaManagerTest extends TestCase
         $newReplicas = $this->replicaManager->removeReplicaFromReplicaSetting($replicaSetting, $replicaToRemove);
 
         $this->assertNotContains($replicaToRemove, $newReplicas);
+        $this->assertContains('replica1', $newReplicas);
+        $this->assertContains('replica3', $newReplicas);
+
     }
 }


### PR DESCRIPTION
**Summary**

This PR backports a fix to the detach replica logic. An issue was identified while porting replica changes for 3.14 (on https://github.com/algolia/algoliasearch-magento-2/pull/1718) to 3.15 (on https://github.com/algolia/algoliasearch-magento-2/pull/1741).

**Result**

Unit tests
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/6edc624f-56cf-4d7b-b857-9c88e8462009" />
Integration tests
<img width="1472" alt="image" src="https://github.com/user-attachments/assets/d5287fa3-eb84-4366-a48f-89a45421a1aa" />
