### PR TITLE
MAGE-1251 Replica enhancements ported to 3.16

### DIFF
--- a/Api/Product/ReplicaManagerInterface.php
+++ b/Api/Product/ReplicaManagerInterface.php
@@ -31,7 +31,7 @@ interface ReplicaManagerInterface
     /**
      * Delete the replica indices on a store index
      * @param int $storeId
-     * @param bool $unused Defaults to false - if true identifies any straggler indices and deletes those, otherwise deletes the replicas it knows aobut
+     * @param bool $unused Defaults to false - if true identifies any straggler indices and deletes those, otherwise deletes the replicas it knows about
      * @return void
      *
      * @throws LocalizedException

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -2,6 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Registry\ReplicaState;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
@@ -59,28 +62,53 @@ class RebuildReplicasPatch implements DataPatchInterface
             // Area code is already set - nothing to do
         }
 
-        $storeIds = array_keys($this->storeManager->getStores());
-        // Delete all replicas before resyncing in case of incorrect replica assignments
-        foreach ($storeIds as $storeId) {
-            if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                $this->logger->warning("Algolia credentials are not configured for store $storeId. Skipping auto replica rebuild for this store. If you need to rebuild your replicas run `bin/magento algolia:replicas:rebuild`");
-                continue;
+        $storeIds = $this->getStoreIdsEligibleForPatch();
+
+        try {
+            // Delete all replicas before resyncing in case of incorrect replica assignments
+            foreach ($storeIds as $storeId) {
+                $this->retryDeleteReplica($storeId);
             }
-
-            $this->replicaManager->deleteReplicasFromAlgolia($storeId);
-        }
-
-        foreach ($storeIds as $storeId) {
-            if (!$this->algoliaCredentialsManager->checkCredentialsWithSearchOnlyAPIKey($storeId)) {
-                continue;
+            foreach ($storeIds as $storeId) {
+                $this->replicaState->setChangeState(ReplicaState::REPLICA_STATE_CHANGED, $storeId); // avoids latency
+                $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
             }
-
-            $this->replicaState->setChangeState(ReplicaState::REPLICA_STATE_CHANGED, $storeId); // avoids latency
-            $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
+        } catch (AlgoliaException $e) {
+            // Log the error but do not prevent setup:update
+            $this->logger->error("Could not rebuild replicas - a full reindex may be required.");
         }
 
         $this->moduleDataSetup->getConnection()->endSetup();
 
         return $this;
+    }
+
+    protected function getStoreIdsEligibleForPatch(): array
+    {
+        return array_filter(
+            array_keys($this->storeManager->getStores()),
+            function (int $storeId) {
+                if (!$this->replicaManager->isReplicaSyncEnabled($storeId)) return false;
+                if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
+                    $this->logger->warning("Algolia credentials are not configured for store $storeId. Skipping auto replica rebuild for this store. If you need to rebuild your replicas run `bin/magento algolia:replicas:rebuild`");
+                    return false;
+                }
+                return true;
+            }
+        );
+    }
+
+    protected function retryDeleteReplica(int $storeId, int $maxRetries = 3, int $interval = 5)
+    {
+        for ($tries = $maxRetries - 1; $tries >= 0; $tries--) {
+            try {
+                $this->replicaManager->deleteReplicasFromAlgolia($storeId);
+                return;
+            } catch (AlgoliaException $e) {
+                $this->logger->warning(__("Unable to delete replicas, %1 tries remaining: %2", $tries, $e->getMessage()));
+                sleep($interval);
+            }
+        }
+        throw new ExceededRetriesException('Unable to delete old replica indices after $maxRetries retries.');
     }
 }

--- a/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
@@ -2,14 +2,30 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Product;
 
+use Algolia\AlgoliaSearch\Algolia;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Test\Integration\Indexing\Product\Traits\ReplicaAssertionsTrait;
+use Algolia\AlgoliaSearch\Registry\ReplicaState;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
+use Algolia\AlgoliaSearch\Service\Product\SortingTransformer;
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use Algolia\AlgoliaSearch\Test\Integration\TestCase;
+use Algolia\AlgoliaSearch\Validator\VirtualReplicaValidatorFactory;
+use Magento\Framework\App\State as AppState;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class ReplicaIndexingTest extends TestCase
 {
@@ -19,13 +35,18 @@ class ReplicaIndexingTest extends TestCase
 
     protected ?IndicesConfigurator $indicesConfigurator = null;
 
+    protected ?IndexOptionsBuilder $indexOptionsBuilder = null;
+
     protected ?string $indexName = null;
+
+    protected ?int $patchRetries = 3;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->replicaManager = $this->objectManager->get(ReplicaManagerInterface::class);
         $this->indicesConfigurator = $this->objectManager->get(IndicesConfigurator::class);
+        $this->indexOptionsBuilder = $this->objectManager->get(IndexOptionsBuilder::class);
         $this->indexSuffix = 'products';
         $this->indexName = $this->getIndexName('default');
     }
@@ -45,11 +66,13 @@ class ReplicaIndexingTest extends TestCase
         $this->assertSortingAttribute($sortAttr, $sortDir);
 
         $this->indicesConfigurator->saveConfigurationToAlgolia(1);
-        $this->algoliaHelper->waitLastTask();
+        $this->algoliaConnector->waitLastTask();
 
         // Assert replica config created
         $primaryIndexName = $this->indexName;
-        $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName);
+        $currentSettings = $this->algoliaConnector->getSettings(
+            $this->indexOptionsBuilder->buildWithEnforcedIndex($primaryIndexName)
+        );
         $this->assertArrayHasKey('replicas', $currentSettings);
 
         $replicaIndexName = $primaryIndexName . '_' . $sortAttr . '_' . $sortDir;
@@ -99,10 +122,13 @@ class ReplicaIndexingTest extends TestCase
         $this->setConfig(ConfigHelper::IS_INSTANT_ENABLED, 1);
 
         $this->indicesConfigurator->saveConfigurationToAlgolia(1);
-        $this->algoliaHelper->waitLastTask();
+        $this->algoliaConnector->waitLastTask();
 
         // Assert replica config created
-        $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName);
+        $currentSettings = $this->algoliaConnector->getSettings(
+            $this->indexOptionsBuilder->buildWithEnforcedIndex($primaryIndexName)
+        );
+
         $this->assertArrayHasKey('replicas', $currentSettings);
 
         $replicaIndexName = $primaryIndexName . '_' . $sortAttr . '_' . $sortDir;
@@ -128,15 +154,10 @@ class ReplicaIndexingTest extends TestCase
      */
     public function testReplicaRebuild(): void
     {
-        $primaryIndexName = $this->getIndexName('default');
-
+        // Make one replica virtual
         $this->mockSortUpdate('price', 'desc', ['virtualReplica' => 1]);
-        $sorting = $this->objectManager->get(\Algolia\AlgoliaSearch\Service\Product\SortingTransformer::class)->getSortingIndices(1, null, null, true);
 
-        $syncCmd = $this->objectManager->get(\Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand::class);
-        $this->mockProperty($syncCmd, 'output', \Symfony\Component\Console\Output\OutputInterface::class);
-        $syncCmd->syncReplicas();
-        $this->algoliaHelper->waitLastTask();
+        $sorting = $this->populateReplicas(1);
 
         $rebuildCmd = $this->objectManager->get(\Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand::class);
         $this->invokeMethod(
@@ -147,14 +168,11 @@ class ReplicaIndexingTest extends TestCase
                 $this->createMock(\Symfony\Component\Console\Output\OutputInterface::class)
             ]
         );
