### PR TITLE
MAGE-1419 Prevent 422 Insights Event - Add to Cart with Discount

### DIFF
--- a/Service/Insights/EventProcessor.php
+++ b/Service/Insights/EventProcessor.php
@@ -259,7 +259,7 @@ class EventProcessor implements EventProcessorInterface
      */
     protected function getQuoteItemDiscount(Item $item): float
     {
-        return floatval($item->getProduct()->getPrice()) - $this->getQuoteItemSalePrice($item);
+        return round(floatval($item->getProduct()->getPrice()) - $this->getQuoteItemSalePrice($item),2);
     }
 
     /**


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Adding a product to the cart may trigger a PHP and Algolia error due to the discount amount being too large due to improper math by PHP.

### PHP Version
```
php -v
PHP 8.2.28 (cli) (built: Mar 13 2025 18:13:24) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.28, Copyright (c) Zend Technologies
    with Zend OPcache v8.2.28, Copyright (c), by Zend Technologies
    with Xdebug v3.4.2, Copyright (c) 2002-2025, by Derick Rethans
```

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

### PHP Error
This error is thrown in `var/log/system.log`
```
main.CRITICAL: Unable to send add to cart event due to Algolia events model misconfiguration: Discount must be a valid decimal number and total length must be no longer than 16 characters [] []
```
### Algolia Error
A `422` status code is returned in the Algolia Events Debugger.
![image](https://github.com/user-attachments/assets/9803a1b2-dd9a-45da-aefe-f707a1aa5464)

Here using xdebug in PHPStorm we can see what is happening.

The product discount amount should be `0.06`.  But PHP comes up with the value of `0.059999999999999` instead.
- `floatval($item->getProduct()->getPrice())` = `23.99`
- `$this->getQuoteItemSalePrice($item)` = `23.93`
- `floatval($item->getProduct()->getPrice()) - $this->getQuoteItemSalePrice($item)` = `0.059999999999999`

I don't understand this math and how it fails...  🤷‍♂️ But we can protect against it with a `round()`.  (maybe it should be added to other methods in this class but I didn't observe issues from those at this time)

![image](https://github.com/user-attachments/assets/783b7ea9-71c8-46b0-bb6c-e7130d052da6)

The discount amount on this product is using the core Magento **Customer Group Price** feature - adding the discount amount to table `catalog_product_entity_tier_price`.
![image](https://github.com/user-attachments/assets/fb779c6f-cd89-435d-8059-d961beb7d6f6)


```
SELECT * FROM catalog_product_index_price WHERE entity_id = 5981 AND customer_group_id = 22;
 entity_id | customer_group_id | website_id | tax_class_id | price     | final_price | min_price | max_price | tier_price 
-----------+-------------------+------------+--------------+-----------+-------------+-----------+-----------+------------
      5981 |                22 |          2 |            2 | 23.990000 |   23.930000 | 23.930000 | 23.930000 |  23.930000 

SELECT * FROM catalog_product_entity_tier_price WHERE entity_id = 5981 AND customer_group_id = 22;
 value_id | entity_id | all_groups | customer_group_id | qty    | value     | website_id | percentage_value 
----------+-----------+------------+-------------------+--------+-----------+------------+------------------
   490854 |      5981 |          0 |                22 | 1.0000 | 23.930000 |          0 |           [NULL] 
```



