### PR TITLE
MAGE-1272 Concrete injectable logger

### DIFF
--- a/Api/LoggerInterface.php
+++ b/Api/LoggerInterface.php
@@ -1,0 +1,4 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api;
+interface LoggerInterface extends \Psr\Log\LoggerInterface {}

--- a/Logger/AlgoliaLogger.php
+++ b/Logger/AlgoliaLogger.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Logger;
+
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
+use Monolog\Logger;
+
+class AlgoliaLogger extends Logger implements LoggerInterface {}

--- a/Logger/TimedLogger.php
+++ b/Logger/TimedLogger.php
@@ -2,9 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Logger;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Monolog\Logger;
-use Psr\Log\LoggerInterface;
 
 class TimedLogger
 {

--- a/Observer/Insights/CheckoutCartProductAddAfter.php
+++ b/Observer/Insights/CheckoutCartProductAddAfter.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Observer\Insights;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Configuration\PersonalizationHelper;
@@ -13,7 +14,6 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Model\Quote\Item;
-use Psr\Log\LoggerInterface;
 
 class CheckoutCartProductAddAfter implements ObserverInterface
 {

--- a/Observer/Insights/CheckoutOnePageControllerSuccessAction.php
+++ b/Observer/Insights/CheckoutOnePageControllerSuccessAction.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Observer\Insights;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\InsightsHelper;
@@ -11,7 +12,6 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderFactory;
-use Psr\Log\LoggerInterface;
 
 class CheckoutOnePageControllerSuccessAction implements ObserverInterface
 {

--- a/Observer/Insights/WishlistProductAddAfter.php
+++ b/Observer/Insights/WishlistProductAddAfter.php
@@ -2,13 +2,13 @@
 
 namespace Algolia\AlgoliaSearch\Observer\Insights;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Helper\Configuration\PersonalizationHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\InsightsHelper;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Wishlist\Model\Item;
-use Psr\Log\LoggerInterface;
 
 class WishlistProductAddAfter implements ObserverInterface
 {

--- a/Observer/RecommendSettings.php
+++ b/Observer/RecommendSettings.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Algolia\AlgoliaSearch\Observer;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Api\RecommendManagementInterface;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Magento\Catalog\Api\ProductRepositoryInterface;
@@ -14,7 +15,6 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
-use Psr\Log\LoggerInterface;
 
 class RecommendSettings implements ObserverInterface
 {

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -2,9 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
+use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Registry\ReplicaState;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
@@ -16,7 +16,6 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Psr\Log\LoggerInterface;
 
 class RebuildReplicasPatch implements DataPatchInterface
 {

--- a/Test/Unit/Logger/AlgoliaLoggerTest.php
+++ b/Test/Unit/Logger/AlgoliaLoggerTest.php
@@ -10,9 +10,9 @@ use Psr\Log\LoggerInterface;
 
 class AlgoliaLoggerTest extends TestCase
 {
-    protected LoggerInterface $algoliaLogger;
-    protected SystemLoggerHandler $systemLoggerHandler;
-    protected AlgoliaLoggerHandler $algoliaLoggerHandler;
+    protected ?LoggerInterface $algoliaLogger;
+    protected ?SystemLoggerHandler $systemLoggerHandler;
+    protected ?AlgoliaLoggerHandler $algoliaLoggerHandler;
 
     protected function setUp(): void
     {

--- a/Test/Unit/Logger/AlgoliaLoggerTest.php
+++ b/Test/Unit/Logger/AlgoliaLoggerTest.php
@@ -2,9 +2,9 @@
 
 namespace Algolia\AlgoliaSearch\Test\Unit\Logger;
 
+use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler;
 use Algolia\AlgoliaSearch\Logger\Handler\SystemLoggerHandler;
-use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -19,7 +19,7 @@ class AlgoliaLoggerTest extends TestCase
         $this->systemLoggerHandler = $this->createMock(SystemLoggerHandler::class);
         $this->algoliaLoggerHandler = $this->createMock(AlgoliaLoggerHandler::class);
 
-        $this->algoliaLogger = new Logger(
+        $this->algoliaLogger = new AlgoliaLogger(
             'algolia',
             [ $this->systemLoggerHandler, $this->algoliaLoggerHandler ]
         );

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -252,7 +252,7 @@
     </type>
     <!-- custom indexers END -->
 
-    <virtualType name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger" type="Monolog\Logger">
+    <type name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger">
         <arguments>
             <argument name="name" xsi:type="string">algolia</argument>
             <argument name="handlers" xsi:type="array">
@@ -260,16 +260,6 @@
                 <item name="custom" xsi:type="object">Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler</item>
             </argument>
         </arguments>
-    </virtualType>
-    <type name="Algolia\AlgoliaSearch\Logger\TimedLogger">
-        <arguments>
-            <argument name="logger" xsi:type="object">Algolia\AlgoliaSearch\Logger\AlgoliaLogger</argument>
-        </arguments>
     </type>
-
-    <type name="\Algolia\AlgoliaSearch\Observer\RecommendSettings">
-        <arguments>
-            <argument name="logger" xsi:type="object">Algolia\AlgoliaSearch\Logger\AlgoliaLogger</argument>
-        </arguments>
-    </type>
+    <preference for="Algolia\AlgoliaSearch\Api\LoggerInterface" type="Algolia\AlgoliaSearch\Logger\AlgoliaLogger"/>
 </config>


### PR DESCRIPTION
**Summary**

This PR is a proposed change while implementing https://github.com/algolia/algoliasearch-magento-2/pull/1752 that switches from a virtual type logger to a concrete logger which can be referenced in code (unlike the previous virtual type). It is intended as a drop in replacement for `Psr\Log\LoggerInterface` and to provide a simple way to localize Algolia specific logging without needing to inject the heavier `DiagnosticsLogger` or `TimedLogger`.

**Result**

![2025-05-06_15-40-43](https://github.com/user-attachments/assets/d89da50c-9cb5-42f1-aa3d-fc5070a06b72)
