### PR TITLE
MAGE-1138: Configurable temporary index usage

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch\Helper;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
 use Algolia\AlgoliaSearch\Helper\Configuration\AutocompleteHelper;
 use Algolia\AlgoliaSearch\Helper\Configuration\InstantSearchHelper;
+use Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\Serializer;
 use Magento\Cookie\Helper\Cookie as CookieHelper;
@@ -41,11 +42,6 @@ class ConfigHelper
     public const SHOW_CATS_NOT_INCLUDED_IN_NAV = 'algoliasearch_categories/categories/show_cats_not_included_in_navigation';
     public const INDEX_EMPTY_CATEGORIES = 'algoliasearch_categories/categories/index_empty_categories';
     public const CATEGORY_SEPARATOR = 'algoliasearch_categories/categories/category_separator';
-
-    public const IS_ACTIVE = 'algoliasearch_queue/queue/active';
-    public const USE_BUILT_IN_CRON = 'algoliasearch_queue/queue/use_built_in_cron';
-    public const NUMBER_OF_JOB_TO_RUN = 'algoliasearch_queue/queue/number_of_job_to_run';
-    public const RETRY_LIMIT = 'algoliasearch_queue/queue/number_of_retries';
 
     public const XML_PATH_IMAGE_WIDTH = 'algoliasearch_images/image/width';
     public const XML_PATH_IMAGE_HEIGHT = 'algoliasearch_images/image/height';
@@ -156,7 +152,8 @@ class ConfigHelper
         protected GroupExcludedWebsiteRepositoryInterface               $groupExcludedWebsiteRepository,
         protected CookieHelper                                          $cookieHelper,
         protected AutocompleteHelper                                    $autocompleteConfig,
-        protected InstantSearchHelper                                   $instantSearchConfig
+        protected InstantSearchHelper                                   $instantSearchConfig,
+        protected QueueHelper                                           $queueHelper
     )
     {}
 
