### PR TITLE
MAGE-1201 fix recommend model validation

### DIFF
--- a/Model/RecommendManagement.php
+++ b/Model/RecommendManagement.php
@@ -75,7 +75,7 @@ class RecommendManagement implements RecommendManagementInterface
      */
     public function getLookingSimilarRecommendation(string $productId): array
     {
-        return $this->getRecommendations($productId, 'bought-together');
+        return $this->getRecommendations($productId, 'looking-similar');
     }
 
     /**

--- a/Observer/RecommendSettings.php
+++ b/Observer/RecommendSettings.php
@@ -178,11 +178,23 @@ class RecommendSettings implements ObserverInterface
             !array_key_exists('hits', $recommendationResponse);
     }
 
+    /**
+     * If there is no model on the index then a 404 error should be returned
+     * (which will cause the exception on the API call) because there is no model for that index
+     * However errors which say "Index does not exist" are cryptic
+     * This function serves to make this clearer to the user while also filtering out the possible
+     * "ObjectID does not exist" error which can occur if the model does not contain the test product
+     */
     protected function getUserFriendlyRecommendApiErrorMessage(\Exception $e): string
     {
         $msg = $e->getMessage();
-        if ($e->getCode() === 404 && !!preg_match('/index.*does not exist/i', $msg)) {
-            $msg = (string) __("A trained model could not be found.");
+        if ($e->getCode() === 404) {
+            if (!!preg_match('/index.*does not exist/i', $msg)) {
+                $msg = (string) __("A trained model could not be found.");
+            }
+            if (!!preg_match('/objectid does not exist/i', $msg)) {
+                $msg = (string) __("Could not find test product in trained model.");
+            }
         }
         return $msg;
     }

--- a/Observer/RecommendSettings.php
+++ b/Observer/RecommendSettings.php
@@ -154,10 +154,19 @@ class RecommendSettings implements ObserverInterface
             throw new LocalizedException(__(
                 "Unable to save %1 Recommend configuration due to the following error: %2",
                     $modelName,
-                    $e->getMessage()
+                    $this->getUserFriendlyRecommendApiErrorMessage($e)
                 )
             );
         }
+    }
+
+    protected function getUserFriendlyRecommendApiErrorMessage(\Exception $e): string
+    {
+        $msg = $e->getMessage();
+        if ($e->getCode() === 404 && !!preg_match('/index.*does not exist/i', $msg)) {
+            $msg = (string) __("A trained model could not be found.");
+        }
+        return $msg;
     }
 
     /**


### PR DESCRIPTION
**Summary**

This PR:
- Adds friendlier error messaging for 404 errors including "no index found"
- Removes dependency on `renderingContent` - not a good measure of valid model
- Adds soft fail warning on missing hits on configured model
- Fixes validation on Looking Similar 

TODO:
- Address store scoped model validation 

**Result**

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/dc2d0a60-e1c4-4caf-95c4-157ee9de48ee" />
