### PR TITLE
MAGE-1270: Move indexing configuration to the indexing manager

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -21,9 +21,6 @@ use Magento\Store\Model\StoreManagerInterface;
 class ConfigHelper
 {
     public const ENABLE_FRONTEND = 'algoliasearch_credentials/credentials/enable_frontend';
-    public const ENABLE_BACKEND = 'algoliasearch_credentials/credentials/enable_backend';
-    public const ENABLE_QUERY_SUGGESTIONS_INDEX = 'algoliasearch_credentials/credentials/enable_query_suggestions_index';
-    public const ENABLE_PAGES_INDEX = 'algoliasearch_credentials/credentials/enable_pages_index';
     public const LOGGING_ENABLED = 'algoliasearch_credentials/credentials/debug';
     public const APPLICATION_ID = 'algoliasearch_credentials/credentials/application_id';
     public const API_KEY = 'algoliasearch_credentials/credentials/api_key';
@@ -133,6 +130,9 @@ class ConfigHelper
     public const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/queue/archive_clear_limit';
 
     // Indexing Manager settings
+    public const ENABLE_INDEXING = 'algoliasearch_indexing_manager/algolia_indexing/enable_indexing';
+    public const ENABLE_QUERY_SUGGESTIONS_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/enable_query_suggestions_index';
+    public const ENABLE_PAGES_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/credentials/enable_pages_index';
     public const ENABLE_INDEXER_PRODUCTS = 'algoliasearch_indexing_manager/full_indexing/products';
     public const ENABLE_INDEXER_CATEGORIES = 'algoliasearch_indexing_manager/full_indexing/categories';
     public const ENABLE_INDEXER_PAGES = 'algoliasearch_indexing_manager/full_indexing/pages';
@@ -247,9 +247,9 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isEnabledBackend($storeId = null)
+    public function isIndexingEnabled($storeId = null)
     {
-        return $this->configInterface->isSetFlag(self::ENABLE_BACKEND, ScopeInterface::SCOPE_STORE, $storeId);
+        return $this->configInterface->isSetFlag(self::ENABLE_INDEXING, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     /**

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1715,6 +1715,15 @@ class ConfigHelper
      */
     public const LEGACY_USE_VIRTUAL_REPLICA_ENABLED = 'algoliasearch_instant/instant/use_virtual_replica';
 
+    // --- Indexing Manager --- //
+
+    /**
+     * @deprecated This constant has been renamed to be more meaningful and to avoid confusion with "backend rendering" statements
+     * @see \Algolia\AlgoliaSearch\Helper\ConfigHelper::ENABLE_INDEXING
+     */
+    public const ENABLE_BACKEND = self::ENABLE_INDEXING;
+
+
     // --- Autocomplete --- //
 
     /**
@@ -2034,5 +2043,18 @@ class ConfigHelper
     public function hidePaginationInInstantSearchPage($storeId = null)
     {
         return $this->instantSearchConfig->shouldHidePagination($storeId);
+    }
+
+    // --- Indexing Manager --- //
+
+    /**
+     * @param $storeId
+     * @return bool
+     * @deprecated This method has been renamed to be more meaningful and to avoid confusion with "backend rendering" statements
+     * @see \Algolia\AlgoliaSearch\Helper\ConfigHelper::isIndexingEnabled()
+     */
+    public function isEnabledBackend($storeId = null)
+    {
+        return $this->isIndexingEnabled($storeId);
     }
 }

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -132,7 +132,7 @@ class ConfigHelper
     // Indexing Manager settings
     public const ENABLE_INDEXING = 'algoliasearch_indexing_manager/algolia_indexing/enable_indexing';
     public const ENABLE_QUERY_SUGGESTIONS_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/enable_query_suggestions_index';
-    public const ENABLE_PAGES_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/credentials/enable_pages_index';
+    public const ENABLE_PAGES_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/enable_pages_index';
     public const ENABLE_INDEXER_PRODUCTS = 'algoliasearch_indexing_manager/full_indexing/products';
     public const ENABLE_INDEXER_CATEGORIES = 'algoliasearch_indexing_manager/full_indexing/categories';
     public const ENABLE_INDEXER_PAGES = 'algoliasearch_indexing_manager/full_indexing/pages';

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -189,7 +189,7 @@ class Data
      */
     public function isIndexingEnabled($storeId = null): bool
     {
-        if ($this->configHelper->isEnabledBackend($storeId) === false) {
+        if ($this->configHelper->isIndexingEnabled($storeId) === false) {
             $this->logger->log('INDEXING IS DISABLED FOR ' . $this->logger->getStoreName($storeId));
             return false;
         }

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -105,7 +105,7 @@ class PageHelper extends AbstractEntityHelper
         if ($storeId === null) {
             /** @var \Magento\Store\Model\Store $store */
             foreach ($this->storeManager->getStores() as $store) {
-                if ($this->configHelper->isEnabledBackEnd($store->getId()) === false) {
+                if ($this->configHelper->isIndexingEnabled($store->getId()) === false) {
                     continue;
                 }
 

--- a/Service/AbstractIndexBuilder.php
+++ b/Service/AbstractIndexBuilder.php
@@ -30,7 +30,7 @@ abstract class AbstractIndexBuilder
      */
     protected function isIndexingEnabled($storeId = null): bool
     {
-        if ($this->configHelper->isEnabledBackend($storeId) === false) {
+        if ($this->configHelper->isIndexingEnabled($storeId) === false) {
             $this->logger->log('INDEXING IS DISABLED FOR ' . $this->logger->getStoreName($storeId));
             return false;
         }

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -494,7 +494,7 @@ class ReplicaManager implements ReplicaManagerInterface
      */
     public function isReplicaSyncEnabled(int $storeId): bool
     {
-        return $this->configHelper->isInstantEnabled($storeId) && $this->configHelper->isEnabledBackend($storeId);
+        return $this->configHelper->isInstantEnabled($storeId) && $this->configHelper->isIndexingEnabled($storeId);
     }
 
     /**

--- a/Setup/Patch/Data/MigrateIndexingConfigPatch.php
+++ b/Setup/Patch/Data/MigrateIndexingConfigPatch.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchInterface;
+
+class MigrateIndexingConfigPatch implements DataPatchInterface
+{
+    public function __construct(
+        protected ModuleDataSetupInterface $moduleDataSetup,
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    public function apply(): PatchInterface
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+
+        $this->moveIndexingSettings();
+
+        $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
+    }
+
+    /**
+     * Migrate old Indexing configurations
+     * @return void
+     */
+    protected function moveIndexingSettings(): void
+    {
+        $movedConfig = [
+            'algoliasearch_credentials/credentials/enable_backend'                 => ConfigHelper::ENABLE_INDEXING,
+            'algoliasearch_credentials/credentials/enable_query_suggestions_index' => ConfigHelper::ENABLE_QUERY_SUGGESTIONS_INDEX,
+            'algoliasearch_credentials/credentials/enable_pages_index'             => ConfigHelper::ENABLE_PAGES_INDEX,
+        ];
+
+        $connection = $this->moduleDataSetup->getConnection();
+        foreach ($movedConfig as $from => $to) {
+            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
+            $whereConfigPath = $connection->quoteInto('path = ?', $from);
+            $connection->update($configDataTable, ['path' => $to], $whereConfigPath);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/Setup/Patch/Schema/ConfigPatch.php
+++ b/Setup/Patch/Schema/ConfigPatch.php
@@ -30,7 +30,7 @@ class ConfigPatch implements SchemaPatchInterface
      * @var string[]
      */
     protected $defaultConfigData = [
-        'algoliasearch_credentials/credentials/enable_backend' => '1',
+        'algoliasearch_indexing_manager/algolia_indexing/enable_indexing' => '1',
         'algoliasearch_credentials/credentials/enable_frontend' => '1',
         'algoliasearch_credentials/credentials/application_id' => '',
         'algoliasearch_credentials/credentials/search_only_api_key' => '',

--- a/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
@@ -192,8 +192,8 @@ class ReplicaIndexingTest extends TestCase
     }
 
     /**
-     * @magentoConfigFixture current_store algoliasearch_credentials/credentials/enable_backend 0
-     * @magentoConfigFixture current_store algoliasearch_instant/instant/is_instant_enabled 1
+     * @magentoConfigFixture current_store algoliasearch_indexing_manager/algolia_indexing/enable_indexing 0
+     * @magentoConfigFixture current_store algoliasearch_indexing_manager/algolia_indexing/enable_indexing 1
      * @throws AlgoliaException
      * @throws ExceededRetriesException
      * @throws \ReflectionException
@@ -241,7 +241,7 @@ class ReplicaIndexingTest extends TestCase
 
     /**
      * Test the RebuildReplicasPatch with API failures
-     * @magentoConfigFixture current_store algoliasearch_credentials/credentials/enable_backend 1
+     * @magentoConfigFixture current_store algoliasearch_indexing_manager/algolia_indexing/enable_indexing 1
      * @magentoConfigFixture current_store algoliasearch_instant/instant/is_instant_enabled 1
      */
     public function testReplicaRebuildPatch(): void

--- a/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
@@ -193,7 +193,7 @@ class ReplicaIndexingTest extends TestCase
 
     /**
      * @magentoConfigFixture current_store algoliasearch_indexing_manager/algolia_indexing/enable_indexing 0
-     * @magentoConfigFixture current_store algoliasearch_indexing_manager/algolia_indexing/enable_indexing 1
+     * @magentoConfigFixture current_store algoliasearch_instant/instant/is_instant_enabled 1
      * @throws AlgoliaException
      * @throws ExceededRetriesException
      * @throws \ReflectionException

--- a/Test/Integration/_files/second_website_with_two_stores_and_products.php
+++ b/Test/Integration/_files/second_website_with_two_stores_and_products.php
@@ -67,10 +67,10 @@ foreach ($websites as $website) {
 
 $configManager = $objectManager->get(\Magento\Framework\App\Config\MutableScopeConfigInterface::class);
 // Temporarily disable indexing during product assignment to stores
-$configManager->setValue('algoliasearch_credentials/credentials/enable_backend', 0, 'store', 'admin');
-$configManager->setValue('algoliasearch_credentials/credentials/enable_backend', 0, 'store', 'default');
-$configManager->setValue('algoliasearch_credentials/credentials/enable_backend', 0, 'store', 'fixture_second_store');
-$configManager->setValue('algoliasearch_credentials/credentials/enable_backend', 0, 'store', 'fixture_third_store');
+$configManager->setValue('algoliasearch_indexing_manager/algolia_indexing/enable_indexing', 0, 'store', 'admin');
+$configManager->setValue('algoliasearch_indexing_manager/algolia_indexing/enable_indexing', 0, 'store', 'default');
+$configManager->setValue('algoliasearch_indexing_manager/algolia_indexing/enable_indexing', 0, 'store', 'fixture_second_store');
+$configManager->setValue('algoliasearch_indexing_manager/algolia_indexing/enable_indexing', 0, 'store', 'fixture_third_store');
 
 $productSkus = MultiStoreProductsTest::SKUS;
 $productRepository = Bootstrap::getObjectManager()
@@ -82,10 +82,10 @@ foreach ($productSkus as $sku) {
     $productRepository->save($product);
 }
 
-$configManager->setValue('algoliasearch_credentials/credentials/enable_backend', 1, 'store', 'admin');
-$configManager->setValue('algoliasearch_credentials/credentials/enable_backend', 1, 'store', 'default');
-$configManager->setValue('algoliasearch_credentials/credentials/enable_backend', 1, 'store', 'fixture_second_store');
-$configManager->setValue('algoliasearch_credentials/credentials/enable_backend', 1, 'store', 'fixture_third_store');
+$configManager->setValue('algoliasearch_indexing_manager/algolia_indexing/enable_indexing', 1, 'store', 'admin');
+$configManager->setValue('algoliasearch_indexing_manager/algolia_indexing/enable_indexing', 1, 'store', 'default');
+$configManager->setValue('algoliasearch_indexing_manager/algolia_indexing/enable_indexing', 1, 'store', 'fixture_second_store');
+$configManager->setValue('algoliasearch_indexing_manager/algolia_indexing/enable_indexing', 1, 'store', 'fixture_third_store');
 
 /* Refresh CatalogSearch index */
 /** @var IndexerRegistry $indexerRegistry */

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -53,43 +53,6 @@
                         ]]>
                     </comment>
                 </field>
-                <field id="enable_backend" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable Indexing</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>
-                        <![CDATA[
-                            Do you want the Algolia extension to push your data to Algolia?<br>
-                            The benefit here is that Algolia will manage to keep your data up to date.
-                            If you choose "No", you will need to push and manage your data in a different way.
-                        ]]>
-                    </comment>
-                </field>
-                <field id="enable_query_suggestions_index" translate="label comment" type="select" sortOrder="41" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable Query Suggestions Index</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>
-                        <![CDATA[
-                            Do you want the Algolia extension to push your search terms/suggestions to Algolia?<br>
-                            If you choose "No", _suggestion indexes will not be created.
-                        ]]>
-                    </comment>
-                    <depends>
-                        <field id="enable_backend">1</field>
-                    </depends>
-                </field>
-                <field id="enable_pages_index" translate="label comment" type="select" sortOrder="41" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable Pages Index</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>
-                        <![CDATA[
-                            Do you want the Algolia extension to push your CMS Pages to Algolia?<br>
-                            If you choose "No", _pages indexes will not be created.
-                        ]]>
-                    </comment>
-                    <depends>
-                        <field id="enable_backend">1</field>
-                    </depends>
-                </field>
                 <field id="enable_frontend" translate="label comment" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Search</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -1085,6 +1048,47 @@
             <label>Indexing Manager</label>
             <tab>algolia</tab>
             <resource>Algolia_AlgoliaSearch::algolia_algoliasearch</resource>
+            <group id="algolia_indexing" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Enable Algolia indexing</label>
+                <attribute type="expanded">1</attribute>
+                <field id="enable_indexing" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Indexing</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                            Do you want the Algolia extension to push your data to Algolia?<br>
+                            The benefit here is that Algolia will manage to keep your data up to date.
+                            If you choose "No", you will need to push and manage your data in a different way.
+                        ]]>
+                    </comment>
+                </field>
+                <field id="enable_query_suggestions_index" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Query Suggestions Index</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                            Do you want the Algolia extension to push your search terms/suggestions to Algolia?<br>
+                            If you choose "No", _suggestion indexes will not be created.
+                        ]]>
+                    </comment>
+                    <depends>
+                        <field id="algolia_indexing">1</field>
+                    </depends>
+                </field>
+                <field id="enable_pages_index" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Pages Index</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                            Do you want the Algolia extension to push your CMS Pages to Algolia?<br>
+                            If you choose "No", _pages indexes will not be created.
+                        ]]>
+                    </comment>
+                    <depends>
+                        <field id="algolia_indexing">1</field>
+                    </depends>
+                </field>
+            </group>
             <group id="full_indexing" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Full indexing via Magento indexers</label>
                 <comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,10 +8,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <algoliasearch_credentials>
-            <credentials>
-                <enable_query_suggestions_index>1</enable_query_suggestions_index>
-                <enable_pages_index>1</enable_pages_index>
-            </credentials>
             <algolia_cookie_configuration>
                 <default_consent_cookie_name>user_allowed_save_cookie</default_consent_cookie_name>
                 <allow_cookie_button_selector>#btn-cookie-allow</allow_cookie_button_selector>
@@ -73,6 +69,11 @@
             </queue>
         </algoliasearch_queue>
         <algoliasearch_indexing_manager>
+            <algolia_indexing>
+                <enable_indexing>1</enable_indexing>
+                <enable_query_suggestions_index>1</enable_query_suggestions_index>
+                <enable_pages_index>1</enable_pages_index>
+            </algolia_indexing>
             <full_indexing>
                 <products>0</products>
                 <categories>0</categories>

--- a/view/adminhtml/web/js/config.js
+++ b/view/adminhtml/web/js/config.js
@@ -39,6 +39,7 @@ require(
 			pageWarning += '</div>';
 
 			let pageWarningSynonyms = '<div class="algolia_dashboard_warning algolia_dashboard_warning_page">';
+			pageWarningSynonyms += '<p>Configurations related to indexing have been moved to the "Indexing Manager" section.</p>';
 			pageWarningSynonyms += '<p>Configurations related to Synonyms have been removed from the Magento dashboard. We advise you to configure synonyms from the Algolia dashboard.</p>';
 			pageWarningSynonyms += '</div>';
 
@@ -69,7 +70,7 @@ require(
 				const searchableSelect = $('select[name="groups[instant_facets][fields][facets][value][' + rowId + '][searchable]"]');
 
 				searchableSelect.on('change', function(){
-					configQrFromSearchableSelect($(this));	
+					configQrFromSearchableSelect($(this));
 				});
 
 				configQrFromSearchableSelect(searchableSelect);
@@ -93,4 +94,4 @@ require(
 		}
 
 	}
-);	
+);


### PR DESCRIPTION
This PR contains:
- Moved indexing configuration from "Credentials and Basic setup" section to the newly created "Indexing Manager" section
- Renamed "Enable Backend" occurrences to "Enable Indexing" to be more meaningful and to avoid confusion with "backend rendering" statements in the extension.
- Fixed tests according to these changes
- Added a data patch to ensure the configuration doesn't get lost in the process.