### PR TITLE
Fix store id for queue job

### DIFF
--- a/Model/Job.php
+++ b/Model/Job.php
@@ -94,8 +94,8 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
 
             $this->setDecodedData($decodedData);
 
-            if (isset($decodedData['store_id'])) {
-                $this->setStoreId($decodedData['store_id']);
+            if (isset($decodedData['storeId'])) {
+                $this->setStoreId($decodedData['storeId']);
             }
         }
 

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -580,7 +580,7 @@ class Queue
                 SORT_ASC,
                 'method',
                 SORT_ASC,
-                'store_id',
+                'storId',
                 SORT_ASC,
                 'job_id',
                 SORT_ASC


### PR DESCRIPTION
**Summary**
The “algoliasearch_queue” table keeps job entries. Job's "data" field is a JSON string with job details.
Starting from 3.6.0 the field names in "data" JSON got a new format: from snake case they were changed to camel case:

How job was added to the table before version 3.6.0: field names with snake case:
https://github.com/algolia/algoliasearch-magento-2/blob/338a9433d9a89e98dca7ad316c284186c897baa9/Model/Indexer/Product.php#L85
```
  $this->queue->addToQueue(
      Data::class,
      'rebuildStoreProductIndex',
      ['store_id' => $storeId, 'product_ids' => $chunk],
      count($chunk)
  );
```
in 3.6.0 the format was changed to camel case:
https://github.com/algolia/algoliasearch-magento-2/blob/5554a79abd04e93331ffcf1d7769270253da0a90/Model/Indexer/Product.php#L85
```
  $this->queue->addToQueue(
      Data::class,
      'rebuildStoreProductIndex',
      ['storeId' => $storeId, 'productIds' => $chunk],
      count($chunk)
  );
```

But there are two places where code works with the old snake case format:
* while loading a job record and decoding "data" values
* while sorting jobs
