### PR TITLE
adds explicit nullable types to missing arguments for PHP 8.4

### DIFF
--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -297,7 +297,7 @@ class AlgoliaHelper extends AbstractHelper
      *
      * @throws AlgoliaException|NoSuchEntityException
      */
-    public function searchRules(string $indexName, array $searchRulesParams = null, ?int $storeId = null)
+    public function searchRules(string $indexName, ?array $searchRulesParams = null, ?int $storeId = null)
     {
         $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 

--- a/Helper/Configuration/PersonalizationHelper.php
+++ b/Helper/Configuration/PersonalizationHelper.php
@@ -51,7 +51,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isPersoEnabled(int $storeId = null): bool
+    public function isPersoEnabled(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_PERSO_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -61,7 +61,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return void
      */
-    public function disablePerso(int $storeId = null): void
+    public function disablePerso(?int $storeId = null): void
     {
         $this->configResourceInterface->saveConfig(self::IS_PERSO_ENABLED, 0, 'default', 0);
     }
@@ -71,7 +71,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isViewProductTracked(int $storeId = null): bool
+    public function isViewProductTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::VIEW_PRODUCT, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -81,7 +81,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isProductClickedTracked(int $storeId = null): bool
+    public function isProductClickedTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::PRODUCT_CLICKED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -91,7 +91,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getProductClickedSelector(int $storeId = null): string
+    public function getProductClickedSelector(?int $storeId = null): string
     {
         return $this->configInterface->getValue(self::PRODUCT_CLICKED_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -101,7 +101,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isFilterClickedTracked(int $storeId = null): bool
+    public function isFilterClickedTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::FILTER_CLICKED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -111,7 +111,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isWishlistAddTracked(int $storeId = null): bool
+    public function isWishlistAddTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::WISHLIST_ADD, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -121,7 +121,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getWishlistAddSelector(int $storeId = null): string
+    public function getWishlistAddSelector(?int $storeId = null): string
     {
         return $this->configInterface->getValue(self::WISHLIST_ADD_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -131,7 +131,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isProductRecommendedTracked(int $storeId = null): bool
+    public function isProductRecommendedTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::PRODUCT_RECOMMENDED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -141,7 +141,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getProductRecommendedSelector(int $storeId = null): string
+    public function getProductRecommendedSelector(?int $storeId = null): string
     {
         return $this->configInterface->getValue(self::PRODUCT_RECOMMENDED_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -151,7 +151,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isCartAddTracked(int $storeId = null): bool
+    public function isCartAddTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::CART_ADD, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -161,7 +161,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getCartAddSelector(int $storeId = null): string
+    public function getCartAddSelector(?int $storeId = null): string
     {
         return $this->configInterface->getValue(self::CART_ADD_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -171,7 +171,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isOrderPlacedTracked(int $storeId = null): bool
+    public function isOrderPlacedTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::ORDER_PLACED, ScopeInterface::SCOPE_STORE, $storeId);
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -59,7 +59,7 @@ class Data
      * @deprecated
      * Use Algolia\AlgoliaSearch\Service\Page\IndexBuilder::buildIndexFull() instead
      */
-    public function rebuildStorePageIndex($storeId, array $pageIds = null): void
+    public function rebuildStorePageIndex($storeId, ?array $pageIds = null): void
     {
         $this->pageIndexBuilder->buildIndexFull($storeId, ['entityIds' => $pageIds]);
     }
@@ -203,7 +203,7 @@ class Data
      * @return string
      * @throws NoSuchEntityException
      */
-    public function getIndexName(string $indexSuffix, int $storeId = null, bool $tmp = false): string
+    public function getIndexName(string $indexSuffix, ?int $storeId = null, bool $tmp = false): string
     {
         return $this->indexNameFetcher->getIndexName($indexSuffix, $storeId, $tmp);
     }
@@ -213,7 +213,7 @@ class Data
      * @return string
      * @throws NoSuchEntityException
      */
-    public function getBaseIndexName(int $storeId = null): string
+    public function getBaseIndexName(?int $storeId = null): string
     {
         return $this->indexNameFetcher->getBaseIndexName($storeId);
     }
@@ -237,7 +237,7 @@ class Data
      * @return array
      * @throws NoSuchEntityException
      */
-    protected function buildIndexData(StoreInterface $store = null): array
+    protected function buildIndexData(?StoreInterface $store = null): array
     {
         $storeId = !is_null($store) ? $store->getStoreId() : null;
         $currencyCode = !is_null($store) ?

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -48,7 +48,7 @@ class PageHelper extends AbstractEntityHelper
         return $indexSettings;
     }
 
-    public function getPages($storeId, array $pageIds = null)
+    public function getPages($storeId, ?array $pageIds = null)
     {
         $magentoPages = $this->pageCollectionFactory->create()
             ->addStoreFilter($storeId)

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -577,7 +577,7 @@ class ProductHelper extends AbstractEntityHelper
      * @return void
      * @throws AlgoliaException
      */
-    protected function setFacetsQueryRules(string $indexName, int $storeId = null)
+    protected function setFacetsQueryRules(string $indexName, ?int $storeId = null)
     {
         $this->clearFacetsQueryRules($indexName, $storeId);
 
@@ -623,7 +623,7 @@ class ProductHelper extends AbstractEntityHelper
      * @return void
      * @throws AlgoliaException
      */
-    protected function clearFacetsQueryRules($indexName, int $storeId = null): void
+    protected function clearFacetsQueryRules($indexName, ?int $storeId = null): void
     {
         try {
             $hitsPerPage = 100;

--- a/Helper/InsightsHelper.php
+++ b/Helper/InsightsHelper.php
@@ -162,7 +162,7 @@ class InsightsHelper
      * @param int|null $storeId
      * @return bool
      */
-    public function isInsightsEnabled(int $storeId = null): bool
+    public function isInsightsEnabled(?int $storeId = null): bool
     {
         return $this->configHelper->isClickConversionAnalyticsEnabled($storeId)
             || $this->personalizationHelper->isPersoEnabled($storeId);
@@ -174,7 +174,7 @@ class InsightsHelper
      *
      * @return bool
      */
-    public function isOrderPlacedTracked(int $storeId = null): bool
+    public function isOrderPlacedTracked(?int $storeId = null): bool
     {
         return $this->personalizationHelper->isPersoEnabled($storeId)
             && $this->personalizationHelper->isOrderPlacedTracked($storeId)
@@ -188,7 +188,7 @@ class InsightsHelper
      * @param int|null $storeId
      * @return bool
      */
-    public function isConversionTrackedPlaceOrder(int $storeId = null): bool
+    public function isConversionTrackedPlaceOrder(?int $storeId = null): bool
     {
         return $this->configHelper->isClickConversionAnalyticsEnabled($storeId)
             && in_array($this->configHelper->getConversionAnalyticsMode($storeId),
@@ -206,7 +206,7 @@ class InsightsHelper
      *
      * @return bool
      */
-    public function isAddedToCartTracked(int $storeId = null): bool
+    public function isAddedToCartTracked(?int $storeId = null): bool
     {
         return $this->personalizationHelper->isPersoEnabled($storeId)
             && $this->personalizationHelper->isCartAddTracked($storeId)
@@ -220,7 +220,7 @@ class InsightsHelper
      * @param int|null $storeId
      * @return bool
      */
-    public function isConversionTrackedAddToCart(int $storeId = null): bool
+    public function isConversionTrackedAddToCart(?int $storeId = null): bool
     {
         return $this->configHelper->isClickConversionAnalyticsEnabled($storeId)
             && in_array($this->configHelper->getConversionAnalyticsMode($storeId),

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -41,8 +41,8 @@ class MerchandisingHelper
                                   int    $entityId,
                                   array  $rawPositions,
                                   string $entityType,
-                                  string $query = null,
-                                  string $banner = null): void
+                                  ?string $query = null,
+                                  ?string $banner = null): void
     {
         if ($this->coreHelper->isIndexingEnabled($storeId) === false) {
             return;

--- a/Model/Backend/EnableCustomerGroups.php
+++ b/Model/Backend/EnableCustomerGroups.php
@@ -22,8 +22,8 @@ class EnableCustomerGroups extends Value
         TypeListInterface       $cacheTypeList,
         protected ReplicaState  $replicaState,
         protected ConfigChecker $configChecker,
-        AbstractResource        $resource = null,
-        AbstractDb              $resourceCollection = null,
+        ?AbstractResource       $resource = null,
+        ?AbstractDb             $resourceCollection = null,
         array                   $data = []
     )
     {

--- a/Model/Backend/Sorts.php
+++ b/Model/Backend/Sorts.php
@@ -24,10 +24,10 @@ class Sorts extends ArraySerialized
         TypeListInterface       $cacheTypeList,
         protected ReplicaState  $replicaState,
         protected ConfigChecker $configChecker,
-        AbstractResource        $resource = null,
-        AbstractDb              $resourceCollection = null,
+        ?AbstractResource       $resource = null,
+        ?AbstractDb             $resourceCollection = null,
         array                   $data = [],
-        Json                    $serializer = null
+        ?Json                   $serializer = null
     )
     {
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);

--- a/Model/Indexer/ProductObserver.php
+++ b/Model/Indexer/ProductObserver.php
@@ -69,7 +69,7 @@ class ProductObserver
      *
      * @return Action
      */
-    public function afterUpdateAttributes(Action $subject, Action $result = null, $productIds)
+    public function afterUpdateAttributes(Action $subject, ?Action $result = null, $productIds)
     {
         if (!$this->indexer->isScheduled()) {
             $this->indexer->reindexList(array_unique($productIds));
@@ -85,7 +85,7 @@ class ProductObserver
      *
      * @return mixed
      */
-    public function afterUpdateWebsites(Action $subject, Action $result = null, array $productIds)
+    public function afterUpdateWebsites(Action $subject, ?Action $result = null, array $productIds)
     {
         if (!$this->indexer->isScheduled()) {
             $this->indexer->reindexList(array_unique($productIds));

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -41,8 +41,8 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Framework\ObjectManagerInterface $objectManager,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -571,7 +571,7 @@ class Queue
      *
      * @return array
      */
-    protected function stackSortedJobs(array $sortedJobs, array $tempSortableJobs, Job $job = null)
+    protected function stackSortedJobs(array $sortedJobs, array $tempSortableJobs, ?Job $job = null)
     {
         if ($tempSortableJobs && $tempSortableJobs !== []) {
             $tempSortableJobs = $this->jobSort(

--- a/Model/ResourceModel/Job/Grid/Collection.php
+++ b/Model/ResourceModel/Job/Grid/Collection.php
@@ -38,7 +38,7 @@ class Collection extends JobCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -97,7 +97,7 @@ class Collection extends JobCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -127,7 +127,7 @@ class Collection extends JobCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/LandingPage/Grid/Collection.php
+++ b/Model/ResourceModel/LandingPage/Grid/Collection.php
@@ -37,7 +37,7 @@ class Collection extends LandingPageCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -112,7 +112,7 @@ class Collection extends LandingPageCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/Query/Grid/Collection.php
+++ b/Model/ResourceModel/Query/Grid/Collection.php
@@ -37,7 +37,7 @@ class Collection extends QueryCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -82,7 +82,7 @@ class Collection extends QueryCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -112,7 +112,7 @@ class Collection extends QueryCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/QueueArchive/Grid/Collection.php
+++ b/Model/ResourceModel/QueueArchive/Grid/Collection.php
@@ -44,7 +44,7 @@ class Collection extends QueueArchiveCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        AbstractDb $resource = null
+        ?AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -89,7 +89,7 @@ class Collection extends QueueArchiveCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -119,7 +119,7 @@ class Collection extends QueueArchiveCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/Run/Grid/Collection.php
+++ b/Model/ResourceModel/Run/Grid/Collection.php
@@ -37,7 +37,7 @@ class Collection extends RunCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -82,7 +82,7 @@ class Collection extends RunCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -112,7 +112,7 @@ class Collection extends RunCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Plugin/AddToCartRedirectForInsights.php
+++ b/Plugin/AddToCartRedirectForInsights.php
@@ -41,7 +41,7 @@ class AddToCartRedirectForInsights
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function beforeAddProduct(Cart $cartModel, int|Product $productInfo, array|int|DataObject $requestInfo = null)
+    public function beforeAddProduct(Cart $cartModel, int|Product $productInfo, ?array|int|DataObject $requestInfo = null)
     {
         // First, check is Insights are enabled
         if (!$this->configHelper->isClickConversionAnalyticsEnabled($this->storeManager->getStore()->getId())) {

--- a/Plugin/StockItemObserver.php
+++ b/Plugin/StockItemObserver.php
@@ -44,7 +44,7 @@ class StockItemObserver
      */
     public function afterDelete(
         \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $stockItemResource,
-        \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $result = null,
+        ?\Magento\CatalogInventory\Model\ResourceModel\Stock\Item $result = null,
         \Magento\CatalogInventory\Api\Data\StockItemInterface $stockItem
     ) {
         $stockItemResource->addCommitCallback(function () use ($stockItem) {

--- a/Service/AbstractIndexBuilder.php
+++ b/Service/AbstractIndexBuilder.php
@@ -74,7 +74,7 @@ abstract class AbstractIndexBuilder
      * @return void
      * @throws \Exception
      */
-    protected function saveObjects(array $objects, string $indexName, int $storeId = null): void
+    protected function saveObjects(array $objects, string $indexName, ?int $storeId = null): void
     {
         $this->algoliaHelper->saveObjects($indexName, $objects, $this->configHelper->isPartialUpdateEnabled(), $storeId);
     }

--- a/Service/AdditionalSection/IndexBuilder.php
+++ b/Service/AdditionalSection/IndexBuilder.php
@@ -36,7 +36,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
      * @throws ExceededRetriesException
      * @throws NoSuchEntityException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, null, null);
     }

--- a/Service/AlgoliaCredentialsManager.php
+++ b/Service/AlgoliaCredentialsManager.php
@@ -24,7 +24,7 @@ class AlgoliaCredentialsManager
      * @param int|null $storeId
      * @return bool
      */
-    public function checkCredentials(int $storeId = null): bool
+    public function checkCredentials(?int $storeId = null): bool
     {
         return $this->configHelper->getApplicationID($storeId) && $this->configHelper->getAPIKey($storeId);
     }
@@ -35,7 +35,7 @@ class AlgoliaCredentialsManager
      * @param int|null $storeId
      * @return bool
      */
-    public function checkCredentialsWithSearchOnlyAPIKey(int $storeId = null): bool
+    public function checkCredentialsWithSearchOnlyAPIKey(?int $storeId = null): bool
     {
         return $this->checkCredentials($storeId) && $this->configHelper->getSearchOnlyAPIKey($storeId);
     }

--- a/Service/Category/IndexBuilder.php
+++ b/Service/Category/IndexBuilder.php
@@ -37,7 +37,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @throws NoSuchEntityException
      * @throws AlgoliaException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, null, $options);
     }
@@ -51,7 +51,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function buildIndexList(int $storeId, array $entityIds = null, array $options = null): void
+    public function buildIndexList(int $storeId, ?array $entityIds = null, ?array $options = null): void
     {
         $this->buildIndex($storeId, $entityIds, $options);
     }

--- a/Service/Insights/EventProcessor.php
+++ b/Service/Insights/EventProcessor.php
@@ -128,7 +128,7 @@ class EventProcessor implements EventProcessorInterface
     /**
      * @inheritDoc
      */
-    public function convertAddToCart(string $eventName, string $indexName, Item $item, string $queryID = null): array
+    public function convertAddToCart(string $eventName, string $indexName, Item $item, ?string $queryID = null): array
     {
         $this->checkDependencies();
 
@@ -157,7 +157,7 @@ class EventProcessor implements EventProcessorInterface
     /**
      * @inheritDoc
      */
-    public function convertPurchaseForItems(string $eventName, string $indexName, array $items, string $queryID = null): array
+    public function convertPurchaseForItems(string $eventName, string $indexName, array $items, ?string $queryID = null): array
     {
         $this->checkDependencies();
 

--- a/Service/Page/IndexBuilder.php
+++ b/Service/Page/IndexBuilder.php
@@ -36,7 +36,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
      * @throws ExceededRetriesException
      * @throws NoSuchEntityException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, $options['entityIds'] ?? null, null);
     }

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -50,7 +50,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, null, $options);
     }
@@ -63,7 +63,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function buildIndexList(int $storeId, array $entityIds = null, array $options = null): void
+    public function buildIndexList(int $storeId, ?array $entityIds = null, ?array $options = null): void
     {
         $this->buildIndex($storeId, $entityIds, $options);
     }

--- a/Service/Suggestion/IndexBuilder.php
+++ b/Service/Suggestion/IndexBuilder.php
@@ -37,7 +37,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
      * @throws ExceededRetriesException
      * @throws NoSuchEntityException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, null, null);
     }

--- a/Test/Integration/Indexing/Config/Traits/ConfigAssertionsTrait.php
+++ b/Test/Integration/Indexing/Config/Traits/ConfigAssertionsTrait.php
@@ -12,7 +12,7 @@ trait ConfigAssertionsTrait
      * @return int
      * @throws AlgoliaException
      */
-    protected function countStoreIndices(StoreInterface $store = null): int
+    protected function countStoreIndices(?StoreInterface $store = null): int
     {
         $indices = $this->algoliaHelper->listIndexes($store->getId());
 

--- a/Test/Integration/Indexing/IndexingTestCase.php
+++ b/Test/Integration/Indexing/IndexingTestCase.php
@@ -40,7 +40,7 @@ abstract class IndexingTestCase extends TestCase
         string $indexName,
         string $recordId,
         array $expectedValues,
-        int $storeId = null
+        ?int $storeId = null
     ) : void {
         $res = $this->algoliaHelper->getObjects($indexName, [$recordId], $storeId);
         $record = reset($res['results']);

--- a/Test/Integration/Indexing/MultiStoreTestCase.php
+++ b/Test/Integration/Indexing/MultiStoreTestCase.php
@@ -53,7 +53,7 @@ abstract class MultiStoreTestCase extends IndexingTestCase
         string $storeCode,
         string $entity,
         int $expectedNumber,
-        int $storeId = null
+        ?int $storeId = null
     ): void
     {
         $resultsDefault = $this->algoliaHelper->query(

--- a/Test/Integration/Indexing/Product/MultiStoreProductsTest.php
+++ b/Test/Integration/Indexing/Product/MultiStoreProductsTest.php
@@ -170,7 +170,7 @@ class MultiStoreProductsTest extends MultiStoreTestCase
      * @return ProductInterface
      * @throws NoSuchEntityException
      */
-    private function loadProduct(int $productId, int $storeId = null): ProductInterface
+    private function loadProduct(int $productId, ?int $storeId = null): ProductInterface
     {
         return $this->productRepository->getById($productId, true, $storeId);
     }

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -291,7 +291,7 @@ abstract class TestCase extends \TC
      * @param string|null $key - a unique key for this operation - if null a unique key will be derived
      * @return mixed
      */
-    function runOnce(callable $callback, string $key = null): mixed
+    function runOnce(callable $callback, ?string $key = null): mixed
     {
         static $executed = [];
         $key ??= is_string($callback) ? $callback : spl_object_hash((object) $callback);

--- a/ViewModel/Adminhtml/Analytics/Overview.php
+++ b/ViewModel/Adminhtml/Analytics/Overview.php
@@ -107,7 +107,7 @@ class Overview implements \Magento\Framework\View\Element\Block\ArgumentInterfac
      * @return \DateTime
      * @throws NoSuchEntityException
      */
-    protected function parseFormSubmittedDate(string $dateString = null, string $timezone = null): \DateTime
+    protected function parseFormSubmittedDate(?string $dateString = null, ?string $timezone = null): \DateTime
     {
         if (empty($timezone)) {
             $timezone = $this->getTimeZone();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
Adds explicit nullable types to missing arguments for PHP 8.4 compatibility.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
Using Adobe Commerce 2.4.8+, PHP 8.4 is recommended.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Example of output from running `setup:upgrade`

```Deprecated Functionality: Algolia\AlgoliaSearch\Model\ResourceModel\Job\Grid\Collection::setSearchCriteria(): Implicitly marking parameter $searchCriteria as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/algolia/algoliasearch-magento-2/Model/ResourceModel/Job/Grid/Collection.php on line 100```