### PR TITLE
Refactor Product With Children to remove Double Conversion

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -58,8 +58,17 @@ abstract class ProductWithChildren extends ProductWithoutChildren
                 } else {
                     $minPrice = $specialPrice[0];
                 }
-                $price     = $minPrice ?? $this->getTaxPrice($product, $subProduct->getFinalPrice(), $withTax);
-                $basePrice = $this->getTaxPrice($product, $subProduct->getPrice(), $withTax);
+
+                $finalPrice = $subProduct->getFinalPrice();
+                $basePrice  = $subProduct->getPrice();
+
+                if ($currencyCode !== $this->baseCurrencyCode) {
+                    $finalPrice = $this->convertPrice($finalPrice, $currencyCode);
+                    $basePrice  = $this->convertPrice($basePrice, $currencyCode);
+                }
+
+                $price     = $minPrice ?? $this->getTaxPrice($product, $finalPrice, $withTax);
+                $basePrice = $this->getTaxPrice($product, $basePrice, $withTax);
                 $min = min($min, $price);
                 $original = min($original, $basePrice);
                 $max = max($max, $price);
@@ -68,14 +77,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
         } else {
             $originalMax = $original = $min = $max;
         }
-        if ($currencyCode !== $this->baseCurrencyCode) {
-            $min      = $this->convertPrice($min, $currencyCode);
-            $original = $this->convertPrice($original, $currencyCode);
-            if ($min !== $max) {
-                $max = $this->convertPrice($max, $currencyCode);
-                $originalMax = $this->convertPrice($originalMax, $currencyCode);
-            }
-        }
+
         return [$min, $max, $original, $originalMax];
     }
 


### PR DESCRIPTION
**Summary**

`$this->getSpecialPrice()` and `$this->getTierPrice()` Return a converted price when using multiple currencies, however these prices there converted again a little bit further down the function

Example: Base Currency GBP, Product Price 1200, also shows prices in EUR with a conversion rate of 1.2 (simplified numbers for example)

[`$this->getSpecialPrice()` ](https://github.com/algolia/algoliasearch-magento-2/blob/3ecbf4e1313a3b19a85c2c9dc89b027447e0d286/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php#L260) will return the Product Final price but converted (1200 * 1.2 = 1440) and then this gets converted again on line 72 (1440 * 1.2 = 1728) giving us an incorrect amount.

I have refactored the currency conversion to convert just the final Price and Base Price so that if a special price / Tiered price returns a value then  these are converted twice.

**Result**

prices are only converted when necessary so they are only converted once. 