### PR TITLE
MAGE-1276 Expand creds by default on admin form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGE LOG
 
+## 3.16.0-beta.2
+
+### Updates
+
+- Credentials form expanded by default in admin
+
 ## 3.16.0-beta.1
 
 ### Features

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -15,6 +15,7 @@
             <resource>Algolia_AlgoliaSearch::algolia_algoliasearch</resource>
             <group id="credentials" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Credentials and Setup</label>
+                <attribute type="expanded">1</attribute>
                 <comment>
                     <![CDATA[
                         <div class="algolia-admin-content"></div>


### PR DESCRIPTION
**Summary**

Too easy to miss the credentials form on initial render. This PR simply expands the admin group by default. 

**Result**

Before:
![image](https://github.com/user-attachments/assets/e1ecb2f2-1c71-4588-bd0b-af08a749630b)

After:
<img width="1378" alt="2025-05-28_09-26-03" src="https://github.com/user-attachments/assets/2c554b32-7fd7-4ffe-aa10-fb395bfde14d" />