-        $this->algoliaHelper->waitLastTask();
+        $this->algoliaConnector->waitLastTask();
 
-        $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName);
-        $this->assertArrayHasKey('replicas', $currentSettings);
-        $replicas = $currentSettings['replicas'];
+        $replicas = $this->assertReplicasCreated($sorting);
 
-        $this->assertEquals(count($sorting), count($replicas));
-        $this->assertSortToReplicaConfigParity($primaryIndexName, $sorting, $replicas);
+        $this->assertSortToReplicaConfigParity($this->indexName, $sorting, $replicas);
     }
 
     /**
@@ -165,24 +183,243 @@ class ReplicaIndexingTest extends TestCase
      */
     public function testReplicaSync(): void
     {
-        $primaryIndexName = $this->getIndexName('default');
+        // Make one replica virtual
         $this->mockSortUpdate('created_at', 'desc', ['virtualReplica' => 1]);
 
-        $sorting = $this->objectManager->get(\Algolia\AlgoliaSearch\Service\Product\SortingTransformer::class)->getSortingIndices(1, null, null, true);
+        $sorting = $this->populateReplicas(1);
+
+        $replicas = $this->assertReplicasCreated($sorting);
+
+        $this->assertSortToReplicaConfigParity($this->indexName, $sorting, $replicas);
+    }
+
+    /**
+     * @magentoConfigFixture current_store algoliasearch_credentials/credentials/enable_backend 0
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/is_instant_enabled 1
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws \ReflectionException
+     */
+    public function testReplicaSyncDisabled(): void
+    {
+        $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($this->indexName);
+        $settings = $this->algoliaConnector->getSettings($indexOptions);
+
+        $this->assertArrayNotHasKey(ReplicaManager::ALGOLIA_SETTINGS_KEY_REPLICAS, $settings);
+
+        $this->populateReplicas(1);
+
+        $newSettings = $this->algoliaConnector->getSettings($indexOptions);
+        $this->assertArrayNotHasKey(ReplicaManager::ALGOLIA_SETTINGS_KEY_REPLICAS, $newSettings);
+    }
+
+    /**
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/is_instant_enabled 1
+     */
+    public function testReplicaDelete(): void
+    {
+        // Make one replica virtual
+        $this->mockSortUpdate('price', 'asc', ['virtualReplica' => 1]);
+
+        $replicas = $this->assertReplicasCreated($this->populateReplicas(1));
+
+        $this->replicaManager->deleteReplicasFromAlgolia(1);
+
+        $this->assertReplicasDeleted($replicas);
+    }
+
+    /**
+     * Test failure to clear index replica setting
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/is_instant_enabled 1
+     */
+    public function testReplicaDeleteUnreliable(): void
+    {
+        $replicas = $this->assertReplicasCreated($this->populateReplicas(1));
+
+        $this->getMustPrevalidateMockReplicaManager()->deleteReplicasFromAlgolia(1);
+
+        $this->assertReplicasDeleted($replicas);
+    }
+
+    /**
+     * Test the RebuildReplicasPatch with API failures
+     * @magentoConfigFixture current_store algoliasearch_credentials/credentials/enable_backend 1
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/is_instant_enabled 1
+     */
+    public function testReplicaRebuildPatch(): void
+    {
+        $currentStoreId = 1;
+
+        $credentialsManager = $this->objectManager->get(AlgoliaCredentialsManager::class);
+        $this->assertTrue($credentialsManager->checkCredentials(), "Credentials not available to apply patch.");
+        $this->assertTrue($this->replicaManager->isReplicaSyncEnabled($currentStoreId), "Replica sync is not enabled for test store $currentStoreId.");
+
+        $sorting = $this->populateReplicas($currentStoreId);
+        $replicas = $this->assertReplicasCreated($sorting);
+
+        $patch = new \Algolia\AlgoliaSearch\Setup\Patch\Data\RebuildReplicasPatch(
+            $this->objectManager->get(ModuleDataSetupInterface::class),
+            $this->objectManager->get(StoreManagerInterface::class),
+            $this->getTroublesomePatchReplicaManager($replicas),
+            $this->objectManager->get(ProductHelper::class),
+            $this->objectManager->get(AppState::class),
+            $this->objectManager->get(ReplicaState::class),
+            $credentialsManager,
+            $this->objectManager->get(LoggerInterface::class)
+        );
+
+        $patch->apply();
+
+        $this->algoliaConnector->waitLastTask();
+
+        $replicas = $this->assertReplicasCreated($sorting);
+
+        $this->assertSortToReplicaConfigParity($this->indexName, $sorting, $replicas);
+    }
+
+    protected function extractIndexFromReplicaSetting(string $setting): string {
+        return preg_replace('/^virtual\((.*)\)$/', '$1', $setting);
+    }
+
+    /**
+     * If a replica fails to detach from the primary it can create deletion errors
+     * Typically this is the result of latency even if task reports as completed from the API (hypothesis)
+     * This aims to reproduce this potential scenario by not disassociating the replica
+     *
+     */
+    protected function getMustPrevalidateMockReplicaManager(): ReplicaManagerInterface
+    {
+        $mockedMethod = 'clearReplicasSettingInAlgolia';
+
+        $mock = $this->getMockReplicaManager([
+            $mockedMethod => function(...$params) {
+                //DO NOTHING
+                return;
+            }
+        ]);
+        $mock->expects($this->once())->method($mockedMethod);
+        return $mock;
+    }
+
+    /**
+     * This mock is to recreate the scenario where a patch tries to apply up to 3 times but the replicas
+     * are never detached which throws a replica delete error until the last attempt which should succeed
+     *
+     * @param array $replicas - replicas that are to be deleted
+     */
+    protected function getTroublesomePatchReplicaManager(array $replicas): ReplicaManager
+    {
+        $mock = $this->getMockReplicaManager([
+            'clearReplicasSettingInAlgolia' => null,
+            'deleteReplicas' => null
+        ]);
+        $mock
+            ->expects($this->exactly($this->patchRetries))
+            ->method('clearReplicasSettingInAlgolia')
+            ->willReturnCallback(function(...$params) use ($mock) {
+                if (--$this->patchRetries) return;
+                $originalMethod = new \ReflectionMethod(ReplicaManager::class, 'clearReplicasSettingInAlgolia');
+                $originalMethod->invoke($mock, ...$params);
+            });
+        $mock
+            ->expects($this->any())
+            ->method('deleteReplicas')
+            ->willReturnCallback(function(int $storeId, array $replicasToDelete, ...$params) use ($mock, $replicas) {
+                $originalMethod = new \ReflectionMethod(ReplicaManager::class, 'deleteReplicas');
+                $originalMethod->invoke($mock, $storeId, $replicasToDelete, false, false);
+                if ($this->patchRetries) return;
+                $this->runOnce(
+                    function() use ($replicas) {
+                        $this->algoliaConnector->waitLastTask();
+                        $this->assertReplicasDeleted($replicas);
+                    },
+                    'patchDeleteTest'
+                );
+            });
+
+        return $mock;
+    }
+
+    protected function getMockReplicaManager($mockedMethods = array()): MockObject & ReplicaManager
+    {
+        $mockedClass = ReplicaManager::class;
+        $mockedReplicaManager = $this->getMockBuilder($mockedClass)
+            ->setConstructorArgs([
+                $this->configHelper,
+                $this->algoliaConnector,
+                $this->objectManager->get(IndexOptionsBuilder::class),
+                $this->objectManager->get(ReplicaState::class),
+                $this->objectManager->get(VirtualReplicaValidatorFactory::class),
+                $this->objectManager->get(IndexNameFetcher::class),
+                $this->objectManager->get(StoreNameFetcher::class),
+                $this->objectManager->get(SortingTransformer::class),
+                $this->objectManager->get(StoreManagerInterface::class),
+                $this->objectManager->get(DiagnosticsLogger::class)
+            ])
+            ->onlyMethods(array_keys($mockedMethods))
+            ->getMock();
+
+        foreach ($mockedMethods as $method => $callback) {
+            if (!$callback) continue;
+            $mockedReplicaManager
+                ->method($method)
+                ->willReturnCallback($callback);
+        }
+
+        return $mockedReplicaManager;
+    }
+
+    /**
+     * Setup replicas for testing and assert that they have been synced to Algolia
+     * @param array $sorting - the array of sorts from Magento
+     * @return array - The replica setting from Algolia
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws \ReflectionException
+     */
+    protected function assertReplicasCreated(array $sorting): array
+    {
+        $currentSettings = $this->algoliaConnector->getSettings(
+            $this->indexOptionsBuilder->buildWithEnforcedIndex($this->indexName)
+        );
+        $this->assertArrayHasKey(ReplicaManager::ALGOLIA_SETTINGS_KEY_REPLICAS, $currentSettings);
+        $replicas = $currentSettings[ReplicaManager::ALGOLIA_SETTINGS_KEY_REPLICAS];
+
+        $this->assertEquals(count($sorting), count($replicas));
+
+        return $replicas;
+    }
+
+    protected function assertReplicasDeleted($originalReplicas): void
+    {
+        $newSettings = $this->algoliaConnector->getSettings(
+            $this->indexOptionsBuilder->buildWithEnforcedIndex($this->indexName)
+        );
+        $this->assertArrayNotHasKey(ReplicaManager::ALGOLIA_SETTINGS_KEY_REPLICAS, $newSettings);
+        foreach ($originalReplicas as $replica) {
+            $this->assertIndexNotExists($this->extractIndexFromReplicaSetting($replica));
+        }
+    }
+
+    /**
+     * Populate replica indices for test based on store id and return sorting configuration used
+     *
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws \ReflectionException
+     */
+    protected function populateReplicas(int $storeId): array
+    {
+        $sorting = $this->objectManager->get(\Algolia\AlgoliaSearch\Service\Product\SortingTransformer::class)->getSortingIndices($storeId, null, null, true);
 
         $cmd = $this->objectManager->get(\Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand::class);
 
         $this->mockProperty($cmd, 'output', \Symfony\Component\Console\Output\OutputInterface::class);
 
         $cmd->syncReplicas();
-        $this->algoliaHelper->waitLastTask();
+        $this->algoliaConnector->waitLastTask();
 
-        $currentSettings = $this->algoliaHelper->getSettings($primaryIndexName);
-        $this->assertArrayHasKey('replicas', $currentSettings);
-        $replicas = $currentSettings['replicas'];
-
-        $this->assertEquals(count($sorting), count($replicas));
-        $this->assertSortToReplicaConfigParity($primaryIndexName, $sorting, $replicas);
+        return $sorting;
     }
 
     protected function tearDown(): void
