### PR TITLE
Prevent 422 Insights Event - Instant Search Click

### DIFF
--- a/view/frontend/templates/instant/hit.phtml
+++ b/view/frontend/templates/instant/hit.phtml
@@ -24,7 +24,7 @@ $origFormatedVar = $block->escapeHtml('price' . $priceKey . '_original_formated'
                 {{^__queryID}} href="{{url}}" {{/__queryID}}
                 {{#__queryID}} href="{{urlForInsights}}" {{/__queryID}}
                 data-objectid="{{objectID}}"
-                data-indexname="{{__indexName}}"
+                data-index="{{__indexName}}"
                 data-position="{{__position}}"
                 data-queryid="{{__queryID}}">
                 <div class="result-content">
@@ -92,7 +92,7 @@ $origFormatedVar = $block->escapeHtml('price' . $priceKey . '_original_formated'
                             <input name="form_key" type="hidden" value="{{ addToCart.formKey }}">
                             <button type="submit" title="<?php echo __('Add to Cart') ?>" class="action tocart primary"
                             data-objectid="{{objectID}}"
-                            data-indexname="{{__indexName}}"
+                            data-index="{{__indexName}}"
                             data-position="{{__position}}"
                             data-queryid="{{__queryID}}"
                             >


### PR DESCRIPTION
Prevent http status code 422 from Instant Search Insights click events due to a missing index name

The Algolia event debugger shows error events with a `422` status code from **Instant Search** `click` insights events due to a missing `index` field.

**Summary**

Bug Fix: Clicking a hit on the **Instant Search** results page does not pass the `index` to the insights `click` event thus creating a `422` status code.

This relates to PR #1763 

**Result**

1. Open the dev tools to the **Network** tab
2. Click the **Preserve Log** check box
3. Go to the homepage of the Algolia search powered website
4. Search for any search term and press **Enter** to go to the **Instant Search** results page
5. Click on any product on the **Instant Search** results page
6. In the **Network** panel, select **All** and filter by: `insights.algolia.io`
7. Look at the requests, viewing the **Payload** tab. Expand the **Request Payload** for an event where the `eventType` = `click`
8. If the bug is fixed, we should see the `index` property with the correct index name as the value.