### PR TITLE
MAGE-1367: Add unit tests to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,13 +73,13 @@ jobs:
       - store_test_results:
           path: ~/Sites/unit-tests
       - run:
-          name: Run Unit Coverage
+          name: Run Unit Test Coverage and copy results to CircleCI
           working_directory: ~/Sites
           command: |
-            bin/test/unit-coverage vendor/algolia/algoliasearch-magento-2/Test/Unit
-            docker cp $(docker compose ps -q phpfpm):/var/www/html/dev/tests/unit/report ~/Sites/unit-coverage/
+            bin/cli php -d xdebug.mode=coverage vendor/bin/phpunit --log-junit /var/www/html/dev/tests/unit/report/junit.xml --coverage-html /var/www/html/dev/tests/unit/report --coverage-filter /var/www/html/vendor/algolia/algoliasearch-magento-2/ /var/www/html/vendor/algolia/algoliasearch-magento-2/Test/Unit
+            docker cp $(docker compose ps -q phpfpm):/var/www/html/dev/tests/unit/report ./unit-coverage/
       - store_artifacts:
-          path: ~/Sites/unit-coverage
+          path: ~/Sites/unit-coverage/report
           destination: test-results/magento-<< parameters.magento-version >>-php-<< parameters.php-version >>
 
 workflows:


### PR DESCRIPTION
# MAGE-1367: Add unit tests to CircleCI

**Summary**

- Add unit testing steps to CircleCI
- Add unit coverage steps to CircleCI
- Store unit tests results in "test" tab
- Store artifacts available for download

**Result**

<img width="1506" height="579" alt="image" src="https://github.com/user-attachments/assets/331653a5-85bb-4bab-b555-25ae7dd7c4f2" />
