### PR TITLE
MAGE-1364 MAGE-1365 PHP 8.4 implicit nullable types plus 8.2 base refactor

### DIFF
--- a/Api/Insights/EventProcessorInterface.php
+++ b/Api/Insights/EventProcessorInterface.php
@@ -91,7 +91,7 @@ interface EventProcessorInterface
         string $eventName,
         string $indexName,
         Item   $item,
-        string $queryID = null
+        ?string $queryID = null
     ): array;
 
     /**
@@ -123,7 +123,7 @@ interface EventProcessorInterface
         string $eventName,
         string $indexName,
         array  $items,
-        string $queryID = null
+        ?string $queryID = null
     ): array;
 
 }

--- a/Block/Adminhtml/LandingPage/Edit/AbstractButton.php
+++ b/Block/Adminhtml/LandingPage/Edit/AbstractButton.php
@@ -52,7 +52,7 @@ abstract class AbstractButton
             $landingPage->getResource()->load($landingPage, $modelId);
 
             return $landingPage;
-        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+        } catch (\Magento\Framework\Exception\NoSuchEntityException) {
         }
 
         return null;

--- a/Block/Adminhtml/Query/Edit/AbstractButton.php
+++ b/Block/Adminhtml/Query/Edit/AbstractButton.php
@@ -52,7 +52,7 @@ abstract class AbstractButton
             $query->getResource()->load($query, $modelId);
 
             return $query;
-        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+        } catch (\Magento\Framework\Exception\NoSuchEntityException) {
         }
 
         return null;

--- a/Block/Adminhtml/Queue/Status.php
+++ b/Block/Adminhtml/Queue/Status.php
@@ -70,20 +70,12 @@ class Status extends Template
     public function getQueueRunnerStatus()
     {
         $status = 'unknown';
-        switch ($this->queueRunnerIndexer->getStatus()) {
-            case \Magento\Framework\Indexer\StateInterface::STATUS_VALID:
-                $status = 'Ready';
-
-                break;
-            case \Magento\Framework\Indexer\StateInterface::STATUS_INVALID:
-                $status = 'Reindex required';
-
-                break;
-            case \Magento\Framework\Indexer\StateInterface::STATUS_WORKING:
-                $status = 'Processing';
-
-                break;
-        }
+        $status = match ($this->queueRunnerIndexer->getStatus()) {
+            \Magento\Framework\Indexer\StateInterface::STATUS_VALID => 'Ready',
+            \Magento\Framework\Indexer\StateInterface::STATUS_INVALID => 'Reindex required',
+            \Magento\Framework\Indexer\StateInterface::STATUS_WORKING => 'Processing',
+            default => $status,
+        };
 
         return $status;
     }

--- a/Block/Checkout/Conversion.php
+++ b/Block/Checkout/Conversion.php
@@ -54,7 +54,7 @@ class Conversion extends Template
         /** @var Item $item */
         foreach ($orderItems as $item) {
             if ($item->hasData(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)) {
-                $orderItemsData[$item->getProductId()] = json_decode($item->getData(InsightsHelper::QUOTE_ITEM_QUERY_PARAM));
+                $orderItemsData[$item->getProductId()] = json_decode((string) $item->getData(InsightsHelper::QUOTE_ITEM_QUERY_PARAM));
             }
         }
 

--- a/Block/Configuration.php
+++ b/Block/Configuration.php
@@ -57,7 +57,7 @@ class Configuration extends Algolia implements CollectionDataSourceInterface
      * @param array $arr
      * @return array
      */
-    protected function getChildCategoryUrls(\Magento\Catalog\Model\Category $cat, string $parent = '', array $arr = array()): array {
+    protected function getChildCategoryUrls(\Magento\Catalog\Model\Category $cat, string $parent = '', array $arr = []): array {
         if (!$parent) {
             $parent = $this->initCategoryParentPath($cat);
         }

--- a/Block/LandingPage.php
+++ b/Block/LandingPage.php
@@ -90,7 +90,7 @@ class LandingPage extends Result
         $page = $this->getPage();
         $this->pageConfig->addBodyClass('algolia-landingpage-' . $page->getUrlKey());
         $metaTitle = $page->getMetaTitle();
-        $this->pageConfig->getTitle()->set($page->getTitle() ? $page->getTitle() : $metaTitle);
+        $this->pageConfig->getTitle()->set($page->getTitle() ?: $metaTitle);
         $this->pageConfig->setKeywords($page->getMetaKeywords());
         $this->pageConfig->setDescription($page->getMetaDescription());
 

--- a/Block/Navigation/Renderer/SliderRenderer.php
+++ b/Block/Navigation/Renderer/SliderRenderer.php
@@ -158,6 +158,6 @@ class SliderRenderer extends Template implements FilterRendererInterface
         $regexp = "/({$filter->getRequestVar()})=(-?[0-9A-Z\-\%]+)/";
         $replacement = '${1}=<%- from %>-<%- to %>';
 
-        return preg_replace($regexp, $replacement, $item->getUrl());
+        return preg_replace($regexp, $replacement, (string) $item->getUrl());
     }
 }

--- a/Block/System/Form/Field/Select.php
+++ b/Block/System/Form/Field/Select.php
@@ -9,6 +9,6 @@ class Select extends \Magento\Framework\View\Element\Html\Select
         $this->setData('name', $this->getData('input_name'));
         $this->setClass('select');
 
-        return trim(preg_replace('/\s+/', ' ', parent::_toHtml()));
+        return trim((string) preg_replace('/\s+/', ' ', parent::_toHtml()));
     }
 }

--- a/Block/Widget/LookingSimilar.php
+++ b/Block/Widget/LookingSimilar.php
@@ -51,7 +51,7 @@ class LookingSimilar extends Template implements BlockInterface
      */
     public function getProductIds()
     {
-        return json_encode(explode(",", $this->getData('productIds')));
+        return json_encode(explode(",", (string) $this->getData('productIds')));
     }
 
     /**

--- a/Console/Command/AbstractStoreCommand.php
+++ b/Console/Command/AbstractStoreCommand.php
@@ -87,7 +87,7 @@ abstract class AbstractStoreCommand extends Command
     protected function validateStoreIds(array $storeIds): array
     {
         foreach ($storeIds as $storeId) {
-            if (!ctype_digit($storeId) || (int) $storeId < 1) {
+            if (!ctype_digit((string) $storeId) || (int) $storeId < 1) {
                 throw new LocalizedException(__("Store ID argument must be an integer"));
             }
         }
@@ -123,7 +123,7 @@ abstract class AbstractStoreCommand extends Command
     {
         $msg = str_replace('{{target}}', $this->getOperationTargetLabel($storeIds), $msg);
         return ($storeIds)
-            ? "<info>$msg: " . join(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>'
+            ? "<info>$msg: " . implode(", ", $this->storeNameFetcher->getStoreNames($storeIds)) . '</info>'
             : "<info>$msg</info>";
     }
 

--- a/Console/Command/ReplicaDisableVirtualCommand.php
+++ b/Console/Command/ReplicaDisableVirtualCommand.php
@@ -139,9 +139,9 @@ class ReplicaDisableVirtualCommand extends AbstractReplicaCommand implements Rep
 
     protected function disableVirtualReplicasForAllStores(): void
     {
-        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, [$this, 'removeLegacyVirtualReplicaConfig']);
+        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, $this->removeLegacyVirtualReplicaConfig(...));
 
-        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::SORTING_INDICES, [$this, 'disableVirtualReplicaSortConfig']);
+        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::SORTING_INDICES, $this->disableVirtualReplicaSortConfig(...));
 
         $this->scopeConfig->reinit();
 

--- a/Console/Command/SynonymDeduplicateCommand.php
+++ b/Console/Command/SynonymDeduplicateCommand.php
@@ -151,17 +151,13 @@ class SynonymDeduplicateCommand extends AbstractStoreCommand
             array_combine(
                 $settingNames,
                 array_map(
-                    function($settingName) use ($settings) {
-                        return isset($settings[$settingName])
-                            ? $this->dedupeArrayOfArrays($settings[$settingName])
-                            : null;
-                    },
+                    fn($settingName) => isset($settings[$settingName])
+                        ? $this->dedupeArrayOfArrays($settings[$settingName])
+                        : null,
                     $settingNames
                 )
             ),
-            function($val) {
-                return $val !== null;
-            }
+            fn($val) => $val !== null
         );
     }
 
@@ -174,8 +170,8 @@ class SynonymDeduplicateCommand extends AbstractStoreCommand
     protected function dedupeArrayOfArrays(array $data): array {
         $encoded = array_map('json_encode', $data);
         $unique = array_values(array_unique($encoded));
-        $decoded = array_map(function($item) {
-            return json_decode($item, true); },
+        $decoded = array_map(
+            fn($item) => json_decode((string) $item, true),
             $unique
         );
         return $decoded;

--- a/Controller/Adminhtml/IndexingManager/Reindex.php
+++ b/Controller/Adminhtml/IndexingManager/Reindex.php
@@ -16,6 +16,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Algolia\AlgoliaSearch\Service\Category\BatchQueueProcessor as CategoryBatchQueueProcessor;
 use Algolia\AlgoliaSearch\Service\Page\BatchQueueProcessor as PageBatchQueueProcessor;
 use Algolia\AlgoliaSearch\Service\Product\BatchQueueProcessor as ProductBatchQueueProcessor;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -131,8 +132,9 @@ class Reindex extends Action
      * @throws AlgoliaException
      * @throws DiagnosticsException
      * @throws NoSuchEntityException
+     * @throws LocalizedException
      */