@@ -210,4 +447,5 @@ class ReplicaIndexingTest extends TestCase
             ]
         );
     }
+
 }

--- a/Test/Integration/Indexing/Product/Traits/ReplicaAssertionsTrait.php
+++ b/Test/Integration/Indexing/Product/Traits/ReplicaAssertionsTrait.php
@@ -44,7 +44,14 @@ trait ReplicaAssertionsTrait
         return $replicaSettings;
     }
 
-    protected function assertReplicaRanking(array $replicaSettings, string $rankingKey, string $sort) {
+    protected function assertIndexNotExists(string $indexName, ?int $storeId = null): void
+    {
+        $indexSettings = $this->algoliaHelper->getSettings($indexName, $storeId);
+        $this->assertCount(0, $indexSettings, "Settings found for index that should not exist");
+    }
+
+    protected function assertReplicaRanking(array $replicaSettings, string $rankingKey, string $sort): void
+    {
         $this->assertArrayHasKey($rankingKey, $replicaSettings);
         $this->assertEquals($sort, reset($replicaSettings[$rankingKey]));
     }
@@ -129,7 +136,6 @@ trait ReplicaAssertionsTrait
         $existing = array_filter($sorting, function ($item) use ($sortAttr, $sortDir) {
             return $item['attribute'] === $sortAttr && $item['sort'] === $sortDir;
         });
-
 
         if ($existing) {
             $idx = array_key_first($existing);

--- a/Test/Unit/Service/ReplicaManagerTest.php
+++ b/Test/Unit/Service/ReplicaManagerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Registry\ReplicaState;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
+use Algolia\AlgoliaSearch\Service\Product\SortingTransformer;
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Algolia\AlgoliaSearch\Validator\VirtualReplicaValidatorFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class ReplicaManagerTest extends TestCase
+{
+    protected ?ReplicaManager $replicaManager;
+
+    public function setUp(): void
+    {
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $algoliaConnector = $this->createMock(AlgoliaConnector::class);
+        $indexOptionsBuilder = $this->createMock(IndexOptionsBuilder::class);
+        $replicaState = $this->createMock(ReplicaState::class);
+        $virtualReplicaValidatorFactory = $this->createMock(VirtualReplicaValidatorFactory::class);
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $storeNameFetcher = $this->createMock(StoreNameFetcher::class);
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $logger = $this->createMock(DiagnosticsLogger::class);
+
+        $this->replicaManager = new ReplicaManagerTestable(
+            $configHelper,
+            $algoliaConnector,
+            $indexOptionsBuilder,
+            $replicaState,
+            $virtualReplicaValidatorFactory,
+            $indexNameFetcher,
+            $storeNameFetcher,
+            $sortingTransformer,
+            $storeManager,
+            $logger
+        );
+    }
+
+    public function testVirtualReplicaSettingRemove(): void
+    {
+        $replicaSetting = [
+            'virtual(replica1)',
+            'virtual(replica2)',
+            'virtual(replica3)'
+        ];
+        $replicaToRemove = 'replica2';
+
+        $newReplicas = $this->replicaManager->removeReplicaFromReplicaSetting($replicaSetting, $replicaToRemove);
+
+        $this->assertNotContains("virtual($replicaToRemove)", $newReplicas);
+        $this->assertContains('virtual(replica1)', $newReplicas);
+        $this->assertContains('virtual(replica3)', $newReplicas);
+    }
+
+    public function testStandardReplicaSettingRemove(): void
+    {
+        $replicaSetting = [
+            'replica1',
+            'replica2',
+            'replica3'
+        ];
+        $replicaToRemove = 'replica2';
+
+        $newReplicas = $this->replicaManager->removeReplicaFromReplicaSetting($replicaSetting, $replicaToRemove);
+
+        $this->assertNotContains($replicaToRemove, $newReplicas);
+        $this->assertContains('replica1', $newReplicas);
+        $this->assertContains('replica3', $newReplicas);
+
+    }
+}

--- a/Test/Unit/Service/ReplicaManagerTestable.php
+++ b/Test/Unit/Service/ReplicaManagerTestable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
+
+class ReplicaManagerTestable extends ReplicaManager
+{
+    public function removeReplicaFromReplicaSetting(...$params): array
+    {
+        return parent::removeReplicaFromReplicaSetting(...$params);
+    }
+}


### PR DESCRIPTION
**Summary**

 This PR in includes the updates from https://github.com/algolia/algoliasearch-magento-2/pull/1741 

**Result**

Verified on 3.16.0-beta

Integration tests
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/3b45daf5-4789-4dca-8cd5-02dc1aa1ee9a" />
<img width="1480" alt="image" src="https://github.com/user-attachments/assets/5460cdc3-e0a8-4fd8-aa4a-cc566b6546f2" />

Unit tests
<img width="1478" alt="image" src="https://github.com/user-attachments/assets/b0f8fdbd-6be8-4d56-bc70-c0c2b8c694f4" />

Magento vs Algolia
![image](https://github.com/user-attachments/assets/5d3d0137-2132-4e81-88fa-d43648f08421)
<img width="874" alt="image" src="https://github.com/user-attachments/assets/d073816d-095f-4f54-b9cf-6f7286c7e488" />

