### PR TITLE
MAGE-1378 Fix handling of Varnish X-Magento-Vary cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed WSOD error on invalid creds when using manual SKU indexer (also included in 3.15.1).
 - Fixed Recommend model validation when configuring through the Magento admin 
 - Fixed edge case with null queries - thank you @PromInc 
+- Removed conditional behavior on setting the vary string from the plugin on `\Magento\Framework\App\Http\Context` so that a consistent `X-Magento-Vary` cookie is sent across all requests 
 
 ### Updates
 - `beforecontent.html` is no longer used and has been deprecated. If you're overriding or referencing this file, please update your layout and customizations accordingly.
@@ -42,6 +43,7 @@
 - Added support for PHPUnit 10
 - Added support for Magento 2.4.8 on PHP 8.4 - Special shout out to @jajajaime for his help here
 - Refactored code to PHP 8.2 baseline standard
+- The InstantSearch "replace categories" feature must now be explicitly enabled on new instances aligning with our documentation: https://www.algolia.com/doc/integration/magento-2/guides/category-pages/#enable-category-pages
 
 ### Breaking Changes
 - `ProductHelper::setSettings()` is now taking `IndexOptions` objects as two first parameters instead of index names (strings).

--- a/Plugin/RenderingCacheContextPlugin.php
+++ b/Plugin/RenderingCacheContextPlugin.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Plugin;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Configuration\InstantSearchHelper;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -25,7 +26,8 @@ class RenderingCacheContextPlugin
     public const CATEGORY_ROUTE = 'catalog/category/view';
 
     public function __construct(
-        protected ConfigHelper $configHelper,
+        protected ConfigHelper $baseConfig,
+        protected InstantSearchHelper $isConfig,
         protected StoreManagerInterface $storeManager,
         protected Http $request,
         protected UrlFinderInterface $urlFinder
@@ -50,7 +52,7 @@ class RenderingCacheContextPlugin
             return $data;
         }
 
-        $context = $this->configHelper->preventBackendRendering() ?
+        $context = $this->baseConfig->preventBackendRendering() ?
             self::RENDERING_WITHOUT_BACKEND :
             self::RENDERING_WITH_BACKEND;
 
@@ -89,6 +91,7 @@ class RenderingCacheContextPlugin
      *
      * @param int $storeId
      * @return bool
+     * @deprecated This method will be removed in a future version
      */
     protected function isCategoryPage(int $storeId): bool
     {
@@ -104,6 +107,6 @@ class RenderingCacheContextPlugin
     protected function shouldApplyCacheContext(): bool
     {
         $storeId = $this->storeManager->getStore()->getId();
-        return $this->isCategoryPage($storeId) && $this->configHelper->replaceCategories($storeId);
+        return $this->isConfig->shouldReplaceCategories($storeId);
     }
 }

--- a/Setup/Patch/Schema/ConfigPatch.php
+++ b/Setup/Patch/Schema/ConfigPatch.php
@@ -51,7 +51,6 @@ class ConfigPatch implements SchemaPatchInterface
         'algoliasearch_instant/instant/instant_selector' => '.columns',
         'algoliasearch_instant/instant/number_product_results' => '9',
         'algoliasearch_instant/instant/max_values_per_facet' => '10',
-        'algoliasearch_instant/instant/replace_categories' => '1',
         'algoliasearch_instant/instant/show_suggestions_on_no_result_page' => '1',
         'algoliasearch_instant/instant/add_to_cart_enable' => '1',
         'algoliasearch_instant/instant/infinite_scroll_enable' => '0',

--- a/Test/Unit/Plugin/RenderingCacheContextPluginTest.php
+++ b/Test/Unit/Plugin/RenderingCacheContextPluginTest.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Plugin;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Configuration\InstantSearchHelper;
 use Algolia\AlgoliaSearch\Plugin\RenderingCacheContextPlugin;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\App\Request\Http;