-    protected function reindexEntities(array $entities, array $storeIds = null, array $entityIds = null): void
+    protected function reindexEntities(array $entities, ?array $storeIds = null, ?array $entityIds = null): void
     {
         foreach ($entities as $entity) {
             $processor = match ($entity) {

--- a/Controller/Adminhtml/Landingpage/Save.php
+++ b/Controller/Adminhtml/Landingpage/Save.php
@@ -106,7 +106,7 @@ class Save extends AbstractAction
             if (isset($data['algolia_configuration']) && $data['algolia_configuration'] != $data['configuration']) {
                 $data['configuration'] = $data['algolia_configuration'];
                 if ($this->configHelper->isCustomerGroupsEnabled($data['store_id'])) {
-                    $configuration = json_decode($data['algolia_configuration'], true);
+                    $configuration = json_decode((string) $data['algolia_configuration'], true);
                     if (isset($configuration['price'.$data['price_key']])) {
                         $priceConfig = $configuration['price'.$data['price_key']];
                         $customerGroups = $this->customerGroupCollectionFactory->create();
@@ -163,7 +163,7 @@ class Save extends AbstractAction
      */
     protected function manageQueryRules(int $landingPageId, array $data): void
     {
-        $positions = json_decode($data['algolia_merchandising_positions'], true);
+        $positions = json_decode((string) $data['algolia_merchandising_positions'], true);
         $stores = [];
         if ($data['store_id'] == 0) {
             foreach ($this->storeManager->getStores() as $store) {

--- a/Controller/Adminhtml/Query/Save.php
+++ b/Controller/Adminhtml/Query/Save.php
@@ -157,7 +157,7 @@ class Save extends AbstractAction
      */
     private function manageQueryRules(int $queryId, array $data): void
     {
-        $positions = json_decode($data['algolia_merchandising_positions'], true);
+        $positions = json_decode((string) $data['algolia_merchandising_positions'], true);
         $stores = [];
         if ($data['store_id'] == 0) {
             $stores = $this->getActiveStores();

--- a/Controller/Adminhtml/Reindex/Save.php
+++ b/Controller/Adminhtml/Reindex/Save.php
@@ -45,7 +45,7 @@ class Save extends \Magento\Backend\App\Action
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $resultRedirect->setPath('*/*/index');
-        $skus = preg_split("/(,|\r\n|\n|\r)/", $this->getRequest()->getParam('skus'));
+        $skus = preg_split("/(,|\r\n|\n|\r)/", (string) $this->getRequest()->getParam('skus'));
 
         $stores = $this->storeManager->getStores();
 

--- a/Factory/CatalogPermissionsFactory.php
+++ b/Factory/CatalogPermissionsFactory.php
@@ -38,17 +38,17 @@ class CatalogPermissionsFactory
 
     public function getPermissionsIndexResource()
     {
-        return $this->objectManager->create('\Magento\CatalogPermissions\Model\ResourceModel\Permission\Index');
+        return $this->objectManager->create(\Magento\CatalogPermissions\Model\ResourceModel\Permission\Index::class);
     }
 
     public function getCatalogPermissionsHelper()
     {
-        return $this->objectManager->create('\Magento\CatalogPermissions\Helper\Data');
+        return $this->objectManager->create(\Magento\CatalogPermissions\Helper\Data::class);
     }
 
     public function getCatalogPermissionsConfig()
     {
-        return $this->objectManager->create('\Magento\CatalogPermissions\App\Config');
+        return $this->objectManager->create(\Magento\CatalogPermissions\App\Config::class);
     }
 
     public function getCategoryPermissionsCollection()

--- a/Factory/SharedCatalogFactory.php
+++ b/Factory/SharedCatalogFactory.php
@@ -115,7 +115,7 @@ class SharedCatalogFactory
             $groups = $this->getSharedCatalogGroups();
 
             foreach ($productItems as $productId => $permissions) {
-                $permissions = explode(',', $permissions);
+                $permissions = explode(',', (string) $permissions);
                 $finalPermissions = [];
                 foreach ($groups as $groupId) {
                     $finalPermissions[] = $groupId . '_' . (in_array($groupId, $permissions) ? '1' : '0');

--- a/Helper/Adapter/FiltersHelper.php
+++ b/Helper/Adapter/FiltersHelper.php
@@ -103,7 +103,7 @@ class FiltersHelper
         $landingPageFilter = [];
         $landingPage = $this->registry->registry('current_landing_page');
         if ($landingPage) {
-            $landingPageConfiguration = json_decode($landingPage->getConfiguration(), true);
+            $landingPageConfiguration = json_decode((string) $landingPage->getConfiguration(), true);
             $landingPageFilter['facetFilters'] = $this->getFacetFilters($storeId, $landingPageConfiguration);
             $landingPageFilter = array_merge(
                 $landingPageFilter,
@@ -153,7 +153,7 @@ class FiltersHelper
 
             $facetValues = is_array($parameters[$facet['attribute']]) ?
                 $parameters[$facet['attribute']] :
-                explode('~', $parameters[$facet['attribute']]);
+                explode('~', (string) $parameters[$facet['attribute']]);
 
             // Backward compatibility with native Magento filtering
             if (!$this->config->isInstantEnabled($storeId)) {
@@ -172,7 +172,7 @@ class FiltersHelper
             }
 
             if ($facet['type'] === 'conjunctive') {
-                foreach ($facetValues as $key => $facetValue) {
+                foreach ($facetValues as $facetValue) {
                     $facetFilters[] = $facet['attribute'] . ':' . $facetValue;
                 }
             }

--- a/Helper/AlgoliaHelper.php
+++ b/Helper/AlgoliaHelper.php
@@ -297,7 +297,7 @@ class AlgoliaHelper extends AbstractHelper
      *
      * @throws AlgoliaException|NoSuchEntityException
      */
-    public function searchRules(string $indexName, array $searchRulesParams = null, ?int $storeId = null)
+    public function searchRules(string $indexName, ?array $searchRulesParams = null, ?int $storeId = null)
     {
         $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 

--- a/Helper/AnalyticsHelper.php
+++ b/Helper/AnalyticsHelper.php
@@ -200,7 +200,7 @@ class AnalyticsHelper
      */
     public function getTopHitsForSearch($search, array $params): array
     {
-        return $this->safeFetch(self::ANALYTICS_HITS_PATH . '?search=' . urlencode($search), $params);
+        return $this->safeFetch(self::ANALYTICS_HITS_PATH . '?search=' . urlencode((string) $search), $params);
     }
 
     /**

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -849,7 +849,7 @@ class ConfigHelper
      * @param int|null $storeId
      * @return string
      */
-    public function getIndexPrefix(int $storeId = null): string
+    public function getIndexPrefix(?int $storeId = null): string
     {
         return (string) $this->configInterface->getValue(self::INDEX_PREFIX, ScopeInterface::SCOPE_STORE, $storeId);
     }

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -763,7 +763,7 @@ class ConfigHelper
     /**
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getCurrencyCode(int $storeId = null): string
+    public function getCurrencyCode(?int $storeId = null): string
     {
         /** @var \Magento\Store\Model\Store $store */
         $store = $this->storeManager->getStore($storeId);

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -940,7 +940,7 @@ class ConfigHelper
      */
     public function getExtraSettings($section, $storeId = null)
     {
-        $constant = 'EXTRA_SETTINGS_' . mb_strtoupper($section);
+        $constant = 'EXTRA_SETTINGS_' . mb_strtoupper((string) $section);
         $value = $this->configInterface->getValue(constant('self::' . $constant), ScopeInterface::SCOPE_STORE, $storeId);
         return trim((string)$value);
     }
@@ -963,13 +963,13 @@ class ConfigHelper
         if (!isset($_SERVER['HTTP_USER_AGENT'])) {
             return false;
         }
-        $userAgent = mb_strtolower($_SERVER['HTTP_USER_AGENT'], 'utf-8');
+        $userAgent = mb_strtolower((string) $_SERVER['HTTP_USER_AGENT'], 'utf-8');
         $allowedUserAgents = $this->configInterface->getValue(
             self::BACKEND_RENDERING_ALLOWED_USER_AGENTS,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
-        $allowedUserAgents = trim($allowedUserAgents);
+        $allowedUserAgents = trim((string) $allowedUserAgents);
         if ($allowedUserAgents === '') {
             return true;
         }
@@ -1141,9 +1141,7 @@ class ConfigHelper
             $storeId
         ));
         $customRankings = $customRankings ?: [];
-        $customRankings = array_filter($customRankings, function ($customRanking) {
-            return $customRanking['attribute'] !== 'custom_attribute';
-        });
+        $customRankings = array_filter($customRankings, fn($customRanking) => $customRanking['attribute'] !== 'custom_attribute');
         $attributes = $this->addIndexableAttributes($attributes, $customRankings, '0', '0');
         if (is_array($attributes)) {
             return $attributes;
@@ -1199,9 +1197,7 @@ class ConfigHelper
             $storeId
         ));
         $customRankings = $customRankings ?: [];
-        $customRankings = array_filter($customRankings, function ($customRanking) {
-            return $customRanking['attribute'] !== 'custom_attribute';
-        });
+        $customRankings = array_filter($customRankings, fn($customRanking) => $customRanking['attribute'] !== 'custom_attribute');
         $attributes = $this->addIndexableAttributes($attributes, $customRankings, '0', '0');
         if (is_array($attributes)) {
             return $attributes;
@@ -1445,9 +1441,7 @@ class ConfigHelper
     {
         return (bool) count(array_filter(
             $this->getSorting($storeId),
-            function ($sort) {
-                return $sort[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA];
-            }
+            fn($sort) => $sort[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA]
         ));
     }
 

--- a/Helper/Configuration/InstantSearchHelper.php
+++ b/Helper/Configuration/InstantSearchHelper.php
@@ -170,6 +170,6 @@ class InstantSearchHelper
     public function getInstantRedirectOptions(?int $storeId = null): array
     {
         $value = $this->configInterface->getValue(self::REDIRECT_OPTIONS, ScopeInterface::SCOPE_STORE, $storeId);
-        return empty($value) ? [] : explode(',', $value);
+        return empty($value) ? [] : explode(',', (string) $value);
     }
 }

--- a/Helper/Configuration/NoticeHelper.php
+++ b/Helper/Configuration/NoticeHelper.php
@@ -307,7 +307,7 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         // Module installation is only needed if there's more than one source
-        $sourceCollection = $this->objectManager->create('\Magento\Inventory\Model\ResourceModel\Source\Collection');
+        $sourceCollection = $this->objectManager->create(\Magento\Inventory\Model\ResourceModel\Source\Collection::class);
         if ($sourceCollection->getSize() <= 1) {
             return false;
         }

--- a/Helper/Configuration/PersonalizationHelper.php
+++ b/Helper/Configuration/PersonalizationHelper.php
@@ -51,7 +51,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isPersoEnabled(int $storeId = null): bool
+    public function isPersoEnabled(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_PERSO_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -61,7 +61,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return void
      */
-    public function disablePerso(int $storeId = null): void
+    public function disablePerso(?int $storeId = null): void
     {
         $this->configResourceInterface->saveConfig(self::IS_PERSO_ENABLED, 0, 'default', 0);
     }
@@ -71,7 +71,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isViewProductTracked(int $storeId = null): bool
+    public function isViewProductTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::VIEW_PRODUCT, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -81,7 +81,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isProductClickedTracked(int $storeId = null): bool
+    public function isProductClickedTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::PRODUCT_CLICKED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -91,7 +91,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getProductClickedSelector(int $storeId = null): string
+    public function getProductClickedSelector(?int $storeId = null): string
     {
         return $this->configInterface->getValue(self::PRODUCT_CLICKED_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -101,7 +101,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isFilterClickedTracked(int $storeId = null): bool
+    public function isFilterClickedTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::FILTER_CLICKED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -111,7 +111,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isWishlistAddTracked(int $storeId = null): bool
+    public function isWishlistAddTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::WISHLIST_ADD, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -121,7 +121,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getWishlistAddSelector(int $storeId = null): string
+    public function getWishlistAddSelector(?int $storeId = null): string
     {
         return $this->configInterface->getValue(self::WISHLIST_ADD_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -131,7 +131,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isProductRecommendedTracked(int $storeId = null): bool
+    public function isProductRecommendedTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::PRODUCT_RECOMMENDED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -141,7 +141,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getProductRecommendedSelector(int $storeId = null): string
+    public function getProductRecommendedSelector(?int $storeId = null): string
     {
         return $this->configInterface->getValue(self::PRODUCT_RECOMMENDED_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -151,7 +151,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isCartAddTracked(int $storeId = null): bool
+    public function isCartAddTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::CART_ADD, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -161,7 +161,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getCartAddSelector(int $storeId = null): string
+    public function getCartAddSelector(?int $storeId = null): string
     {
         return $this->configInterface->getValue(self::CART_ADD_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -171,7 +171,7 @@ class PersonalizationHelper extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return bool
      */
-    public function isOrderPlacedTracked(int $storeId = null): bool
+    public function isOrderPlacedTracked(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::ORDER_PLACED, ScopeInterface::SCOPE_STORE, $storeId);
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -59,7 +59,7 @@ class Data
      * @deprecated
      * Use Algolia\AlgoliaSearch\Service\Page\IndexBuilder::buildIndexFull() instead
      */
-    public function rebuildStorePageIndex($storeId, array $pageIds = null): void
+    public function rebuildStorePageIndex($storeId, ?array $pageIds = null): void
     {
         $this->pageIndexBuilder->buildIndexFull($storeId, ['entityIds' => $pageIds]);
     }
@@ -203,7 +203,7 @@ class Data
      * @return string
      * @throws NoSuchEntityException
      */
-    public function getIndexName(string $indexSuffix, int $storeId = null, bool $tmp = false): string
+    public function getIndexName(string $indexSuffix, ?int $storeId = null, bool $tmp = false): string
     {
         return $this->indexNameFetcher->getIndexName($indexSuffix, $storeId, $tmp);
     }
@@ -213,7 +213,7 @@ class Data
      * @return string
      * @throws NoSuchEntityException
      */
-    public function getBaseIndexName(int $storeId = null): string
+    public function getBaseIndexName(?int $storeId = null): string
     {
         return $this->indexNameFetcher->getBaseIndexName($storeId);
     }
@@ -237,7 +237,7 @@ class Data
      * @return array
      * @throws NoSuchEntityException
      */
-    protected function buildIndexData(StoreInterface $store = null): array
+    protected function buildIndexData(?StoreInterface $store = null): array
     {
         $storeId = !is_null($store) ? $store->getStoreId() : null;
         $currencyCode = !is_null($store) ?

--- a/Helper/Entity/PageHelper.php
+++ b/Helper/Entity/PageHelper.php
@@ -48,7 +48,7 @@ class PageHelper extends AbstractEntityHelper
         return $indexSettings;
     }
 
-    public function getPages($storeId, array $pageIds = null)
+    public function getPages($storeId, ?array $pageIds = null)
     {
         $magentoPages = $this->pageCollectionFactory->create()
             ->addStoreFilter($storeId)

--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -20,7 +20,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
      */
     protected function addAdditionalData($product, $withTax, $subProducts, $currencyCode, $field)
     {
-        list($min, $max, $minOriginal, $maxOriginal) =
+        [$min, $max, $minOriginal, $maxOriginal] =
             $this->getMinMaxPrices($product, $withTax, $subProducts, $currencyCode);
         $dashedFormat = $this->getDashedPriceFormat($min, $max, $currencyCode);
         if ($min !== $max) {

--- a/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
@@ -126,7 +126,7 @@ abstract class ProductWithoutChildren
         if (!$this->areCustomersGroupsEnabled) {
             $this->groups->addFieldToFilter('main_table.customer_group_id', 0);
         } else {
-            $excludedGroups = array();
+            $excludedGroups = [];
             foreach ($this->groups as $group) {
                 $groupId = (int)$group->getData('customer_group_id');
                 $excludedWebsites = $this->groupExcludedWebsiteRepository->getCustomerGroupExcludedWebsites($groupId);
@@ -158,9 +158,9 @@ abstract class ProductWithoutChildren
                     $this->addCustomerGroupsPrices($product, $currencyCode, $withTax, $field);
                 }
                 $this->customData[$field][$currencyCode]['special_from_date'] =
-                    (!empty($product->getSpecialFromDate())) ? strtotime($product->getSpecialFromDate()) : '';
+                    (!empty($product->getSpecialFromDate())) ? strtotime((string) $product->getSpecialFromDate()) : '';
                 $this->customData[$field][$currencyCode]['special_to_date'] =
-                    (!empty($product->getSpecialToDate())) ? strtotime($product->getSpecialToDate()) : '';
+                    (!empty($product->getSpecialToDate())) ? strtotime((string) $product->getSpecialToDate()) : '';
                 $this->addSpecialPrices($specialPrice, $field, $currencyCode);
                 $this->addTierPrices($tierPrice, $field, $currencyCode);
                 $this->addAdditionalData($product, $withTax, $subProducts, $currencyCode, $field);
@@ -258,9 +258,7 @@ abstract class ProductWithoutChildren
             $specialPrices[$groupId][] = $this->getRulePrice($groupId, $product, $subProducts);
             // The price with applied catalog rules
             $specialPrices[$groupId][] = $product->getFinalPrice(); // The product's special price
-            $specialPrices[$groupId] = array_filter($specialPrices[$groupId], function ($price) {
-                return $price > 0;
-            });
+            $specialPrices[$groupId] = array_filter($specialPrices[$groupId], fn($price) => $price > 0);
             $specialPrice[$groupId] = false;
             if ($specialPrices[$groupId] && $specialPrices[$groupId] !== []) {
                 $specialPrice[$groupId] = min($specialPrices[$groupId]);

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -142,9 +142,7 @@ class ProductHelper extends AbstractEntityHelper
             $attributes[''] = '';
         }
 
-        uksort($attributes, function ($a, $b) {
-            return strcmp($a, $b);
-        });
+        uksort($attributes, fn($a, $b) => strcmp((string) $a, (string) $b));
 
         return $attributes;
     }

--- a/Helper/InsightsHelper.php
+++ b/Helper/InsightsHelper.php
@@ -162,7 +162,7 @@ class InsightsHelper
      * @param int|null $storeId
      * @return bool
      */
-    public function isInsightsEnabled(int $storeId = null): bool
+    public function isInsightsEnabled(?int $storeId = null): bool
     {
         return $this->configHelper->isClickConversionAnalyticsEnabled($storeId)
             || $this->personalizationHelper->isPersoEnabled($storeId);
@@ -174,7 +174,7 @@ class InsightsHelper
      *
      * @return bool
      */
-    public function isOrderPlacedTracked(int $storeId = null): bool
+    public function isOrderPlacedTracked(?int $storeId = null): bool
     {
         return $this->personalizationHelper->isPersoEnabled($storeId)
             && $this->personalizationHelper->isOrderPlacedTracked($storeId)
@@ -188,7 +188,7 @@ class InsightsHelper
      * @param int|null $storeId
      * @return bool
      */
-    public function isConversionTrackedPlaceOrder(int $storeId = null): bool
+    public function isConversionTrackedPlaceOrder(?int $storeId = null): bool
     {
         return $this->configHelper->isClickConversionAnalyticsEnabled($storeId)
             && in_array($this->configHelper->getConversionAnalyticsMode($storeId),
@@ -206,7 +206,7 @@ class InsightsHelper
      *
      * @return bool
      */
-    public function isAddedToCartTracked(int $storeId = null): bool
+    public function isAddedToCartTracked(?int $storeId = null): bool
     {
         return $this->personalizationHelper->isPersoEnabled($storeId)
             && $this->personalizationHelper->isCartAddTracked($storeId)
@@ -220,7 +220,7 @@ class InsightsHelper
      * @param int|null $storeId
      * @return bool
      */
-    public function isConversionTrackedAddToCart(int $storeId = null): bool
+    public function isConversionTrackedAddToCart(?int $storeId = null): bool
     {
         return $this->configHelper->isClickConversionAnalyticsEnabled($storeId)
             && in_array($this->configHelper->getConversionAnalyticsMode($storeId),

--- a/Helper/MerchandisingHelper.php
+++ b/Helper/MerchandisingHelper.php
@@ -30,8 +30,8 @@ class MerchandisingHelper
                                   int    $entityId,
                                   array  $rawPositions,
                                   string $entityType,
-                                  string $query = null,
-                                  string $banner = null): void
+                                  ?string $query = null,
+                                  ?string $banner = null): void
     {
         if ($this->coreHelper->isIndexingEnabled($storeId) === false) {
             return;

--- a/Model/Backend/EnableCustomerGroups.php
+++ b/Model/Backend/EnableCustomerGroups.php
@@ -22,8 +22,8 @@ class EnableCustomerGroups extends Value
         TypeListInterface       $cacheTypeList,
         protected ReplicaState  $replicaState,
         protected ConfigChecker $configChecker,
-        AbstractResource        $resource = null,
-        AbstractDb              $resourceCollection = null,
+        ?AbstractResource       $resource = null,
+        ?AbstractDb             $resourceCollection = null,
         array                   $data = []
     )
     {

--- a/Model/Backend/ExtraSettings.php
+++ b/Model/Backend/ExtraSettings.php
@@ -12,7 +12,7 @@ class ExtraSettings extends Value
 {
     public function beforeSave()
     {
-        $value = trim($this->getData('value'));
+        $value = trim((string) $this->getData('value'));
 
         if (!$value) {
             return parent::beforeSave();

--- a/Model/Backend/QueueCron.php
+++ b/Model/Backend/QueueCron.php
@@ -20,7 +20,7 @@ class QueueCron extends Value
 
     public function beforeSave()
     {
-        $value = trim($this->getData('value'));
+        $value = trim((string) $this->getData('value'));
 
         if (isset($this->mappings[$value])) {
             $value = $this->mappings[$value];

--- a/Model/Backend/Sorts.php
+++ b/Model/Backend/Sorts.php
@@ -24,10 +24,10 @@ class Sorts extends ArraySerialized
         TypeListInterface       $cacheTypeList,
         protected ReplicaState  $replicaState,
         protected ConfigChecker $configChecker,
-        AbstractResource        $resource = null,
-        AbstractDb              $resourceCollection = null,
+        ?AbstractResource       $resource = null,
+        ?AbstractDb             $resourceCollection = null,
         array                   $data = [],
-        Json                    $serializer = null
+        ?Json                   $serializer = null
     )
     {
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);

--- a/Model/Config/AutomaticPriceIndexingComment.php
+++ b/Model/Config/AutomaticPriceIndexingComment.php
@@ -15,7 +15,7 @@ class AutomaticPriceIndexingComment implements CommentInterface
     {
         $url = $this->urlInterface->getUrl('https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/#configure-the-queue');
 
-        $comment = array();
+        $comment = [];
         $comment[] = 'Algolia relies on the core Magento Product Price index when serializing product data. If the price index is not up to date, Algolia will not be able to accurately determine what should be included in the search index.';
         $comment[] = 'If you are experiencing problems with products not syncing to Algolia due to this issue, enabling this setting will allow Algolia to automatically update the price index as needed.';
         $comment[] = 'NOTE: This can introduce a marginal amount of overhead to the indexing process so only enable if necessary. Be sure to <a href="' . $url . '" target="_blank">optimize the indexing queue</a> based on the impact of this operation.';

--- a/Model/ImageUploader.php
+++ b/Model/ImageUploader.php
@@ -172,7 +172,7 @@ class ImageUploader
                 $baseTmpImagePath,
                 $baseImagePath
             );
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             throw new \Magento\Framework\Exception\LocalizedException(
                 __('Something went wrong while saving the file(s).')
             );

--- a/Model/Indexer/ProductObserver.php
+++ b/Model/Indexer/ProductObserver.php
@@ -64,12 +64,12 @@ class ProductObserver
 
     /**
      * @param Action $subject
-     * @param Action|null $result
+     * @param Action $result
      * @param array $productIds
      *
      * @return Action
      */
-    public function afterUpdateAttributes(Action $subject, Action $result = null, $productIds)
+    public function afterUpdateAttributes(Action $subject, Action $result, $productIds)
     {
         if (!$this->indexer->isScheduled()) {
             $this->indexer->reindexList(array_unique($productIds));
@@ -80,12 +80,12 @@ class ProductObserver
 
     /**
      * @param Action $subject
-     * @param Action|null $result
+     * @param Action $result
      * @param array $productIds
      *
      * @return mixed
      */
-    public function afterUpdateWebsites(Action $subject, Action $result = null, array $productIds)
+    public function afterUpdateWebsites(Action $subject, Action $result, array $productIds)
     {
         if (!$this->indexer->isScheduled()) {
             $this->indexer->reindexList(array_unique($productIds));

--- a/Model/Indexer/ProductObserver.php
+++ b/Model/Indexer/ProductObserver.php
@@ -13,17 +13,9 @@ class ProductObserver
     /** @var Product */
     private $indexer;
 
-    /** @var ConfigHelper */
-    private $configHelper;
-
-    /**
-     * @param IndexerRegistry $indexerRegistry
-     * @param ConfigHelper $configHelper
-     */
-    public function __construct(IndexerRegistry $indexerRegistry, ConfigHelper $configHelper)
+    public function __construct(IndexerRegistry $indexerRegistry)
     {
         $this->indexer = $indexerRegistry->get('algolia_products');
-        $this->configHelper = $configHelper;
     }
 
     /**
@@ -31,9 +23,9 @@ class ProductObserver
      * @param ProductResource $result
      * @param ProductModel $product
      *
-     * @return ProductModel[]
+     * @return ProductResource
      */
-    public function afterSave(ProductResource $productResource, ProductResource $result, ProductModel $product)
+    public function afterSave(ProductResource $productResource, ProductResource $result, ProductModel $product): ProductResource
     {
         $productResource->addCommitCallback(function () use ($product) {
             if (!$this->indexer->isScheduled()) {
@@ -49,9 +41,9 @@ class ProductObserver
      * @param ProductResource $result
      * @param ProductModel $product
      *
-     * @return ProductModel[]
+     * @return ProductResource
      */
-    public function afterDelete(ProductResource $productResource, ProductResource $result, ProductModel $product)
+    public function afterDelete(ProductResource $productResource, ProductResource $result, ProductModel $product): ProductResource
     {
         $productResource->addCommitCallback(function () use ($product) {
             if (!$this->indexer->isScheduled()) {
@@ -69,7 +61,7 @@ class ProductObserver
      *
      * @return Action
      */
-    public function afterUpdateAttributes(Action $subject, Action $result, $productIds)
+    public function afterUpdateAttributes(Action $subject, Action $result, array $productIds): Action
     {
         if (!$this->indexer->isScheduled()) {
             $this->indexer->reindexList(array_unique($productIds));
@@ -80,17 +72,15 @@ class ProductObserver
 
     /**
      * @param Action $subject
-     * @param Action $result
+     * @param null $result
      * @param array $productIds
      *
-     * @return mixed
+     * @return void
      */
-    public function afterUpdateWebsites(Action $subject, Action $result, array $productIds)
+    public function afterUpdateWebsites(Action $subject, null $result, array $productIds): void
     {
         if (!$this->indexer->isScheduled()) {
             $this->indexer->reindexList(array_unique($productIds));
         }
-
-        return $result;
     }
 }

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -41,8 +41,8 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Framework\ObjectManagerInterface $objectManager,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -90,7 +90,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
         }
 
         if ($this->getDecodedData() === null) {
-            $decodedData = json_decode($this->getData('data'), true);
+            $decodedData = json_decode((string) $this->getData('data'), true);
 
             $this->setDecodedData($decodedData);
 

--- a/Model/Observer/CatalogPermissions/CategoryCollectionAddPermissions.php
+++ b/Model/Observer/CatalogPermissions/CategoryCollectionAddPermissions.php
@@ -52,13 +52,13 @@ class CategoryCollectionAddPermissions implements ObserverInterface
 
         $catalogPermissionsHelper = $this->permissionsFactory->getCatalogPermissionsHelper();
         foreach ($permissionsCollection as $categoryId => $permissions) {
-            $permissions = explode(',', $permissions);
+            $permissions = explode(',', (string) $permissions);
             foreach ($permissions as $permission) {
                 $permission = explode('_', $permission);
                 if (count($permission) < 2) { // prevent undefined
                     continue;
                 }
-                list($customerGroupId, $level) = $permission;
+                [$customerGroupId, $level] = $permission;
                 if ($category = $collection->getItemById($categoryId)) {
                     $category->setData(
                         'customer_group_permission_' . $customerGroupId,
@@ -83,13 +83,13 @@ class CategoryCollectionAddPermissions implements ObserverInterface
         }
 
         foreach ($sharedCollection as $categoryId => $permissions) {
-            $permissions = explode(',', $permissions);
+            $permissions = explode(',', (string) $permissions);
             foreach ($permissions as $permission) {
                 $permission = explode('_', $permission);
                 if (count($permission) < 2) { // prevent undefined
                     continue;
                 }
-                list($customerGroupId, $level) = $permission;
+                [$customerGroupId, $level] = $permission;
                 if ($category = $collection->getItemById($categoryId)) {
                     $category->setData('shared_catalog_permission_' . $customerGroupId, $level == -1 ? 1 : 0);
                 }

--- a/Model/Observer/CatalogPermissions/ProductCollectionAddPermissions.php
+++ b/Model/Observer/CatalogPermissions/ProductCollectionAddPermissions.php
@@ -61,13 +61,13 @@ class ProductCollectionAddPermissions implements ObserverInterface
         $permissionsCollection = array_intersect_key($productPermissionsCollection, $productIds);
         $catalogPermissionsHelper = $this->permissionsFactory->getCatalogPermissionsHelper();
         foreach ($permissionsCollection as $productId => $permissions) {
-            $permissions = explode(',', $permissions);
+            $permissions = explode(',', (string) $permissions);
             foreach ($permissions as $permission) {
                 $permission = explode('_', $permission);
                 if (count($permission) < 3) { // prevent undefined
                     continue;
                 }
-                list($permissionStoreId, $customerGroupId, $level) = $permission;
+                [$permissionStoreId, $customerGroupId, $level] = $permission;
                 if ($permissionStoreId == $storeId) {
                     $additionalData->addProductData($productId, [
                         'customer_group_permission_' . $customerGroupId => ($level == -2 ? 0 : 1),
@@ -90,13 +90,13 @@ class ProductCollectionAddPermissions implements ObserverInterface
 
         $sharedCollection = array_intersect_key($sharedCatalogCollection, $productIds);
         foreach ($sharedCollection as $productId => $permissions) {
-            $permissions = explode(',', $permissions);
+            $permissions = explode(',', (string) $permissions);
             foreach ($permissions as $permission) {
                 $permission = explode('_', $permission);
                 if (count($permission) < 2) { // prevent undefined
                     continue;
                 }
-                list($customerGroupId, $level) = $permission;
+                [$customerGroupId, $level] = $permission;
                 $additionalData->addProductData($productId, [
                     'shared_catalog_permission_' . $customerGroupId => $level,
                 ]);

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -117,7 +117,7 @@ class Queue
     public function addToQueue($className, $method, array $data, $dataSize = 1, $isFullReindex = false)
     {
         if (is_object($className)) {
-            $className = get_class($className);
+            $className = $className::class;
         }
 
         if ($this->configHelper->isQueueActive()) {
@@ -252,7 +252,7 @@ class Queue
                     Parameters: ' . json_encode($job->getDecodedData());
         $this->logger->log($logMessage);
 
-        $logMessage = date('c') . ' ERROR: ' . get_class($e) . ':
+        $logMessage = date('c') . ' ERROR: ' . $e::class . ':
                     ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() .
             "\nStack trace:\n" . $e->getTraceAsString();
         $this->logger->log($logMessage);

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -571,7 +571,7 @@ class Queue
      *
      * @return array
      */
-    protected function stackSortedJobs(array $sortedJobs, array $tempSortableJobs, Job $job = null)
+    protected function stackSortedJobs(array $sortedJobs, array $tempSortableJobs, ?Job $job = null)
     {
         if ($tempSortableJobs && $tempSortableJobs !== []) {
             $tempSortableJobs = $this->jobSort(

--- a/Model/QueueArchive.php
+++ b/Model/QueueArchive.php
@@ -11,7 +11,7 @@ class QueueArchive extends AbstractModel implements QueueArchiveInterface
      */
     protected function _construct()
     {
-        $this->_init('Algolia\AlgoliaSearch\Model\ResourceModel\QueueArchive');
+        $this->_init(\Algolia\AlgoliaSearch\Model\ResourceModel\QueueArchive::class);
     }
 
     /**

--- a/Model/ResourceModel/Job/Grid/Collection.php
+++ b/Model/ResourceModel/Job/Grid/Collection.php
@@ -38,7 +38,7 @@ class Collection extends JobCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -97,7 +97,7 @@ class Collection extends JobCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -127,7 +127,7 @@ class Collection extends JobCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/Job/Grid/Collection.php
+++ b/Model/ResourceModel/Job/Grid/Collection.php
@@ -36,7 +36,7 @@ class Collection extends JobCollection implements SearchResultInterface
         $eventPrefix,
         $eventObject,
         $resourceModel,
-        $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
+        $model = \Magento\Framework\View\Element\UiComponent\DataProvider\Document::class,
         $connection = null,
         ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {

--- a/Model/ResourceModel/LandingPage/Grid/Collection.php
+++ b/Model/ResourceModel/LandingPage/Grid/Collection.php
@@ -35,7 +35,7 @@ class Collection extends LandingPageCollection implements SearchResultInterface
         $eventPrefix,
         $eventObject,
         $resourceModel,
-        $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
+        $model = \Magento\Framework\View\Element\UiComponent\DataProvider\Document::class,
         $connection = null,
         ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {

--- a/Model/ResourceModel/LandingPage/Grid/Collection.php
+++ b/Model/ResourceModel/LandingPage/Grid/Collection.php
@@ -37,7 +37,7 @@ class Collection extends LandingPageCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -82,7 +82,7 @@ class Collection extends LandingPageCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -112,7 +112,7 @@ class Collection extends LandingPageCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/NoteBuilder.php
+++ b/Model/ResourceModel/NoteBuilder.php
@@ -107,9 +107,7 @@ class NoteBuilder
             $headers = array_keys($firstRow);
             $noteText[] = implode(' || ', $headers);
 
-            $archiveRows = array_map(function ($row) {
-                return implode(' || ', $row);
-            }, $archiveRows);
+            $archiveRows = array_map(fn($row) => implode(' || ', $row), $archiveRows);
 
             $queueArchiveInfo = array_merge($queueArchiveInfo, $archiveRows);
         }
@@ -252,9 +250,7 @@ class NoteBuilder
             $headers = array_keys($firstRow);
             $modulesText[] = implode(' || ', $headers);
 
-            $modules = array_map(function ($row) {
-                return implode(' || ', $row);
-            }, $modules);
+            $modules = array_map(fn($row) => implode(' || ', $row), $modules);
 
             $modulesText = array_merge($modulesText, $modules);
         }

--- a/Model/ResourceModel/Query/Grid/Collection.php
+++ b/Model/ResourceModel/Query/Grid/Collection.php
@@ -35,7 +35,7 @@ class Collection extends QueryCollection implements SearchResultInterface
         $eventPrefix,
         $eventObject,
         $resourceModel,
-        $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
+        $model = \Magento\Framework\View\Element\UiComponent\DataProvider\Document::class,
         $connection = null,
         ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {

--- a/Model/ResourceModel/Query/Grid/Collection.php
+++ b/Model/ResourceModel/Query/Grid/Collection.php
@@ -37,7 +37,7 @@ class Collection extends QueryCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -82,7 +82,7 @@ class Collection extends QueryCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -112,7 +112,7 @@ class Collection extends QueryCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/QueueArchive/Grid/Collection.php
+++ b/Model/ResourceModel/QueueArchive/Grid/Collection.php
@@ -44,7 +44,7 @@ class Collection extends QueueArchiveCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        AbstractDb $resource = null
+        ?AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -89,7 +89,7 @@ class Collection extends QueueArchiveCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -119,7 +119,7 @@ class Collection extends QueueArchiveCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/QueueArchive/Grid/Collection.php
+++ b/Model/ResourceModel/QueueArchive/Grid/Collection.php
@@ -42,7 +42,7 @@ class Collection extends QueueArchiveCollection implements SearchResultInterface
         $eventPrefix,
         $eventObject,
         $resourceModel,
-        $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
+        $model = \Magento\Framework\View\Element\UiComponent\DataProvider\Document::class,
         $connection = null,
         ?AbstractDb $resource = null
     ) {

--- a/Model/ResourceModel/Run/Grid/Collection.php
+++ b/Model/ResourceModel/Run/Grid/Collection.php
@@ -37,7 +37,7 @@ class Collection extends RunCollection implements SearchResultInterface
         $resourceModel,
         $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
         $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct(
             $entityFactory,
@@ -82,7 +82,7 @@ class Collection extends RunCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null)
     {
         return $this;
     }
@@ -112,7 +112,7 @@ class Collection extends RunCollection implements SearchResultInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(array $items = null)
+    public function setItems(?array $items = null)
     {
         return $this;
     }

--- a/Model/ResourceModel/Run/Grid/Collection.php
+++ b/Model/ResourceModel/Run/Grid/Collection.php
@@ -35,7 +35,7 @@ class Collection extends RunCollection implements SearchResultInterface
         $eventPrefix,
         $eventObject,
         $resourceModel,
-        $model = 'Magento\Framework\View\Element\UiComponent\DataProvider\Document',
+        $model = \Magento\Framework\View\Element\UiComponent\DataProvider\Document::class,
         $connection = null,
         ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {

--- a/Model/Source/CustomRankingCategory.php
+++ b/Model/Source/CustomRankingCategory.php
@@ -17,7 +17,7 @@ class CustomRankingCategory extends AbstractTable
                     $attributes = $categoryHelper->getAllAttributes();
 
                     foreach ($attributes as $key => $label) {
-                        $options[$key] = $key ? $key : $label;
+                        $options[$key] = $key ?: $label;
                     }
 
                     return $options;

--- a/Model/Source/CustomRankingProduct.php
+++ b/Model/Source/CustomRankingProduct.php
@@ -17,7 +17,7 @@ class CustomRankingProduct extends AbstractTable
                     $attributes = $productHelper->getAllAttributes();
 
                     foreach ($attributes as $key => $label) {
-                        $options[$key] = $key ? $key : $label;
+                        $options[$key] = $key ?: $label;
                     }
 
                     return $options;

--- a/Model/Source/Facets.php
+++ b/Model/Source/Facets.php
@@ -19,7 +19,7 @@ class Facets extends AbstractTable
                     $attributes = $productHelper->getAllAttributes();
 
                     foreach ($attributes as $key => $label) {
-                        $options[$key] = $key ? $key : $label;
+                        $options[$key] = $key ?: $label;
                     }
 
                     return $options;

--- a/Model/Source/JobClasses.php
+++ b/Model/Source/JobClasses.php
@@ -5,15 +5,15 @@ namespace Algolia\AlgoliaSearch\Model\Source;
 class JobClasses implements \Magento\Framework\Data\OptionSourceInterface
 {
     private $classes = [
-        'Algolia\AlgoliaSearch\Model\IndicesConfigurator' => 'Model\IndicesConfigurator',
-        'Algolia\AlgoliaSearch\Model\IndexMover' => 'Model\IndexMover',
-        'Algolia\AlgoliaSearch\Service\AdditionalSection\IndexBuilder' => 'AdditionalSection\IndexBuilder',
-        'Algolia\AlgoliaSearch\Service\Category\IndexBuilder' => 'Category\IndexBuilder',
-        'Algolia\AlgoliaSearch\Service\Page\IndexBuilder' => 'Page\IndexBuilder',
-        'Algolia\AlgoliaSearch\Service\Product\IndexBuilder' => 'Product\IndexBuilder',
-        'Algolia\AlgoliaSearch\Service\Suggestion\IndexBuilder' => 'Suggestion\IndexBuilder',
+        \Algolia\AlgoliaSearch\Model\IndicesConfigurator::class => 'Model\IndicesConfigurator',
+        \Algolia\AlgoliaSearch\Model\IndexMover::class => 'Model\IndexMover',
+        \Algolia\AlgoliaSearch\Service\AdditionalSection\IndexBuilder::class => 'AdditionalSection\IndexBuilder',
+        \Algolia\AlgoliaSearch\Service\Category\IndexBuilder::class => 'Category\IndexBuilder',
+        \Algolia\AlgoliaSearch\Service\Page\IndexBuilder::class => 'Page\IndexBuilder',
+        \Algolia\AlgoliaSearch\Service\Product\IndexBuilder::class => 'Product\IndexBuilder',
+        \Algolia\AlgoliaSearch\Service\Suggestion\IndexBuilder::class => 'Suggestion\IndexBuilder',
         // @deprecated
-        'Algolia\AlgoliaSearch\Helper\Data' => 'Helper\Data',
+        \Algolia\AlgoliaSearch\Helper\Data::class => 'Helper\Data',
     ];
 
     /** @return array */

--- a/Model/Source/ProductAttributes.php
+++ b/Model/Source/ProductAttributes.php
@@ -17,7 +17,7 @@ class ProductAttributes extends AbstractTable
                     $attributes = $productHelper->getAllAttributes();
 
                     foreach ($attributes as $key => $label) {
-                        $options[$key] = $key ? $key : $label;
+                        $options[$key] = $key ?: $label;
                     }
 
                     return $options;

--- a/Model/Source/Sections.php
+++ b/Model/Source/Sections.php
@@ -31,7 +31,7 @@ class Sections extends AbstractTable
 
                         $sections[] = [
                             'name' => $attribute['attribute'],
-                            'label' => $attribute['label'] ? $attribute['label'] : $attribute['attribute'],
+                            'label' => $attribute['label'] ?: $attribute['attribute'],
                         ];
                     }
 

--- a/Model/Source/SortOrderCategory.php
+++ b/Model/Source/SortOrderCategory.php
@@ -16,7 +16,7 @@ class SortOrderCategory extends AbstractTable
                     $attributes = $categoryHelper->getAllAttributes();
 
                     foreach ($attributes as $key => $label) {
-                        $options[$key] = $key ? $key : $label;
+                        $options[$key] = $key ?: $label;
                     }
 
                     return $options;

--- a/Model/Source/SortOrderProduct.php
+++ b/Model/Source/SortOrderProduct.php
@@ -16,7 +16,7 @@ class SortOrderProduct extends AbstractTable
                     $attributes = $productHelper->getAllAttributes();
 
                     foreach ($attributes as $key => $label) {
-                        $options[$key] = $key ? $key : $label;
+                        $options[$key] = $key ?: $label;
                     }
 
                     return $options;

--- a/Model/Source/Sorts.php
+++ b/Model/Source/Sorts.php
@@ -22,7 +22,7 @@ class Sorts extends AbstractTable
                     $attributes = $productHelper->getAllAttributes();
 
                     foreach ($attributes as $key => $label) {
-                        $options[$key] = $key ? $key : $label;
+                        $options[$key] = $key ?: $label;
                     }
 
                     return $options;

--- a/Observer/Insights/WishlistProductAddAfter.php
+++ b/Observer/Insights/WishlistProductAddAfter.php
@@ -36,9 +36,7 @@ class WishlistProductAddAfter implements ObserverInterface
         }
 
         $eventProcessor = $this->insightsHelper->getEventProcessor();
-        $productIds = array_map(function (Item $item) {
-            return $item->getProductId();
-        }, $items);
+        $productIds = array_map(fn(Item $item) => $item->getProductId(), $items);
 
         try {
             $eventProcessor->convertedObjectIDs(

--- a/Plugin/AddToCartRedirectForInsights.php
+++ b/Plugin/AddToCartRedirectForInsights.php
@@ -41,7 +41,7 @@ class AddToCartRedirectForInsights
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function beforeAddProduct(Cart $cartModel, int|Product $productInfo, array|int|DataObject $requestInfo = null)
+    public function beforeAddProduct(Cart $cartModel, int|Product $productInfo, array|int|DataObject|null $requestInfo)
     {
         // First, check is Insights are enabled
         if (!$this->configHelper->isClickConversionAnalyticsEnabled($this->storeManager->getStore()->getId())) {

--- a/Plugin/SetAdminCurrentCategory.php
+++ b/Plugin/SetAdminCurrentCategory.php
@@ -45,7 +45,7 @@ class SetAdminCurrentCategory
         try {
             $currentCategory = $this->categoryRepository->get($categoryId);
             $this->currentCategory->set($currentCategory);
-        } catch (NoSuchEntityException $e) {
+        } catch (NoSuchEntityException) {
             return null;
         }
 

--- a/Plugin/StockItemObserver.php
+++ b/Plugin/StockItemObserver.php
@@ -44,7 +44,7 @@ class StockItemObserver
      */
     public function afterDelete(
         \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $stockItemResource,
-        \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $result = null,
+        \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $result,
         \Magento\CatalogInventory\Api\Data\StockItemInterface $stockItem
     ) {
         $stockItemResource->addCommitCallback(function () use ($stockItem) {

--- a/Plugin/StockItemObserver.php
+++ b/Plugin/StockItemObserver.php
@@ -38,9 +38,9 @@ class StockItemObserver
 
     /**
      * @param \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $stockItemResource
-     * @param \Magento\CatalogInventory\Model\ResourceModel\Stock\Item|null $result
+     * @param \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $result
      * @param \Magento\CatalogInventory\Api\Data\StockItemInterface $stockItem
-     * @return \Magento\CatalogInventory\Model\ResourceModel\Stock\Item|null
+     * @return \Magento\CatalogInventory\Model\ResourceModel\Stock\Item
      */
     public function afterDelete(
         \Magento\CatalogInventory\Model\ResourceModel\Stock\Item $stockItemResource,

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ Algolia Search & Discovery extension for Magento 2
 ==================================================
 
 ![Latest version](https://img.shields.io/badge/latest-3.16.0-green)
-![Magento 2](https://img.shields.io/badge/Magento-2.4.6+-orange)
+![Magento 2](https://img.shields.io/badge/Magento-2.4.7+-orange)
 
-![PHP](https://img.shields.io/badge/PHP-8.1%2C8.2%2C8.3-blue)
+![PHP](https://img.shields.io/badge/PHP-8.1%2C8.2%2C8.3%2C8.4-blue)
 
-[![CircleCI](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/master.svg?style=svg)](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/master)
+[![CircleCI](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/main.svg?style=svg)](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/main)
 
 -------
 
@@ -35,18 +35,18 @@ Magento 2.3 and earlier versions are no longer supported by the Algolia extensio
 
 Version 3.x of our extension is compatible with Magento 2.4. Review the [Customisation](https://github.com/algolia/algoliasearch-magento-2#customisation) section to learn more about the differences between our extension versions.
 
-| Extension Version | End of Life | Magento            | PHP                                    |
-|-------------------|-------------|--------------------|----------------------------------------|
+| Extension Version | End of Life | Magento                      | PHP                                    |
+|-------------------|-------------|------------------------------|----------------------------------------|
 | v3.7.x            | 10/10/2023  | `~2.3.7\|\|~2.4.5\|\|~2.4.6` | `~7.3.0\|\|~7.4.0\|\|~8.1.0\|\|~8.2.0` |
-| v3.8.x            | 3/8/2023    | `~2.4.5\|\|~2.4.6` | `~7.4.0\|\|~8.1.0\|\|~8.2.0`           |
-| v3.9.x            | 10/13/2023  | `~2.4.5\|\|~2.4.6` | `~7.4.0\|\|~8.1.0\|\|~8.2.0`           |
-| v3.10.x           | 12/12/2023  | `~2.4.6`           | `~8.1.0\|\|~8.2.0`                     |
-| v3.11.x           | 1/26/2024   | `~2.4.6`           | `~8.1.0\|\|~8.2.0`                     |
-| v3.12.x           | 8/2/2024    | `~2.4.6`           | `~8.1.0\|\|~8.2.0`                     |
-| v3.13.x           | N/A         | `~2.4.6`           | `~8.1.0\|\|~8.2.0`                     |
-| v3.14.x           | N/A         | `~2.4.6\|\|~2.4.7` | `~8.1.0\|\|~8.2.0\|\|~8.3.0`           |
-| v3.15.x           | N/A         | `~2.4.6\|\|~2.4.7` | `~8.1.0\|\|~8.2.0\|\|~8.3.0`           |
-| v3.16.x           | N/A         | `~2.4.6\|\|~2.4.7` | `~8.1.0\|\|~8.2.0\|\|~8.3.0`           |
+| v3.8.x            | 3/8/2023    | `~2.4.5\|\|~2.4.6`           | `~7.4.0\|\|~8.1.0\|\|~8.2.0`           |
+| v3.9.x            | 10/13/2023  | `~2.4.5\|\|~2.4.6`           | `~7.4.0\|\|~8.1.0\|\|~8.2.0`           |
+| v3.10.x           | 12/12/2023  | `~2.4.6`                     | `~8.1.0\|\|~8.2.0`                     |
+| v3.11.x           | 1/26/2024   | `~2.4.6`                     | `~8.1.0\|\|~8.2.0`                     |
+| v3.12.x           | 8/2/2024    | `~2.4.6`                     | `~8.1.0\|\|~8.2.0`                     |
+| v3.13.x           | 4/9/2025    | `~2.4.6`                     | `~8.1.0\|\|~8.2.0`                     |
+| v3.14.x           | 9/1/2025    | `~2.4.6\|\|~2.4.7`           | `~8.1.0\|\|~8.2.0\|\|~8.3.0`           |
+| v3.15.x           | N/A         | `~2.4.6\|\|~2.4.7`           | `~8.1.0\|\|~8.2.0\|\|~8.3.0`           |
+| v3.16.x           | N/A         | `~2.4.7\|\|~2.4.8`           | `~8.2.0\|\|~8.3.0\|\|~8.4.0`           |
 
 ## Documentation
 

--- a/Service/AdditionalSection/IndexBuilder.php
+++ b/Service/AdditionalSection/IndexBuilder.php
@@ -44,7 +44,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
      * @throws ExceededRetriesException
      * @throws NoSuchEntityException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, null, null);
     }

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -628,7 +628,7 @@ class AlgoliaConnector
      * @throws AlgoliaException
      * @throws NoSuchEntityException
      */
-    public function searchRules(IndexOptionsInterface $indexOptions, array$searchRulesParams = null)
+    public function searchRules(IndexOptionsInterface $indexOptions, ?array $searchRulesParams = null)
     {
         $indexName = $indexOptions->getIndexName();
 

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -61,17 +61,17 @@ class AlgoliaConnector
     /**
      * @var string|null
      */
-    protected ?string $lastUsedIndexName;
+    protected ?string $lastUsedIndexName = null;
 
     /**
      * @var string|null
      */
-    protected ?string $lastTaskId;
+    protected ?string $lastTaskId = null;
 
     /**
      * @var array|null
      */
-    protected ?array $lastTaskInfoByStore;
+    protected ?array $lastTaskInfoByStore = null;
 
     public function __construct(
         protected ConfigHelper $config,
@@ -150,16 +150,6 @@ class AlgoliaConnector
     }
 
     /**
-     * @param string $name
-     * @throws AlgoliaException
-     * @deprecated This method has been completely removed from the Algolia PHP connector version 4 and should not be used.
-     */
-    public function getIndex(string $name)
-    {
-        throw new AlgoliaException("This method is no longer supported for PHP client v4!");
-    }
-
-    /**
      * @return ListIndicesResponse|array<string,mixed>
      * @throws AlgoliaException
      */
@@ -211,12 +201,10 @@ class AlgoliaConnector
 
         $requests = array_values(
             array_map(
-                function($id) use ($indexName) {
-                    return [
-                        self::ALGOLIA_API_INDEX_NAME => $indexName,
-                        self::ALGOLIA_API_OBJECT_ID => $id
-                    ];
-                },
+                fn($id) => [
+                    self::ALGOLIA_API_INDEX_NAME => $indexName,
+                    self::ALGOLIA_API_OBJECT_ID => $id
+                ],
                 $objectIds
             )
         );
@@ -293,14 +281,12 @@ class AlgoliaConnector
     {
         $requests = array_values(
             array_map(
-                function ($id) {
-                    return [
-                        'action' => 'deleteObject',
-                        'body'   => [
-                            self::ALGOLIA_API_OBJECT_ID => $id
-                        ]
-                    ];
-                },
+                fn($id) => [
+                    'action' => 'deleteObject',
+                    'body'   => [
+                        self::ALGOLIA_API_OBJECT_ID => $id
+                    ]
+                ],
                 $ids
             )
         );
@@ -393,7 +379,7 @@ class AlgoliaConnector
             }
 
             $onlineSettings = $this->getClient($storeId)->getSettings($sourceIndex);
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
 
         if (isset($settings['attributesToIndex'])) {
@@ -466,12 +452,10 @@ class AlgoliaConnector
 
         $requests = array_values(
             array_map(
-                function ($object) use ($action) {
-                    return [
-                        'action' => $action,
-                        'body'   => $object
-                    ];
-                },
+                fn($object) => [
+                    'action' => $action,
+                    'body'   => $object
+                ],
                 $objects
             )
         );
@@ -840,7 +824,7 @@ class AlgoliaConnector
 
             if (is_array($data) === false) {
                 if ($data != null) {
-                    $data = explode('|', $data);
+                    $data = explode('|', (string) $data);
                     if (count($data) === 1) {
                         $data = $data[0];
                         $data = $this->castAttribute($data);
@@ -1016,8 +1000,8 @@ class AlgoliaConnector
         foreach ($queryParams['disjunctiveFacets'] as $facetName) {
             $params = $queryParams;
             $params['facets'] = [$facetName];
-            $facetFilters = isset($params['facetFilters']) ? $params['facetFilters'] : [];
-            $numericFilters = isset($params['numericFilters']) ? $params['numericFilters'] : [];
+            $facetFilters = $params['facetFilters'] ?? [];
+            $numericFilters = $params['numericFilters'] ?? [];
 
             $additionalParams = [
                 'hitsPerPage' => 1,
@@ -1050,7 +1034,7 @@ class AlgoliaConnector
         for ($i = 0; $i < count($filters); $i++) {
             if (is_array($filters[$i])) {
                 foreach ($filters[$i] as $filter) {
-                    if (mb_substr($filter, 0, mb_strlen($needle)) === $needle) {
+                    if (mb_substr((string) $filter, 0, mb_strlen((string) $needle)) === $needle) {
                         unset($filters[$i]);
                         $filters = array_values($filters);
                         $i--;
@@ -1059,7 +1043,7 @@ class AlgoliaConnector
                     }
                 }
             } else {
-                if (mb_substr($filters[$i], 0, mb_strlen($needle)) === $needle) {
+                if (mb_substr((string) $filters[$i], 0, mb_strlen((string) $needle)) === $needle) {
                     unset($filters[$i]);
                     $filters = array_values($filters);
                     $i--;

--- a/Service/AlgoliaCredentialsManager.php
+++ b/Service/AlgoliaCredentialsManager.php
@@ -24,7 +24,7 @@ class AlgoliaCredentialsManager
      * @param int|null $storeId
      * @return bool
      */
-    public function checkCredentials(int $storeId = null): bool
+    public function checkCredentials(?int $storeId = null): bool
     {
         return $this->configHelper->getApplicationID($storeId) && $this->configHelper->getAPIKey($storeId);
     }
@@ -35,7 +35,7 @@ class AlgoliaCredentialsManager
      * @param int|null $storeId
      * @return bool
      */
-    public function checkCredentialsWithSearchOnlyAPIKey(int $storeId = null): bool
+    public function checkCredentialsWithSearchOnlyAPIKey(?int $storeId = null): bool
     {
         return $this->checkCredentials($storeId) && $this->configHelper->getSearchOnlyAPIKey($storeId);
     }

--- a/Service/Category/IndexBuilder.php
+++ b/Service/Category/IndexBuilder.php
@@ -211,7 +211,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
 
             try {
                 $this->categoryHelper->canCategoryBeReindexed($category, $storeId);
-            } catch (CategoryReindexingException $e) {
+            } catch (CategoryReindexingException) {
                 $categoriesToRemove[$categoryId] = $categoryId;
                 continue;
             }

--- a/Service/Category/IndexBuilder.php
+++ b/Service/Category/IndexBuilder.php
@@ -46,7 +46,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @throws NoSuchEntityException
      * @throws AlgoliaException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, null, $options);
     }
@@ -60,7 +60,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function buildIndexList(int $storeId, array $entityIds = null, array $options = null): void
+    public function buildIndexList(int $storeId, ?array $entityIds = null, ?array $options = null): void
     {
         $this->buildIndex($storeId, $entityIds, $options);
     }

--- a/Service/Category/RecordBuilder.php
+++ b/Service/Category/RecordBuilder.php
@@ -80,7 +80,7 @@ class RecordBuilder implements RecordBuilderInterface
 
         try {
             $imageUrl = $category->getImageUrl();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             /* no image, no default: not fatal */
         }
 

--- a/Service/IndexNameFetcher.php
+++ b/Service/IndexNameFetcher.php
@@ -56,7 +56,7 @@ class IndexNameFetcher
 
     public function isTempIndex($indexName): bool
     {
-        return str_ends_with($indexName, self::INDEX_TEMP_SUFFIX);
+        return str_ends_with((string) $indexName, self::INDEX_TEMP_SUFFIX);
     }
 
     /**
@@ -69,7 +69,7 @@ class IndexNameFetcher
      */
     public function isQuerySuggestionsIndex($indexName): bool
     {
-        return str_ends_with($indexName, self::INDEX_QUERY_SUGGESTIONS_SUFFIX);
+        return str_ends_with((string) $indexName, self::INDEX_QUERY_SUGGESTIONS_SUFFIX);
     }
 
 }

--- a/Service/Insights/EventProcessor.php
+++ b/Service/Insights/EventProcessor.php
@@ -238,9 +238,10 @@ class EventProcessor implements EventProcessorInterface
      */
     protected function getTotalRevenueForEvent(array $objectData): float
     {
-        return array_reduce($objectData, function($carry, $item) {
-           return floatval($carry) + floatval($item['quantity']) * floatval($item['price']);
-        });
+        return array_reduce(
+            $objectData,
+            fn($carry, $item) => floatval($carry) + floatval($item['quantity']) * floatval($item['price'])
+        );
     }
 
     /**
@@ -306,13 +307,11 @@ class EventProcessor implements EventProcessorInterface
      */
     protected function getObjectDataForPurchase(array $items): array
     {
-        return array_map(function($item) {
-            return [
-                'price'    => $this->getOrderItemSalePrice($item),
-                'discount' => max(0, $this->getOrderItemDiscount($item)),
-                'quantity' => intval($item->getQtyOrdered())
-            ];
-        }, $items);
+        return array_map(fn($item) => [
+            'price'    => $this->getOrderItemSalePrice($item),
+            'discount' => max(0, $this->getOrderItemDiscount($item)),
+            'quantity' => intval($item->getQtyOrdered())
+        ], $items);
     }
 
     /**
@@ -321,9 +320,7 @@ class EventProcessor implements EventProcessorInterface
      */
     protected function getObjectIdsForPurchase(array $items): array
     {
-        return array_map(function($item) {
-            return $item->getProduct()->getId();
-        }, $items);
+        return array_map(fn($item) => $item->getProduct()->getId(), $items);
     }
 
 

--- a/Service/Insights/EventProcessor.php
+++ b/Service/Insights/EventProcessor.php
@@ -130,7 +130,7 @@ class EventProcessor implements EventProcessorInterface
     /**
      * @inheritDoc
      */
-    public function convertAddToCart(string $eventName, string $indexName, Item $item, string $queryID = null): array
+    public function convertAddToCart(string $eventName, string $indexName, Item $item, ?string $queryID = null): array
     {
         $this->checkDependencies();
 
@@ -159,7 +159,7 @@ class EventProcessor implements EventProcessorInterface
     /**
      * @inheritDoc
      */
-    public function convertPurchaseForItems(string $eventName, string $indexName, array $items, string $queryID = null): array
+    public function convertPurchaseForItems(string $eventName, string $indexName, array $items, ?string $queryID = null): array
     {
         $this->checkDependencies();
 

--- a/Service/Page/IndexBuilder.php
+++ b/Service/Page/IndexBuilder.php
@@ -42,7 +42,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
      * @throws ExceededRetriesException
      * @throws NoSuchEntityException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, $options['entityIds'] ?? null, null);
     }

--- a/Service/Page/RecordBuilder.php
+++ b/Service/Page/RecordBuilder.php
@@ -71,7 +71,7 @@ class RecordBuilder implements RecordBuilderInterface
         if ($completeRemoveTags && $completeRemoveTags !== [] && $s) {
             $dom = new \DOMDocument();
             libxml_use_internal_errors(true);
-            $encodedStr = mb_encode_numericentity($s, [0x80, 0x10fffff, 0, ~0]);
+            $encodedStr = mb_encode_numericentity((string) $s, [0x80, 0x10fffff, 0, ~0]);
             $dom->loadHTML($encodedStr);
             libxml_use_internal_errors(false);
 
@@ -91,13 +91,13 @@ class RecordBuilder implements RecordBuilderInterface
             $s = $dom->saveHTML();
         }
 
-        $s = html_entity_decode($s, 0, 'UTF-8');
+        $s = html_entity_decode((string) $s, 0, 'UTF-8');
 
-        $s = trim(preg_replace('/\s+/', ' ', $s));
+        $s = trim((string) preg_replace('/\s+/', ' ', $s));
         $s = preg_replace('/&nbsp;/', ' ', $s);
-        $s = preg_replace('!\s+!', ' ', $s);
-        $s = preg_replace('/\{\{[^}]+\}\}/', ' ', $s);
-        $s = strip_tags($s);
+        $s = preg_replace('!\s+!', ' ', (string) $s);
+        $s = preg_replace('/\{\{[^}]+\}\}/', ' ', (string) $s);
+        $s = strip_tags((string) $s);
         $s = trim($s);
 
         return $s;

--- a/Service/Product/FacetBuilder.php
+++ b/Service/Product/FacetBuilder.php
@@ -43,9 +43,7 @@ class FacetBuilder
     public function getAttributesForFaceting(int $storeId): array
     {
         return array_map(
-            function($facet) {
-                return $this->decorateAttributeForFaceting($facet);
-            },
+            fn($facet) => $this->decorateAttributeForFaceting($facet),
             $this->addMerchandisingFacets($storeId, $this->getRawFacets($storeId))
         );
     }
@@ -83,9 +81,7 @@ class FacetBuilder
     protected function extractFacetAttributeNames(array $facets): array
     {
         return array_map(
-            function($facet) {
-                return $facet[self::FACET_KEY_ATTRIBUTE_NAME];
-            },
+            fn($facet) => $facet[self::FACET_KEY_ATTRIBUTE_NAME],
             $facets
         );
     }
@@ -166,9 +162,7 @@ class FacetBuilder
         foreach ($configFacets as $configFacet) {
             if ($configFacet[self::FACET_KEY_ATTRIBUTE_NAME] === self::FACET_ATTRIBUTE_PRICE) {
                 $rawFacets = array_merge($rawFacets, array_map(
-                    function(string $attribute) {
-                        return $this->getRawFacet($attribute);
-                    },
+                    fn(string $attribute) => $this->getRawFacet($attribute),
                     $this->getPricingAttributes($storeId)
                 ));
             } else {
@@ -189,9 +183,7 @@ class FacetBuilder
      */
     protected function hasCategoryFacet(array $facets): bool
     {
-        return !!array_filter($facets, function($facet) {
-            return $facet['attribute'] === self::FACET_ATTRIBUTE_CATEGORIES;
-        });
+        return !!array_filter($facets, fn($facet) => $facet['attribute'] === self::FACET_ATTRIBUTE_CATEGORIES);
     }
 
     /**

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -332,7 +332,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             try {
                 $this->logger->startProfiling("canProductBeReindexed");
                 $this->productRecordBuilder->canProductBeReindexed($product, $storeId);
-            } catch (ProductReindexingException $e) {
+            } catch (ProductReindexingException) {
                 $productsToRemove[$productId] = $productId;
                 continue;
             } finally {
@@ -384,7 +384,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             $ordersTableName = $this->resource->getTableName('sales_order_item');
             try {
                 $salesConnection = $this->resource->getConnectionByName('sales');
-            } catch (\DomainException $e) {
+            } catch (\DomainException) {
                 $salesConnection = $this->resource->getConnection();
             }
             $select = $salesConnection->select()

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -58,7 +58,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, null, $options);
     }
@@ -71,7 +71,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function buildIndexList(int $storeId, array $entityIds = null, array $options = null): void
+    public function buildIndexList(int $storeId, ?array $entityIds = null, ?array $options = null): void
     {
         $this->buildIndex($storeId, $entityIds, $options);
     }

--- a/Service/Product/RecordBuilder.php
+++ b/Service/Product/RecordBuilder.php
@@ -438,7 +438,7 @@ class RecordBuilder implements RecordBuilderInterface
      */
     protected function getValidCategoryName($category, $rootCat, $storeId): ?string
     {
-        $pathParts = explode('/', $category->getPath());
+        $pathParts = explode('/', (string) $category->getPath());
         if (isset($pathParts[1]) && $pathParts[1] !== $rootCat) {
             return null;
         }
@@ -524,7 +524,7 @@ class RecordBuilder implements RecordBuilderInterface
     protected function flattenCategoryPaths(array $paths, int $storeId): array
     {
         return array_map(
-            function ($path) use ($storeId) { return implode($this->configHelper->getCategorySeparator($storeId), $path); },
+            fn($path) => implode($this->configHelper->getCategorySeparator($storeId), $path),
             $paths
         );
     }
@@ -759,7 +759,7 @@ class RecordBuilder implements RecordBuilderInterface
      */
     protected function addSubProductImage($subProductImages, $attribute, $subProduct, $valueText)
     {
-        if (mb_strtolower($attribute['attribute'], 'utf-8') !== 'color') {
+        if (mb_strtolower((string) $attribute['attribute'], 'utf-8') !== 'color') {
             return $subProductImages;
         }
 
@@ -776,7 +776,7 @@ class RecordBuilder implements RecordBuilderInterface
         }
 
         try {
-            $textValueInLower = mb_strtolower($valueText, 'utf-8');
+            $textValueInLower = mb_strtolower((string) $valueText, 'utf-8');
             $subProductImages[$textValueInLower] = $image->getUrl();
         } catch (\Exception $e) {
             $this->logger->log($e->getMessage());

--- a/Service/Product/ReplicaManager.php
+++ b/Service/Product/ReplicaManager.php
@@ -168,9 +168,7 @@ class ReplicaManager implements ReplicaManagerInterface
     {
         return array_filter(
             $algoliaReplicas,
-            function ($algoliaReplicaSetting) use ($baseIndexName) {
-                return $this->isMagentoReplicaIndex($this->getBareIndexNameFromReplicaSetting($algoliaReplicaSetting), $baseIndexName);
-            }
+            fn($algoliaReplicaSetting) => $this->isMagentoReplicaIndex($this->getBareIndexNameFromReplicaSetting($algoliaReplicaSetting), $baseIndexName)
         );
     }
 
@@ -355,9 +353,7 @@ class ReplicaManager implements ReplicaManagerInterface
     protected function getBareIndexNamesFromReplicaSetting(array $replicas): array
     {
         return array_map(
-            function ($str) {
-                return $this->getBareIndexNameFromReplicaSetting($str);
-            },
+            fn($str) => $this->getBareIndexNameFromReplicaSetting($str),
             $replicas
         );
     }
@@ -446,9 +442,7 @@ class ReplicaManager implements ReplicaManagerInterface
         return array_values(
             array_filter(
                 $replicaSetting,
-                function ($replicaIndexSetting) use ($regex) {
-                    return !preg_match($regex, $replicaIndexSetting);
-                }
+                fn($replicaIndexSetting) => !preg_match($regex, (string) $replicaIndexSetting)
             )
         );
     }
@@ -468,9 +462,7 @@ class ReplicaManager implements ReplicaManagerInterface
         $sortingIndices = $this->sortingTransformer->getSortingIndices($storeId);
         $replicaDetails = array_filter(
             $sortingIndices,
-            function($replica) use ($replicas) {
-                return in_array($replica['name'], $replicas);
-            }
+            fn($replica) => in_array($replica['name'], $replicas)
         );
         foreach ($replicaDetails as $replica) {
             $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($replica['name'], $storeId);

--- a/Service/Serializer.php
+++ b/Service/Serializer.php
@@ -43,7 +43,7 @@ class Serializer
             return false;
         }
 
-        $unserialized = json_decode($value, true);
+        $unserialized = json_decode((string) $value, true);
         if (json_last_error() === JSON_ERROR_NONE) {
             return $unserialized;
         }

--- a/Service/StoreNameFetcher.php
+++ b/Service/StoreNameFetcher.php
@@ -34,9 +34,7 @@ class StoreNameFetcher
     public function getStoreNames(array $storeIds): array
     {
         return array_map(
-            function($storeId) {
-                return $this->getStoreName($storeId);
-            },
+            fn($storeId) => $this->getStoreName($storeId),
             $storeIds
         );
     }

--- a/Service/Suggestion/IndexBuilder.php
+++ b/Service/Suggestion/IndexBuilder.php
@@ -46,7 +46,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
      * @throws ExceededRetriesException
      * @throws NoSuchEntityException
      */
-    public function buildIndexFull(int $storeId, array $options = null): void
+    public function buildIndexFull(int $storeId, ?array $options = null): void
     {
         $this->buildIndex($storeId, null, null);
     }

--- a/Service/Suggestion/IndexBuilder.php
+++ b/Service/Suggestion/IndexBuilder.php
@@ -118,12 +118,12 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
         foreach ($collection as $suggestion) {
             $suggestion->setStoreId($storeId);
             $suggestionObject = $this->suggestionRecordBuilder->buildRecord($suggestion);
-            if (mb_strlen($suggestionObject['query']) >= 3) {
+            if (mb_strlen((string) $suggestionObject['query']) >= 3) {
                 array_push($indexData, $suggestionObject);
             }
         }
         if (count($indexData) > 0) {
-            $this->saveObjects($indexData, $indexOptions, $storeId);
+            $this->saveObjects($indexData, $indexOptions);
         }
 
         unset($indexData);

--- a/Service/Suggestion/RecordBuilder.php
+++ b/Service/Suggestion/RecordBuilder.php
@@ -26,7 +26,7 @@ class RecordBuilder implements RecordBuilderInterface
             'query'                                 => $entity->getData('query_text'),
             'number_of_results'                     => (int) $entity->getData('num_results'),
             'popularity'                            => (int) $entity->getData('popularity'),
-            'updated_at'                            => (int) strtotime($entity->getData('updated_at')),
+            'updated_at'                            => (int) strtotime((string) $entity->getData('updated_at')),
         ];
 
         $transport = new DataObject($suggestionObject);

--- a/Setup/Patch/Data/MigrateConversionAnalyticsModePatch.php
+++ b/Setup/Patch/Data/MigrateConversionAnalyticsModePatch.php
@@ -40,7 +40,7 @@ class MigrateConversionAnalyticsModePatch implements DataPatchInterface
     {
         $this->moduleDataSetup->getConnection()->startSetup();
 
-        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::CC_CONVERSION_ANALYTICS_MODE, [$this, 'migrateSetting']);
+        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::CC_CONVERSION_ANALYTICS_MODE, $this->migrateSetting(...));
 
         $this->moduleDataSetup->getConnection()->endSetup();
 

--- a/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
+++ b/Setup/Patch/Data/MigrateVirtualReplicaConfigPatch.php
@@ -48,7 +48,7 @@ class MigrateVirtualReplicaConfigPatch implements DataPatchInterface
     {
         $this->moduleDataSetup->getConnection()->startSetup();
 
-        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, [$this, 'migrateSetting']);
+        $this->configChecker->checkAndApplyAllScopes(ConfigHelper::LEGACY_USE_VIRTUAL_REPLICA_ENABLED, $this->migrateSetting(...));
 
         $this->scopeConfig->reinit();
 

--- a/Setup/Patch/Data/RebuildReplicasPatch.php
+++ b/Setup/Patch/Data/RebuildReplicasPatch.php
@@ -72,7 +72,7 @@ class RebuildReplicasPatch implements DataPatchInterface
                 $this->replicaState->setChangeState(ReplicaState::REPLICA_STATE_CHANGED, $storeId); // avoids latency
                 $this->replicaManager->syncReplicasToAlgolia($storeId, $this->productHelper->getIndexSettings($storeId));
             }
-        } catch (AlgoliaException $e) {
+        } catch (AlgoliaException) {
             // Log the error but do not prevent setup:update
             $this->logger->error("Could not rebuild replicas - a full reindex may be required.");
         }

--- a/Setup/Patch/Data/UpdateMviewPatch.php
+++ b/Setup/Patch/Data/UpdateMviewPatch.php
@@ -57,7 +57,7 @@ class UpdateMviewPatch implements DataPatchInterface
                 ]
             );
             $subscriptionInstance->remove();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Skip
         }
         $this->moduleDataSetup->getConnection()->endSetup();

--- a/Setup/Patch/Schema/AutocompleteConfigPatch.php
+++ b/Setup/Patch/Schema/AutocompleteConfigPatch.php
@@ -41,7 +41,7 @@ class AutocompleteConfigPatch implements SchemaPatchInterface
         foreach ($movedConfigDirectives as $from => $to) {
             try {
                 $connection->query('UPDATE ' . $table . ' SET path = "' . $to . '" WHERE path = "' . $from . '"');
-            } catch (\Magento\Framework\DB\Adapter\DuplicateException $e) {
+            } catch (\Magento\Framework\DB\Adapter\DuplicateException) {
                 //
             }
         }

--- a/Setup/Patch/Schema/ConfigPatch.php
+++ b/Setup/Patch/Schema/ConfigPatch.php
@@ -311,7 +311,7 @@ class ConfigPatch implements SchemaPatchInterface
         foreach ($movedConfigDirectives as $from => $to) {
             try {
                 $connection->query('UPDATE ' . $table . ' SET path = "' . $to . '" WHERE path = "' . $from . '"');
-            } catch (\Magento\Framework\DB\Adapter\DuplicateException $e) {
+            } catch (\Magento\Framework\DB\Adapter\DuplicateException) {
                 // Skip
             }
         }

--- a/Setup/Patch/Schema/RecommendConfigPatch.php
+++ b/Setup/Patch/Schema/RecommendConfigPatch.php
@@ -66,7 +66,7 @@ class RecommendConfigPatch implements SchemaPatchInterface
         foreach ($movedConfigDirectives as $from => $to) {
             try {
                 $connection->query('UPDATE ' . $table . ' SET path = "' . $to . '" WHERE path = "' . $from . '"');
-            } catch (\Magento\Framework\DB\Adapter\DuplicateException $e) {
+            } catch (\Magento\Framework\DB\Adapter\DuplicateException) {
                 //
             }
         }

--- a/Test/Integration/Frontend/Category/CategoryCacheTest.php
+++ b/Test/Integration/Frontend/Category/CategoryCacheTest.php
@@ -12,8 +12,8 @@ use Magento\TestFramework\TestCase\AbstractController;
 
 class CategoryCacheTest extends AbstractController
 {
-    protected ?CacheManager $cacheManager;
-    protected ?ScopeConfigInterface $config;
+    protected ?CacheManager $cacheManager = null;
+    protected ?ScopeConfigInterface $config = null;
 
     protected static $cacheResets = [];
 
@@ -102,7 +102,7 @@ class CategoryCacheTest extends AbstractController
         );
         $this->assertContains(
             'FPC',
-            explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue()),
+            explode(',', (string) $response->getHeader('X-Magento-Tags')->getFieldValue()),
             "expected FPC tag on category {$name} id {$categoryId}"
         );
 
@@ -153,7 +153,7 @@ class CategoryCacheTest extends AbstractController
         );
         $this->assertContains(
             'FPC',
-            explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue()),
+            explode(',', (string) $response->getHeader('X-Magento-Tags')->getFieldValue()),
             "expected FPC tag on category {$name} id {$categoryId}"
         );
 
@@ -208,7 +208,7 @@ class CategoryCacheTest extends AbstractController
         );
         $this->assertContains(
             'FPC',
-            explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue()),
+            explode(',', (string) $response->getHeader('X-Magento-Tags')->getFieldValue()),
             "expected FPC tag on category {$name} id {$categoryId}"
         );
 

--- a/Test/Integration/Frontend/Search/SearchTest.php
+++ b/Test/Integration/Frontend/Search/SearchTest.php
@@ -41,7 +41,7 @@ class SearchTest extends TestCase
         // Result exists in DB
         $this->assertNotEmpty($product->getName(), "Query result item couldn't find in the DB");
         // Query word exists title
-        $this->assertStringContainsString($query, strtolower($product->getName()), "Query word doesn't exist in product name");
+        $this->assertStringContainsString($query, strtolower((string) $product->getName()), "Query word doesn't exist in product name");
     }
 
     public function testSearchBySku()
@@ -63,7 +63,7 @@ class SearchTest extends TestCase
     public function testCategorySearch()
     {
         // Get products by categoryId
-        list($results, $totalHits, $facetsFromAlgolia) = $this->search('', 1, [
+        [$results, $totalHits, $facetsFromAlgolia] = $this->search('', 1, [
             'facetFilters' => ['categoryIds:' . self::BAGS_CATEGORY_ID]
         ]);
         // Category filter returns result
@@ -86,7 +86,7 @@ class SearchTest extends TestCase
      */
     protected function getFirstResult(array $results): array
     {
-        list($results, $totalHits, $facetsFromAlgolia) = $results;
+        [$results, $totalHits, $facetsFromAlgolia] = $results;
         return array_shift($results);
     }
 
@@ -100,7 +100,7 @@ class SearchTest extends TestCase
     {
         try {
             return $this->backendSearch->getSearchResult($query, $storeId, $params);
-        } catch (NoSuchEntityException $e) {
+        } catch (NoSuchEntityException) {
             return [];
         }
     }

--- a/Test/Integration/Indexing/Category/CategoriesIndexingTest.php
+++ b/Test/Integration/Indexing/Category/CategoriesIndexingTest.php
@@ -47,8 +47,8 @@ class CategoriesIndexingTest extends IndexingTestCase
             'product_count',
         ];
 
-        foreach ($defaultAttributes as $key => $attribute) {
-            $this->assertTrue(key_exists($attribute, $hit), 'Category attribute "' . $attribute . '" should be indexed but it is not"');
+        foreach ($defaultAttributes as $attribute) {
+            $this->assertTrue(array_key_exists($attribute, $hit), 'Category attribute "' . $attribute . '" should be indexed but it is not"');
             unset($hit[$attribute]);
         }
 

--- a/Test/Integration/Indexing/Config/ConfigTest.php
+++ b/Test/Integration/Indexing/Config/ConfigTest.php
@@ -140,9 +140,7 @@ class ConfigTest extends TestCase
         $this->algoliaConnector->waitLastTask();
 
         $indices = $this->algoliaConnector->listIndexes();
-        $indicesNames = array_map(function ($indexData) {
-            return $indexData['name'];
-        }, $indices['items']);
+        $indicesNames = array_map(fn($indexData) => $indexData['name'], $indices['items']);
 
         foreach ($sortingIndicesWithRankingWhichShouldBeCreated as $indexName => $firstRanking) {
             $this->assertContains($indexName, $indicesNames);

--- a/Test/Integration/Indexing/Config/Traits/ConfigAssertionsTrait.php
+++ b/Test/Integration/Indexing/Config/Traits/ConfigAssertionsTrait.php
@@ -21,7 +21,7 @@ trait ConfigAssertionsTrait
         foreach ($indices['items'] as $index) {
             $name = $index['name'];
 
-            if (mb_strpos($name, $this->indexPrefix . $store->getCode()) === 0) {
+            if (mb_strpos((string) $name, $this->indexPrefix . $store->getCode()) === 0) {
                 $indicesCreatedByTest++;
             }
         }

--- a/Test/Integration/Indexing/Config/Traits/ConfigAssertionsTrait.php
+++ b/Test/Integration/Indexing/Config/Traits/ConfigAssertionsTrait.php
@@ -12,7 +12,7 @@ trait ConfigAssertionsTrait
      * @return int
      * @throws AlgoliaException
      */
-    protected function countStoreIndices(StoreInterface $store = null): int
+    protected function countStoreIndices(?StoreInterface $store = null): int
     {
         $indices = $this->algoliaConnector->listIndexes($store->getId());
 

--- a/Test/Integration/Indexing/IndexingTestCase.php
+++ b/Test/Integration/Indexing/IndexingTestCase.php
@@ -97,7 +97,7 @@ abstract class IndexingTestCase extends TestCase
         string $indexName,
         string $recordId,
         array $expectedValues,
-        int $storeId = null
+        ?int $storeId = null
     ) : void {
         $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 

--- a/Test/Integration/Indexing/MultiStoreTestCase.php
+++ b/Test/Integration/Indexing/MultiStoreTestCase.php
@@ -44,7 +44,7 @@ abstract class MultiStoreTestCase extends IndexingTestCase
 
     protected function reindexToAllStores(
         BatchQueueProcessorInterface $batchQueueProcessor,
-        array $categoryIds = null
+        ?array $categoryIds = null
     ): void
     {
         foreach (array_keys($this->storeManager->getStores()) as $storeId) {

--- a/Test/Integration/Indexing/MultiStoreTestCase.php
+++ b/Test/Integration/Indexing/MultiStoreTestCase.php
@@ -65,7 +65,7 @@ abstract class MultiStoreTestCase extends IndexingTestCase
         string $storeCode,
         string $entity,
         int $expectedNumber,
-        int $storeId = null
+        ?int $storeId = null
     ): void
     {
         $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex(

--- a/Test/Integration/Indexing/MultiStoreTestCase.php
+++ b/Test/Integration/Indexing/MultiStoreTestCase.php
@@ -143,12 +143,12 @@ abstract class MultiStoreTestCase extends IndexingTestCase
             foreach ($indices['items'] as $index) {
                 $name = $index['name'];
 
-                if (mb_strpos($name, $this->indexPrefix) === 0) {
+                if (mb_strpos((string) $name, $this->indexPrefix) === 0) {
                     try {
                         $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($name, $store->getId());
                         $this->algoliaConnector->deleteIndex($indexOptions);
                         $deletedStoreIndices++;
-                    } catch (AlgoliaException $e) {
+                    } catch (AlgoliaException) {
                         // Might be a replica
                     }
                 }

--- a/Test/Integration/Indexing/Page/MultiStorePagesTest.php
+++ b/Test/Integration/Indexing/Page/MultiStorePagesTest.php
@@ -68,7 +68,7 @@ class MultiStorePagesTest extends MultiStoreTestCase
 
         try {
             $homePage = $this->loadPage(self::HOME_PAGE_ID);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $this->markTestIncomplete('Page could not be found.');
         }
 

--- a/Test/Integration/Indexing/Page/PagesIndexingTest.php
+++ b/Test/Integration/Indexing/Page/PagesIndexingTest.php
@@ -81,8 +81,8 @@ class PagesIndexingTest extends IndexingTestCase
             '_snippetResult',
         ];
 
-        foreach ($defaultAttributes as $key => $attribute) {
-            $this->assertTrue(key_exists($attribute, $hit), 'Pages attribute "' . $attribute . '" should be indexed but it is not"');
+        foreach ($defaultAttributes as $attribute) {
+            $this->assertTrue(array_key_exists($attribute, $hit), 'Pages attribute "' . $attribute . '" should be indexed but it is not"');
             unset($hit[$attribute]);
         }
 

--- a/Test/Integration/Indexing/Product/MultiStoreProductsTest.php
+++ b/Test/Integration/Indexing/Product/MultiStoreProductsTest.php
@@ -85,7 +85,7 @@ class MultiStoreProductsTest extends MultiStoreTestCase
 
         try {
             $voyageYogaBag = $this->loadProduct(self::VOYAGE_YOGA_BAG_ID, $defaultStore->getId());
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $this->markTestIncomplete('Product could not be found.');
         }
 

--- a/Test/Integration/Indexing/Product/MultiStoreProductsTest.php
+++ b/Test/Integration/Indexing/Product/MultiStoreProductsTest.php
@@ -161,7 +161,7 @@ class MultiStoreProductsTest extends MultiStoreTestCase
      * @return ProductInterface
      * @throws NoSuchEntityException
      */
-    private function loadProduct(int $productId, int $storeId = null): ProductInterface
+    private function loadProduct(int $productId, ?int $storeId = null): ProductInterface
     {
         return $this->productRepository->getById($productId, true, $storeId);
     }

--- a/Test/Integration/Indexing/Product/PricingTest.php
+++ b/Test/Integration/Indexing/Product/PricingTest.php
@@ -122,7 +122,7 @@ class PricingTest extends ProductsIndexingTestCase
         /**
          * @var Product $product
          */
-        $product = $this->objectManager->get('Magento\Catalog\Model\ProductRepository')->getById($productId);
+        $product = $this->objectManager->get(\Magento\Catalog\Model\ProductRepository::class)->getById($productId);
         $this->assertTrue($product->isInStock(), "Product is not in stock");
         $this->assertTrue($product->getIsSalable(), "Product is not salable");
         $actualPrice = $product->getFinalPrice();
@@ -132,9 +132,7 @@ class PricingTest extends ProductsIndexingTestCase
     public static function productProvider(): array
     {
         return array_map(
-            function ($key, $value) {
-                return [$key, $value];
-            },
+            fn($key, $value) => [$key, $value],
             array_keys(self::ASSERT_PRODUCT_PRICES),
             self::ASSERT_PRODUCT_PRICES
         );

--- a/Test/Integration/Indexing/Product/ProductsIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ProductsIndexingTest.php
@@ -80,7 +80,7 @@ class ProductsIndexingTest extends ProductsIndexingTestCase
             $this->markTestIncomplete('Hit was not returned correctly from Algolia. No Hit to run assetions on.');
         }
 
-        foreach ($defaultAttributes as $key => $attribute) {
+        foreach ($defaultAttributes as $attribute) {
             $this->assertArrayHasKey($attribute, $hit, 'Products attribute "' . $attribute . '" should be indexed but it is not"');
             unset($hit[$attribute]);
         }

--- a/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
@@ -338,7 +338,7 @@ class ReplicaIndexingTest extends TestCase
         return $mock;
     }
 
-    protected function getMockReplicaManager($mockedMethods = array()): MockObject & ReplicaManager
+    protected function getMockReplicaManager($mockedMethods = []): MockObject & ReplicaManager
     {
         $mockedClass = ReplicaManager::class;
         $mockedReplicaManager = $this->getMockBuilder($mockedClass)

--- a/Test/Integration/Indexing/Product/Traits/ReplicaAssertionsTrait.php
+++ b/Test/Integration/Indexing/Product/Traits/ReplicaAssertionsTrait.php
@@ -89,9 +89,7 @@ trait ReplicaAssertionsTrait
     {
         return (bool) array_filter(
             $replicaSetting,
-            function ($replica) use ($replicaIndexName) {
-                return str_contains($replica, "virtual($replicaIndexName)");
-            }
+            fn($replica) => str_contains((string) $replica, "virtual($replicaIndexName)")
         );
     }
 
@@ -111,10 +109,8 @@ trait ReplicaAssertionsTrait
         $sorting = $this->configHelper->getSorting();
         return (bool) array_filter(
             $sorting,
-            function($sort) use ($sortAttr, $sortDir) {
-                return $sort['attribute'] == $sortAttr
-                    && $sort['sort'] == $sortDir;
-            }
+            fn($sort) => $sort['attribute'] == $sortAttr
+                && $sort['sort'] == $sortDir
         );
     }
 
@@ -135,9 +131,7 @@ trait ReplicaAssertionsTrait
     protected function mockSortUpdate(string $sortAttr, string $sortDir, array $attr, ?StoreInterface $store = null): void
     {
         $sorting = $this->configHelper->getSorting(!is_null($store) ? $store->getId() : null);
-        $existing = array_filter($sorting, function ($item) use ($sortAttr, $sortDir) {
-            return $item['attribute'] === $sortAttr && $item['sort'] === $sortDir;
-        });
+        $existing = array_filter($sorting, fn($item) => $item['attribute'] === $sortAttr && $item['sort'] === $sortDir);
 
         if ($existing) {
             $idx = array_key_first($existing);

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -282,7 +282,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @param string|null $key - a unique key for this operation - if null a unique key will be derived
      * @return mixed
      */
-    function runOnce(callable $callback, string $key = null): mixed
+    function runOnce(callable $callback, ?string $key = null): mixed
     {
         static $executed = [];
         $key ??= is_string($callback) ? $callback : spl_object_hash((object) $callback);

--- a/Test/Integration/TestCase.php
+++ b/Test/Integration/TestCase.php
@@ -143,9 +143,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return array_combine(
             $bootstrap,
             array_map(
-                function($setting) use ($config) {
-                    return $config->getValue($setting, ScopeInterface::SCOPE_STORE);
-                },
+                fn($setting) => $config->getValue($setting, ScopeInterface::SCOPE_STORE),
                 $bootstrap
             )
         );
@@ -170,11 +168,11 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         foreach ($indices['items'] as $index) {
             $name = $index['name'];
 
-            if (mb_strpos($name, $this->indexPrefix) === 0) {
+            if (mb_strpos((string) $name, $this->indexPrefix) === 0) {
                 try {
                     $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($name);
                     $this->algoliaConnector->deleteIndex($indexOptions);
-                } catch (AlgoliaException $e) {
+                } catch (AlgoliaException) {
                     // Might be a replica
                 }
             }
@@ -257,7 +255,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function invokeMethod(object $object, string $methodName, array $parameters = [])
     {
-        $reflection = new \ReflectionClass(get_class($object));
+        $reflection = new \ReflectionClass($object::class);
         return $reflection->getMethod($methodName)->invokeArgs($object, $parameters);
     }
 

--- a/Test/Integration/_files/backend_render_user_agents.php
+++ b/Test/Integration/_files/backend_render_user_agents.php
@@ -8,6 +8,6 @@ $scopeConfig = $objectManager->get(MutableScopeConfigInterface::class);
 // Set complex configuration value
 $scopeConfig->setValue(
     'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents',
-    join("\n", ["Googlebot", "Bingbot", "Foobot"]),
+    implode("\n", ["Googlebot", "Bingbot", "Foobot"]),
     \Magento\Store\Model\ScopeInterface::SCOPE_STORE
 );

--- a/Ui/Component/Listing/Column/Data.php
+++ b/Ui/Component/Listing/Column/Data.php
@@ -25,7 +25,7 @@ class Data extends \Magento\Ui\Component\Listing\Columns\Column
         $fieldName = $this->getData('name');
 
         foreach ($dataSource['data']['items'] as &$item) {
-            $data = json_decode($item[$fieldName], true);
+            $data = json_decode((string) $item[$fieldName], true);
             $item[$fieldName] = is_array($data) ? $this->formatData($data) : '';;
         }
 

--- a/Ui/Component/Listing/Column/QueueArchiveData.php
+++ b/Ui/Component/Listing/Column/QueueArchiveData.php
@@ -22,7 +22,7 @@ class QueueArchiveData extends \Magento\Ui\Component\Listing\Columns\Column
         $fieldName = $this->getData('name');
 
         foreach ($dataSource['data']['items'] as &$item) {
-            $data = json_decode($item[$fieldName], true);
+            $data = json_decode((string) $item[$fieldName], true);
             $formattedData = '';
             if (is_array($data)) {
                 foreach ($data as $key => $value) {

--- a/ViewModel/Adminhtml/Analytics/Overview.php
+++ b/ViewModel/Adminhtml/Analytics/Overview.php
@@ -229,7 +229,7 @@ class Overview implements \Magento\Framework\View\Element\Block\ArgumentInterfac
                 $search['conversion'] = $this->getDateValue($conversion, $search['date'], 'rate');
             }
 
-            $search['formatted'] = date('M, d', strtotime($search['date']));
+            $search['formatted'] = date('M, d', strtotime((string) $search['date']));
         }
 
         return $searches;
@@ -262,7 +262,7 @@ class Overview implements \Magento\Framework\View\Element\Block\ArgumentInterfac
             $this->getAnalyticsParams(['limit' => self::LIMIT_RESULTS])
         );
 
-        return isset($topSearches['searches']) ? $topSearches['searches'] : [];
+        return $topSearches['searches'] ?? [];
     }
 
     /**
@@ -273,12 +273,10 @@ class Overview implements \Magento\Framework\View\Element\Block\ArgumentInterfac
     public function getPopularResults()
     {
         $popular = $this->analyticsHelper->getTopHits($this->getAnalyticsParams(['limit' => self::LIMIT_RESULTS]));
-        $hits = isset($popular['hits']) ? $popular['hits'] : [];
+        $hits = $popular['hits'] ?? [];
 
         if (!empty($hits)) {
-            $objectIds = array_map(function ($arr) {
-                return $arr['hit'];
-            }, $hits);
+            $objectIds = array_map(fn($arr) => $arr['hit'], $hits);
 
             $storeId = $this->getStore()->getId();
 

--- a/ViewModel/Adminhtml/Analytics/Overview.php
+++ b/ViewModel/Adminhtml/Analytics/Overview.php
@@ -107,7 +107,7 @@ class Overview implements \Magento\Framework\View\Element\Block\ArgumentInterfac
      * @return \DateTime
      * @throws NoSuchEntityException
      */
-    protected function parseFormSubmittedDate(string $dateString = null, string $timezone = null): \DateTime
+    protected function parseFormSubmittedDate(?string $dateString = null, ?string $timezone = null): \DateTime
     {
         if (empty($timezone)) {
             $timezone = $this->getTimeZone();

--- a/dev/cloud/teardown.php
+++ b/dev/cloud/teardown.php
@@ -7,8 +7,8 @@ require '/app/app/bootstrap.php';
 $bootstrap = Bootstrap::create(BP, $_SERVER);
 $objectManager = $bootstrap->getObjectManager();
 
-$algoliaConnector = $objectManager->get('\Algolia\AlgoliaSearch\Service\AlgoliaConnector');
-$indexOptionsBuilder = $objectManager->get('\Algolia\AlgoliaSearch\Service\IndexOptionsBuilder');
+$algoliaConnector = $objectManager->get(\Algolia\AlgoliaSearch\Service\AlgoliaConnector::class);
+$indexOptionsBuilder = $objectManager->get(\Algolia\AlgoliaSearch\Service\IndexOptionsBuilder::class);
 $indexNamePrefix = getenv('MAGENTO_CLOUD_ENVIRONMENT');
 
 /**
@@ -22,13 +22,13 @@ function deleteIndexes($algoliaConnector, $indexOptionsBuilder, array $indices, 
     foreach ($indices['items'] as $index) {
         $name = $index['name'];
 
-        if (mb_strpos($name, $indexNamePrefix) === 0) {
+        if (mb_strpos((string) $name, (string) $indexNamePrefix) === 0) {
             try {
                 $indexOptions = $indexOptionsBuilder->buildWithEnforcedIndex($name);
                 $algoliaConnector->deleteIndex($name);
                 echo 'Index "' . $name . '" has been deleted.';
                 echo "\n";
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // Might be a replica
             }
         }


### PR DESCRIPTION
**Summary**

This PR aims to provide full compatibility with Magento 2.4.8 on PHP 8.2 to 8.4. PHP 8.2 was considered the baseline and tools like PHP_CodeSniffer and Rector were utilized to help identify potential problem areas.

- All implicit nullable types are removed (thanks @jajajaime for the assist 🙂 )
- Removed unused variables in try/catch 
- Added explicit string casts where ambiguous
- Switch/case changed to `match` where beneficial (PHP 8.0)
- String class constants used for type safety
- Alias functions replaced with preferred PHP native for consistency
- First-class callables used for type safety (PHP 8.1)
- Switch to arrow functions for conciseness, implicit `use` and immutable variable capture (PHP 7.4)
- Ternaries replaced with null coalescing or "Elvis" operators as needed
- Consistent array syntax applied - Shorter array syntax and destructuring vs legacy `list` function
- Clarified version EOL in README and linked to new CI pipeline

Not addressed:

- Full PHP 8 constructor property promotion (future)

**Result**

<img width="1480" height="352" alt="image" src="https://github.com/user-attachments/assets/4a8e5fd6-7bbf-49af-9484-e0d48f8fce44" />

Integration tests still need to be refactored on PHPUnit 10 but all pass on PHPUnit 9 with Magento 2.4.7:
<img width="2048" height="1275" alt="image" src="https://github.com/user-attachments/assets/0875bbc4-f1c8-4405-9091-0d9efc28c8d0" />
