### PR TITLE
MAGE-1391: Update maximum batch size config

### DIFF
--- a/Console/Command/BatchingOptimizeCommand.php
+++ b/Console/Command/BatchingOptimizeCommand.php
@@ -292,7 +292,7 @@ class BatchingOptimizeCommand extends AbstractStoreCommand
         $this->output->writeln('<fg=red>Important:</fg=red> Those numbers are estimates only. Indexing activity should be monitored after making changes to ensure batches are not exceeding the recommended size of 10 MB.');
         $this->output->writeln('<info> ============ </info>');
         $this->output->writeln(
-            'This will override your "Maximum number of records processed per indexing job" configuration to <info>' . $recommendedBatchCount . '</info> for store "' . $storeName . '".');
+            'This will override your "Maximum number of records sent per indexing request" configuration to <info>' . $recommendedBatchCount . '</info> for store "' . $storeName . '".');
         $this->output->writeln(' ');
 
         if ($this->confirmOperation()) {

--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -126,6 +126,7 @@ class ConfigHelper
     public const BACKEND_RENDERING_ALLOWED_USER_AGENTS =
         'algoliasearch_advanced/advanced/backend_rendering_allowed_user_agents';
     public const NON_CASTABLE_ATTRIBUTES = 'algoliasearch_advanced/advanced/non_castable_attributes';
+    public const NUMBER_OF_ELEMENT_BY_PAGE = 'algoliasearch_advanced/advanced/number_of_element_by_page';
     public const MAX_RECORD_SIZE_LIMIT = 'algoliasearch_advanced/advanced/max_record_size_limit';
     public const ANALYTICS_REGION = 'algoliasearch_advanced/advanced/analytics_region';
     public const CONNECTION_TIMEOUT = 'algoliasearch_advanced/advanced/connection_timeout';
@@ -137,7 +138,6 @@ class ConfigHelper
 
     // Indexing Queue advanced settings
     public const ENHANCED_QUEUE_ARCHIVE = 'algoliasearch_advanced/queue/enhanced_archive';
-    public const NUMBER_OF_ELEMENT_BY_PAGE = 'algoliasearch_advanced/queue/number_of_element_by_page';
     public const ARCHIVE_LOG_CLEAR_LIMIT = 'algoliasearch_advanced/queue/archive_clear_limit';
 
     // --- Extra index settings --- //
@@ -1294,6 +1294,15 @@ class ConfigHelper
      * @param $storeId
      * @return int
      */
+    public function getNumberOfElementByPage($storeId = null): int
+    {
+        return (int) $this->configInterface->getValue(self::NUMBER_OF_ELEMENT_BY_PAGE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return int
+     */
     public function getMaxRecordSizeLimit($storeId = null)
     {
         return (int) $this->configInterface->getValue(
@@ -1366,16 +1375,7 @@ class ConfigHelper
         return $this->configInterface->isSetFlag(self::PROFILER_ENABLED, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
-    // Indexing Queue advanced settings
-    /**
-     * @param $storeId
-     * @return int
-     */
-    public function getNumberOfElementByPage($storeId = null): int
-    {
-        return (int) $this->configInterface->getValue(self::NUMBER_OF_ELEMENT_BY_PAGE, ScopeInterface::SCOPE_STORE, $storeId);
-    }
-
+    // Indexing Queue advanced settingg
     /**
      * @param $storeId
      * @return int

--- a/Helper/Configuration/NoticeHelper.php
+++ b/Helper/Configuration/NoticeHelper.php
@@ -100,7 +100,7 @@ class NoticeHelper extends \Magento\Framework\App\Helper\AbstractHelper
                                 in approx. ' . $eta . '.
                                 You may want to <a href="' . $indexingQueuePageUrl . '">clear the queue</a> or <a href="' . $indexingQueueConfigUrl . '">configure indexing queue</a>.
                                 <br><br>
-                                Depending on your configuration set on "Advanced > Maximum number of records processed per indexing job" and if the jobs can be merged into batches, you can expect higher performances.
+                                Depending on your configuration set on "Advanced > Maximum number of records sent per indexing request" and if the jobs can be merged into batches, you can expect higher performances.
                                 <br><br>
                                 Find out more about Indexing Queue in <a href="https://www.algolia.com/doc/integration/magento-2/how-it-works/indexing-queue/?utm_source=magento&utm_medium=extension&utm_campaign=magento_2&utm_term=shop-owner&utm_content=doc-link" target="_blank">documentation</a>.';
         }

--- a/Setup/Patch/Data/MigrateBatchSizeConfigPatch.php
+++ b/Setup/Patch/Data/MigrateBatchSizeConfigPatch.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchInterface;
+
+class MigrateBatchSizeConfigPatch implements DataPatchInterface
+{
+    public function __construct(
+        protected ModuleDataSetupInterface $moduleDataSetup,
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    public function apply(): PatchInterface
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+
+        $this->moveIndexingSettings();
+
+        $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
+    }
+
+    /**
+     * Migrate old Indexing configurations
+     * @return void
+     */
+    protected function moveIndexingSettings(): void
+    {
+        $movedConfig = [
+            'algoliasearch_advanced/queue/number_of_element_by_page' => ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE,
+       ];
+
+        $connection = $this->moduleDataSetup->getConnection();
+        foreach ($movedConfig as $from => $to) {
+            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
+            $whereConfigPath = $connection->quoteInto('path = ?', $from);
+            $connection->update($configDataTable, ['path' => $to], $whereConfigPath);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/Setup/Patch/Schema/ConfigPatch.php
+++ b/Setup/Patch/Schema/ConfigPatch.php
@@ -81,7 +81,7 @@ class ConfigPatch implements SchemaPatchInterface
 
         'algoliasearch_synonyms/synonyms_group/enable_synonyms' => '0',
 
-        'algoliasearch_advanced/queue/number_of_element_by_page' => '300',
+        'algoliasearch_advanced/advanced/number_of_element_by_page' => '1000',
         'algoliasearch_advanced/advanced/remove_words_if_no_result' => 'allOptional',
         'algoliasearch_advanced/advanced/partial_update' => '0',
         'algoliasearch_advanced/advanced/customer_groups_enable' => '0',

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1518,6 +1518,15 @@
                         ]]>
                     </comment>
                 </field>
+                <field id="number_of_element_by_page" translate="label comment" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <validate>validate-digits</validate>
+                    <label>Maximum number of records sent per indexing request</label>
+                    <comment>
+                        <![CDATA[
+                            Default value is 1000.
+                        ]]>
+                    </comment>
+                </field>
                 <field id="max_record_size_limit" translate="label comment" type="text" sortOrder="96" showInDefault="1">
                     <label>Max record size limit per record</label>
                     <comment>
@@ -1578,15 +1587,6 @@
                             Indexing Queue is enabled under the "Indexing Queue / Cron" tab.
                       ]]>
                 </comment>
-                <field id="number_of_element_by_page" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <validate>validate-digits</validate>
-                    <label>Maximum number of records processed per indexing job</label>
-                    <comment>
-                        <![CDATA[
-                            Default value is 300.
-                        ]]>
-                    </comment>
-                </field>
                 <field id="archive_clear_limit" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Archive log clean limit</label>
                     <comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -121,6 +121,7 @@
         </algoliasearch_recommend>
         <algoliasearch_advanced>
             <advanced>
+                <number_of_element_by_page>1000</number_of_element_by_page>
                 <max_record_size_limit>10000</max_record_size_limit>
                 <analytics_region>us</analytics_region>
                 <connection_timeout>2</connection_timeout>
@@ -131,7 +132,6 @@
                 <enable_profiler>0</enable_profiler>
             </advanced>
             <queue>
-                <number_of_element_by_page>300</number_of_element_by_page>
                 <archive_clear_limit>30</archive_clear_limit>
                 <enhanced_archive>0</enhanced_archive>
             </queue>


### PR DESCRIPTION
This PR contains:
- Moved "Maximum number of records sent per indexing request" config
- Updated `ConfigHelper` class
- Set default value to 1000 
- Added config patch to keep existing config