### PR TITLE
MAGE-991: Update CircleCI build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           name: Configure composer authentication
           command: |
             composer config --global http-basic.repo.magento.com ${MAGENTO_AUTH_USERNAME} ${MAGENTO_AUTH_PASSWORD}
-            composer config repositories.algolia vcs https://github.com/algolia/algoliasearch-magento-2
+            composer config --global repositories.algolia vcs https://github.com/algolia/algoliasearch-magento-2
       - run:
           name: Setup folder structure and override file
           command: |
@@ -43,22 +43,13 @@ jobs:
           working_directory: ~/Sites
           command: |
             curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash
-            docker compose -f compose.yaml -f compose.override.yml up -d --remove-orphans 
+            docker compose -f compose.yaml -f compose.override.yml up -d --remove-orphans
+            bin/cli rm -rf composer.lock vendor composer.json
             bin/fixowns
             bin/setup-composer-auth
             bin/cli git clone git@github.com:magento/magento2.git .
             bin/cli git checkout tags/<< parameters.magento-version >>
-            bin/composer require "algolia/algoliasearch-magento-2:${CIRCLE_BRANCH}"
-            bin/composer install
-      # - run:
-      #     name: Configure AlgoliaSearch extension
-      #     working_directory: ~/Sites
-      #     command: |
-      #       cp -r ~/project/ AlgoliaSearch
-      #       bin/cli mkdir -p app/code/Algolia
-      #       docker cp AlgoliaSearch/ "$(bin/docker-compose ps -q phpfpm|awk '{print $1}')":/var/www/html/app/code/Algolia
-      #       bin/fixowns
-      #       bin/fixperms
+            bin/composer require "algolia/algoliasearch-magento-2:dev-${CIRCLE_BRANCH}"
       - run:
           name: Enable AlgoliaSearch extension
           working_directory: ~/Sites


### PR DESCRIPTION
**Summary**

- Update build process for CircleCI to setup magento enterprise + matrix build the extension for magento 2.4.6 and 2.4.7 on PHP 8.2

**Result**
<img width="529" alt="image" src="https://github.com/user-attachments/assets/f14d5e5b-552d-4041-8d1d-be457a7df931" />

<img width="509" alt="image" src="https://github.com/user-attachments/assets/343f1c91-e5f7-434a-93f9-41c8a5900daa" />

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/8728af8c-ae01-402f-815a-13012e9f3f22" />
