### PR TITLE
Fix product getUrl method by aligning with Magento core behavior

### DIFF
--- a/Model/Product/Url.php
+++ b/Model/Product/Url.php
@@ -67,6 +67,7 @@ class Url extends ProductUrl
                     UrlRewrite::ENTITY_ID   => $product->getId(),
                     UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
                     UrlRewrite::STORE_ID    => $storeId,
+                    UrlRewrite::REDIRECT_TYPE => 0,
                 ];
                 if ($categoryId) {
                     $filterData[UrlRewrite::METADATA]['category_id'] = $categoryId;


### PR DESCRIPTION
This commit adds the UrlRewrite::REDIRECT_TYPE => 0 parameter to the product URL filter data, ensuring that only non-redirect URL rewrites are  considered when generating product URLs.
This aligns the Algolia URL generation  with Magento's core URL handling behavior and prevents potential issues with  redirect loops or incorrect URL generation.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Adding filter redirect_type = 0
This parameter is important because: in the core Magento Catalog/Model/Product/Url.php class, it is included in the filter data, but it's missing in the Algolia extension's version.**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Without this parameter, the URL finder might return redirect URLs instead of direct URLs, which could lead to redirect chains or incorrect URL generation.**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->