### PR TITLE
MAGE-1201 Concrete injectable logger

### DIFF
--- a/Api/LoggerInterface.php
+++ b/Api/LoggerInterface.php
@@ -1,0 +1,4 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api;
+interface LoggerInterface extends \Psr\Log\LoggerInterface {}

--- a/Logger/AlgoliaLogger.php
+++ b/Logger/AlgoliaLogger.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Logger;
+
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
+use Monolog\Logger;
+
+class AlgoliaLogger extends Logger implements LoggerInterface {}

--- a/Logger/TimedLogger.php
+++ b/Logger/TimedLogger.php
@@ -2,9 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Logger;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Monolog\Logger;
-use Psr\Log\LoggerInterface;
 
 class TimedLogger
 {

--- a/Model/RecommendManagement.php
+++ b/Model/RecommendManagement.php
@@ -75,7 +75,7 @@ class RecommendManagement implements RecommendManagementInterface
      */
     public function getLookingSimilarRecommendation(string $productId): array
     {
-        return $this->getRecommendations($productId, 'bought-together');
+        return $this->getRecommendations($productId, 'looking-similar');
     }
 
     /**

--- a/Observer/Insights/CheckoutCartProductAddAfter.php
+++ b/Observer/Insights/CheckoutCartProductAddAfter.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Observer\Insights;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Configuration\PersonalizationHelper;
@@ -13,7 +14,6 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Model\Quote\Item;
-use Psr\Log\LoggerInterface;
 
 class CheckoutCartProductAddAfter implements ObserverInterface
 {

--- a/Observer/Insights/CheckoutOnePageControllerSuccessAction.php
+++ b/Observer/Insights/CheckoutOnePageControllerSuccessAction.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Observer\Insights;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\InsightsHelper;
@@ -11,7 +12,6 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderFactory;
-use Psr\Log\LoggerInterface;
 
 class CheckoutOnePageControllerSuccessAction implements ObserverInterface
 {

--- a/Observer/Insights/WishlistProductAddAfter.php
+++ b/Observer/Insights/WishlistProductAddAfter.php
@@ -2,13 +2,13 @@
 
 namespace Algolia\AlgoliaSearch\Observer\Insights;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Helper\Configuration\PersonalizationHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\InsightsHelper;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Wishlist\Model\Item;
-use Psr\Log\LoggerInterface;
 
 class WishlistProductAddAfter implements ObserverInterface
 {

--- a/Observer/RecommendSettings.php
+++ b/Observer/RecommendSettings.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Algolia\AlgoliaSearch\Observer;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Api\RecommendManagementInterface;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Catalog\Api\ProductRepositoryInterface;
@@ -14,7 +15,6 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
-use Psr\Log\LoggerInterface;
 
 class RecommendSettings implements ObserverInterface
 {

--- a/Observer/RecommendSettings.php
+++ b/Observer/RecommendSettings.php
@@ -9,15 +9,20 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\State;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Psr\Log\LoggerInterface;
 
 class RecommendSettings implements ObserverInterface
 {
     const QUANTITY_AND_STOCK_STATUS = 'quantity_and_stock_status';
     const STATUS = 'status';
     const VISIBILITY = 'visibility';
+
+    const ENFORCE_VALIDATION = 0;
 
     /**
      * @var string
@@ -36,7 +41,10 @@ class RecommendSettings implements ObserverInterface
         protected readonly WriterInterface              $configWriter,
         protected readonly ProductRepositoryInterface   $productRepository,
         protected readonly RecommendManagementInterface $recommendManagement,
-        protected readonly SearchCriteriaBuilder        $searchCriteriaBuilder
+        protected readonly SearchCriteriaBuilder        $searchCriteriaBuilder,
+        protected readonly State                        $appState,
+        protected readonly MessageManagerInterface      $messageManager,
+        protected readonly LoggerInterface              $logger
     ){}
 
     /**
@@ -143,24 +151,122 @@ class RecommendSettings implements ObserverInterface
     {
         try {
             $recommendations = $this->recommendManagement->$recommendationMethod($this->getProductId());
-            if (empty($recommendations['renderingContent'])) {
-                throw new LocalizedException(__(
-                    "It appears that there is no trained model available for Algolia application ID %1.",
-                    $this->configHelper->getApplicationID()
-                ));
-            }
+
+            $this->validateRecommendApiResponse($recommendations, $modelName);
         } catch (\Exception $e) {
-            $this->configWriter->save($changedPath, 0);
-            throw new LocalizedException(__(
-                "Unable to save %1 Recommend configuration due to the following error: %2",
-                    $modelName,
-                    $e->getMessage()
-                )
-            );
+            $this->handleRecommendApiException($e, $modelName, $changedPath);
         }
     }
 
     /**
+     * If API does not return a hits response the model may not be configured correctly.
+     * Do not hard fail but alert the end user.
+     *
+     * @throws LocalizedException
+     */
+    protected function validateRecommendApiResponse(array $recommendResponse, string $modelName): void
+    {
+        if (!array_key_exists('hits', $recommendResponse)) {
+            $msg = __(
+                "It appears that there is no trained %1 model available for Algolia application ID %2. "
+                . "Please verify your configuration in the Algolia Dashboard before continuing.",
+                $modelName,
+                $this->configHelper->getApplicationID()
+            );
+
+            if ($this->shouldDisplayWarning()) {
+                $this->messageManager->addWarningMessage($msg);
+            }
+            else {
+                $this->logger->warning($msg);
+            }
+        }
+    }
+
+    /**
+     * Handles exceptions on the test request against the Recommend API
+     *
+     * The goal is to warn the user of potential issues so they do not enable a model on the front end that has not been
+     * properly configured in Algolia
+     *
+     * TODO: Implement store scoped validation
+     *
+     * @throws LocalizedException
+     */
+    protected function handleRecommendApiException(\Exception $e, string $modelName, string $changedPath): void
+    {
+        $msg = $this->getUserFriendlyRecommendApiErrorMessage($e);
+
+        if (self::ENFORCE_VALIDATION) {
+            $this->rollBack($changedPath, __(
+                    "Unable to save %1 Recommend configuration due to the following error: %2",
+                    $modelName,
+                    $msg
+                )
+            );
+        }
+
+        $msg = __(
+            "Error encountered while enabling %1 recommendations: %2",
+            $modelName,
+            $msg
+        );
+
+        if ($this->shouldDisplayWarning()) {
+            $this->messageManager->addWarningMessage(
+                $msg
+                . ' Please verify your configuration in the Algolia Dashboard before continuing.');
+        }
+        else {
+            $this->logger->warning($msg);
+        }
+    }
+
+    /*
+     * For hard fail only
+     */
+    protected function rollBack(string $changedPath, \Magento\Framework\Phrase $message): void
+    {
+        $this->configWriter->save($changedPath, 0);
+        throw new LocalizedException($message);
+    }
+
+    /**
+     * Warnings should only be displayed within the admin panel
+     * @throws LocalizedException
+     */
+    protected function shouldDisplayWarning(): bool
+    {
+        return $this->appState->getAreaCode() === \Magento\Framework\App\Area::AREA_ADMINHTML
+            && php_sapi_name() !== 'cli';
+    }
+
+    /**
+     * If there is no model on the index then a 404 error should be returned
+     * (which will cause the exception on the API call) because there is no model for that index
+     * However errors which say "Index does not exist" are cryptic
+     * This function serves to make this clearer to the user while also filtering out the possible
+     * "ObjectID does not exist" error which can occur if the model does not contain the test product
+     */
+    protected function getUserFriendlyRecommendApiErrorMessage(\Exception $e): string
+    {
+        $msg = $e->getMessage();
+        if ($e->getCode() === 404) {
+            if (!!preg_match('/index.*does not exist/i', $msg)) {
+                $msg = (string) __("A trained model could not be found.");
+            }
+            if (!!preg_match('/objectid does not exist/i', $msg)) {
+                $msg = (string) __("Could not find test product in trained model.");
+            }
+        }
+        return $msg;
+    }
+
+    /**
+     * Retrieve a test product for requests against the Recommend API
+     *
+     * TODO: Implement store scoping and independently address 404 where objectID is not found
+     *
      * @return string - Product ID string for use in API calls
      * @throws LocalizedException
      */

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -2,9 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Registry\ReplicaState;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
@@ -16,7 +16,6 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Psr\Log\LoggerInterface;
 
 class RebuildReplicasPatch implements DataPatchInterface
 {

--- a/Test/Unit/Logger/AlgoliaLoggerTest.php
+++ b/Test/Unit/Logger/AlgoliaLoggerTest.php
@@ -2,9 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Test\Unit\Logger;
 
+use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler;
 use Algolia\AlgoliaSearch\Logger\Handler\SystemLoggerHandler;
-use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -19,7 +19,7 @@ class AlgoliaLoggerTest extends TestCase
         $this->systemLoggerHandler = $this->createMock(SystemLoggerHandler::class);
         $this->algoliaLoggerHandler = $this->createMock(AlgoliaLoggerHandler::class);
 
-        $this->algoliaLogger = new Logger(
+        $this->algoliaLogger = new AlgoliaLogger(
             'algolia',
             [ $this->systemLoggerHandler, $this->algoliaLoggerHandler ]
         );

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -252,7 +252,7 @@
     </type>
     <!-- custom indexers END -->
 
-    <virtualType name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger" type="Monolog\Logger">
+    <type name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger">
         <arguments>
             <argument name="name" xsi:type="string">algolia</argument>
             <argument name="handlers" xsi:type="array">
@@ -260,16 +260,6 @@
                 <item name="custom" xsi:type="object">Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler</item>
             </argument>
         </arguments>
-    </virtualType>
-    <type name="Algolia\AlgoliaSearch\Logger\TimedLogger">
-        <arguments>
-            <argument name="logger" xsi:type="object">Algolia\AlgoliaSearch\Logger\AlgoliaLogger</argument>
-        </arguments>
     </type>
-
-    <type name="\Algolia\AlgoliaSearch\Observer\RecommendSettings">
-        <arguments>
-            <argument name="logger" xsi:type="object">Algolia\AlgoliaSearch\Logger\AlgoliaLogger</argument>
-        </arguments>
-    </type>
+    <preference for="Algolia\AlgoliaSearch\Api\LoggerInterface" type="Algolia\AlgoliaSearch\Logger\AlgoliaLogger"/>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -266,4 +266,10 @@
             <argument name="logger" xsi:type="object">Algolia\AlgoliaSearch\Logger\AlgoliaLogger</argument>
         </arguments>
     </type>
+
+    <type name="\Algolia\AlgoliaSearch\Observer\RecommendSettings">
+        <arguments>
+            <argument name="logger" xsi:type="object">Algolia\AlgoliaSearch\Logger\AlgoliaLogger</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
**Summary**

This PR is a proposed change while implementing https://github.com/algolia/algoliasearch-magento-2/pull/1752 that switches from a virtual type logger to a concrete logger which can be referenced in code (unlike the previous virtual type). It is intended as a drop in replacement for `Psr\Log\LoggerInterface` and to provide a simple way to localize Algolia specific logging without needing to inject the heavier `DiagnosticsLogger` or `TimedLogger`.

**Result**

![2025-05-06_15-40-43](https://github.com/user-attachments/assets/d89da50c-9cb5-42f1-aa3d-fc5070a06b72)
