### PR TITLE
MAGE-1394 queue clear CLI

### DIFF
--- a/Console/Command/AbstractStoreCommand.php
+++ b/Console/Command/AbstractStoreCommand.php
@@ -127,10 +127,10 @@ abstract class AbstractStoreCommand extends Command
             : "<info>$msg</info>";
     }
 
-    protected function confirmOperation(string $okMessage = '', string $cancelMessage = 'Operation cancelled'): bool
+    protected function confirmOperation(string $okMessage = '', string $cancelMessage = 'Operation cancelled', bool $default = false): bool
     {
         $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion('<question>Are you sure wish to proceed? (y/n)</question> ', false);
+        $question = new ConfirmationQuestion('<question>Are you sure wish to proceed? (y/n)</question> ', $default);
         if (!$helper->ask($this->input, $this->output, $question)) {
             if ($cancelMessage) {
                 $this->output->writeln("<comment>$cancelMessage</comment>");

--- a/Console/Command/Queue/ClearQueueCommand.php
+++ b/Console/Command/Queue/ClearQueueCommand.php
@@ -89,7 +89,8 @@ class ClearQueueCommand extends AbstractStoreCommand
         $this->output->writeln('<fg=red>WARNING:</fg=red> This will clear all pending indexing jobs from the queue for the specified store(s). This action cannot be undone!');
         return $this->confirmOperation(
             'Indexing queue clear operation confirmed',
-            'Indexing queue clear operation cancelled'
+            'Indexing queue clear operation cancelled',
+            true
         );
     }
 

--- a/Console/Command/Queue/ClearQueueCommand.php
+++ b/Console/Command/Queue/ClearQueueCommand.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Console\Command\Queue;
+
+use Algolia\AlgoliaSearch\Console\Command\AbstractStoreCommand;
+use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResourceModel;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Magento\Framework\App\State;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ClearQueueCommand extends AbstractStoreCommand
+{
+    public function __construct(
+        protected State                 $state,
+        protected StoreNameFetcher      $storeNameFetcher,
+        protected StoreManagerInterface $storeManager,
+        protected JobResourceModel      $jobResourceModel,
+        ?string                         $name = null
+    ) {
+        parent::__construct($state, $storeNameFetcher, $name);
+    }
+
+    protected function getCommandPrefix(): string
+    {
+        return parent::getCommandPrefix() . 'queue:';
+    }
+
+    protected function getCommandName(): string
+    {
+        return 'clear';
+    }
+
+    protected function getCommandDescription(): string
+    {
+        return "Clear the indexing queue for specified store(s) or all stores. This will remove all pending indexing tasks from the queue.";
+    }
+
+    protected function getStoreArgumentDescription(): string
+    {
+        return 'ID(s) for store(s) to clear indexing queue (optional), if not specified, indexing queue for all stores will be cleared. Pass multiple store IDs as a list of integers separated by spaces. e.g.: <info>bin/magento algolia:queue:clear 1 2 3</info>';
+    }
+
+    protected function getAdditionalDefinition(): array
+    {
+        return [];
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input = $input;
+        $this->output = $output;
+        $this->setAreaCode();
+
+        if (!$this->confirmClearOperation()) {
+            return Cli::RETURN_SUCCESS;
+        }
+
+        $storeIds = $this->getStoreIds($input);
+
+        $output->writeln($this->decorateOperationAnnouncementMessage('Clearing indexing queue for {{target}}', $storeIds));
+
+        try {
+            $this->clearIndexingQueue($storeIds);
+        } catch (\Exception $e) {
+            $this->output->writeln('<error>' . $e->getMessage() . '</error>');
+            return Cli::RETURN_FAILURE;
+        }
+
+        $output->writeln('<info>Indexing queue cleared successfully!</info>');
+        return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * Confirm the clear operation as it's destructive
+     *
+     * @return bool
+     */
+    protected function confirmClearOperation(): bool
+    {
+        $this->output->writeln('<fg=red>WARNING:</fg=red> This will clear all pending indexing jobs from the queue for the specified store(s). This action cannot be undone!');
+        return $this->confirmOperation(
+            'Indexing queue clear operation confirmed',
+            'Indexing queue clear operation cancelled'
+        );
+    }
+
+    /**
+     * Clear indexing queue for specified stores or all stores
+     *
+     * @param array $storeIds
+     * @throws NoSuchEntityException
+     */
+    public function clearIndexingQueue(array $storeIds = []): void
+    {
+        if (count($storeIds)) {
+            foreach ($storeIds as $storeId) {
+                $this->clearIndexingQueueForStore($storeId);
+            }
+        } else {
+            $this->clearIndexingQueueForAllStores();
+        }
+    }
+
+    /**
+     * Clear indexing queue for a specific store
+     *
+     * @param int $storeId
+     * @throws NoSuchEntityException
+     */
+    public function clearIndexingQueueForStore(int $storeId): void
+    {
+        $storeName = $this->storeNameFetcher->getStoreName($storeId);
+        $this->output->writeln('<info>Clearing indexing queue for ' . $storeName . '...</info>');
+
+        try {
+            // Clear the indexing queue for this store
+            // Note: You'll need to implement the actual queue clearing logic based on your queue implementation
+            $this->clearQueueForStore($storeId);
+
+            $this->output->writeln('<info>✓ Indexing queue cleared for ' . $storeName . '</info>');
+        } catch (\Exception $e) {
+            $this->output->writeln('<error>✗ Failed to clear indexing queue for ' . $storeName . ': ' . $e->getMessage() . '</error>');
+        }
+    }
+
+    /**
+     * Clear indexing queue for all stores
+     *
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function clearIndexingQueueForAllStores(): void
+    {
+        $connection = $this->jobResourceModel->getConnection();
+        $connection->truncateTable($this->jobResourceModel->getMainTable());
+    }
+
+    /**
+     * Clear the actual queue for a specific store
+     * This method should be implemented based on your specific queue implementation
+     *
+     * @param int $storeId
+     * @throws \Exception
+     */
+    protected function clearQueueForStore(int $storeId): void
+    {
+        throw new \Exception('Queue clearing method not implemented by store');
+    }
+}

--- a/Console/Command/Queue/ProcessQueueCommand.php
+++ b/Console/Command/Queue/ProcessQueueCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Console\Command\Indexer;
+namespace Algolia\AlgoliaSearch\Console\Command\Queue;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Model\Queue;
@@ -29,7 +29,7 @@ class ProcessQueueCommand extends Command
 
     protected function getCommandName(): string
     {
-        return 'algolia:reindex:process_queue';
+        return 'algolia:queue:process';
     }
 
     protected function getCommandDescription(): string
@@ -40,7 +40,8 @@ class ProcessQueueCommand extends Command
     protected function configure(): void
     {
         $this->setName($this->getCommandName())
-            ->setDescription($this->getCommandDescription());
+            ->setDescription($this->getCommandDescription())
+            ->setAliases(['algolia:reindex:process_queue']);
 
         parent::configure();
     }

--- a/Console/Command/Replica/AbstractReplicaCommand.php
+++ b/Console/Command/Replica/AbstractReplicaCommand.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Console\Command;
+namespace Algolia\AlgoliaSearch\Console\Command\Replica;
+
+use Algolia\AlgoliaSearch\Console\Command\AbstractStoreCommand;
 
 abstract class AbstractReplicaCommand extends AbstractStoreCommand
 {

--- a/Console/Command/Replica/ReplicaDeleteCommand.php
+++ b/Console/Command/Replica/ReplicaDeleteCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Console\Command;
+namespace Algolia\AlgoliaSearch\Console\Command\Replica;
 
 use Algolia\AlgoliaSearch\Api\Console\ReplicaDeleteCommandInterface;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;

--- a/Console/Command/Replica/ReplicaDisableVirtualCommand.php
+++ b/Console/Command/Replica/ReplicaDisableVirtualCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Console\Command;
+namespace Algolia\AlgoliaSearch\Console\Command\Replica;
 
 use Algolia\AlgoliaSearch\Api\Console\ReplicaSyncCommandInterface;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;

--- a/Console/Command/Replica/ReplicaRebuildCommand.php
+++ b/Console/Command/Replica/ReplicaRebuildCommand.php
@@ -1,32 +1,35 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Console\Command;
+namespace Algolia\AlgoliaSearch\Console\Command\Replica;
 
+use Algolia\AlgoliaSearch\Api\Console\ReplicaDeleteCommandInterface;
 use Algolia\AlgoliaSearch\Api\Console\ReplicaSyncCommandInterface;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Console\Traits\ReplicaDeleteCommandTrait;
 use Algolia\AlgoliaSearch\Console\Traits\ReplicaSyncCommandTrait;
 use Algolia\AlgoliaSearch\Exception\ReplicaLimitExceededException;
-use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
-use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Registry\ReplicaState;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use Magento\Framework\App\State as AppState;
 use Magento\Framework\Console\Cli;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCommandInterface
+class ReplicaRebuildCommand
+    extends AbstractReplicaCommand
+    implements ReplicaSyncCommandInterface, ReplicaDeleteCommandInterface
 {
     use ReplicaSyncCommandTrait;
+    use ReplicaDeleteCommandTrait;
 
     public function __construct(
         protected ReplicaManagerInterface $replicaManager,
         protected ProductHelper           $productHelper,
         protected StoreManagerInterface   $storeManager,
+        protected ReplicaState            $replicaState,
         AppState                          $appState,
         StoreNameFetcher                  $storeNameFetcher,
         ?string                           $name = null
@@ -37,17 +40,17 @@ class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCo
 
     protected function getCommandName(): string
     {
-        return 'sync';
+        return 'rebuild';
     }
 
     protected function getCommandDescription(): string
     {
-        return 'Sync configured sorting attributes in Magento to Algolia replica indices';
+        return "Delete and rebuild replica configuration for Magento sorting attributes (only run this operation if errors are encountered during regular sync)";
     }
 
     protected function getStoreArgumentDescription(): string
     {
-        return 'ID(s) for store(s) to be synced with Algolia (optional), if not specified all stores will be synced';
+        return 'ID(s) for store(s) to rebuild replicas (optional), if not specified all store replicas will be rebuilt';
     }
 
     protected function getAdditionalDefinition(): array
@@ -55,16 +58,6 @@ class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCo
         return [];
     }
 
-    /**
-     * @inheritDoc
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @return int
-     * @throws AlgoliaException
-     * @throws ExceededRetriesException
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
@@ -72,21 +65,42 @@ class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCo
 
         $storeIds = $this->getStoreIds($input);
 
-        $output->writeln($this->decorateOperationAnnouncementMessage('Syncing replicas for {{target}}', $storeIds));
+        $output->writeln($this->decorateOperationAnnouncementMessage('Rebuilding replicas for {{target}}', $storeIds));
+
+        $this->deleteReplicas($storeIds);
+        $this->forceState($storeIds);
 
         try {
             $this->syncReplicas($storeIds);
-        } catch (BadRequestException) {
-            $this->output->writeln('<comment>You appear to have a corrupted replica configuration in Algolia for your Magento instance.</comment>');
-            $this->output->writeln('<comment>Run the "algolia:replicas:rebuild" command to correct this.</comment>');
-            return CLI::RETURN_FAILURE;
         } catch (ReplicaLimitExceededException $e) {
             $this->output->writeln('<error>' . $e->getMessage() . '</error>');
             $this->output->writeln('<comment>Reduce the number of sorting attributes that have enabled virtual replicas and try again.</comment>');
             return CLI::RETURN_FAILURE;
+        } catch (BadRequestException $e) {
+            $this->output->writeln('<error>' . $e->getMessage() . '</error>');
+            if ($storeIds) {
+                $this->output->writeln('<comment>Your Algolia application may contain cris-crossed replicas. Try running "algolia:replicas:rebuild" for all stores to correct this.');
+            }
+            return CLI::RETURN_FAILURE;
         }
 
         return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * Force the replica change state to always sync the replica configuration
+     * Also serves to avoid latency from Algolia API when reading replica configuration for comparison with local Magento config
+     * @param int[] $storeIds
+     * @return void
+     */
+    protected function forceState(array $storeIds): void
+    {
+        if (!count($storeIds)) {
+            $storeIds = array_keys($this->storeManager->getStores());
+        }
+        foreach ($storeIds as $storeId) {
+            $this->replicaState->setChangeState(ReplicaState::REPLICA_STATE_CHANGED, $storeId);
+        }
     }
 
 }

--- a/Console/Command/Replica/ReplicaSyncCommand.php
+++ b/Console/Command/Replica/ReplicaSyncCommand.php
@@ -1,35 +1,32 @@
 <?php
 
-namespace Algolia\AlgoliaSearch\Console\Command;
+namespace Algolia\AlgoliaSearch\Console\Command\Replica;
 
-use Algolia\AlgoliaSearch\Api\Console\ReplicaDeleteCommandInterface;
 use Algolia\AlgoliaSearch\Api\Console\ReplicaSyncCommandInterface;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
-use Algolia\AlgoliaSearch\Console\Traits\ReplicaDeleteCommandTrait;
 use Algolia\AlgoliaSearch\Console\Traits\ReplicaSyncCommandTrait;
 use Algolia\AlgoliaSearch\Exception\ReplicaLimitExceededException;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\BadRequestException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
-use Algolia\AlgoliaSearch\Registry\ReplicaState;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use Magento\Framework\App\State as AppState;
 use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ReplicaRebuildCommand
-    extends AbstractReplicaCommand
-    implements ReplicaSyncCommandInterface, ReplicaDeleteCommandInterface
+class ReplicaSyncCommand extends AbstractReplicaCommand implements ReplicaSyncCommandInterface
 {
     use ReplicaSyncCommandTrait;
-    use ReplicaDeleteCommandTrait;
 
     public function __construct(
         protected ReplicaManagerInterface $replicaManager,
         protected ProductHelper           $productHelper,
         protected StoreManagerInterface   $storeManager,
-        protected ReplicaState            $replicaState,
         AppState                          $appState,
         StoreNameFetcher                  $storeNameFetcher,
         ?string                           $name = null
@@ -40,17 +37,17 @@ class ReplicaRebuildCommand
 
     protected function getCommandName(): string
     {
-        return 'rebuild';
+        return 'sync';
     }
 
     protected function getCommandDescription(): string
     {
-        return "Delete and rebuild replica configuration for Magento sorting attributes (only run this operation if errors are encountered during regular sync)";
+        return 'Sync configured sorting attributes in Magento to Algolia replica indices';
     }
 
     protected function getStoreArgumentDescription(): string
     {
-        return 'ID(s) for store(s) to rebuild replicas (optional), if not specified all store replicas will be rebuilt';
+        return 'ID(s) for store(s) to be synced with Algolia (optional), if not specified all stores will be synced';
     }
 
     protected function getAdditionalDefinition(): array
@@ -58,6 +55,16 @@ class ReplicaRebuildCommand
         return [];
     }
 
+    /**
+     * @inheritDoc
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     * @throws AlgoliaException
+     * @throws ExceededRetriesException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
@@ -65,42 +72,21 @@ class ReplicaRebuildCommand
 
         $storeIds = $this->getStoreIds($input);
 
-        $output->writeln($this->decorateOperationAnnouncementMessage('Rebuilding replicas for {{target}}', $storeIds));
-
-        $this->deleteReplicas($storeIds);
-        $this->forceState($storeIds);
+        $output->writeln($this->decorateOperationAnnouncementMessage('Syncing replicas for {{target}}', $storeIds));
 
         try {
             $this->syncReplicas($storeIds);
+        } catch (BadRequestException) {
+            $this->output->writeln('<comment>You appear to have a corrupted replica configuration in Algolia for your Magento instance.</comment>');
+            $this->output->writeln('<comment>Run the "algolia:replicas:rebuild" command to correct this.</comment>');
+            return CLI::RETURN_FAILURE;
         } catch (ReplicaLimitExceededException $e) {
             $this->output->writeln('<error>' . $e->getMessage() . '</error>');
             $this->output->writeln('<comment>Reduce the number of sorting attributes that have enabled virtual replicas and try again.</comment>');
             return CLI::RETURN_FAILURE;
-        } catch (BadRequestException $e) {
-            $this->output->writeln('<error>' . $e->getMessage() . '</error>');
-            if ($storeIds) {
-                $this->output->writeln('<comment>Your Algolia application may contain cris-crossed replicas. Try running "algolia:replicas:rebuild" for all stores to correct this.');
-            }
-            return CLI::RETURN_FAILURE;
         }
 
         return Cli::RETURN_SUCCESS;
-    }
-
-    /**
-     * Force the replica change state to always sync the replica configuration
-     * Also serves to avoid latency from Algolia API when reading replica configuration for comparison with local Magento config
-     * @param int[] $storeIds
-     * @return void
-     */
-    protected function forceState(array $storeIds): void
-    {
-        if (!count($storeIds)) {
-            $storeIds = array_keys($this->storeManager->getStores());
-        }
-        foreach ($storeIds as $storeId) {
-            $this->replicaState->setChangeState(ReplicaState::REPLICA_STATE_CHANGED, $storeId);
-        }
     }
 
 }

--- a/Test/Integration/Indexing/Product/MultiStoreReplicaTest.php
+++ b/Test/Integration/Indexing/Product/MultiStoreReplicaTest.php
@@ -3,8 +3,8 @@
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Product;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
-use Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand;
-use Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand;
+use Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaRebuildCommand;
+use Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaSyncCommand;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder as ProductIndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Service\Product\SortingTransformer;

--- a/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
@@ -2,7 +2,6 @@
 
 namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Product;
 
-use Algolia\AlgoliaSearch\Algolia;
 use Algolia\AlgoliaSearch\Api\LoggerInterface;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
@@ -11,15 +10,14 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
-use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
-use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder;
-use Algolia\AlgoliaSearch\Test\Integration\Indexing\Product\Traits\ReplicaAssertionsTrait;
 use Algolia\AlgoliaSearch\Registry\ReplicaState;
-use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Service\Product\ReplicaManager;
 use Algolia\AlgoliaSearch\Service\Product\SortingTransformer;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
+use Algolia\AlgoliaSearch\Test\Integration\Indexing\Product\Traits\ReplicaAssertionsTrait;
 use Algolia\AlgoliaSearch\Test\Integration\TestCase;
 use Algolia\AlgoliaSearch\Validator\VirtualReplicaValidatorFactory;
 use Magento\Framework\App\State as AppState;
@@ -157,7 +155,7 @@ class ReplicaIndexingTest extends TestCase
 
         $sorting = $this->populateReplicas(1);
 
-        $rebuildCmd = $this->objectManager->get(\Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand::class);
+        $rebuildCmd = $this->objectManager->get(\Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaRebuildCommand::class);
         $this->invokeMethod(
             $rebuildCmd,
             'execute',
@@ -410,7 +408,7 @@ class ReplicaIndexingTest extends TestCase
     {
         $sorting = $this->objectManager->get(\Algolia\AlgoliaSearch\Service\Product\SortingTransformer::class)->getSortingIndices($storeId, null, null, true);
 
-        $cmd = $this->objectManager->get(\Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand::class);
+        $cmd = $this->objectManager->get(\Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaSyncCommand::class);
 
         $this->mockProperty($cmd, 'output', \Symfony\Component\Console\Output\OutputInterface::class);
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -147,21 +147,26 @@
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
+                <!-- Replicas -->
                 <item name="replica_sync_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand</item>
                 <item name="replica_delete_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDeleteCommand</item>
                 <item name="replica_rebuild_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand</item>
                 <item name="replica_disable_virtual_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDisableVirtualCommand</item>
                 <item name="synonym_deduplicate_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\SynonymDeduplicateCommand</item>
                 <item name="batching_optimize_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\BatchingOptimizeCommand</item>
-                <!-- custom indexers -->
+
+                <!-- Custom indexers -->
                 <item name="reindex_products_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\IndexProductsCommand</item>
                 <item name="reindex_categories_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\IndexCategoriesCommand</item>
                 <item name="reindex_pages_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\IndexPagesCommand</item>
                 <item name="reindex_suggestions_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\IndexSuggestionsCommand</item>
                 <item name="reindex_additional_sections_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\IndexAdditionalSectionsCommand</item>
                 <item name="delete_products_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\DeleteProductsCommand</item>
-                <item name="process_queue_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\ProcessQueueCommand</item>
                 <item name="reindex_all_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\IndexAllCommand</item>
+
+                <!-- Queue processing-->
+                <item name="process_queue_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Queue\ProcessQueueCommand</item>
+                <item name="clear_queue_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Queue\ClearQueueCommand</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -254,19 +254,26 @@
             <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
         </arguments>
     </type>
-    <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\ProcessQueueCommand">
-        <arguments>
-            <argument name="configHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\ConfigHelper\Proxy</argument>
-            <argument name="queue" xsi:type="object">Algolia\AlgoliaSearch\Model\Queue\Proxy</argument>
-            <argument name="algoliaCredentialsManager" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager\Proxy</argument>
-        </arguments>
-    </type>
     <type name="Algolia\AlgoliaSearch\Console\Command\Indexer\IndexAllCommand">
         <arguments>
             <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
         </arguments>
     </type>
     <!-- custom indexers END -->
+
+    <!-- queue handling -->
+    <type name="Algolia\AlgoliaSearch\Console\Command\Queue\ProcessQueueCommand">
+        <arguments>
+            <argument name="configHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\ConfigHelper\Proxy</argument>
+            <argument name="queue" xsi:type="object">Algolia\AlgoliaSearch\Model\Queue\Proxy</argument>
+            <argument name="algoliaCredentialsManager" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Console\Command\Queue\ClearQueueCommand">
+        <arguments>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+        </arguments>
+    </type>
 
     <type name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger">
         <arguments>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -148,12 +148,10 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <!-- Replicas -->
-                <item name="replica_sync_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand</item>
-                <item name="replica_delete_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDeleteCommand</item>
-                <item name="replica_rebuild_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand</item>
-                <item name="replica_disable_virtual_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\ReplicaDisableVirtualCommand</item>
-                <item name="synonym_deduplicate_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\SynonymDeduplicateCommand</item>
-                <item name="batching_optimize_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\BatchingOptimizeCommand</item>
+                <item name="replica_sync_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaSyncCommand</item>
+                <item name="replica_delete_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaDeleteCommand</item>
+                <item name="replica_rebuild_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaRebuildCommand</item>
+                <item name="replica_disable_virtual_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaDisableVirtualCommand</item>
 
                 <!-- Custom indexers -->
                 <item name="reindex_products_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Indexer\IndexProductsCommand</item>
@@ -167,53 +165,41 @@
                 <!-- Queue processing-->
                 <item name="process_queue_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Queue\ProcessQueueCommand</item>
                 <item name="clear_queue_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\Queue\ClearQueueCommand</item>
+
+                <!-- Misc -->
+                <item name="synonym_deduplicate_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\SynonymDeduplicateCommand</item>
+                <item name="batching_optimize_command" xsi:type="object">Algolia\AlgoliaSearch\Console\Command\BatchingOptimizeCommand</item>
+
             </argument>
         </arguments>
     </type>
 
-    <type name="Algolia\AlgoliaSearch\Console\Command\ReplicaSyncCommand">
+    <!-- Replicas -->
+    <type name="Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaSyncCommand">
         <arguments>
             <argument name="replicaManager" xsi:type="object">Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface\Proxy</argument>
             <argument name="productHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\Entity\ProductHelper\Proxy</argument>
         </arguments>
     </type>
 
-    <type name="Algolia\AlgoliaSearch\Console\Command\ReplicaDeleteCommand">
+    <type name="Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaDeleteCommand">
         <arguments>
             <argument name="replicaManager" xsi:type="object">Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface\Proxy</argument>
         </arguments>
     </type>
 
-    <type name="Algolia\AlgoliaSearch\Console\Command\ReplicaRebuildCommand">
+    <type name="Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaRebuildCommand">
         <arguments>
             <argument name="replicaManager" xsi:type="object">Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface\Proxy</argument>
             <argument name="productHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\Entity\ProductHelper\Proxy</argument>
         </arguments>
     </type>
 
-    <type name="Algolia\AlgoliaSearch\Console\Command\ReplicaDisableVirtualCommand">
+    <type name="Algolia\AlgoliaSearch\Console\Command\Replica\ReplicaDisableVirtualCommand">
         <arguments>
             <argument name="configHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\ConfigHelper\Proxy</argument>
             <argument name="replicaManager" xsi:type="object">Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface\Proxy</argument>
             <argument name="productHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\Entity\ProductHelper\Proxy</argument>
-        </arguments>
-    </type>
-
-    <type name="Algolia\AlgoliaSearch\Console\Command\SynonymDeduplicateCommand">
-        <arguments>
-            <argument name="algoliaConnector" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaConnector\Proxy</argument>
-            <argument name="indexOptionsBuilder" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder\Proxy</argument>
-        </arguments>
-    </type>
-
-    <type name="Algolia\AlgoliaSearch\Console\Command\BatchingOptimizeCommand">
-        <arguments>
-            <argument name="algoliaConnector" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaConnector\Proxy</argument>
-            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
-            <argument name="indexOptionsBuilder" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder\Proxy</argument>
-            <argument name="productHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\Entity\ProductHelper\Proxy</argument>
-            <argument name="recordBuilder" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\RecordBuilder\Proxy</argument>
-            <argument name="configHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\ConfigHelper\Proxy</argument>
         </arguments>
     </type>
 
@@ -274,6 +260,26 @@
             <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
         </arguments>
     </type>
+
+    <!-- Misc commands -->
+    <type name="Algolia\AlgoliaSearch\Console\Command\SynonymDeduplicateCommand">
+        <arguments>
+            <argument name="algoliaConnector" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaConnector\Proxy</argument>
+            <argument name="indexOptionsBuilder" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder\Proxy</argument>
+        </arguments>
+    </type>
+
+    <type name="Algolia\AlgoliaSearch\Console\Command\BatchingOptimizeCommand">
+        <arguments>
+            <argument name="algoliaConnector" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaConnector\Proxy</argument>
+            <argument name="storeNameFetcher" xsi:type="object">Algolia\AlgoliaSearch\Service\StoreNameFetcher\Proxy</argument>
+            <argument name="indexOptionsBuilder" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder\Proxy</argument>
+            <argument name="productHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\Entity\ProductHelper\Proxy</argument>
+            <argument name="recordBuilder" xsi:type="object">Algolia\AlgoliaSearch\Service\Product\RecordBuilder\Proxy</argument>
+            <argument name="configHelper" xsi:type="object">Algolia\AlgoliaSearch\Helper\ConfigHelper\Proxy</argument>
+        </arguments>
+    </type>
+
 
     <type name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger">
         <arguments>


### PR DESCRIPTION
**Summary**

To help support advanced scripting for deployments and testing this PR provides an "algolia:queue:clear" command.

- Supports non-interactive mode for scripting
  e.g.
  ```
  bin/magento algolia:queue:clear -n 
  ```

- Supports store specific queue clear operations
- Reorganizes existing CLIs for 3.17
- Provides an alias for `algolia:reindex:process_queue`


**Result**
<img width="2488" height="272" alt="image" src="https://github.com/user-attachments/assets/8556f323-c430-41ec-a755-aad4a9b6c877" />

**Todo**

Supply unit tests
