### PR TITLE
MAGE-1281 Replica settings forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The indexing queue cron job can now be configured from the Magento admin.
 - Dynamic faceting through Algolia merchandising rules is now supported in Magento via an opt-in feature flag.
 - No code redirects via merchandising rules in Algolia are now supported in Magento for both Autocomplete and InstantSearch. Support is enabled by default for Autocomplete.
+- Settings updates are now automatically forwarded to replicas (if this behavior is not desirable it can be disabled in the admin)
 - Integration tests and unit tests added
 
 ### Bug Fixes

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -308,7 +308,7 @@ class ConfigHelper
     }
 
     // --- Products --- //
-    
+
     /**
      * @param $storeId
      * @return array
@@ -2038,15 +2038,12 @@ class ConfigHelper
     /**
      * @param $storeId
      * @return bool
-     * @deprecated This method will be moved to the InstantSearch config helper
+     * @deprecated This method has been moved to the InstantSearch config helper and will be removed in a future version
+     * @see \Algolia\AlgoliaSearch\Helper\Configuration\InstantSearchHelper::shouldShowSuggestionsOnNoResultsPage()
      */
     public function showSuggestionsOnNoResultsPage($storeId = null)
     {
-        return $this->configInterface->isSetFlag(
-            self::SHOW_SUGGESTIONS_NO_RESULTS,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
+        return $this->instantSearchConfig->shouldShowSuggestionsOnNoResultsPage($storeId);
     }
 
     /**

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -21,6 +21,7 @@ use Magento\Store\Model\StoreManagerInterface;
 class ConfigHelper
 {
     // --- Credentials & Basic Setup --- //
+
     public const ENABLE_FRONTEND = 'algoliasearch_credentials/credentials/enable_frontend';
     public const LOGGING_ENABLED = 'algoliasearch_credentials/credentials/debug';
     public const APPLICATION_ID = 'algoliasearch_credentials/credentials/application_id';
@@ -32,6 +33,7 @@ class ConfigHelper
     public const ALGOLIA_COOKIE_DURATION = 'algoliasearch_credentials/algolia_cookie_configuration/cookie_duration';
 
     // --- Products --- //
+
     public const PRODUCT_ATTRIBUTES = 'algoliasearch_products/products/product_additional_attributes';
     public const PRODUCT_CUSTOM_RANKING = 'algoliasearch_products/products/custom_ranking_product_attributes';
     public const USE_ADAPTIVE_IMAGE = 'algoliasearch_products/products/use_adaptive_image';
@@ -40,14 +42,15 @@ class ConfigHelper
     public const INCLUDE_NON_VISIBLE_PRODUCTS_IN_INDEX = 'algoliasearch_products/products/include_non_visible_products_in_index';
 
     // --- Categories --- //
+
     public const CATEGORY_ATTRIBUTES = 'algoliasearch_categories/categories/category_additional_attributes';
     public const CATEGORY_CUSTOM_RANKING = 'algoliasearch_categories/categories/custom_ranking_category_attributes';
     public const SHOW_CATS_NOT_INCLUDED_IN_NAV = 'algoliasearch_categories/categories/show_cats_not_included_in_navigation';
     public const INDEX_EMPTY_CATEGORIES = 'algoliasearch_categories/categories/index_empty_categories';
     public const CATEGORY_SEPARATOR = 'algoliasearch_categories/categories/category_separator';
 
-
     // --- Recommend Products Settings --- //
+
     public const IS_RECOMMEND_FREQUENTLY_BOUGHT_TOGETHER_ENABLED = 'algoliasearch_recommend/recommend/frequently_bought_together/is_frequently_bought_together_enabled';
     public const IS_RECOMMEND_RELATED_PRODUCTS_ENABLED = 'algoliasearch_recommend/recommend/related_product/is_related_products_enabled';
     public const IS_RECOMMEND_FREQUENTLY_BOUGHT_TOGETHER_ENABLED_ON_CART_PAGE = 'algoliasearch_recommend/recommend/frequently_bought_together/is_frequently_bought_together_enabled_in_cart_page';
@@ -76,17 +79,20 @@ class ConfigHelper
     protected const TRENDING_ITEMS_TITLE = 'algoliasearch_recommend/recommend/trends_item/title';
 
     // --- Images --- //
+
     public const XML_PATH_IMAGE_WIDTH = 'algoliasearch_images/image/width';
     public const XML_PATH_IMAGE_HEIGHT = 'algoliasearch_images/image/height';
     public const XML_PATH_IMAGE_TYPE = 'algoliasearch_images/image/type';
 
     // --- Indexing Queue / Cron --- //
+
     public const IS_ACTIVE = 'algoliasearch_queue/queue/active';
     public const USE_BUILT_IN_CRON = 'algoliasearch_queue/queue/use_built_in_cron';
     public const NUMBER_OF_JOB_TO_RUN = 'algoliasearch_queue/queue/number_of_job_to_run';
     public const RETRY_LIMIT = 'algoliasearch_queue/queue/number_of_retries';
 
     // --- Indexing Manager --- //
+
     public const ENABLE_INDEXING = 'algoliasearch_indexing_manager/algolia_indexing/enable_indexing';
     public const ENABLE_QUERY_SUGGESTIONS_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/enable_query_suggestions_index';
     public const ENABLE_PAGES_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/enable_pages_index';
@@ -99,23 +105,25 @@ class ConfigHelper
     public const ENABLE_INDEXER_QUEUE = 'algoliasearch_indexing_manager/full_indexing/queue';
 
     // --- Click & Conversion Analytics --- //
+
     public const CC_ANALYTICS_ENABLE = 'algoliasearch_cc_analytics/cc_analytics_group/enable';
     public const CC_ANALYTICS_IS_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/is_selector';
     public const CC_CONVERSION_ANALYTICS_MODE = 'algoliasearch_cc_analytics/cc_analytics_group/conversion_analytics_mode';
     public const CC_ADD_TO_CART_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector';
 
     // --- Google Analytics --- //
+
     public const GA_ENABLE = 'algoliasearch_analytics/analytics_group/enable';
     public const GA_DELAY = 'algoliasearch_analytics/analytics_group/delay';
     public const GA_TRIGGER_ON_UI_INTERACTION = 'algoliasearch_analytics/analytics_group/trigger_on_ui_interaction';
     public const GA_PUSH_INITIAL_SEARCH = 'algoliasearch_analytics/analytics_group/push_initial_search';
 
     // --- Advanced --- //
+
     public const REMOVE_IF_NO_RESULT = 'algoliasearch_advanced/advanced/remove_words_if_no_result';
     public const PARTIAL_UPDATES = 'algoliasearch_advanced/advanced/partial_update';
     public const CUSTOMER_GROUPS_ENABLE = 'algoliasearch_advanced/advanced/customer_groups_enable';
     public const REMOVE_PUB_DIR_IN_URL = 'algoliasearch_advanced/advanced/remove_pub_dir_in_url';
-    public const MAKE_SEO_REQUEST = 'algoliasearch_advanced/advanced/make_seo_request';
     public const REMOVE_BRANDING = 'algoliasearch_advanced/advanced/remove_branding';
     public const IDX_PRODUCT_ON_CAT_PRODUCTS_UPD = 'algoliasearch_advanced/advanced/index_product_on_category_products_update';
     public const PREVENT_BACKEND_RENDERING = 'algoliasearch_advanced/advanced/prevent_backend_rendering';
@@ -129,16 +137,17 @@ class ConfigHelper
     public const CONNECTION_TIMEOUT = 'algoliasearch_advanced/advanced/connection_timeout';
     public const READ_TIMEOUT = 'algoliasearch_advanced/advanced/read_timeout';
     public const WRITE_TIMEOUT = 'algoliasearch_advanced/advanced/write_timeout';
+    protected const FORWARD_TO_REPLICAS = 'algoliasearch_advanced/advanced/forward_to_replicas';
     public const AUTO_PRICE_INDEXING_ENABLED = 'algoliasearch_advanced/advanced/auto_price_indexing';
-
     public const PROFILER_ENABLED = 'algoliasearch_advanced/advanced/enable_profiler';
 
-    // Indexing Queue Advanced settings
+    // Indexing Queue advanced settings
     public const ENHANCED_QUEUE_ARCHIVE = 'algoliasearch_advanced/queue/enhanced_archive';
     public const NUMBER_OF_ELEMENT_BY_PAGE = 'algoliasearch_advanced/queue/number_of_element_by_page';
     public const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/queue/archive_clear_limit';
 
     // --- Extra index settings --- //
+
     public const EXTRA_SETTINGS_PRODUCTS = 'algoliasearch_extra_settings/extra_settings/products_extra_settings';
     public const EXTRA_SETTINGS_CATEGORIES = 'algoliasearch_extra_settings/extra_settings/categories_extra_settings';
     public const EXTRA_SETTINGS_PAGES = 'algoliasearch_extra_settings/extra_settings/pages_extra_settings';
@@ -147,6 +156,7 @@ class ConfigHelper
         'algoliasearch_extra_settings/extra_settings/additional_sections_extra_settings';
 
     // --- Magento Core --- //
+
     public const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
     public const USE_SECURE_IN_FRONTEND = 'web/secure/use_in_frontend';
     public const MAGENTO_DEFAULT_CACHE_TIME = 'system/full_page_cache/ttl';
@@ -171,14 +181,226 @@ class ConfigHelper
     )
     {}
 
+    // --- Credentials & Basic Setup --- //
+
+    /**
+     * @param $storeId
+     * @return bool
+     * @deprecated Use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager instead
+     */
+    public function credentialsAreConfigured($storeId = null): bool
+    {
+        return $this->getApplicationID($storeId) &&
+            $this->getAPIKey($storeId) &&
+            $this->getSearchOnlyAPIKey($storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed'
+     */
+    public function getApplicationID($storeId = null)
+    {
+        return $this->configInterface->getValue(self::APPLICATION_ID, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getAPIKey($storeId = null)
+    {
+        return $this->configInterface->getValue(self::API_KEY, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getSearchOnlyAPIKey($storeId = null)
+    {
+        return $this->configInterface->getValue(self::SEARCH_ONLY_API_KEY, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getIndexPrefix(?int $storeId = null): string
+    {
+        return (string) $this->configInterface->getValue(self::INDEX_PREFIX, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
     /**
      * @param $storeId
      * @return bool
      */
-    public function showCatsNotIncludedInNavigation($storeId = null)
+    public function isEnabledFrontEnd($storeId = null): bool
     {
-        return $this->configInterface->isSetFlag(
-            self::SHOW_CATS_NOT_INCLUDED_IN_NAV,
+        return $this->configInterface->isSetFlag(self::ENABLE_FRONTEND, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isLoggingEnabled($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::LOGGING_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * Used for front end search API key generation
+     * @param $groupId
+     * @return array
+     */
+    public function getAttributesToFilter($groupId)
+    {
+        $transport = new DataObject();
+        $this->eventManager->dispatch(
+            'algolia_get_attributes_to_filter',
+            ['filter_object' => $transport, 'customer_group_id' => $groupId]
+        );
+        $attributes = $transport->getData();
+        $attributes = array_unique($attributes);
+        $attributes = array_values($attributes);
+        return count($attributes) ? ['filters' => implode(' AND ', $attributes)] : [];
+    }
+
+    // Algolia Cookie Configuration
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getDefaultConsentCookieName($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::COOKIE_DEFAULT_CONSENT_COOKIE_NAME,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getAllowCookieButtonSelector($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::ALLOW_COOKIE_BUTTON_SELECTOR,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getAlgoliaCookieDuration($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::ALGOLIA_COOKIE_DURATION,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    // --- Products --- //
+    
+    /**
+     * @param $storeId
+     * @return array
+     */
+    public function getProductAdditionalAttributes($storeId = null)
+    {
+        $attributes = $this->serializer->unserialize($this->configInterface->getValue(
+            self::PRODUCT_ATTRIBUTES,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ));
+
+        $facets = $this->serializer->unserialize($this->configInterface->getValue(
+            self::FACETS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ));
+        $attributes = $this->addIndexableAttributes($attributes, $facets, '0');
+
+        $sorts = $this->serializer->unserialize($this->configInterface->getValue(
+            self::SORTING_INDICES,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ));
+        $attributes = $this->addIndexableAttributes($attributes, $sorts, '0');
+
+        $customRankings = $this->serializer->unserialize($this->configInterface->getValue(
+            self::PRODUCT_CUSTOM_RANKING,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ));
+        $customRankings = $customRankings ?: [];
+        $customRankings = array_filter($customRankings, fn($customRanking) => $customRanking['attribute'] !== 'custom_attribute');
+        $attributes = $this->addIndexableAttributes($attributes, $customRankings, '0', '0');
+        if (is_array($attributes)) {
+            return $attributes;
+        }
+        return [];
+    }
+
+    /**
+     * @param $attributes
+     * @param $addedAttributes
+     * @param $searchable
+     * @param $retrievable
+     * @param $indexNoValue
+     * @return mixed
+     */
+    protected function addIndexableAttributes(
+        $attributes,
+        $addedAttributes,
+        $searchable = '1',
+        $retrievable = '1',
+        $indexNoValue = '1'
+    ) {
+        foreach ((array)$addedAttributes as $addedAttribute) {
+            foreach ((array)$attributes as $attribute) {
+                if ($addedAttribute['attribute'] === $attribute['attribute']) {
+                    continue 2;
+                }
+            }
+            $attributes[] = [
+                'attribute' => $addedAttribute['attribute'],
+                'searchable' => $searchable,
+                'retrievable' => $retrievable,
+                'index_no_value' => $indexNoValue,
+            ];
+        }
+        return $attributes;
+    }
+
+    /**
+     * @param $storeId
+     * @return array
+     */
+    public function getProductCustomRanking($storeId = null)
+    {
+        $attrs = $this->serializer->unserialize($this->getRawProductCustomRanking($storeId));
+        if (is_array($attrs)) {
+            return $attrs;
+        }
+        return [];
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getRawProductCustomRanking($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::PRODUCT_CUSTOM_RANKING,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
@@ -188,33 +410,27 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function shouldIndexEmptyCategories($storeId = null)
+    public function useAdaptiveImage($storeId = null): bool
     {
-        return $this->configInterface->isSetFlag(self::INDEX_EMPTY_CATEGORIES, ScopeInterface::SCOPE_STORE, $storeId);
+        return $this->configInterface->isSetFlag(self::USE_ADAPTIVE_IMAGE, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isVisualMerchEnabled($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::ENABLE_VISUAL_MERCHANDISING, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
      * @return string
      */
-    public function getMagentoVersion()
+    public function getCategoryPageIdAttributeName($storeId = null): string
     {
-        return $this->productMetadata->getVersion();
-    }
-
-    /**
-     * @return string
-     */
-    public function getMagentoEdition()
-    {
-        return $this->productMetadata->getEdition();
-    }
-
-    /**
-     * @return false|string
-     */
-    public function getExtensionVersion()
-    {
-        return $this->moduleResource->getDbVersion('Algolia_AlgoliaSearch');
+        return (string) $this->configInterface->getValue(self::CATEGORY_PAGE_ID_ATTRIBUTE_NAME, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     /**
@@ -233,80 +449,133 @@ class ConfigHelper
     }
 
     /**
-     * @param $storeId
-     * @return mixed
+     * NOTE: This method is currently only used in integration tests and was removed from the general implementation
+     * TODO: Evaluate use cases with product permissions where we may need to restore this functionality
+     * @param $groupId
+     * @return array
      */
-    public function indexProductOnCategoryProductsUpdate($storeId = null)
+    public function getAttributesToRetrieve($groupId)
     {
-        return $this->configInterface->getValue(
-            self::IDX_PRODUCT_ON_CAT_PRODUCTS_UPD,
+        if (false === $this->isCustomerGroupsEnabled()) {
+            return [];
+        }
+        $attributes = [];
+        foreach ($this->getProductAdditionalAttributes() as $attribute) {
+            if ($attribute['attribute'] !== 'price' && $attribute['retrievable'] === '1') {
+                $attributes[] = $attribute['attribute'];
+            }
+        }
+        foreach ($this->getCategoryAdditionalAttributes() as $attribute) {
+            if ($attribute['retrievable'] === '1') {
+                $attributes[] = $attribute['attribute'];
+            }
+        }
+        $attributes = array_merge($attributes, [
+            AlgoliaConnector::ALGOLIA_API_OBJECT_ID,
+            'name',
+            'url',
+            'visibility_search',
+            'visibility_catalog',
+            'categories',
+            'categories_without_path',
+            'thumbnail_url',
+            'image_url',
+            'images_data',
+            'in_stock',
+            'type_id',
+            'value',
+            'query', # suggestions
+            'path', # categories
+            'default_bundle_options',
+        ]);
+        $currencies = $this->dirCurrency->getConfigAllowCurrencies();
+        foreach ($currencies as $currency) {
+            $attributes[] = 'price.' . $currency . '.default';
+            $attributes[] = 'price.' . $currency . '.default_tier';
+            $attributes[] = 'price.' . $currency . '.default_max';
+            $attributes[] = 'price.' . $currency . '.default_formated';
+            $attributes[] = 'price.' . $currency . '.default_original_formated';
+            $attributes[] = 'price.' . $currency . '.default_tier_formated';
+            $attributes[] = 'price.' . $currency . '.group_' . $groupId;
+            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_tier';
+            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_max';
+            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_formated';
+            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_tier_formated';
+            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_original_formated';
+            $attributes[] = 'price.' . $currency . '.special_from_date';
+            $attributes[] = 'price.' . $currency . '.special_to_date';
+        }
+        $transport = new DataObject($attributes);
+        $this->eventManager->dispatch('algolia_get_retrievable_attributes', ['attributes' => $transport]);
+        $attributes = $transport->getData();
+        $attributes = array_unique($attributes);
+        $attributes = array_values($attributes);
+        return ['attributesToRetrieve' => $attributes];
+    }
+
+    /**
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function useVirtualReplica(?int $storeId = null): bool
+    {
+        return (bool) count(array_filter(
+            $this->getSorting($storeId),
+            fn($sort) => $sort[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA]
+        ));
+    }
+
+    // --- Categories --- //
+    /**
+     * @param $storeId
+     * @return array
+     */
+    public function getCategoryAdditionalAttributes($storeId = null)
+    {
+        $attributes = $this->serializer->unserialize($this->configInterface->getValue(
+            self::CATEGORY_ATTRIBUTES,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ));
+        $customRankings = $this->serializer->unserialize($this->configInterface->getValue(
+            self::CATEGORY_CUSTOM_RANKING,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ));
+        $customRankings = $customRankings ?: [];
+        $customRankings = array_filter($customRankings, fn($customRanking) => $customRanking['attribute'] !== 'custom_attribute');
+        $attributes = $this->addIndexableAttributes($attributes, $customRankings, '0', '0');
+        if (is_array($attributes)) {
+            return $attributes;
+        }
+        return [];
     }
 
     /**
      * @param $storeId
-     * @return bool
+     * @return array
      */
-    public function isEnabledFrontEnd($storeId = null)
+    public function getCategoryCustomRanking($storeId = null): array
     {
-        return $this->configInterface->isSetFlag(self::ENABLE_FRONTEND, ScopeInterface::SCOPE_STORE, $storeId);
+        $attrs = $this->serializer->unserialize($this->configInterface->getValue(
+            self::CATEGORY_CUSTOM_RANKING,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ));
+        if (is_array($attrs)) {
+            return $attrs;
+        }
+        return [];
     }
 
     /**
      * @param $storeId
      * @return bool
      */
-    public function isIndexingEnabled($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::ENABLE_INDEXING, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function makeSeoRequest($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::MAKE_SEO_REQUEST, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isLoggingEnabled($storeId = null): bool
-    {
-        return $this->configInterface->isSetFlag(self::LOGGING_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isProfilerEnabled($storeId = null): bool
-    {
-        return $this->configInterface->isSetFlag(self::PROFILER_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function getShowOutOfStock($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::SHOW_OUT_OF_STOCK, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function useSecureUrlsInFrontend($storeId = null)
+    public function showCatsNotIncludedInNavigation($storeId = null)
     {
         return $this->configInterface->isSetFlag(
-            self::USE_SECURE_IN_FRONTEND,
+            self::SHOW_CATS_NOT_INCLUDED_IN_NAV,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
@@ -314,148 +583,29 @@ class ConfigHelper
 
     /**
      * @param $storeId
-     * @return int
+     * @return bool
      */
-    public function getImageWidth($storeId = null)
+    public function shouldIndexEmptyCategories($storeId = null): bool
     {
-        $imageWidth = $this->configInterface->getValue(
-            self::XML_PATH_IMAGE_WIDTH,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-
-        if (!$imageWidth) {
-            return 265;
-        }
-
-        return (int)$imageWidth;
+        return $this->configInterface->isSetFlag(self::INDEX_EMPTY_CATEGORIES, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     /**
      * @param $storeId
-     * @return int
+     * @return string
      */
-    public function getImageHeight($storeId = null)
+    public function getCategorySeparator($storeId = null): string
     {
-        $imageHeight = $this->configInterface->getValue(
-            self::XML_PATH_IMAGE_HEIGHT,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-
-        if (!$imageHeight) {
-            return 265;
-        }
-
-        return (int)$imageHeight;
+        return (string) $this->configInterface->getValue(self::CATEGORY_SEPARATOR, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getImageType($storeId = null)
-    {
-        return $this->configInterface->getValue(self::XML_PATH_IMAGE_TYPE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
+    // --- Recommend Product Settings --- //
 
     /**
      * @param $storeId
      * @return bool
      */
-    public function shouldRemovePubDirectory($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::REMOVE_PUB_DIR_IN_URL, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isPartialUpdateEnabled($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::PARTIAL_UPDATES, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isRemoveBranding($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::REMOVE_BRANDING, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return int
-     */
-    public function getNumberOfElementByPage($storeId = null)
-    {
-        return (int)$this->configInterface->getValue(self::NUMBER_OF_ELEMENT_BY_PAGE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getNumberOfJobToRun($storeId = null)
-    {
-        $nbJobs = (int)$this->configInterface->getValue(self::NUMBER_OF_JOB_TO_RUN, ScopeInterface::SCOPE_STORE, $storeId);
-
-        return max($nbJobs, 1);
-    }
-
-    /**
-     * @param $storeId
-     * @return int
-     */
-    public function getRetryLimit($storeId = null)
-    {
-        return (int)$this->configInterface->getValue(self::RETRY_LIMIT, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isQueueActive($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::IS_ACTIVE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function useBuiltInCron($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::USE_BUILT_IN_CRON, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isEnhancedQueueArchiveEnabled($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::ENHANCED_QUEUE_ARCHIVE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getRemoveWordsIfNoResult($storeId = null)
-    {
-        return $this->configInterface->getValue(self::REMOVE_IF_NO_RESULT, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isRecommendFrequentlyBroughtTogetherEnabled($storeId = null)
+    public function isRecommendFrequentlyBroughtTogetherEnabled($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_RECOMMEND_FREQUENTLY_BOUGHT_TOGETHER_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -464,7 +614,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isRecommendRelatedProductsEnabled($storeId = null)
+    public function isRecommendRelatedProductsEnabled($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_RECOMMEND_RELATED_PRODUCTS_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -473,7 +623,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isRecommendFrequentlyBroughtTogetherEnabledOnCartPage($storeId = null)
+    public function isRecommendFrequentlyBroughtTogetherEnabledOnCartPage($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_RECOMMEND_FREQUENTLY_BOUGHT_TOGETHER_ENABLED_ON_CART_PAGE, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -482,7 +632,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isRecommendRelatedProductsEnabledOnCartPage($storeId = null)
+    public function isRecommendRelatedProductsEnabledOnCartPage($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_RECOMMEND_RELATED_PRODUCTS_ENABLED_ON_CART_PAGE, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -491,7 +641,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isRemoveCoreRelatedProductsBlock($storeId = null)
+    public function isRemoveCoreRelatedProductsBlock($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_REMOVE_RELATED_PRODUCTS_BLOCK, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -500,7 +650,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isRemoveUpsellProductsBlock($storeId = null)
+    public function isRemoveUpsellProductsBlock($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_REMOVE_UPSELL_PRODUCTS_BLOCK, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -509,9 +659,9 @@ class ConfigHelper
      * @param $storeId
      * @return int
      */
-    public function getNumberOfRelatedProducts($storeId = null)
+    public function getNumberOfRelatedProducts($storeId = null): int
     {
-        return (int)$this->configInterface->getValue(
+        return (int) $this->configInterface->getValue(
             self::NUM_OF_RECOMMEND_RELATED_PRODUCTS,
             ScopeInterface::SCOPE_STORE,
             $storeId
@@ -522,9 +672,9 @@ class ConfigHelper
      * @param $storeId
      * @return int
      */
-    public function getNumberOfFrequentlyBoughtTogetherProducts($storeId = null)
+    public function getNumberOfFrequentlyBoughtTogetherProducts($storeId = null): int
     {
-        return (int)$this->configInterface->getValue(
+        return (int) $this->configInterface->getValue(
             self::NUM_OF_RECOMMEND_FREQUENTLY_BOUGHT_TOGETHER_PRODUCTS,
             ScopeInterface::SCOPE_STORE,
             $storeId
@@ -532,9 +682,9 @@ class ConfigHelper
     }
 
     /**
-    * @param int $storeId
-    * @return int
-    */
+     * @param int $storeId
+     * @return int
+     */
     public function isRecommendTrendingItemsEnabled($storeId = null)
     {
         return (int)$this->configInterface->getValue(
@@ -548,9 +698,9 @@ class ConfigHelper
      * @param $storeId
      * @return int
      */
-    public function getNumberOfTrendingItems($storeId = null)
+    public function getNumberOfTrendingItems($storeId = null): int
     {
-        return (int)$this->configInterface->getValue(
+        return (int) $this->configInterface->getValue(
             self::NUM_OF_TRENDING_ITEMS,
             ScopeInterface::SCOPE_STORE,
             $storeId
@@ -563,9 +713,9 @@ class ConfigHelper
      * @param $storeId
      * @return int
      */
-    public function getNumberOfLookingSimilar($storeId = null)
+    public function getNumberOfLookingSimilar($storeId = null): int
     {
-        return (int)$this->configInterface->getValue(
+        return (int) $this->configInterface->getValue(
             self::NUM_OF_LOOKING_SIMILAR,
             ScopeInterface::SCOPE_STORE,
             $storeId
@@ -679,7 +829,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isAddToCartEnabledInFrequentlyBoughtTogether($storeId = null)
+    public function isAddToCartEnabledInFrequentlyBoughtTogether($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_ADDTOCART_ENABLED_IN_FREQUENTLY_BOUGHT_TOGETHER, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -688,7 +838,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isAddToCartEnabledInRelatedProducts($storeId = null)
+    public function isAddToCartEnabledInRelatedProducts($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_ADDTOCART_ENABLED_IN_RELATED_PRODUCTS, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -697,7 +847,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isAddToCartEnabledInTrendsItem($storeId = null)
+    public function isAddToCartEnabledInTrendsItem($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::IS_ADDTOCART_ENABLED_IN_TRENDS_ITEM, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -708,7 +858,7 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isAddToCartEnabledInLookingSimilar($storeId = null)
+    public function isAddToCartEnabledInLookingSimilar($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(
             self::IS_ADDTOCART_ENABLED_IN_LOOKING_SIMILAR,
@@ -744,667 +894,111 @@ class ConfigHelper
         return $this->configInterface->getValue(self::TRENDING_ITEMS_TITLE, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function useAdaptiveImage($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::USE_ADAPTIVE_IMAGE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
+    // --- Images --- //
 
     /**
      * @param $storeId
-     * @return bool
-     */
-    public function isVisualMerchEnabled($storeId = null): bool
-    {
-        return $this->configInterface->isSetFlag(self::ENABLE_VISUAL_MERCHANDISING, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return string
-     */
-    public function getCategoryPageIdAttributeName($storeId = null): string
-    {
-        return (string) $this->configInterface->getValue(self::CATEGORY_PAGE_ID_ATTRIBUTE_NAME, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     */
-    public function getCurrencyCode(?int $storeId = null): string
-    {
-        /** @var \Magento\Store\Model\Store $store */
-        $store = $this->storeManager->getStore($storeId);
-        return $store->getCurrentCurrencyCode();
-    }
-
-    /**
-     * Obtain the store scoped currency configuration or fall back to all allowed currencies
-     * @return array
-     */
-    public function getAllowedCurrencies(?int $storeId = null): array
-    {
-        $configured = explode(
-            ',',
-            $this->configInterface->getValue(
-                DirCurrency::XML_PATH_CURRENCY_ALLOW,
-                ScopeInterface::SCOPE_STORE,
-                $storeId
-            ) ?? ''
-        );
-        return $configured ?: $this->dirCurrency->getConfigAllowCurrencies();
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isCustomerGroupsEnabled($storeId = null): bool
-    {
-        return $this->configInterface->isSetFlag(self::CUSTOMER_GROUPS_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    public function setCustomerGroupsEnabled(bool $val, ?string $scope = null, ?int $scopeId = null): void
-    {
-        $this->configWriter->save(
-            self::CUSTOMER_GROUPS_ENABLE,
-            $val ? '1' : '0',
-            $scope,
-            $scopeId
-        );
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     * @deprecated Use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager instead
-     */
-    public function credentialsAreConfigured($storeId = null)
-    {
-        return $this->getApplicationID($storeId) &&
-            $this->getAPIKey($storeId) &&
-            $this->getSearchOnlyAPIKey($storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed'
-     */
-    public function getApplicationID($storeId = null)
-    {
-        return $this->configInterface->getValue(self::APPLICATION_ID, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getAPIKey($storeId = null)
-    {
-        return $this->configInterface->getValue(self::API_KEY, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getSearchOnlyAPIKey($storeId = null)
-    {
-        return $this->configInterface->getValue(self::SEARCH_ONLY_API_KEY, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param int|null $storeId
-     * @return string
-     */
-    public function getIndexPrefix(?int $storeId = null): string
-    {
-        return (string) $this->configInterface->getValue(self::INDEX_PREFIX, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed'
-     */
-    public function getConnectionTimeout($storeId = null)
-    {
-        return $this->configInterface->getValue(self::CONNECTION_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed'
-     */
-    public function getReadTimeout($storeId = null)
-    {
-        return $this->configInterface->getValue(self::READ_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed'
-     */
-    public function getWriteTimeout($storeId = null)
-    {
-        return $this->configInterface->getValue(self::WRITE_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    public function isAutoPriceIndexingEnabled(?int $storeId = null): bool
-    {
-        return $this->configInterface->isSetFlag(
-            self::AUTO_PRICE_INDEXING_ENABLED,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    public function getCategoryCustomRanking($storeId = null)
-    {
-        $attrs = $this->serializer->unserialize($this->configInterface->getValue(
-            self::CATEGORY_CUSTOM_RANKING,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
-        if (is_array($attrs)) {
-            return $attrs;
-        }
-        return [];
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    public function getProductCustomRanking($storeId = null)
-    {
-        $attrs = $this->serializer->unserialize($this->getRawProductCustomRanking($storeId));
-        if (is_array($attrs)) {
-            return $attrs;
-        }
-        return [];
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getRawProductCustomRanking($storeId = null)
-    {
-        return $this->configInterface->getValue(
-            self::PRODUCT_CUSTOM_RANKING,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * @param $section
-     * @param $storeId
-     * @return string
-     */
-    public function getExtraSettings($section, $storeId = null)
-    {
-        $constant = 'EXTRA_SETTINGS_' . mb_strtoupper((string) $section);
-        $value = $this->configInterface->getValue(constant('self::' . $constant), ScopeInterface::SCOPE_STORE, $storeId);
-        return trim((string)$value);
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     * @deprecated This feature is deprecated and will be replaced in an upcoming version
-     */
-    public function preventBackendRendering($storeId = null)
-    {
-        $preventBackendRendering = $this->configInterface->isSetFlag(
-            self::PREVENT_BACKEND_RENDERING,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-        if ($preventBackendRendering === false) {
-            return false;
-        }
-        if (!isset($_SERVER['HTTP_USER_AGENT'])) {
-            return false;
-        }
-        $userAgent = mb_strtolower((string) $_SERVER['HTTP_USER_AGENT'], 'utf-8');
-        $allowedUserAgents = $this->configInterface->getValue(
-            self::BACKEND_RENDERING_ALLOWED_USER_AGENTS,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-        $allowedUserAgents = trim((string) $allowedUserAgents);
-        if ($allowedUserAgents === '') {
-            return true;
-        }
-        $allowedUserAgents = preg_split('/\n|\r\n?/', $allowedUserAgents);
-        $allowedUserAgents = array_filter($allowedUserAgents);
-        foreach ($allowedUserAgents as $allowedUserAgent) {
-            $allowedUserAgent = mb_strtolower($allowedUserAgent, 'utf-8');
-            if (mb_strpos($userAgent, $allowedUserAgent) !== false) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getBackendRenderingDisplayMode($storeId = null)
-    {
-        return $this->configInterface->getValue(
-            self::PREVENT_BACKEND_RENDERING_DISPLAY_MODE,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
      * @return int
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getStoreId()
+    public function getImageWidth($storeId = null)
     {
-        return $this->storeManager->getStore()->getId();
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getStoreLocale($storeId)
-    {
-        return $this->configInterface->getValue(
-            \Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE,
+        $imageWidth = $this->configInterface->getValue(
+            self::XML_PATH_IMAGE_WIDTH,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
-    }
 
-    /**
-     * @param $storeId
-     * @return string|null
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     */
-    public function getCurrency($storeId = null)
-    {
-        /** @var \Magento\Store\Model\Store $store */
-        $store = $this->storeManager->getStore($storeId);
-        return $this->currency->getCurrency($store->getCurrentCurrencyCode())->getSymbol();
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function showSuggestionsOnNoResultsPage($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(
-            self::SHOW_SUGGESTIONS_NO_RESULTS,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * NOTE: This method is currently only used in integration tests and was removed from the general implementation
-     * TODO: Evaluate use cases with product permissions where we may need to restore this functionality
-     * @param $groupId
-     * @return array
-     */
-    public function getAttributesToRetrieve($groupId)
-    {
-        if (false === $this->isCustomerGroupsEnabled()) {
-            return [];
+        if (!$imageWidth) {
+            return 265;
         }
-        $attributes = [];
-        foreach ($this->getProductAdditionalAttributes() as $attribute) {
-            if ($attribute['attribute'] !== 'price' && $attribute['retrievable'] === '1') {
-                $attributes[] = $attribute['attribute'];
-            }
-        }
-        foreach ($this->getCategoryAdditionalAttributes() as $attribute) {
-            if ($attribute['retrievable'] === '1') {
-                $attributes[] = $attribute['attribute'];
-            }
-        }
-        $attributes = array_merge($attributes, [
-            AlgoliaConnector::ALGOLIA_API_OBJECT_ID,
-            'name',
-            'url',
-            'visibility_search',
-            'visibility_catalog',
-            'categories',
-            'categories_without_path',
-            'thumbnail_url',
-            'image_url',
-            'images_data',
-            'in_stock',
-            'type_id',
-            'value',
-            'query', # suggestions
-            'path', # categories
-            'default_bundle_options',
-        ]);
-        $currencies = $this->dirCurrency->getConfigAllowCurrencies();
-        foreach ($currencies as $currency) {
-            $attributes[] = 'price.' . $currency . '.default';
-            $attributes[] = 'price.' . $currency . '.default_tier';
-            $attributes[] = 'price.' . $currency . '.default_max';
-            $attributes[] = 'price.' . $currency . '.default_formated';
-            $attributes[] = 'price.' . $currency . '.default_original_formated';
-            $attributes[] = 'price.' . $currency . '.default_tier_formated';
-            $attributes[] = 'price.' . $currency . '.group_' . $groupId;
-            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_tier';
-            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_max';
-            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_formated';
-            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_tier_formated';
-            $attributes[] = 'price.' . $currency . '.group_' . $groupId . '_original_formated';
-            $attributes[] = 'price.' . $currency . '.special_from_date';
-            $attributes[] = 'price.' . $currency . '.special_to_date';
-        }
-        $transport = new DataObject($attributes);
-        $this->eventManager->dispatch('algolia_get_retrievable_attributes', ['attributes' => $transport]);
-        $attributes = $transport->getData();
-        $attributes = array_unique($attributes);
-        $attributes = array_values($attributes);
-        return ['attributesToRetrieve' => $attributes];
-    }
 
-    /**
-     * @param $storeId
-     * @return array
-     */
-    public function getProductAdditionalAttributes($storeId = null)
-    {
-        $attributes = $this->serializer->unserialize($this->configInterface->getValue(
-            self::PRODUCT_ATTRIBUTES,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
-
-        $facets = $this->serializer->unserialize($this->configInterface->getValue(
-            self::FACETS,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
-        $attributes = $this->addIndexableAttributes($attributes, $facets, '0');
-
-        $sorts = $this->serializer->unserialize($this->configInterface->getValue(
-            self::SORTING_INDICES,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
-        $attributes = $this->addIndexableAttributes($attributes, $sorts, '0');
-
-        $customRankings = $this->serializer->unserialize($this->configInterface->getValue(
-            self::PRODUCT_CUSTOM_RANKING,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
-        $customRankings = $customRankings ?: [];
-        $customRankings = array_filter($customRankings, fn($customRanking) => $customRanking['attribute'] !== 'custom_attribute');
-        $attributes = $this->addIndexableAttributes($attributes, $customRankings, '0', '0');
-        if (is_array($attributes)) {
-            return $attributes;
-        }
-        return [];
-    }
-
-    /**
-     * @param $attributes
-     * @param $addedAttributes
-     * @param $searchable
-     * @param $retrievable
-     * @param $indexNoValue
-     * @return mixed
-     */
-    protected function addIndexableAttributes(
-        $attributes,
-        $addedAttributes,
-        $searchable = '1',
-        $retrievable = '1',
-        $indexNoValue = '1'
-    ) {
-        foreach ((array)$addedAttributes as $addedAttribute) {
-            foreach ((array)$attributes as $attribute) {
-                if ($addedAttribute['attribute'] === $attribute['attribute']) {
-                    continue 2;
-                }
-            }
-            $attributes[] = [
-                'attribute' => $addedAttribute['attribute'],
-                'searchable' => $searchable,
-                'retrievable' => $retrievable,
-                'index_no_value' => $indexNoValue,
-            ];
-        }
-        return $attributes;
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    public function getCategoryAdditionalAttributes($storeId = null)
-    {
-        $attributes = $this->serializer->unserialize($this->configInterface->getValue(
-            self::CATEGORY_ATTRIBUTES,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
-        $customRankings = $this->serializer->unserialize($this->configInterface->getValue(
-            self::CATEGORY_CUSTOM_RANKING,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
-        $customRankings = $customRankings ?: [];
-        $customRankings = array_filter($customRankings, fn($customRanking) => $customRanking['attribute'] !== 'custom_attribute');
-        $attributes = $this->addIndexableAttributes($attributes, $customRankings, '0', '0');
-        if (is_array($attributes)) {
-            return $attributes;
-        }
-        return [];
-    }
-
-    /**
-     * @param $storeId
-     * @return string
-     */
-    public function getCategorySeparator($storeId = null): string
-    {
-        return (string) $this->configInterface->getValue(self::CATEGORY_SEPARATOR, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $groupId
-     * @return array
-     */
-    public function getAttributesToFilter($groupId)
-    {
-        $transport = new DataObject();
-        $this->eventManager->dispatch(
-            'algolia_get_attributes_to_filter',
-            ['filter_object' => $transport, 'customer_group_id' => $groupId]
-        );
-        $attributes = $transport->getData();
-        $attributes = array_unique($attributes);
-        $attributes = array_values($attributes);
-        return count($attributes) ? ['filters' => implode(' AND ', $attributes)] : [];
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isClickConversionAnalyticsEnabled($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::CC_ANALYTICS_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getClickConversionAnalyticsISSelector($storeId = null)
-    {
-        return $this->configInterface->getValue(self::CC_ANALYTICS_IS_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getConversionAnalyticsMode($storeId = null)
-    {
-        return $this->configInterface->getValue(
-            self::CC_CONVERSION_ANALYTICS_MODE,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getConversionAnalyticsAddToCartSelector($storeId = null)
-    {
-        return $this->configInterface->getValue(self::CC_ADD_TO_CART_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getDefaultConsentCookieName($storeId = null)
-    {
-        return $this->configInterface->getValue(
-            self::COOKIE_DEFAULT_CONSENT_COOKIE_NAME,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getAllowCookieButtonSelector($storeId = null)
-    {
-        return $this->configInterface->getValue(
-            self::ALLOW_COOKIE_BUTTON_SELECTOR,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getAlgoliaCookieDuration($storeId = null)
-    {
-        return $this->configInterface->getValue(
-            self::ALGOLIA_COOKIE_DURATION,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    public function getAnalyticsConfig($storeId = null)
-    {
-        return [
-            'enabled' => $this->isAnalyticsEnabled(),
-            'delay' => $this->configInterface->getValue(self::GA_DELAY, ScopeInterface::SCOPE_STORE, $storeId),
-            'triggerOnUiInteraction' => $this->configInterface->getValue(
-                self::GA_TRIGGER_ON_UI_INTERACTION,
-                ScopeInterface::SCOPE_STORE,
-                $storeId
-            ),
-            'pushInitialSearch' => $this->configInterface->getValue(
-                self::GA_PUSH_INITIAL_SEARCH,
-                ScopeInterface::SCOPE_STORE,
-                $storeId
-            ),
-        ];
-    }
-
-    /**
-     * @param $storeId
-     * @return bool
-     */
-    public function isAnalyticsEnabled($storeId = null)
-    {
-        return $this->configInterface->isSetFlag(self::GA_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return array
-     */
-    public function getNonCastableAttributes($storeId = null)
-    {
-        $nonCastableAttributes = [];
-        $config = $this->serializer->unserialize($this->configInterface->getValue(
-            self::NON_CASTABLE_ATTRIBUTES,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        ));
-        if (is_array($config)) {
-            foreach ($config as $attributeData) {
-                if (isset($attributeData['attribute'])) {
-                    $nonCastableAttributes[] = $attributeData['attribute'];
-                }
-            }
-        }
-        return $nonCastableAttributes;
+        return (int)$imageWidth;
     }
 
     /**
      * @param $storeId
      * @return int
      */
-    public function getMaxRecordSizeLimit($storeId = null)
+    public function getImageHeight($storeId = null)
     {
-        return (int)$this->configInterface->getValue(
-            self::MAX_RECORD_SIZE_LIMIT,
+        $imageHeight = $this->configInterface->getValue(
+            self::XML_PATH_IMAGE_HEIGHT,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
+
+        if (!$imageHeight) {
+            return 265;
+        }
+
+        return (int)$imageHeight;
     }
 
     /**
      * @param $storeId
-     * @return string
+     * @return mixed
      */
-    public function getAnalyticsRegion($storeId = null)
+    public function getImageType($storeId = null)
     {
-        return $this->configInterface->getValue(
-            self::ANALYTICS_REGION,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
+        return $this->configInterface->getValue(self::XML_PATH_IMAGE_TYPE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    // --- Indexing Queue / Cron --- //
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getNumberOfJobToRun($storeId = null): int
+    {
+        $nbJobs = (int) $this->configInterface->getValue(self::NUMBER_OF_JOB_TO_RUN, ScopeInterface::SCOPE_STORE, $storeId);
+
+        return (int) max($nbJobs, 1);
+    }
+
+    /**
+     * @param $storeId
+     * @return int
+     */
+    public function getRetryLimit($storeId = null): int
+    {
+        return (int) $this->configInterface->getValue(self::RETRY_LIMIT, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     /**
      * @param $storeId
      * @return bool
      */
-    public function isQuerySuggestionsIndexEnabled($storeId = null)
+    public function isQueueActive($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::IS_ACTIVE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function useBuiltInCron($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::USE_BUILT_IN_CRON, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    // --- Indexing Manager --- //
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isIndexingEnabled($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::ENABLE_INDEXING, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isQuerySuggestionsIndexEnabled($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::ENABLE_QUERY_SUGGESTIONS_INDEX, ScopeInterface::SCOPE_STORE, $storeId);
     }
@@ -1413,64 +1007,9 @@ class ConfigHelper
      * @param $storeId
      * @return bool
      */
-    public function isPagesIndexEnabled($storeId = null)
+    public function isPagesIndexEnabled($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::ENABLE_PAGES_INDEX, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
-    /**
-     * @param $storeId
-     * @return int
-     */
-    public function getArchiveLogClearLimit($storeId = null)
-    {
-        return (int)$this->configInterface->getValue(
-            self::ARCHIVE_LOG_CLEAR_LIMIT,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getCacheTime($storeId = null)
-    {
-        return $this->configInterface->getValue(
-            self::MAGENTO_DEFAULT_CACHE_TIME,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-    }
-
-    /**
-     * @param int|null $storeId
-     * @return bool
-     */
-    public function useVirtualReplica(?int $storeId = null): bool
-    {
-        return (bool) count(array_filter(
-            $this->getSorting($storeId),
-            fn($sort) => $sort[ReplicaManagerInterface::SORT_KEY_VIRTUAL_REPLICA]
-        ));
-    }
-
-    /**
-     * @return bool
-     */
-    public function isCookieRestrictionModeEnabled()
-    {
-        return (bool)$this->cookieHelper->isCookieRestrictionModeEnabled();
-    }
-
-    /**
-     * @param $storeId
-     * @return mixed
-     */
-    public function getCookieLifetime($storeId = null)
-    {
-        return $this->configInterface->getValue(self::COOKIE_LIFETIME, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     /**
@@ -1550,10 +1089,482 @@ class ConfigHelper
         );
     }
 
+    // --- Click & Conversion Analytics --- //
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isClickConversionAnalyticsEnabled($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::CC_ANALYTICS_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getClickConversionAnalyticsISSelector($storeId = null)
+    {
+        return $this->configInterface->getValue(self::CC_ANALYTICS_IS_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getConversionAnalyticsMode($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::CC_CONVERSION_ANALYTICS_MODE,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getConversionAnalyticsAddToCartSelector($storeId = null)
+    {
+        return $this->configInterface->getValue(self::CC_ADD_TO_CART_SELECTOR, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    // --- Google Analytics --- //
+
+    /**
+     * @param $storeId
+     * @return array
+     */
+    public function getAnalyticsConfig($storeId = null)
+    {
+        return [
+            'enabled' => $this->isAnalyticsEnabled(),
+            'delay' => $this->configInterface->getValue(self::GA_DELAY, ScopeInterface::SCOPE_STORE, $storeId),
+            'triggerOnUiInteraction' => $this->configInterface->getValue(
+                self::GA_TRIGGER_ON_UI_INTERACTION,
+                ScopeInterface::SCOPE_STORE,
+                $storeId
+            ),
+            'pushInitialSearch' => $this->configInterface->getValue(
+                self::GA_PUSH_INITIAL_SEARCH,
+                ScopeInterface::SCOPE_STORE,
+                $storeId
+            ),
+        ];
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isAnalyticsEnabled($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::GA_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    // --- Advanced --- //
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getRemoveWordsIfNoResult($storeId = null)
+    {
+        return $this->configInterface->getValue(self::REMOVE_IF_NO_RESULT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isPartialUpdateEnabled($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::PARTIAL_UPDATES, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isCustomerGroupsEnabled($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::CUSTOMER_GROUPS_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function setCustomerGroupsEnabled(bool $val, ?string $scope = null, ?int $scopeId = null): void
+    {
+        $this->configWriter->save(
+            self::CUSTOMER_GROUPS_ENABLE,
+            $val ? '1' : '0',
+            $scope,
+            $scopeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function shouldRemovePubDirectory($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::REMOVE_PUB_DIR_IN_URL, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isRemoveBranding($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::REMOVE_BRANDING, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function indexProductOnCategoryProductsUpdate($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::IDX_PRODUCT_ON_CAT_PRODUCTS_UPD,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+
+    /**
+     * @param $storeId
+     * @return bool
+     * @deprecated This feature is deprecated and will be replaced in an upcoming version
+     */
+    public function preventBackendRendering($storeId = null): bool
+    {
+        $preventBackendRendering = $this->configInterface->isSetFlag(
+            self::PREVENT_BACKEND_RENDERING,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+        if ($preventBackendRendering === false) {
+            return false;
+        }
+        if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+            return false;
+        }
+        $userAgent = mb_strtolower((string) $_SERVER['HTTP_USER_AGENT'], 'utf-8');
+        $allowedUserAgents = $this->configInterface->getValue(
+            self::BACKEND_RENDERING_ALLOWED_USER_AGENTS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+        $allowedUserAgents = trim((string) $allowedUserAgents);
+        if ($allowedUserAgents === '') {
+            return true;
+        }
+        $allowedUserAgents = preg_split('/\n|\r\n?/', $allowedUserAgents);
+        $allowedUserAgents = array_filter($allowedUserAgents);
+        foreach ($allowedUserAgents as $allowedUserAgent) {
+            $allowedUserAgent = mb_strtolower($allowedUserAgent, 'utf-8');
+            if (mb_strpos($userAgent, $allowedUserAgent) !== false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getBackendRenderingDisplayMode($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::PREVENT_BACKEND_RENDERING_DISPLAY_MODE,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return array
+     */
+    public function getNonCastableAttributes($storeId = null)
+    {
+        $nonCastableAttributes = [];
+        $config = $this->serializer->unserialize($this->configInterface->getValue(
+            self::NON_CASTABLE_ATTRIBUTES,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ));
+        if (is_array($config)) {
+            foreach ($config as $attributeData) {
+                if (isset($attributeData['attribute'])) {
+                    $nonCastableAttributes[] = $attributeData['attribute'];
+                }
+            }
+        }
+        return $nonCastableAttributes;
+    }
+
+    /**
+     * @param $storeId
+     * @return int
+     */
+    public function getMaxRecordSizeLimit($storeId = null)
+    {
+        return (int) $this->configInterface->getValue(
+            self::MAX_RECORD_SIZE_LIMIT,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return string
+     */
+    public function getAnalyticsRegion($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::ANALYTICS_REGION,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed'
+     */
+    public function getConnectionTimeout($storeId = null)
+    {
+        return $this->configInterface->getValue(self::CONNECTION_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed'
+     */
+    public function getReadTimeout($storeId = null)
+    {
+        return $this->configInterface->getValue(self::READ_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed'
+     */
+    public function getWriteTimeout($storeId = null)
+    {
+        return $this->configInterface->getValue(self::WRITE_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    public function isAutoPriceIndexingEnabled(?int $storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(
+            self::AUTO_PRICE_INDEXING_ENABLED,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    public function isProfilerEnabled(?int $storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::PROFILER_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    // Indexing Queue advanced settings
+    /**
+     * @param $storeId
+     * @return int
+     */
+    public function getNumberOfElementByPage($storeId = null): int
+    {
+        return (int) $this->configInterface->getValue(self::NUMBER_OF_ELEMENT_BY_PAGE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return int
+     */
+    public function getArchiveLogClearLimit($storeId = null)
+    {
+        return (int)$this->configInterface->getValue(
+            self::ARCHIVE_LOG_CLEAR_LIMIT,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isEnhancedQueueArchiveEnabled($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::ENHANCED_QUEUE_ARCHIVE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    // --- Extra index settings --- //
+
+    /**
+     * @param $section
+     * @param $storeId
+     * @return string
+     */
+    public function getExtraSettings($section, $storeId = null): string
+    {
+        $constant = 'EXTRA_SETTINGS_' . mb_strtoupper((string) $section);
+        $value = $this->configInterface->getValue(constant('self::' . $constant), ScopeInterface::SCOPE_STORE, $storeId);
+        return trim((string)$value);
+    }
+
+    // --- Magento Core --- //
+
+    /**
+     * @return string
+     */
+    public function getMagentoVersion()
+    {
+        return $this->productMetadata->getVersion();
+    }
+
+    /**
+     * @return string
+     */
+    public function getMagentoEdition()
+    {
+        return $this->productMetadata->getEdition();
+    }
+
+    /**
+     * @return false|string
+     */
+    public function getExtensionVersion()
+    {
+        return $this->moduleResource->getDbVersion('Algolia_AlgoliaSearch');
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getCurrencyCode(?int $storeId = null): string
+    {
+        /** @var \Magento\Store\Model\Store $store */
+        $store = $this->storeManager->getStore($storeId);
+        return $store->getCurrentCurrencyCode();
+    }
+
+    /**
+     * Obtain the store scoped currency configuration or fall back to all allowed currencies
+     * @return array
+     */
+    public function getAllowedCurrencies(?int $storeId = null): array
+    {
+        $configured = explode(
+            ',',
+            $this->configInterface->getValue(
+                DirCurrency::XML_PATH_CURRENCY_ALLOW,
+                ScopeInterface::SCOPE_STORE,
+                $storeId
+            ) ?? ''
+        );
+        return $configured ?: $this->dirCurrency->getConfigAllowCurrencies();
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getStoreId(): int
+    {
+        return $this->storeManager->getStore()->getId();
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getStoreLocale($storeId)
+    {
+        return $this->configInterface->getValue(
+            \Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return string|null
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getCurrency($storeId = null)
+    {
+        /** @var \Magento\Store\Model\Store $store */
+        $store = $this->storeManager->getStore($storeId);
+        return $this->currency->getCurrency($store->getCurrentCurrencyCode())->getSymbol();
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function getShowOutOfStock($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(self::SHOW_OUT_OF_STOCK, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function useSecureUrlsInFrontend($storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(
+            self::USE_SECURE_IN_FRONTEND,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCookieRestrictionModeEnabled(): bool
+    {
+        return (bool) $this->cookieHelper->isCookieRestrictionModeEnabled();
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getCookieLifetime($storeId = null)
+    {
+        return $this->configInterface->getValue(self::COOKIE_LIFETIME, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return mixed
+     */
+    public function getCacheTime($storeId = null)
+    {
+        return $this->configInterface->getValue(
+            self::MAGENTO_DEFAULT_CACHE_TIME,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
 
     /***************************************
      *   DEPRECATED CONSTANTS & METHODS    *
      **************************************/
+
+    /*** CONSTANTS ***/
 
     // --- Autocomplete --- //
 
@@ -1728,6 +1739,13 @@ class ConfigHelper
      */
     public const ENABLE_BACKEND = self::ENABLE_INDEXING;
 
+    // --- Advanced --- //
+    /**
+     * @deprecated This configuration is no longer being used and will be removed in a future release
+     */
+    public const MAKE_SEO_REQUEST = 'algoliasearch_advanced/advanced/make_seo_request';
+
+    /*** METHODS ***/
 
     // --- Autocomplete --- //
 
@@ -2020,6 +2038,20 @@ class ConfigHelper
     /**
      * @param $storeId
      * @return bool
+     * @deprecated This method will be moved to the InstantSearch config helper
+     */
+    public function showSuggestionsOnNoResultsPage($storeId = null)
+    {
+        return $this->configInterface->isSetFlag(
+            self::SHOW_SUGGESTIONS_NO_RESULTS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
      * @deprecated This method has been moved to the InstantSearch config helper and will be removed in a future version
      * @see \Algolia\AlgoliaSearch\Helper\Configuration\InstantSearchHelper::isAddToCartEnabled()
      */
@@ -2061,5 +2093,14 @@ class ConfigHelper
     public function isEnabledBackend($storeId = null)
     {
         return $this->isIndexingEnabled($storeId);
+    }
+
+    // --- Advanced --- //
+    /**
+     * @deprecated This configuration is no longer being used and will be removed in a future release
+     */
+    public function makeSeoRequest($storeId = null)
+    {
+        return $this->configInterface->isSetFlag(self::MAKE_SEO_REQUEST, ScopeInterface::SCOPE_STORE, $storeId);
     }
 }

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -1362,6 +1362,15 @@ class ConfigHelper
         return $this->configInterface->getValue(self::WRITE_TIMEOUT, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
+    public function shouldForwardPrimaryIndexSettingsToReplicas(?int $storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(
+            self::FORWARD_TO_REPLICAS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
     public function isAutoPriceIndexingEnabled(?int $storeId = null): bool
     {
         return $this->configInterface->isSetFlag(

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -20,6 +20,7 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class ConfigHelper
 {
+    // --- Credentials & Basic Setup --- //
     public const ENABLE_FRONTEND = 'algoliasearch_credentials/credentials/enable_frontend';
     public const LOGGING_ENABLED = 'algoliasearch_credentials/credentials/debug';
     public const APPLICATION_ID = 'algoliasearch_credentials/credentials/application_id';
@@ -30,72 +31,23 @@ class ConfigHelper
     public const ALLOW_COOKIE_BUTTON_SELECTOR = 'algoliasearch_credentials/algolia_cookie_configuration/allow_cookie_button_selector';
     public const ALGOLIA_COOKIE_DURATION = 'algoliasearch_credentials/algolia_cookie_configuration/cookie_duration';
 
+    // --- Products --- //
     public const PRODUCT_ATTRIBUTES = 'algoliasearch_products/products/product_additional_attributes';
     public const PRODUCT_CUSTOM_RANKING = 'algoliasearch_products/products/custom_ranking_product_attributes';
     public const USE_ADAPTIVE_IMAGE = 'algoliasearch_products/products/use_adaptive_image';
     public const ENABLE_VISUAL_MERCHANDISING = 'algoliasearch_products/products/enable_visual_merchandising';
     public const CATEGORY_PAGE_ID_ATTRIBUTE_NAME = 'algoliasearch_products/products/category_page_id_attribute_name';
+    public const INCLUDE_NON_VISIBLE_PRODUCTS_IN_INDEX = 'algoliasearch_products/products/include_non_visible_products_in_index';
 
+    // --- Categories --- //
     public const CATEGORY_ATTRIBUTES = 'algoliasearch_categories/categories/category_additional_attributes';
     public const CATEGORY_CUSTOM_RANKING = 'algoliasearch_categories/categories/custom_ranking_category_attributes';
     public const SHOW_CATS_NOT_INCLUDED_IN_NAV = 'algoliasearch_categories/categories/show_cats_not_included_in_navigation';
     public const INDEX_EMPTY_CATEGORIES = 'algoliasearch_categories/categories/index_empty_categories';
     public const CATEGORY_SEPARATOR = 'algoliasearch_categories/categories/category_separator';
 
-    public const IS_ACTIVE = 'algoliasearch_queue/queue/active';
-    public const USE_BUILT_IN_CRON = 'algoliasearch_queue/queue/use_built_in_cron';
-    public const NUMBER_OF_JOB_TO_RUN = 'algoliasearch_queue/queue/number_of_job_to_run';
-    public const RETRY_LIMIT = 'algoliasearch_queue/queue/number_of_retries';
 
-    public const XML_PATH_IMAGE_WIDTH = 'algoliasearch_images/image/width';
-    public const XML_PATH_IMAGE_HEIGHT = 'algoliasearch_images/image/height';
-    public const XML_PATH_IMAGE_TYPE = 'algoliasearch_images/image/type';
-
-    public const CC_ANALYTICS_ENABLE = 'algoliasearch_cc_analytics/cc_analytics_group/enable';
-    public const CC_ANALYTICS_IS_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/is_selector';
-    public const CC_CONVERSION_ANALYTICS_MODE = 'algoliasearch_cc_analytics/cc_analytics_group/conversion_analytics_mode';
-    public const CC_ADD_TO_CART_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector';
-    public const COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
-
-    public const GA_ENABLE = 'algoliasearch_analytics/analytics_group/enable';
-    public const GA_DELAY = 'algoliasearch_analytics/analytics_group/delay';
-    public const GA_TRIGGER_ON_UI_INTERACTION = 'algoliasearch_analytics/analytics_group/trigger_on_ui_interaction';
-    public const GA_PUSH_INITIAL_SEARCH = 'algoliasearch_analytics/analytics_group/push_initial_search';
-
-    public const REMOVE_IF_NO_RESULT = 'algoliasearch_advanced/advanced/remove_words_if_no_result';
-    public const PARTIAL_UPDATES = 'algoliasearch_advanced/advanced/partial_update';
-    public const CUSTOMER_GROUPS_ENABLE = 'algoliasearch_advanced/advanced/customer_groups_enable';
-    public const REMOVE_PUB_DIR_IN_URL = 'algoliasearch_advanced/advanced/remove_pub_dir_in_url';
-    public const MAKE_SEO_REQUEST = 'algoliasearch_advanced/advanced/make_seo_request';
-    public const REMOVE_BRANDING = 'algoliasearch_advanced/advanced/remove_branding';
-    public const INCLUDE_NON_VISIBLE_PRODUCTS_IN_INDEX = 'algoliasearch_products/products/include_non_visible_products_in_index';
-    public const IDX_PRODUCT_ON_CAT_PRODUCTS_UPD = 'algoliasearch_advanced/advanced/index_product_on_category_products_update';
-    public const PREVENT_BACKEND_RENDERING = 'algoliasearch_advanced/advanced/prevent_backend_rendering';
-    public const PREVENT_BACKEND_RENDERING_DISPLAY_MODE =
-        'algoliasearch_advanced/advanced/prevent_backend_rendering_display_mode';
-    public const BACKEND_RENDERING_ALLOWED_USER_AGENTS =
-        'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents';
-    public const NON_CASTABLE_ATTRIBUTES = 'algoliasearch_advanced/advanced/non_castable_attributes';
-    public const MAX_RECORD_SIZE_LIMIT = 'algoliasearch_advanced/advanced/max_record_size_limit';
-    public const ANALYTICS_REGION = 'algoliasearch_advanced/advanced/analytics_region';
-    public const CONNECTION_TIMEOUT = 'algoliasearch_advanced/advanced/connection_timeout';
-    public const READ_TIMEOUT = 'algoliasearch_advanced/advanced/read_timeout';
-    public const WRITE_TIMEOUT = 'algoliasearch_advanced/advanced/write_timeout';
-    public const AUTO_PRICE_INDEXING_ENABLED = 'algoliasearch_advanced/advanced/auto_price_indexing';
-
-    public const PROFILER_ENABLED = 'algoliasearch_advanced/advanced/enable_profiler';
-
-    public const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
-
-    public const USE_SECURE_IN_FRONTEND = 'web/secure/use_in_frontend';
-
-    public const EXTRA_SETTINGS_PRODUCTS = 'algoliasearch_extra_settings/extra_settings/products_extra_settings';
-    public const EXTRA_SETTINGS_CATEGORIES = 'algoliasearch_extra_settings/extra_settings/categories_extra_settings';
-    public const EXTRA_SETTINGS_PAGES = 'algoliasearch_extra_settings/extra_settings/pages_extra_settings';
-    public const EXTRA_SETTINGS_SUGGESTIONS = 'algoliasearch_extra_settings/extra_settings/suggestions_extra_settings';
-    public const EXTRA_SETTINGS_ADDITIONAL_SECTIONS =
-        'algoliasearch_extra_settings/extra_settings/additional_sections_extra_settings';
-    public const MAGENTO_DEFAULT_CACHE_TIME = 'system/full_page_cache/ttl';
+    // --- Recommend Products Settings --- //
     public const IS_RECOMMEND_FREQUENTLY_BOUGHT_TOGETHER_ENABLED = 'algoliasearch_recommend/recommend/frequently_bought_together/is_frequently_bought_together_enabled';
     public const IS_RECOMMEND_RELATED_PRODUCTS_ENABLED = 'algoliasearch_recommend/recommend/related_product/is_related_products_enabled';
     public const IS_RECOMMEND_FREQUENTLY_BOUGHT_TOGETHER_ENABLED_ON_CART_PAGE = 'algoliasearch_recommend/recommend/frequently_bought_together/is_frequently_bought_together_enabled_in_cart_page';
@@ -119,17 +71,22 @@ class ConfigHelper
     public const IS_LOOKING_SIMILAR_ENABLED_IN_PDP = 'algoliasearch_recommend/recommend/looking_similar/is_looking_similar_enabled_on_pdp';
     public const IS_LOOKING_SIMILAR_ENABLED_IN_SHOPPING_CART = 'algoliasearch_recommend/recommend/looking_similar/is_looking_similar_enabled_on_cart_page';
     protected const LOOKING_SIMILAR_TITLE = 'algoliasearch_recommend/recommend/looking_similar/title';
-
     protected const FREQUENTLY_BOUGHT_TOGETHER_TITLE = 'algoliasearch_recommend/recommend/frequently_bought_together/title';
     protected const RELATED_PRODUCTS_TITLE = 'algoliasearch_recommend/recommend/related_product/title';
     protected const TRENDING_ITEMS_TITLE = 'algoliasearch_recommend/recommend/trends_item/title';
 
-    // Indexing Queue Advanced settings
-    public const ENHANCED_QUEUE_ARCHIVE = 'algoliasearch_advanced/queue/enhanced_archive';
-    public const NUMBER_OF_ELEMENT_BY_PAGE = 'algoliasearch_advanced/queue/number_of_element_by_page';
-    public const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/queue/archive_clear_limit';
+    // --- Images --- //
+    public const XML_PATH_IMAGE_WIDTH = 'algoliasearch_images/image/width';
+    public const XML_PATH_IMAGE_HEIGHT = 'algoliasearch_images/image/height';
+    public const XML_PATH_IMAGE_TYPE = 'algoliasearch_images/image/type';
 
-    // Indexing Manager settings
+    // --- Indexing Queue / Cron --- //
+    public const IS_ACTIVE = 'algoliasearch_queue/queue/active';
+    public const USE_BUILT_IN_CRON = 'algoliasearch_queue/queue/use_built_in_cron';
+    public const NUMBER_OF_JOB_TO_RUN = 'algoliasearch_queue/queue/number_of_job_to_run';
+    public const RETRY_LIMIT = 'algoliasearch_queue/queue/number_of_retries';
+
+    // --- Indexing Manager --- //
     public const ENABLE_INDEXING = 'algoliasearch_indexing_manager/algolia_indexing/enable_indexing';
     public const ENABLE_QUERY_SUGGESTIONS_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/enable_query_suggestions_index';
     public const ENABLE_PAGES_INDEX = 'algoliasearch_indexing_manager/algolia_indexing/enable_pages_index';
@@ -140,6 +97,60 @@ class ConfigHelper
     public const ENABLE_INDEXER_ADDITIONAL_SECTIONS = 'algoliasearch_indexing_manager/full_indexing/additional_sections';
     public const ENABLE_INDEXER_DELETE_PRODUCTS = 'algoliasearch_indexing_manager/full_indexing/delete_products';
     public const ENABLE_INDEXER_QUEUE = 'algoliasearch_indexing_manager/full_indexing/queue';
+
+    // --- Click & Conversion Analytics --- //
+    public const CC_ANALYTICS_ENABLE = 'algoliasearch_cc_analytics/cc_analytics_group/enable';
+    public const CC_ANALYTICS_IS_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/is_selector';
+    public const CC_CONVERSION_ANALYTICS_MODE = 'algoliasearch_cc_analytics/cc_analytics_group/conversion_analytics_mode';
+    public const CC_ADD_TO_CART_SELECTOR = 'algoliasearch_cc_analytics/cc_analytics_group/add_to_cart_selector';
+
+    // --- Google Analytics --- //
+    public const GA_ENABLE = 'algoliasearch_analytics/analytics_group/enable';
+    public const GA_DELAY = 'algoliasearch_analytics/analytics_group/delay';
+    public const GA_TRIGGER_ON_UI_INTERACTION = 'algoliasearch_analytics/analytics_group/trigger_on_ui_interaction';
+    public const GA_PUSH_INITIAL_SEARCH = 'algoliasearch_analytics/analytics_group/push_initial_search';
+
+    // --- Advanced --- //
+    public const REMOVE_IF_NO_RESULT = 'algoliasearch_advanced/advanced/remove_words_if_no_result';
+    public const PARTIAL_UPDATES = 'algoliasearch_advanced/advanced/partial_update';
+    public const CUSTOMER_GROUPS_ENABLE = 'algoliasearch_advanced/advanced/customer_groups_enable';
+    public const REMOVE_PUB_DIR_IN_URL = 'algoliasearch_advanced/advanced/remove_pub_dir_in_url';
+    public const MAKE_SEO_REQUEST = 'algoliasearch_advanced/advanced/make_seo_request';
+    public const REMOVE_BRANDING = 'algoliasearch_advanced/advanced/remove_branding';
+    public const IDX_PRODUCT_ON_CAT_PRODUCTS_UPD = 'algoliasearch_advanced/advanced/index_product_on_category_products_update';
+    public const PREVENT_BACKEND_RENDERING = 'algoliasearch_advanced/advanced/prevent_backend_rendering';
+    public const PREVENT_BACKEND_RENDERING_DISPLAY_MODE =
+        'algoliasearch_advanced/advanced/prevent_backend_rendering_display_mode';
+    public const BACKEND_RENDERING_ALLOWED_USER_AGENTS =
+        'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents';
+    public const NON_CASTABLE_ATTRIBUTES = 'algoliasearch_advanced/advanced/non_castable_attributes';
+    public const MAX_RECORD_SIZE_LIMIT = 'algoliasearch_advanced/advanced/max_record_size_limit';
+    public const ANALYTICS_REGION = 'algoliasearch_advanced/advanced/analytics_region';
+    public const CONNECTION_TIMEOUT = 'algoliasearch_advanced/advanced/connection_timeout';
+    public const READ_TIMEOUT = 'algoliasearch_advanced/advanced/read_timeout';
+    public const WRITE_TIMEOUT = 'algoliasearch_advanced/advanced/write_timeout';
+    public const AUTO_PRICE_INDEXING_ENABLED = 'algoliasearch_advanced/advanced/auto_price_indexing';
+
+    public const PROFILER_ENABLED = 'algoliasearch_advanced/advanced/enable_profiler';
+
+    // Indexing Queue Advanced settings
+    public const ENHANCED_QUEUE_ARCHIVE = 'algoliasearch_advanced/queue/enhanced_archive';
+    public const NUMBER_OF_ELEMENT_BY_PAGE = 'algoliasearch_advanced/queue/number_of_element_by_page';
+    public const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/queue/archive_clear_limit';
+
+    // --- Extra index settings --- //
+    public const EXTRA_SETTINGS_PRODUCTS = 'algoliasearch_extra_settings/extra_settings/products_extra_settings';
+    public const EXTRA_SETTINGS_CATEGORIES = 'algoliasearch_extra_settings/extra_settings/categories_extra_settings';
+    public const EXTRA_SETTINGS_PAGES = 'algoliasearch_extra_settings/extra_settings/pages_extra_settings';
+    public const EXTRA_SETTINGS_SUGGESTIONS = 'algoliasearch_extra_settings/extra_settings/suggestions_extra_settings';
+    public const EXTRA_SETTINGS_ADDITIONAL_SECTIONS =
+        'algoliasearch_extra_settings/extra_settings/additional_sections_extra_settings';
+
+    // --- Magento Core --- //
+    public const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
+    public const USE_SECURE_IN_FRONTEND = 'web/secure/use_in_frontend';
+    public const MAGENTO_DEFAULT_CACHE_TIME = 'system/full_page_cache/ttl';
+    public const COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
 
     public function __construct(
         protected \Magento\Framework\App\Config\ScopeConfigInterface    $configInterface,

--- a/Helper/Configuration/InstantSearchHelper.php
+++ b/Helper/Configuration/InstantSearchHelper.php
@@ -132,6 +132,15 @@ class InstantSearchHelper
         );
     }
 
+    public function shouldShowSuggestionsOnNoResultsPage(?int $storeId = null): bool
+    {
+        return $this->configInterface->isSetFlag(
+            self::SHOW_SUGGESTIONS_NO_RESULTS,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
     public function isSearchBoxEnabled(?int $storeId = null): bool
     {
         return $this->isEnabled($storeId)

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -12,6 +12,7 @@ use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
+use Algolia\AlgoliaSearch\Service\ReplicaSettingsHandler;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -87,6 +88,7 @@ class ProductHelper extends AbstractEntityHelper
         protected ProductInterfaceFactory $productFactory,
         protected ProductRecordBuilder    $productRecordBuilder,
         protected FacetBuilder            $facetBuilder,
+        protected ReplicaSettingsHandler  $replicaSettingsHandler,
     )
     {
         parent::__construct($indexNameFetcher);
@@ -316,21 +318,13 @@ class ProductHelper extends AbstractEntityHelper
     ): void {
         $indexSettings = $this->getIndexSettings($storeId);
 
-        $this->algoliaConnector->setSettings(
-            $indexOptions,
-            $indexSettings,
-            false,
-            true
-        );
+        $this->replicaSettingsHandler->setSettings($indexOptions, $indexSettings);
 
         $this->logger->log('Settings: ' . json_encode($indexSettings));
         if ($saveToTmpIndicesToo) {
-
-            $this->algoliaConnector->setSettings(
+            $this->replicaSettingsHandler->setSettings(
                 $indexTmpOptions,
                 $indexSettings,
-                false,
-                true,
                 $indexOptions->getIndexName()
             );
 

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -17,6 +17,7 @@ use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Service\Category\IndexOptionsBuilder as CategoryIndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Service\Page\IndexOptionsBuilder as PageIndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder as ProductIndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\ReplicaSettingsHandler;
 use Algolia\AlgoliaSearch\Service\Suggestion\IndexOptionsBuilder as SuggestionIndexOptionsBuilder;
 use Magento\Framework\Exception\NoSuchEntityException;
 
@@ -37,6 +38,7 @@ class IndicesConfigurator
         protected SuggestionHelper              $suggestionHelper,
         protected AdditionalSectionHelper       $additionalSectionHelper,
         protected AlgoliaCredentialsManager     $algoliaCredentialsManager,
+        protected ReplicaSettingsHandler        $replicaSettingsHandler,
         protected DiagnosticsLogger             $logger
     ) {}
 
@@ -108,12 +110,7 @@ class IndicesConfigurator
         $settings = $this->categoryHelper->getIndexSettings($storeId);
         $indexOptions = $this->categoryIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
-        $this->algoliaConnector->setSettings(
-            $indexOptions,
-            $settings,
-            false,
-            true
-        );
+        $this->replicaSettingsHandler->setSettings($indexOptions, $settings);
 
         $this->logger->log('Index name: ' . $indexOptions->getIndexName());
         $this->logger->log('Settings: ' . json_encode($settings));
@@ -133,12 +130,7 @@ class IndicesConfigurator
         $settings = $this->pageHelper->getIndexSettings($storeId);
         $indexOptions = $this->pageIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
-        $this->algoliaConnector->setSettings(
-            $indexOptions,
-            $settings,
-            false,
-            true
-        );
+        $this->replicaSettingsHandler->setSettings($indexOptions, $settings);
 
         $this->logger->log('Index name: ' . $indexOptions->getIndexName());
         $this->logger->log('Settings: ' . json_encode($settings));
@@ -158,12 +150,7 @@ class IndicesConfigurator
         $settings = $this->suggestionHelper->getIndexSettings($storeId);
         $indexOptions = $this->suggestionIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
-        $this->algoliaConnector->setSettings(
-            $indexOptions,
-            $settings,
-            false,
-            true
-        );
+        $this->replicaSettingsHandler->setSettings($indexOptions, $settings);
 
         $this->logger->log('Index name: ' . $indexOptions->getIndexName());
         $this->logger->log('Settings: ' . json_encode($settings));
@@ -192,7 +179,7 @@ class IndicesConfigurator
             $settings = $this->additionalSectionHelper->getIndexSettings($storeId);
             $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
-            $this->algoliaConnector->setSettings($indexOptions, $settings);
+            $this->replicaSettingsHandler->setSettings($indexOptions, $settings);
 
             $this->logger->log('Index name: ' . $indexName);
             $this->logger->log('Settings: ' . json_encode($settings));

--- a/Service/ReplicaSettingsHandler.php
+++ b/Service/ReplicaSettingsHandler.php
@@ -23,7 +23,7 @@ class ReplicaSettingsHandler
 
     public function __construct(
         protected AlgoliaConnector $connector,
-        protected ConfigHelper $config,
+        protected ConfigHelper     $config,
     ) {}
 
     /**
@@ -38,19 +38,23 @@ class ReplicaSettingsHandler
     {
         if ($this->config->shouldForwardPrimaryIndexSettingsToReplicas($indexOptions->getStoreId())) {
             [$forward, $noForward] = $this->splitSettings($indexSettings);
-            $this->connector->setSettings(
-                $indexOptions,
-                $forward,
-                true,
-                false
-            );
-            $this->connector->setSettings(
-                $indexOptions,
-                $noForward,
-                false,
-                true,
-                $mergeSettingsFrom
-            );
+            if ($forward) {
+                $this->connector->setSettings(
+                    $indexOptions,
+                    $forward,
+                    true,
+                    false
+                );
+            }
+            if ($noForward) {
+                $this->connector->setSettings(
+                    $indexOptions,
+                    $noForward,
+                    false,
+                    true,
+                    $mergeSettingsFrom
+                );
+            }
         } else {
             $this->connector->setSettings(
                 $indexOptions,

--- a/Service/ReplicaSettingsHandler.php
+++ b/Service/ReplicaSettingsHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+/**
+ *  This class will proxy the settings save operations and forward to replicas based on user configuration
+ *  excluding attributes which should never be forwarded
+ */
+class ReplicaSettingsHandler
+{
+    /**
+     * As replicas are used for sorting we do not want to override these replicas specific configurations
+     */
+    protected const FORWARDING_EXCLUDED_ATTRIBUTES = [
+        'customRanking',
+        'ranking'
+    ];
+
+    public function __construct(
+        protected AlgoliaConnector $connector,
+        protected ConfigHelper $config,
+    ) {}
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws AlgoliaException
+     */
+    public function setSettings(
+        IndexOptionsInterface $indexOptions,
+        array $indexSettings,
+        string $mergeSettingsFrom = ''
+    ): void
+    {
+        if ($this->config->shouldForwardPrimaryIndexSettingsToReplicas($indexOptions->getStoreId())) {
+            [$forward, $noForward] = $this->splitSettings($indexSettings);
+            $this->connector->setSettings(
+                $indexOptions,
+                $forward,
+                true,
+                false
+            );
+            $this->connector->setSettings(
+                $indexOptions,
+                $noForward,
+                false,
+                true,
+                $mergeSettingsFrom
+            );
+        } else {
+            $this->connector->setSettings(
+                $indexOptions,
+                $indexSettings,
+                false,
+                true,
+                $mergeSettingsFrom
+            );
+        }
+    }
+
+    /**
+     * Split settings based on whether they should be forwarded to the replicas
+     * @return array Tuple of settings (to forward and not to forward)
+     */
+    protected function splitSettings(array $settings): array
+    {
+        $excludedKeys = array_flip(self::FORWARDING_EXCLUDED_ATTRIBUTES);
+        return [
+            array_diff_key($settings, $excludedKeys),
+            array_intersect_key($settings, $excludedKeys)
+        ];
+    }
+
+}

--- a/Setup/Patch/Schema/ConfigPatch.php
+++ b/Setup/Patch/Schema/ConfigPatch.php
@@ -85,7 +85,6 @@ class ConfigPatch implements SchemaPatchInterface
         'algoliasearch_advanced/advanced/remove_words_if_no_result' => 'allOptional',
         'algoliasearch_advanced/advanced/partial_update' => '0',
         'algoliasearch_advanced/advanced/customer_groups_enable' => '0',
-        'algoliasearch_advanced/advanced/make_seo_request' => '1',
         'algoliasearch_advanced/advanced/remove_branding' => '0',
         'algoliasearch_autocomplete/autocomplete/autocomplete_selector' => '.algolia-search-input',
         'algoliasearch_advanced/advanced/index_product_on_category_products_update' => '1',

--- a/Test/Unit/Service/ReplicaSettingsHandlerTest.php
+++ b/Test/Unit/Service/ReplicaSettingsHandlerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\ReplicaSettingsHandler;
+use PHPUnit\Framework\TestCase;
+
+class ReplicaSettingsHandlerTest extends TestCase
+{
+    protected ?AlgoliaConnector $connector = null;
+
+    protected ?ConfigHelper $config = null;
+
+    protected ?IndexOptionsInterface $indexOptions = null;
+
+    private ?ReplicaSettingsHandler $handler = null;
+
+    protected function setUp(): void
+    {
+        $this->connector = $this->createMock(AlgoliaConnector::class);
+        $this->config = $this->createMock(ConfigHelper::class);
+        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
+
+        $this->handler = new ReplicaSettingsHandlerTestable($this->connector, $this->config);
+    }
+
+    public function testSetSettingsWithForwardingEnabledAndMixedSettings(): void
+    {
+        $storeId = 1;
+        $settings = [
+            'customRanking' => ['desc(price)'],
+            'attributesToRetrieve' => ['name', 'price']
+        ];
+
+        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->with($storeId)
+            ->willReturn(true);
+
+        $invocations = $this->exactly(2);
+        $this->connector->expects($invocations)
+            ->method('setSettings')
+            ->willReturnCallback(
+                function($indexOptions, $indexSettings, $forwardToReplicas, $mergeSettings, $mergeFrom) use ($invocations) {
+                    switch ($invocations->numberOfInvocations()) {
+                        case 1:
+                            $this->assertEquals(['attributesToRetrieve' => ['name', 'price']], $indexSettings);
+                            $this->assertTrue($forwardToReplicas);
+                            $this->assertFalse($mergeSettings);
+                            break;
+                        case 2:
+                            $this->assertEquals(['customRanking' => ['desc(price)']], $indexSettings);
+                            $this->assertFalse($forwardToReplicas);
+                            $this->assertTrue($mergeSettings);
+                            break;
+                }
+            });
+
+        $this->handler->setSettings($this->indexOptions, $settings);
+    }
+
+    public function testSetSettingsWithForwardingEnabledOnlyExcludedSettings(): void
+    {
+        $storeId = 1;
+        $settings = [
+            'ranking' => ['asc(name)'],
+            'customRanking' => ['desc(price)']
+        ];
+
+        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->willReturn(true);
+
+        // Only one call expected (no forwarded settings since they are sorts)
+        $this->connector->expects($this->once())
+            ->method('setSettings')
+            ->with(
+                $this->indexOptions,
+                $settings,
+                false,
+                true,
+                ''
+            );
+
+        $this->handler->setSettings($this->indexOptions, $settings);
+    }
+
+    public function testSetSettingsWithForwardingEnabledOnlyForwardableSettings(): void
+    {
+        $storeId = 1;
+        $settings = [
+            'attributesToHighlight' => ['title'],
+            'attributesToRetrieve' => ['name']
+        ];
+
+        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->willReturn(true);
+
+        // Only one call expected (all forwarded - no excluded settings)
+        $this->connector->expects($this->once())
+            ->method('setSettings')
+            ->with(
+                $this->indexOptions,
+                $settings,
+                true,
+                false
+            );
+
+        $this->handler->setSettings($this->indexOptions, $settings);
+    }
+
+    public function testSetSettingsWithForwardingDisabled(): void
+    {
+        $storeId = 1;
+        $settings = [
+            'customRanking' => ['desc(price)'],
+            'attributesToRetrieve' => ['name', 'price']
+        ];
+
+        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->willReturn(false);
+
+        $this->connector->expects($this->once())
+            ->method('setSettings')
+            ->with(
+                $this->indexOptions,
+                $settings,
+                false,
+                true,
+                ''
+            );
+
+        $this->handler->setSettings($this->indexOptions, $settings);
+    }
+
+    public function testForwardSettingsWithEmptyInput(): void
+    {
+        $storeId = 1;
+        $settings = [];
+
+        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->willReturn(true);
+
+        // Connector should not be called
+        $this->connector->expects($this->never())->method('setSettings');
+
+        $this->handler->setSettings($this->indexOptions, $settings);
+    }
+
+
+    public function testSplitSettings(): void
+    {
+        $settings = [
+            'customRanking' => ['desc(price)'],
+            'ranking' => ['asc(name)'],
+            'attributesToRetrieve' => ['name']
+        ];
+
+        [$forward, $noForward] = $this->handler->splitSettings($settings);
+
+        $this->assertEquals(['attributesToRetrieve' => ['name']], $forward);
+        $this->assertEquals([
+            'customRanking' => ['desc(price)'],
+            'ranking' => ['asc(name)']
+        ], $noForward);
+    }
+}

--- a/Test/Unit/Service/ReplicaSettingsHandlerTestable.php
+++ b/Test/Unit/Service/ReplicaSettingsHandlerTestable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Service\ReplicaSettingsHandler;
+
+class ReplicaSettingsHandlerTestable extends ReplicaSettingsHandler
+{
+    public function splitSettings(...$params): array
+    {
+        return parent::splitSettings(...$params);
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1072,7 +1072,7 @@
                         ]]>
                     </comment>
                     <depends>
-                        <field id="algolia_indexing">1</field>
+                        <field id="enable_indexing">1</field>
                     </depends>
                 </field>
                 <field id="enable_pages_index" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -1085,12 +1085,16 @@
                         ]]>
                     </comment>
                     <depends>
-                        <field id="algolia_indexing">1</field>
+                        <field id="enable_indexing">1</field>
                     </depends>
                 </field>
             </group>
             <group id="full_indexing" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Full indexing via Magento indexers</label>
+                <depends>
+                    <field id="algoliasearch_indexing_manager/algolia_indexing/enable_indexing">1</field>
+                </depends>
+                <attribute type="expanded">1</attribute>
                 <comment>
                     <![CDATA[
                          <p><span class="algolia-config-warning">&#9888;</span> Since version 3.16.0, the following Magento indexers can be disabled for <strong>full indexing</strong>.
@@ -1524,9 +1528,6 @@
                     <comment>
                         <model>Algolia\AlgoliaSearch\Model\Config\AutomaticPriceIndexingComment</model>
                     </comment>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                 </field>
                 <field id="enable_profiler" translate="label comment" type="select" sortOrder="130" showInDefault="1">
                     <label>Enable Profiler</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1522,6 +1522,17 @@
                 <field id="write_timeout" translate="label comment" type="text" sortOrder="110" showInDefault="1">
                     <label>Write Timeout (In Seconds)</label>
                 </field>
+                <field id="forward_to_replicas" translate="label comment" type="select" sortOrder="115" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Forward index settings to replicas</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                            When this configuration is enabled, settings that are changed in Algolia on the primary index will also be forwarded to its replica indices. It is enabled by default.
+                            <br><br>
+                            The ability to disable this behavior is retained for legacy implementations, but it is highly recommended that you leave this setting enabled especially if you are using dynamic facets.
+                        ]]>
+                    </comment>
+                </field>
                 <field id="auto_price_indexing" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable automatic price indexing</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -122,6 +122,7 @@
                 <connection_timeout>2</connection_timeout>
                 <read_timeout>30</read_timeout>
                 <write_timeout>30</write_timeout>
+                <forward_to_replicas>1</forward_to_replicas>
                 <auto_price_indexing>0</auto_price_indexing>
                 <enable_profiler>0</enable_profiler>
             </advanced>


### PR DESCRIPTION
**Summary**

This PR aims to provide support for forwarding settings to replicas which historically the integration has never done. 

It is enabled by default but can be disabled in the admin under the "Advanced" tab. 

This now enables more reliable function of dynamic facets across alternate sorts (for instance if the primary index `attributesForFaceting` get out of sync with one or more replicas).

It also includes some clean up of `system.xml` and the mega ConfigHelper class (tried to apply some logical grouping here so future additions can be added more sensibly) along with a couple of deprecations. 

**Result**

Unit tests:

<img width="1484" height="233" alt="image" src="https://github.com/user-attachments/assets/de35c954-d18e-443f-8324-ffda82d92ce9" />

Rule config:
<img width="1063" height="140" alt="image" src="https://github.com/user-attachments/assets/283052f0-2506-4d49-9c31-5ddd9675e22e" />

Consistent application of dynamic facet by rule across sorts:
<img width="1279" height="1079" alt="2025-07-18_02-04-24" src="https://github.com/user-attachments/assets/a5553c45-9c4d-4be6-ad72-a11881b2217b" />
<img width="1265" height="1103" alt="2025-07-18_02-05-43" src="https://github.com/user-attachments/assets/3e9be90f-3fb8-4bf4-b7f2-2ea1c56de762" />

