### PR TITLE
MAGE-1363 PHPUnit 10 prep

### DIFF
--- a/Test/Integration/Frontend/Category/CategoryCacheTest.php
+++ b/Test/Integration/Frontend/Category/CategoryCacheTest.php
@@ -23,12 +23,12 @@ class CategoryCacheTest extends AbstractController
     public static function getCategoryProvider(): array
     {
         return [
-            ['categoryId' => 20, 'name' => 'Women', 'hasProducts' => false],
-            ['categoryId' => 21, 'name' => 'Women > Tops', 'hasProducts' => true],
-            ['categoryId' => 22, 'name' => 'Women > Bottoms', 'hasProducts' => true],
-            ['categoryId' => 11, 'name' => 'Men', 'hasProducts' => false],
-            ['categoryId' => 12, 'name' => 'Men > Tops', 'hasProducts' => true],
-            ['categoryId' => 13, 'name' => 'Men > Bottoms', 'hasProducts' => true],
+            [20, 'Women', false],
+            [21, 'Women > Tops', true],
+            [22, 'Women > Bottoms', true],
+            [11, 'Men', false],
+            [12, 'Men > Tops', true],
+            [13, 'Men > Bottoms', true],
         ];
     }
 

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -19,13 +19,7 @@ use Magento\Framework\ObjectManagerInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
-if (class_exists('PHPUnit\Framework\TestCase')) {
-    class_alias('PHPUnit\Framework\TestCase', '\TC');
-} else {
-    class_alias('\PHPUnit_Framework_TestCase', '\TC');
-}
-
-abstract class TestCase extends \TC
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ObjectManagerInterface

--- a/Test/Unit/Controller/Adminhtml/IndexingManager/ReindexTest.php
+++ b/Test/Unit/Controller/Adminhtml/IndexingManager/ReindexTest.php
@@ -185,7 +185,7 @@ class ReindexTest extends TestCase
         $this->assertEquals($result, $this->reindexController->defineEntitiesToIndex($params));
     }
 
-    public function entityParamsProvider()
+    public static function entityParamsProvider(): array
     {
         return [
             [
@@ -219,7 +219,7 @@ class ReindexTest extends TestCase
         $this->assertEquals($result, $this->reindexController->defineRedirectPath($params));
     }
 
-    public function redirectParamsProvider()
+    public static function redirectParamsProvider(): array
     {
         return [
             [

--- a/Test/Unit/Logger/Handler/AbstractHandlerTestCase.php
+++ b/Test/Unit/Logger/Handler/AbstractHandlerTestCase.php
@@ -5,7 +5,7 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Logger\Handler;
 use Magento\Framework\Logger\Handler\Base;
 use PHPUnit\Framework\TestCase;
 
-abstract class AbstractHandlerTest extends TestCase
+abstract class AbstractHandlerTestCase extends TestCase
 {
     protected ?Base $handler = null;
 

--- a/Test/Unit/Logger/Handler/AlgoliaLoggerHandlerTest.php
+++ b/Test/Unit/Logger/Handler/AlgoliaLoggerHandlerTest.php
@@ -5,7 +5,7 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Logger\Handler;
 use Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler;
 use Magento\Framework\Filesystem\DriverInterface;
 
-class AlgoliaLoggerHandlerTest extends AbstractHandlerTest
+class AlgoliaLoggerHandlerTest extends AbstractHandlerTestCase
 {
     protected function setUp(): void
     {

--- a/Test/Unit/Logger/Handler/SystemLoggerHandlerTest.php
+++ b/Test/Unit/Logger/Handler/SystemLoggerHandlerTest.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearch\Logger\Handler\SystemLoggerHandler;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Logger\Handler\Exception as ExceptionHandler;
 
-class SystemLoggerHandlerTest extends AbstractHandlerTest
+class SystemLoggerHandlerTest extends AbstractHandlerTestCase
 {
     /**
      * @throws \Exception

--- a/Test/Unit/Model/Backend/QueueCronTest.php
+++ b/Test/Unit/Model/Backend/QueueCronTest.php
@@ -52,7 +52,7 @@ class QueueCronTest extends TestCase
         }
     }
 
-    public function valuesProvider(): array
+    public static function valuesProvider(): array
     {
         return [
             [

--- a/Test/Unit/Service/EventProcessorTest.php
+++ b/Test/Unit/Service/EventProcessorTest.php
@@ -68,7 +68,7 @@ class EventProcessorTest extends TestCase
         $this->assertEquals($expectedTotalRevenue, $totalRevenue);
     }
 
-    public function orderItemsProvider(): array
+    public static function orderItemsProvider(): array
     {
         return [
             [ // One item

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     }
   ],
   "require-dev": {
-    "phpcompatibility/php-compatibility": "^9.2"
+    "phpcompatibility/php-compatibility": "^9.2",
+    "phpunit/phpunit": "^9.5|^10.5"
   },
   "autoload": {
     "files": [ "registration.php" ],


### PR DESCRIPTION
**Summary**

This PR addresses concerns related to compatibility with PHPUnit 10 in preparation for Magento 2.4.8 as recommended here: https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/adobe-commerce/2-4-8#platform

**Result**

Unit tests work as expected on PHPUnit 10
![image](https://github.com/user-attachments/assets/d8d7ccf5-d2c7-41ce-b409-a176e188a5dd)
Integration tests will need to be refactored further for compatibility. 