@@ -382,44 +379,6 @@ class ConfigHelper
     public function getNumberOfElementByPage($storeId = null)
     {
         return (int)$this->configInterface->getValue(self::NUMBER_OF_ELEMENT_BY_PAGE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getNumberOfJobToRun($storeId = null)
-    {
-        $nbJobs = (int)$this->configInterface->getValue(self::NUMBER_OF_JOB_TO_RUN, ScopeInterface::SCOPE_STORE, $storeId);
-
-        return max($nbJobs, 1);
-    }
-
-    /**
-     * @param $storeId
-     * @return int
-     */
-    public function getRetryLimit($storeId = null)
-    {
-        return (int)$this->configInterface->getValue(self::RETRY_LIMIT, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isQueueActive($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::IS_ACTIVE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function useBuiltInCron($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::USE_BUILT_IN_CRON, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     /**
@@ -1715,6 +1674,32 @@ class ConfigHelper
      */
     public const LEGACY_USE_VIRTUAL_REPLICA_ENABLED = 'algoliasearch_instant/instant/use_virtual_replica';
 
+    // --- Indexing Queue --- //
+
+    /**
+     * @deprecated This constant has been moved to a domain specific config helper and will be removed in a future release
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper::IS_ACTIVE
+     */
+    public const IS_ACTIVE = QueueHelper::IS_ACTIVE;
+
+    /**
+     * @deprecated This constant has been moved to a domain specific config helper and will be removed in a future release
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper::USE_BUILT_IN_CRON
+     */
+    public const USE_BUILT_IN_CRON =  QueueHelper::USE_BUILT_IN_CRON;
+
+    /**
+     * @deprecated This constant has been moved to a domain specific config helper and will be removed in a future release
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper::NUMBER_OF_JOB_TO_RUN
+     */
+    public const NUMBER_OF_JOB_TO_RUN =  QueueHelper::NUMBER_OF_JOB_TO_RUN;
+
+    /**
+     * @deprecated This constant has been moved to a domain specific config helper and will be removed in a future release
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper::RETRY_LIMIT
+     */
+    public const RETRY_LIMIT =  QueueHelper::RETRY_LIMIT;
+
     // --- Indexing Manager --- //
 
     /**
@@ -2043,6 +2028,52 @@ class ConfigHelper
     public function hidePaginationInInstantSearchPage($storeId = null)
     {
         return $this->instantSearchConfig->shouldHidePagination($storeId);
+    }
+
+    // --- Indexing Queue --- //
+
+    /**
+     * @param $storeId
+     * @return bool
+     * @deprecated This method has been moved to the Queue config helper and will be removed in a future version
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper::isQueueActive()
+     */
+    public function isQueueActive($storeId = null)
+    {
+        return $this->queueHelper->isQueueActive($storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     * @deprecated This method has been moved to the Queue config helper and will be removed in a future version
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper::useBuiltInCron()
+     */
+    public function useBuiltInCron($storeId = null)
+    {
+        return $this->queueHelper->useBuiltInCron($storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     * @deprecated This method has been moved to the Queue config helper and will be removed in a future version
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper::getNumberOfJobToRun()
+     */
+    public function getNumberOfJobToRun($storeId = null)
+    {
+        return $this->queueHelper->getNumberOfJobToRun($storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     * @deprecated This method has been moved to the Queue config helper and will be removed in a future version
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper::getRetryLimit()
+     */
+    public function getRetryLimit($storeId = null)
+    {
+        return $this->queueHelper->getRetryLimit($storeId);
     }
 
     // --- Indexing Manager --- //

--- a/Helper/Configuration/QueueHelper.php
+++ b/Helper/Configuration/QueueHelper.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Helper\Configuration;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class QueueHelper
+{
+    public const IS_ACTIVE = 'algoliasearch_queue/queue/active';
+    public const USE_BUILT_IN_CRON = 'algoliasearch_queue/queue/use_built_in_cron';
+    public const NUMBER_OF_JOB_TO_RUN = 'algoliasearch_queue/queue/number_of_job_to_run';
+    public const RETRY_LIMIT = 'algoliasearch_queue/queue/number_of_retries';
+
+    public function __construct(
+        protected ScopeConfigInterface $configInterface,
+    ) {}
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isQueueActive($storeId = null)
+    {
+        return $this->configInterface->isSetFlag(self::IS_ACTIVE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function useBuiltInCron($storeId = null)
+    {
+        return $this->configInterface->isSetFlag(self::USE_BUILT_IN_CRON, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getNumberOfJobToRun($storeId = null)
+    {
+        $nbJobs = (int)$this->configInterface->getValue(self::NUMBER_OF_JOB_TO_RUN, ScopeInterface::SCOPE_STORE, $storeId);
+
+        return max($nbJobs, 1);
+    }
+
+    /**
+     * @param $storeId
+     * @return int
+     */
+    public function getRetryLimit($storeId = null)
+    {
+        return (int)$this->configInterface->getValue(self::RETRY_LIMIT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+}

--- a/Helper/Configuration/QueueHelper.php
+++ b/Helper/Configuration/QueueHelper.php
@@ -11,6 +11,7 @@ class QueueHelper
     public const USE_BUILT_IN_CRON = 'algoliasearch_queue/queue/use_built_in_cron';
     public const NUMBER_OF_JOB_TO_RUN = 'algoliasearch_queue/queue/number_of_job_to_run';
     public const RETRY_LIMIT = 'algoliasearch_queue/queue/number_of_retries';
+    public const USE_TMP_INDEX = 'algoliasearch_queue/queue/use_tmp_index';
 
     public function __construct(
         protected ScopeConfigInterface $configInterface,
@@ -52,5 +53,15 @@ class QueueHelper
     public function getRetryLimit($storeId = null)
     {
         return (int)$this->configInterface->getValue(self::RETRY_LIMIT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function useTmpIndex($storeId = null)
+    {
+        return $this->isQueueActive($storeId) &&
+            $this->configInterface->isSetFlag(self::USE_TMP_INDEX, ScopeInterface::SCOPE_STORE, $storeId);
     }
 }

--- a/Service/Product/BatchQueueProcessor.php
+++ b/Service/Product/BatchQueueProcessor.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Api\Processor\BatchQueueProcessorInterface;
 use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper;
 use Algolia\AlgoliaSearch\Helper\Data;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
@@ -24,6 +25,7 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
         protected Data $dataHelper,
         protected ConfigHelper $configHelper,
         protected ProductHelper $productHelper,
+        protected QueueHelper $queueHelper,
         protected Queue $queue,
         protected DiagnosticsLogger $diag,
         protected AlgoliaCredentialsManager $algoliaCredentialsManager,
@@ -56,7 +58,7 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
             return;
         }
 
-        $useTmpIndex = $this->configHelper->isQueueActive($storeId);
+        $useTmpIndex = $this->queueHelper->useTmpIndex($storeId);
         $this->syncAlgoliaSettings($storeId, $useTmpIndex);
 
         $this->handleFullIndex($storeId, $productsPerPage, $useTmpIndex);

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -101,7 +101,8 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             $collection,
             $options['page'] ?? 1,
             $options['pageSize'] ?? $this->configHelper->getNumberOfElementByPage($storeId),
-            $entityIds
+            $entityIds,
+            $options['useTmpIndex']
         );
 
         $this->stopEmulation();
@@ -144,6 +145,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @param int $page
      * @param int $pageSize
      * @param array|null $productIds - pre-batched product ids - if specified no paging will be applied
+     * @param bool|null $useTmpIndex
      * @return void
      * @throws AlgoliaException
      * @throws DiagnosticsException
@@ -154,7 +156,8 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         Collection $collection,
         int $page,
         int $pageSize,
-        ?array $productIds = null
+        ?array $productIds = null,
+        ?bool $useTmpIndex = false
     ): void
     {
         if ($this->isIndexingEnabled($storeId) === false) {

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -102,7 +102,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             $options['page'] ?? 1,
             $options['pageSize'] ?? $this->configHelper->getNumberOfElementByPage($storeId),
             $entityIds,
-            $options['useTmpIndex']
+            $options['useTmpIndex'] ?? false
         );
 
         $this->stopEmulation();

--- a/Setup/Patch/Schema/ConfigPatch.php
+++ b/Setup/Patch/Schema/ConfigPatch.php
@@ -68,6 +68,7 @@ class ConfigPatch implements SchemaPatchInterface
         'algoliasearch_queue/queue/active' => '0',
         'algoliasearch_queue/queue/number_of_job_to_run' => '5',
         'algoliasearch_queue/queue/number_of_retries' => '3',
+        'algoliasearch_queue/queue/use_tmp_index' => '1',
 
         'algoliasearch_cc_analytics/cc_analytics_group/enable' => '0',
         'algoliasearch_cc_analytics/cc_analytics_group/is_selector' => '.ais-Hits-item a.result, .ais-InfiniteHits-item a.result',

--- a/Test/Integration/Indexing/Queue/QueueTest.php
+++ b/Test/Integration/Indexing/Queue/QueueTest.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Queue;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper;
 use Algolia\AlgoliaSearch\Model\Indexer\QueueRunner;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Model\Job;
@@ -44,11 +45,11 @@ class QueueTest extends TestCase
     public function testFill()
     {
         $this->resetConfigs([
-            ConfigHelper::NUMBER_OF_JOB_TO_RUN,
+            QueueHelper::NUMBER_OF_JOB_TO_RUN,
             ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE,
         ]);
 
-        $this->setConfig(ConfigHelper::IS_ACTIVE, '1');
+        $this->setConfig(QueueHelper::IS_ACTIVE, '1');
         $this->connection->query('TRUNCATE TABLE algoliasearch_queue');
 
         $productBatchQueueProcessor = $this->objectManager->get(ProductBatchQueueProcessor::class);
@@ -84,7 +85,7 @@ class QueueTest extends TestCase
 
     public function testExecute()
     {
-        $this->setConfig(ConfigHelper::IS_ACTIVE, '1');
+        $this->setConfig(QueueHelper::IS_ACTIVE, '1');
         $this->connection->query('TRUNCATE TABLE algoliasearch_queue');
 
         $productBatchQueueProcessor = $this->objectManager->get(ProductBatchQueueProcessor::class);
@@ -136,16 +137,57 @@ class QueueTest extends TestCase
         $this->assertEquals(0, count($rows));
     }
 
+    public function testTmpIndexConfig()
+    {
+        $this->setConfig(QueueHelper::IS_ACTIVE, '1');
+        // Setting "Use a temporary index for full products reindex" configuration to "No"
+        $this->setConfig(QueueHelper::USE_TMP_INDEX, '0');
+        $this->connection->query('TRUNCATE TABLE algoliasearch_queue');
+
+        $productBatchQueueProcessor = $this->objectManager->get(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->processBatch(1);
+
+        $rows = $this->connection->query('SELECT * FROM algoliasearch_queue')->fetchAll();
+        // Without temporary index enabled, there are only 2 jobs (saveConfigurationToAlgolia and buildIndexFull)
+        $this->assertEquals(2, count($rows));
+
+        $indexingJob = $rows[1];
+        $jobData = json_decode($indexingJob['data'], true);
+
+        $this->assertEquals('buildIndexFull', $indexingJob['method']);
+        $this->assertFalse($jobData['options']['useTmpIndex']);
+
+        /** @var Queue $queue */
+        $queue = $this->objectManager->get(Queue::class);
+
+        // Run the first job (saveSettings)
+        $queue->runCron(1, true);
+
+        $this->algoliaConnector->waitLastTask();
+
+        $indices = $this->algoliaConnector->listIndexes();
+
+        $existsDefaultTmpIndex = false;
+        foreach ($indices['items'] as $index) {
+            if ($index['name'] === $this->indexPrefix . 'default_products_tmp') {
+                $existsDefaultTmpIndex = true;
+            }
+        }
+        // Checking if the temporary index hasn't been created
+        $this->assertFalse($existsDefaultTmpIndex, 'Temporary index exists and it should not');
+    }
+
     public function testSettings()
     {
         $this->resetConfigs([
-            ConfigHelper::NUMBER_OF_JOB_TO_RUN,
+            QueueHelper::NUMBER_OF_JOB_TO_RUN,
             ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE,
             ConfigHelper::FACETS,
+            QueueHelper::USE_TMP_INDEX,
             ConfigHelper::PRODUCT_ATTRIBUTES
         ]);
 
-        $this->setConfig(ConfigHelper::IS_ACTIVE, '1');
+        $this->setConfig(QueueHelper::IS_ACTIVE, '1');
 
         $this->connection->query('DELETE FROM algoliasearch_queue');
 
@@ -178,8 +220,8 @@ class QueueTest extends TestCase
 
     public function testMergeSettings()
     {
-        $this->setConfig(ConfigHelper::IS_ACTIVE, '1');
-        $this->setConfig(ConfigHelper::NUMBER_OF_JOB_TO_RUN, 1);
+        $this->setConfig(QueueHelper::IS_ACTIVE, '1');
+        $this->setConfig(QueueHelper::NUMBER_OF_JOB_TO_RUN, 1);
         $this->setConfig(ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE, 300);
 
         $this->connection->query('DELETE FROM algoliasearch_queue');
@@ -791,7 +833,7 @@ class QueueTest extends TestCase
     public function testHugeJob()
     {
         // Default value - maxBatchSize = 1000
-        $this->setConfig(ConfigHelper::NUMBER_OF_JOB_TO_RUN, 10);
+        $this->setConfig(QueueHelper::NUMBER_OF_JOB_TO_RUN, 10);
         $this->setConfig(ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE, 100);
 
         $productIds = range(1, 5000);
@@ -829,7 +871,7 @@ class QueueTest extends TestCase
     public function testMaxSingleJobSize()
     {
         // Default value - maxBatchSize = 1000
-        $this->setConfig(ConfigHelper::NUMBER_OF_JOB_TO_RUN, 10);
+        $this->setConfig(QueueHelper::NUMBER_OF_JOB_TO_RUN, 10);
         $this->setConfig(ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE, 100);
 
         $productIds = range(1, 99);
@@ -870,13 +912,13 @@ class QueueTest extends TestCase
     public function testMaxSingleJobsSizeOnProductReindex()
     {
         $this->resetConfigs([
-            ConfigHelper::NUMBER_OF_JOB_TO_RUN,
+            QueueHelper::NUMBER_OF_JOB_TO_RUN,
             ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE,
         ]);
 
-        $this->setConfig(ConfigHelper::IS_ACTIVE, '1');
+        $this->setConfig(QueueHelper::IS_ACTIVE, '1');
 
-        $this->setConfig(ConfigHelper::NUMBER_OF_JOB_TO_RUN, 10);
+        $this->setConfig(QueueHelper::NUMBER_OF_JOB_TO_RUN, 10);
         $this->setConfig(ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE, 100);
 
         $this->connection->query('TRUNCATE TABLE algoliasearch_queue');

--- a/Ui/Component/Listing/Column/Data.php
+++ b/Ui/Component/Listing/Column/Data.php
@@ -53,7 +53,9 @@ class Data extends \Magento\Ui\Component\Listing\Columns\Column
 
                 continue;
             }
-
+            if (is_bool($value)) {
+               $value = $value ? 'Yes' : 'No';
+            }
             $formattedData .= str_repeat('&nbsp;&nbsp;&nbsp;', $depth ) . $stringKey . ' : ' . $value . '<br>';
         }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1038,6 +1038,23 @@
                     <validate>validate-digits</validate>
                     <label>Number of times to retry processing of queued jobs</label>
                     <source_model>Algolia\AlgoliaSearch\Model\Source\RetryValues</source_model>
+                    <comment>
+                        <![CDATA[
+                           Defines the number of times that the queue tries to process a job.
+                        ]]>
+                    </comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
+                <field id="use_tmp_index" translate="label comment" type="select" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Use a temporary index for full products reindex</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                            This configuration defines if a temporary index suffixed by <code>_tmp</code> will be used for products full reindex. If you set it to "No", product updates will be sent directly to your production index.
+                        ]]>
+                    </comment>
                     <depends>
                         <field id="active">1</field>
                     </depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -66,6 +66,7 @@
             <queue>
                 <use_built_in_cron>0</use_built_in_cron>
                 <cron_expr>*/5 * * * *</cron_expr>
+                <use_tmp_index>1</use_tmp_index>
             </queue>
         </algoliasearch_queue>
         <algoliasearch_indexing_manager>


### PR DESCRIPTION
This PR contains:
- Added "Use temporary index for full products reindex" config to the indexing queue section
- Updated to product batch processing to take this new config into
- Added a small improvement to the Indexing Queue Data column so it now indicates clearly if a temporary index is used in the job or not.
- Added an integration test which ensure that no temporary index is created in case this config is set to "No"
- Recent change on this PR for 3.17.0 introduced `$tmpTmpIndex` to `Product/IndexBuilder::indexPage()` . This changes worked for 3.16.0 but another PR for 3.17.0 removed the parameter: https://github.com/algolia/algoliasearch-magento-2/pull/1764/files#diff-0251b76d832bc7f8f1205481909f582d196147fa77188441b39a86a7885ac3a3L107 => This PR also fixes this issue so it works for 3.17.0 as well. 

WIP