@@ -10,24 +11,26 @@ use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use PHPUnit\Framework\TestCase;
-
 class RenderingCacheContextPluginTest extends TestCase
 {
     protected ?RenderingCacheContextPlugin $plugin;
     protected ?ConfigHelper $configHelper;
+
+    protected ?InstantSearchHelper $instantSearchHelper;
     protected ?StoreManagerInterface $storeManager;
     protected ?Http $request;
     protected ?UrlFinderInterface $urlFinder;
-
     protected function setUp(): void
     {
         $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->instantSearchHelper = $this->createMock(InstantSearchHelper::class);
         $this->storeManager = $this->createMock(StoreManagerInterface::class);
         $this->request = $this->createMock(Http::class);
         $this->urlFinder = $this->createMock(UrlFinderInterface::class);
 
         $this->plugin = new RenderingCacheContextPluginTestable(
             $this->configHelper,
+            $this->instantSearchHelper,
             $this->storeManager,
             $this->request,
             $this->urlFinder
@@ -47,7 +50,7 @@ class RenderingCacheContextPluginTest extends TestCase
         $this->storeManager->method('getStore')->willReturn($this->getStoreMock());
 
         $this->request->method('getControllerName')->willReturn('category');
-        $this->configHelper->method('replaceCategories')->willReturn(true);
+        $this->instantSearchHelper->method('shouldReplaceCategories')->willReturn(true);
 
         $result = $this->plugin->afterGetData(
             $this->createMock(HttpContext::class),
@@ -66,7 +69,7 @@ class RenderingCacheContextPluginTest extends TestCase
         $this->storeManager->method('getStore')->willReturn($this->getStoreMock());
 
         $this->request->method('getControllerName')->willReturn('category');
-        $this->configHelper->method('replaceCategories')->willReturn(true);
+        $this->instantSearchHelper->method('shouldReplaceCategories')->willReturn(true);
 
         $result = $this->plugin->afterGetData(
             $this->createMock(HttpContext::class),
@@ -86,7 +89,7 @@ class RenderingCacheContextPluginTest extends TestCase
 
         $this->request->method('getControllerName')->willReturn('product');
         $this->request->method('getRequestUri')->willReturn('some-product.html');
-        $this->configHelper->method('replaceCategories')->willReturn(false);
+        $this->instantSearchHelper->method('shouldReplaceCategories')->willReturn(false);
 
         $data = ['existing_key' => 'existing_value'];
         $result = $this->plugin->afterGetData($subject, $data);
@@ -121,7 +124,7 @@ class RenderingCacheContextPluginTest extends TestCase
         $this->storeManager->method('getStore')->willReturn($this->getStoreMock());
 
         $this->request->method('getControllerName')->willReturn('category');
-        $this->configHelper->method('replaceCategories')->willReturn(true);
+        $this->instantSearchHelper->method('shouldReplaceCategories')->willReturn(true);
 
         $this->assertTrue($this->plugin->shouldApplyCacheContext());
     }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": ["MIT"],
   "version": "3.16.0",
   "require": {
-    "php": "~8.1|~8.2|~8.3",
+    "php": "~8.2|~8.3|~8.4",
     "magento/framework": "~103.0",
     "algolia/algoliasearch-client-php": "4.18.3",
     "guzzlehttp/guzzle": "^6.3.3|^7.3.0",

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -29,6 +29,9 @@
             </redirects>
         </algoliasearch_autocomplete>
         <algoliasearch_instant>
+            <instant>
+                <replace_categories>0</replace_categories>
+            </instant>
             <instant_facets>
                 <facets><![CDATA[{"_1458145454535_587":{"attribute":"price","type":"slider","label":"Price","searchable":"2","create_rule":"2"},"_2541608784525_123":{"attribute":"categories","type":"conjunctive","label":"Categories","searchable":"2","create_rule":"2"},"_3211608784535_456":{"attribute":"color","type":"disjunctive","label":"Colors","searchable":"1","create_rule":"2"}}]]></facets>
                 <max_values_per_facet>10</max_values_per_facet>


### PR DESCRIPTION
**Summary**

The legacy cache handling has been observed to break with Varnish due to inconsistent setting of the `X-Magento-Vary cookie` across requests.

This PR aims to correct this by the following:

- Disable cache manipulation by default to preclude Varnish `MISS` on category PLP on an non-configured Magento instance
  - This change is dependent on the InstantSearch replace categories feature which now must be explicitly enabled on new instances aligning with our documentation: https://www.algolia.com/doc/integration/magento-2/guides/category-pages/#enable-category-pages
- Remove conditional behavior on setting the vary string from the plugin on `\Magento\Framework\App\Http\Context` so that a consistent `X-Magento-Vary` cookie is sent across all requests based on user context.

**Result**

Integration tests
<img width="2048" height="461" alt="image" src="https://github.com/user-attachments/assets/d045e6f1-bbcf-4e56-ad06-71bb61649b65" />

Unit tests
<img width="2976" height="358" alt="image" src="https://github.com/user-attachments/assets/a9f09407-59dd-41ef-a1ab-b48177f93738" />

Manual testing on Varnish

First `MISS`
<img width="2048" height="781" alt="image" src="https://github.com/user-attachments/assets/4e0c9ff0-e33e-436e-8ec2-e964fa3fc94b" />
Second `HIT` with `X-Magento-Vary` cookie
<img width="2048" height="675" alt="image" src="https://github.com/user-attachments/assets/92ef6b57-ad30-4f66-873a-6ca739c072e4" />

