### PR TITLE
MAGE-1205: Fix Revenue analytics' discount calculation with configured VAT

### DIFF
--- a/Service/Insights/EventProcessor.php
+++ b/Service/Insights/EventProcessor.php
@@ -268,7 +268,7 @@ class EventProcessor implements EventProcessorInterface
      */
     protected function getOrderItemSalePrice(OrderItem $item): float
     {
-        return floatval($item->getPrice()) - $this->getOrderItemCartDiscount($item);
+        return floatval($item->getPriceInclTax()) - $this->getOrderItemCartDiscount($item);
     }
 
     /**
@@ -286,7 +286,7 @@ class EventProcessor implements EventProcessorInterface
      */
     protected function getOrderItemDiscount(OrderItem $item): float
     {
-        $itemDiscount = floatval($item->getOriginalPrice()) - floatval($item->getPrice());
+        $itemDiscount = floatval($item->getOriginalPrice()) - floatval($item->getPriceInclTax());
         return $itemDiscount + $this->getOrderItemCartDiscount($item);
     }
 

--- a/Test/Unit/Service/EventProcessorTest.php
+++ b/Test/Unit/Service/EventProcessorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Api\InsightsClient;
+use Algolia\AlgoliaSearch\Service\Insights\EventProcessor;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class EventProcessorTest extends TestCase
+{
+    protected ?InsightsClient $client;
+    protected ?string $userToken;
+    protected ?string $authenticatedUserToken;
+    protected ?StoreManagerInterface $storeManager;
+    protected ?EventProcessor $eventProcessor;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(InsightsClient::class);
+        $this->userToken = 'foo';
+        $this->authenticatedUserToken = 'authenticated-foo';
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+
+        $this->eventProcessor = new EventProcessorTestable(
+            $this->client,
+            $this->userToken,
+            $this->authenticatedUserToken,
+            $this->storeManager
+        );
+    }
+
+    /**
+     * @dataProvider orderItemsProvider
+     */
+    public function testObjectDataForPurchase($orderItemsData, $expectedResult, $expectedTotalRevenue): void
+    {
+        $orderItems = [];
+
+        foreach ($orderItemsData as $orderItemData) {
+            $orderItem = $this->getMockBuilder(OrderItem::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            foreach ($orderItemData as $method => $value){
+                $orderItem->method($method)->willReturn($value);
+            }
+
+            $orderItems[] = $orderItem;
+        }
+
+        $object = $this->eventProcessor->getObjectDataForPurchase($orderItems);
+        $this->assertEquals($expectedResult, $object);
+
+        $totalRevenue = $this->eventProcessor->getTotalRevenueForEvent($object);
+        $this->assertEquals($expectedTotalRevenue, $totalRevenue);
+    }
+
+    public function orderItemsProvider(): array
+    {
+        return [
+            [ // One item
+                'orderItemsData' => [
+                    [
+                        'getPriceInclTax' => 32.00,
+                        'getOriginalPrice' => 32.00,
+                        'getDiscountAmount' => 0.00,
+                        'getQtyOrdered' => 1,
+                    ]
+                ],
+                'expectedResult' => [
+                    [
+                        'price' => 32.00,
+                        'discount' => 0.00,
+                        'quantity' => 1,
+                    ]
+                ],
+                'expectedTotalRevenue' => 32.00
+            ],
+            [ // One item with discount
+                'orderItemsData' => [
+                    [
+                        'getPriceInclTax' => 32.00,
+                        'getOriginalPrice' => 32.00,
+                        'getDiscountAmount' => 7.00,
+                        'getQtyOrdered' => 1,
+                    ]
+                ],
+                'expectedResult' => [
+                    [
+                        'price' => 25.00,
+                        'discount' => 7.00,
+                        'quantity' => 1,
+                    ]
+                ],
+                'expectedTotalRevenue' => 25.00
+            ],
+            [ // Two items
+                'orderItemsData' => [
+                    [
+                        'getPriceInclTax' => 32.00,
+                        'getOriginalPrice' => 32.00,
+                        'getDiscountAmount' => 7.00,
+                        'getQtyOrdered' => 1,
+                    ],
+                    [
+                        'getPriceInclTax' => 32.00,
+                        'getOriginalPrice' => 32.00,
+                        'getDiscountAmount' => 0.00,
+                        'getQtyOrdered' => 2,
+                    ],
+                ],
+                'expectedResult' => [
+                    [
+                        'price' => 25.00,
+                        'discount' => 7.00,
+                        'quantity' => 1,
+                    ],
+                    [
+                        'price' => 32.00,
+                        'discount' => 0.00,
+                        'quantity' => 2,
+                    ]
+                ],
+                'expectedTotalRevenue' => 89.00 // 25 + 32*2
+            ],
+        ];
+    }
+}

--- a/Test/Unit/Service/EventProcessorTestable.php
+++ b/Test/Unit/Service/EventProcessorTestable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Service\Insights\EventProcessor;
+
+class EventProcessorTestable extends EventProcessor
+{
+    public function getObjectDataForPurchase(...$params): array
+    {
+        return parent::getObjectDataForPurchase(...$params);
+    }
+
+    public function getTotalRevenueForEvent(...$params): float
+    {
+        return parent::getTotalRevenueForEvent(...$params);
+    }
+}


### PR DESCRIPTION
This PR contains:
- A fix for revenue calculation on `place order` events where discounts weren't properly calculated in case website has a setup with configured VAT. 
- Units tests for this precise feature.