### PR TITLE
Fix double currency conversion for configurable products

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -52,7 +52,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
             /** @var Product $subProduct */
             foreach ($subProducts as $subProduct) {
                 $specialPrice = $this->getSpecialPrice($subProduct, $currencyCode, $withTax, $subProducts);
-                $tierPrice = $this->getTierPrice($subProduct, $currencyCode, $withTax);
+                $tierPrice = $this->getTierPrice($subProduct, $currencyCode, $withTax, $subProducts);
                 if (!empty($tierPrice[0]) && $specialPrice[0] > $tierPrice[0]){
                     $minPrice = $tierPrice[0];
                 } else {
@@ -231,7 +231,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
                 $subProduct->setData('customer_group_id', $groupId);
                 $subProduct->setData('website_id', $subProduct->getStore()->getWebsiteId());
                 $specialPrice = $this->getSpecialPrice($subProduct, $currencyCode, $withTax, []);
-                $tierPrice = $this->getTierPrice($subProduct, $currencyCode, $withTax);
+                $tierPrice = $this->getTierPrice($subProduct, $currencyCode, $withTax, []);
                 $price     = $this->getTaxPrice($product, $subProduct->getPriceModel()->getFinalPrice(1, $subProduct), $withTax);
 
                 if (!empty($tierPrice[$groupId]) && $specialPrice[$groupId] > $tierPrice[$groupId]) {


### PR DESCRIPTION
## Description
Fixes double currency conversion issue for configurable products that caused incorrect prices in non-base currencies (e.g., AUD prices were double-converted from EUR).

## Problem
- Configurable products had prices converted twice: once in `getSpecialPrice()` and again in `getMinMaxPrices()`
- This resulted in incorrect prices like: 122.05 EUR → 214.15 AUD → 375.76 AUD (double conversion)

## Solution
- Modified `getSpecialPrice()` to only convert currencies for simple products
- Configurable products now rely on `getMinMaxPrices()` for currency conversion
- Added condition: `(!$subProducts || count($subProducts) === 0)` to determine conversion logic

## Testing
- [x] Tested with configurable products in AUD/USD currencies
- [x] Verified simple products still work correctly
- [x] Confirmed no double conversion in logs