### PR TITLE
MAGE-1357: Re-add missing boolean to Product Index Builder

### DIFF
--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -101,7 +101,8 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             $collection,
             $options['page'] ?? 1,
             $options['pageSize'] ?? $this->configHelper->getNumberOfElementByPage($storeId),
-            $entityIds
+            $entityIds,
+            $options['useTmpIndex']
         );
 
         $this->stopEmulation();
@@ -144,6 +145,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @param int $page
      * @param int $pageSize
      * @param array|null $productIds - pre-batched product ids - if specified no paging will be applied
+     * @param bool|null $useTmpIndex
      * @return void
      * @throws AlgoliaException
      * @throws DiagnosticsException
@@ -154,7 +156,8 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         Collection $collection,
         int $page,
         int $pageSize,
-        ?array $productIds = null
+        ?array $productIds = null,
+        ?bool $useTmpIndex = false
     ): void
     {
         if ($this->isIndexingEnabled($storeId) === false) {


### PR DESCRIPTION
Recent change on this PR for 3.17.0 introduct `$tmpTmpIndex` to `Product/IndexBuilder::indexPage()` . This changes worked for 3.16.0 but another PR for 3.17.0 removed the parameter: https://github.com/algolia/algoliasearch-magento-2/pull/1764/files#diff-0251b76d832bc7f8f1205481909f582d196147fa77188441b39a86a7885ac3a3L107

This PR re-adds the missing parameter so it works for 3.17.0 as well. 