### PR TITLE
Prevent 422 Insights Event

### DIFF
--- a/view/frontend/web/js/insights.js
+++ b/view/frontend/web/js/insights.js
@@ -180,7 +180,7 @@ define([
                         var eventData = self.buildEventData(
                             'Clicked',
                             $this.data('objectid'),
-                            $this.data('indexname'),
+                            $this.data('index'),
                             $this.data('position'),
                             $this.data('queryid')
                         );


### PR DESCRIPTION
The Algolia event debugger indicates a large number of `422` status codes from Autocomplete click insights events due to a missing `index` field.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
Bug Fix: Clicking a hit within the Autocomplete product section does not pass the `index` to the insights `click` event thus creating a `422` status code.

**Result**

1. Open the dev tools to the **Network** tab
2. Check the **Preserve Log** check box
3. Go to a page with the Algolia autcomplete box
4. Search for any term triggering the autocomplete results
5. Click on any hit (product) in the autocomplete dropdown
6. In the **Network** panel of the dev tools, select **All** and filter by `insights.algolia.io`
7. Look at the requests, viewing the **Payload** tab. Expand the **Request Payload** for an event where the `eventType` = `click`
   - If the bug is fixed, the `index` property with the correct index name as the `value` will be present

This change will use the `data-index` property that is defined by the templates from https://github.com/algolia/algoliasearch-magento-2/tree/main/view/frontend/web/js/template/autocomplete

## Illustration of the issue
### Error events in the Algolia Events Debugger
![image](https://github.com/user-attachments/assets/d8661e36-54e4-4ac8-98f6-6da9ea91ec14)

### Illustration of the `422` status code occurring in the browser
![image](https://github.com/user-attachments/assets/d9919bdc-68ac-4b9e-9c3e-b537fa301208)