### PR TITLE
MAGE-1341 Fix dropped products during full reindex via queue

### DIFF
--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -251,7 +251,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         $collection->load();
         $this->logger->log('Loaded ' . count($collection) . ' products');
         $this->logger->stop($logMessage);
-        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, $useTmpIndex);
         $indexData = $this->getProductsRecords($storeId, $collection, $productIds);
         if (!empty($indexData['toIndex'])) {
             $this->logger->start('ADD/UPDATE TO ALGOLIA');


### PR DESCRIPTION
**Summary**

This PR addresses an issue where products were written to the wrong index during a full reindex with indexing queue enabled. 

This issue only affects the 3.16.0 beta and was identified during testing.

**Result**

Before:
![image](https://github.com/user-attachments/assets/4bc6e017-1df9-4264-8999-2712e051c1f8)
After:
![image](https://github.com/user-attachments/assets/12cbb172-1dd4-4251-9022-67a12f094117)

