### PR TITLE
MAGE-1110: Indexing Queue updates

### DIFF
--- a/Model/Job.php
+++ b/Model/Job.php
@@ -33,11 +33,11 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     protected $_eventPrefix = 'algoliasearch_queue_job';
 
     public function __construct(
-        protected Context                $context,
-        protected Registry               $registry,
+        Context                          $context,
+        Registry                         $registry,
         protected ObjectManagerInterface $objectManager,
-        protected ?AbstractResource      $resource = null,
-        protected ?AbstractDb            $resourceCollection = null,
+        ?AbstractResource                $resource = null,
+        ?AbstractDb                      $resourceCollection = null,
         array                            $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -32,28 +32,15 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
 {
     protected $_eventPrefix = 'algoliasearch_queue_job';
 
-    /** @var ObjectManagerInterface */
-    protected ObjectManagerInterface $objectManager;
-
-    /**
-     * @param Context                $context
-     * @param Registry               $registry
-     * @param ObjectManagerInterface $objectManager
-     * @param AbstractResource|null  $resource
-     * @param AbstractDb|null        $resourceCollection
-     * @param array                  $data
-     */
     public function __construct(
-        Context                $context,
-        Registry               $registry,
-        ObjectManagerInterface $objectManager,
-        ?AbstractResource      $resource = null,
-        ?AbstractDb            $resourceCollection = null,
-        array                  $data = []
+        protected Context                $context,
+        protected Registry               $registry,
+        protected ObjectManagerInterface $objectManager,
+        protected ?AbstractResource      $resource = null,
+        protected ?AbstractDb            $resourceCollection = null,
+        array                            $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
-
-        $this->objectManager = $objectManager;
     }
 
     /**
@@ -61,7 +48,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
      *
      * @return void
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(ResourceModel\Job::class);
     }
@@ -71,7 +58,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
      * @throws AlreadyExistsException|\Exception
      *
      */
-    public function execute()
+    public function execute(): Job
     {
         $model = $this->objectManager->get($this->getClass());
         $method = $this->getMethod();
@@ -89,7 +76,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     /**
      * @return $this
      */
-    public function prepare()
+    public function prepare(): Job
     {
         if ($this->getMergedIds() === null) {
             $this->setMergedIds([$this->getId()]);
@@ -99,10 +86,6 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
             $decodedData = json_decode((string) $this->getData('data'), true);
 
             $this->setDecodedData($decodedData);
-
-            if (isset($decodedData['store_id'])) {
-                $this->setStoreId($decodedData['store_id']);
-            }
 
             if (isset($decodedData['storeId'])) {
                 $this->setStoreId($decodedData['storeId']);
@@ -118,7 +101,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
      *
      * @return bool
      */
-    public function canMerge(Job $job, $maxJobDataSize)
+    public function canMerge(Job $job, $maxJobDataSize): bool
     {
         if ($this->getClass() !== $job->getClass()) {
             return false;
@@ -156,7 +139,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
      *
      * @return Job
      */
-    public function merge(Job $mergedJob)
+    public function merge(Job $mergedJob): Job
     {
         $mergedIds = $this->getMergedIds();
         array_push($mergedIds, $mergedJob->getId());
@@ -186,7 +169,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     /**
      * @return array
      */
-    public function getDefaultValues()
+    public function getDefaultValues(): array
     {
         $values = [];
 
@@ -196,7 +179,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
     /**
      * @return string
      */
-    public function getStatus()
+    public function getStatus(): string
     {
         $status = JobInterface::STATUS_PROCESSING;
 
@@ -218,7 +201,7 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
      *
      * @return Job
      */
-    public function saveError(\Exception $e)
+    public function saveError(\Exception $e): Job
     {
         $this->setErrorLog($e->getMessage());
         $this->getResource()->save($this);

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -483,7 +483,12 @@ class Queue
     protected function getStoreMaxBatchSize(int $storeId): int
     {
         if (!isset($this->storeMaxBatchSizes[$storeId])) {
-            $this->storeMaxBatchSizes[$storeId] = $this->configHelper->getNumberOfElementByPage($storeId);
+            try {
+                $this->storeMaxBatchSizes[$storeId] = $this->configHelper->getNumberOfElementByPage($storeId);
+            } catch (\Exception $e) {
+                // In case a job was created before a store deletion
+                $this->storeMaxBatchSizes[$storeId] = $this->configHelper->getNumberOfElementByPage();
+            }
         }
 
         return $this->storeMaxBatchSizes[$storeId];

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -37,12 +37,6 @@ class Queue
     protected $archiveTable;
 
     /** @var int */
-    protected $elementsPerPage;
-
-    /** @var int */
-    protected $maxSingleJobDataSize;
-
-    /** @var int */
     protected $noOfFailedJobs = 0;
 
     /** @var array */
@@ -73,9 +67,6 @@ class Queue
         $this->logTable = $resourceConnection->getTableName('algoliasearch_queue_log');
         $this->archiveTable = $resourceConnection->getTableName('algoliasearch_queue_archive');
         $this->db = $objectManager->create(ResourceConnection::class)->getConnection('core_write');
-
-        $this->elementsPerPage = $this->configHelper->getNumberOfElementByPage();
-        $this->maxSingleJobDataSize = $this->configHelper->getNumberOfElementByPage();
     }
 
     /**
@@ -513,7 +504,7 @@ class Queue
             if (count($unmergedJobs) > 0) {
                 $nextJob = array_shift($unmergedJobs);
 
-                if ($currentJob->canMerge($nextJob, $this->maxSingleJobDataSize)) {
+                if ($currentJob->canMerge($nextJob, $this->getStoreMaxBatchSize($currentJob->getStoreId()))) {
                     $currentJob->merge($nextJob);
 
                     continue;

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -21,9 +21,6 @@ class Queue
     public const UNLOCK_STACKED_JOBS_AFTER_MINUTES = 15;
     public const CLEAR_ARCHIVE_LOGS_AFTER_DAYS = 30;
 
-    public const SUCCESS_LOG = 'algoliasearch_queue_log.txt';
-    public const ERROR_LOG = 'algoliasearch_queue_errors.log';
-
     public const FAILED_JOB_ARCHIVE_CRITERIA = 'retries >= max_retries';
     public const MOVE_INDEX_METHOD_NAME = 'moveIndexWithSetSettings';
 
@@ -39,22 +36,8 @@ class Queue
     /** @var string */
     protected $archiveTable;
 
-    /** @var ObjectManagerInterface */
-    protected $objectManager;
-
-    /** @var ConsoleOutput */
-    protected $output;
-
     /** @var int */
     protected $elementsPerPage;
-
-    /** @var ConfigHelper */
-    protected $configHelper;
-
-    /** @var DiagnosticsLogger */
-    protected $logger;
-
-    protected $jobCollectionFactory;
 
     /** @var int */
     protected $maxSingleJobDataSize;
@@ -72,38 +55,20 @@ class Queue
     /** @var array */
     protected $logRecord;
 
-    /**
-     * @param ConfigHelper $configHelper
-     * @param DiagnosticsLogger $logger
-     * @param JobCollectionFactory $jobCollectionFactory
-     * @param ResourceConnection $resourceConnection
-     * @param ObjectManagerInterface $objectManager
-     * @param ConsoleOutput $output
-     */
     public function __construct(
-        ConfigHelper           $configHelper,
-        DiagnosticsLogger      $logger,
-        JobCollectionFactory   $jobCollectionFactory,
-        ResourceConnection     $resourceConnection,
-        ObjectManagerInterface $objectManager,
-        ConsoleOutput          $output
+        protected ConfigHelper           $configHelper,
+        protected DiagnosticsLogger      $logger,
+        protected JobCollectionFactory   $jobCollectionFactory,
+        protected ResourceConnection     $resourceConnection,
+        protected ObjectManagerInterface $objectManager,
+        protected ConsoleOutput          $output
     ) {
-        $this->configHelper = $configHelper;
-        $this->logger = $logger;
-        $this->jobCollectionFactory = $jobCollectionFactory;
-
         $this->table = $resourceConnection->getTableName('algoliasearch_queue');
         $this->logTable = $resourceConnection->getTableName('algoliasearch_queue_log');
         $this->archiveTable = $resourceConnection->getTableName('algoliasearch_queue_archive');
-
-        //$this->db = $resourceConnection->getConnection();
-
-        $this->objectManager = $objectManager;
         $this->db = $objectManager->create(ResourceConnection::class)->getConnection('core_write');
-        $this->output = $output;
 
         $this->elementsPerPage = $this->configHelper->getNumberOfElementByPage();
-
         $this->maxSingleJobDataSize = $this->configHelper->getNumberOfElementByPage();
     }
 

--- a/Service/Category/BatchQueueProcessor.php
+++ b/Service/Category/BatchQueueProcessor.php
@@ -41,7 +41,7 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
             return;
         }
 
-        $categoriesPerPage = $this->configHelper->getNumberOfElementByPage();
+        $categoriesPerPage = $this->configHelper->getNumberOfElementByPage($storeId);
 
         if (is_array($entityIds) && count($entityIds) > 0) {
             $this->processSpecificCategories($entityIds, $categoriesPerPage, $storeId);

--- a/Service/Category/IndexBuilder.php
+++ b/Service/Category/IndexBuilder.php
@@ -117,14 +117,14 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             }
 
             if ($size > 0) {
-                $pages = ceil($size / $this->configHelper->getNumberOfElementByPage());
+                $pages = ceil($size / $this->configHelper->getNumberOfElementByPage($storeId));
                 $page = 1;
                 while ($page <= $pages) {
                     $this->buildIndexPage(
                         $storeId,
                         $collection,
                         $page,
-                        $this->configHelper->getNumberOfElementByPage(),
+                        $this->configHelper->getNumberOfElementByPage($storeId),
                         $categoryIds
                     );
                     $page++;

--- a/Service/Product/BatchQueueProcessor.php
+++ b/Service/Product/BatchQueueProcessor.php
@@ -51,7 +51,7 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
             return;
         }
 
-        $productsPerPage = $this->configHelper->getNumberOfElementByPage();
+        $productsPerPage = $this->configHelper->getNumberOfElementByPage($storeId);
 
         if (!empty($entityIds)) {
             $this->handleDeltaIndex($entityIds, $storeId, $productsPerPage);

--- a/Service/Suggestion/IndexBuilder.php
+++ b/Service/Suggestion/IndexBuilder.php
@@ -75,7 +75,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
         $size = $collection->getSize();
 
         if ($size > 0) {
-            $pages = ceil($size / $this->configHelper->getNumberOfElementByPage());
+            $pages = ceil($size / $this->configHelper->getNumberOfElementByPage($storeId));
             $collection->clear();
             $page = 1;
 
@@ -84,7 +84,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
                     $storeId,
                     $collection,
                     $page,
-                    $this->configHelper->getNumberOfElementByPage()
+                    $this->configHelper->getNumberOfElementByPage($storeId)
                 );
                 $page++;
             }

--- a/Test/Integration/Indexing/Queue/QueueTest.php
+++ b/Test/Integration/Indexing/Queue/QueueTest.php
@@ -848,7 +848,7 @@ class QueueTest extends TestCase
         /** @var Job[] $jobs */
         $jobs = $this->invokeMethod($this->queue, 'getJobs', ['maxJobs' => 10]);
 
-        $this->assertEquals(1, count($jobs));
+        $this->assertEquals(2, count($jobs));
 
         $job = reset($jobs);
         $this->assertEquals(5000, $job->getDataSize());
@@ -862,7 +862,7 @@ class QueueTest extends TestCase
         $lastJob = end($dbJobs);
 
         $this->assertEquals($pid, $firstJob['pid']);
-        $this->assertNull($lastJob['pid']);
+        $this->assertEquals($pid, $lastJob['pid']);
     }
 
     /**


### PR DESCRIPTION
This PR contains:
- Some cleaning on the `Queue` and `Job` models
- A new way of calculating maximum batch size in the queue, now we take into account the values defined at store level instead of the default one. This allows to take the values set by the batching optimizer into consideration.
- Added some missing store scopings
- Fixed a merge test