### PR TITLE
MAGE-1112: Make `price` attribute optional during product indexing

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1069,16 +1069,41 @@ class ConfigHelper
     }
 
     /**
+     * @param $attributes
+     * @param $attributeName
+     * @return bool
+     */
+    public function isAttributeInList($attributes, $attributeName): bool
+    {
+        foreach ($attributes as $attr) {
+            if ($attr['attribute'] === $attributeName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getProductAttributesList($storeId = null)
+    {
+        return $this->serializer->unserialize($this->configInterface->getValue(
+            self::PRODUCT_ATTRIBUTES,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ));
+    }
+
+    /**
      * @param $storeId
      * @return array
      */
     public function getProductAdditionalAttributes($storeId = null)
     {
-        $attributes = $this->serializer->unserialize($this->configInterface->getValue(
-            self::PRODUCT_ATTRIBUTES,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
+        $attributes = $this->getProductAttributesList($storeId);
 
         $facets = $this->serializer->unserialize($this->configInterface->getValue(
             self::FACETS,

--- a/Helper/Configuration/NoticeHelper.php
+++ b/Helper/Configuration/NoticeHelper.php
@@ -23,6 +23,7 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
         'getRecommendNotice',
         'getCookieConfigurationNotice',
         'getMultiApplicationIDsNotice',
+        'getPriceIndexingNotice',
     ];
 
     /** @var array[] */
@@ -189,8 +190,8 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
         ];
     }
 
-   protected function getCookieConfigurationNotice()
-   {
+    protected function getCookieConfigurationNotice()
+    {
         $noticeContent = '';
         $selector = '';
         $method = 'after';
@@ -356,6 +357,34 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
         $noticeTitle = 'Multi Application IDs';
         $noticeContent = '<p>You are currently using multiple Algolia application IDs with your Magento installation.</p>
         <p>When verifying data in Algolia, please make sure you are referencing the correct application.</p>';
+
+        $this->notices[] = [
+            'selector' => '.entry-edit',
+            'method' => 'before',
+            'message' => $this->formatNotice($noticeTitle, $noticeContent),
+        ];
+    }
+
+
+    /**
+     * This notice serves as a warning when user removes the price attribute from the attributes list but it's still present either in the sortings or in the facets
+     * @return void
+     */
+    protected function getPriceIndexingNotice(): void
+    {
+        $attributesToIndex = $this->configHelper->getProductAdditionalAttributes();
+        $attributesList = $this->configHelper->getProductAttributesList();
+
+        // we want to display the warning only if price is not present in the attribute list but is present somewhere else
+        if (!($this->configHelper->isAttributeInList($attributesToIndex, 'price')
+            && !$this->configHelper->isAttributeInList($attributesList, 'price'))
+        ) {
+            return;
+        }
+
+        $noticeTitle = 'Price attribute indexing';
+        $noticeContent = '<p>Price attribute has been removed from the product attributes list but is still present in the facets, sortings or custom rankings lists.</p>
+        <p>If you want to remove prices from the product records, you need to remove them from those lists as well.</p>';
 
         $this->notices[] = [
             'selector' => '.entry-edit',

--- a/Helper/Configuration/NoticeHelper.php
+++ b/Helper/Configuration/NoticeHelper.php
@@ -384,7 +384,8 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
 
         $noticeTitle = 'Price attribute indexing';
         $noticeContent = '<p>Price attribute has been removed from the product attributes list but is still present in the facets, sortings or custom rankings lists.</p>
-        <p>If you want to remove prices from the product records, you need to remove them from those lists as well.</p>';
+        <p>If you want to remove prices from the product records, you need to remove them from those lists as well.</p>
+        <p>If you want the prices to be included in the product records, you need to add it in the product attributes list in the "Products" section of the configuration.</p>';
 
         $this->notices[] = [
             'selector' => '.entry-edit',

--- a/Helper/Configuration/NoticeHelper.php
+++ b/Helper/Configuration/NoticeHelper.php
@@ -385,7 +385,7 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
         $noticeTitle = 'Price attribute indexing';
         $noticeContent = '<p>Price attribute has been removed from the product attributes list but is still present in the facets, sortings or custom rankings lists.</p>
         <p>If you want to remove prices from the product records, you need to remove them from those lists as well.</p>
-        <p>If you want the prices to be included in the product records, you need to add it in the product attributes list in the "Products" section of the configuration.</p>';
+        <p>If you want the prices to be included in the product records, you need to add the price attribute in the product attributes list in the "Products" section of the configuration.</p>';
 
         $this->notices[] = [
             'selector' => '.entry-edit',

--- a/Service/Product/RecordBuilder.php
+++ b/Service/Product/RecordBuilder.php
@@ -123,7 +123,11 @@ class RecordBuilder implements RecordBuilderInterface
         }
         $subProducts = $this->getSubProducts($product);
         $customData = $this->addAdditionalAttributes($customData, $additionalAttributes, $product, $subProducts);
-        $customData = $this->priceManager->addPriceDataByProductType($customData, $product, $subProducts);
+
+        if ($this->isPriceIndexingEnabled($additionalAttributes)) {
+            $customData = $this->priceManager->addPriceDataByProductType($customData, $product, $subProducts);
+        }
+
         $transport = new DataObject($customData);
         $this->eventManager->dispatch(
             'algolia_subproducts_index',
@@ -193,6 +197,15 @@ class RecordBuilder implements RecordBuilderInterface
         }
 
         return false;
+    }
+
+    /**
+     * @param array $additionalAttributes
+     * @return bool
+     */
+    protected function isPriceIndexingEnabled(array $additionalAttributes): bool
+    {
+        return $this->isAttributeEnabled($additionalAttributes, 'price');
     }
 
     /**
@@ -816,3 +829,4 @@ class RecordBuilder implements RecordBuilderInterface
         return $product->isSaleable() && $stockItem->getIsInStock();
     }
 }
+

--- a/Service/Product/RecordBuilder.php
+++ b/Service/Product/RecordBuilder.php
@@ -190,13 +190,7 @@ class RecordBuilder implements RecordBuilderInterface
      */
     public function isAttributeEnabled($additionalAttributes, $attributeName): bool
     {
-        foreach ($additionalAttributes as $attr) {
-            if ($attr['attribute'] === $attributeName) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->configHelper->isAttributeInList($additionalAttributes, $attributeName);
     }
 
     /**
@@ -205,7 +199,7 @@ class RecordBuilder implements RecordBuilderInterface
      */
     protected function isPriceIndexingEnabled(array $additionalAttributes): bool
     {
-        return $this->isAttributeEnabled($additionalAttributes, 'price');
+        return $this->configHelper->isAttributeInList($additionalAttributes, 'price');
     }
 
     /**

--- a/Test/Integration/Indexing/Product/ProductsIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ProductsIndexingTest.php
@@ -70,7 +70,7 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
             'thumbnail_url',
             'image_url',
             'in_stock',
-            'price',
+            //'price', since version 3.17.0, the price attribute is not mandatory if it's not present in any attributes list
             'type_id',
             'algoliaLastUpdateAtCET',
             'categoryIds',
@@ -84,6 +84,8 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
             $this->assertArrayHasKey($attribute, $hit, 'Products attribute "' . $attribute . '" should be indexed but it is not"');
             unset($hit[$attribute]);
         }
+
+        $this->assertArrayNotHasKey('price', $hit, 'Record has a price attribute but it should not');
 
         $extraAttributes = implode(', ', array_keys($hit));
         $this->assertEmpty($hit, 'Extra products attributes (' . $extraAttributes . ') are indexed and should not be.');


### PR DESCRIPTION
This PR contains:
- Make the `price` attribute optional => now it shouldn't be indexed if the price attribute is **not** present in the **product attributes**, the **sortings**, the **facets** and the **custom rankings** lists.
- Display a notice in the admin when the user removes the `price` attribute from the attributes list but not from another list (which would make the `price` attribute still indexed)
- Updated the product indexing integration test to ensure this new logic is applied.