### PR TITLE
MAGE-1393: fixed indexing queue notices display in phtml  (3.16.1)

### DIFF
--- a/view/adminhtml/templates/queue/status.phtml
+++ b/view/adminhtml/templates/queue/status.phtml
@@ -1,6 +1,9 @@
 <?php
 /** @var \Magento\Backend\Block\Template $block */
 /** @var \Magento\Framework\Escaper $escaper */
+
+$allowedTags = ['a', 'strong', 'br'];
+
 ?>
 <div class="algolia-admin-content">
     <div class="algolia-admin-content-wrapper">
@@ -30,18 +33,18 @@
 <?php if ($block->isQueueActive()): ?>
     <div class="message message-notice notice algolia-notice">
         <div data-ui-id="messages-message-notice">
-            <?= $escaper->escapeHtml(__('Status of the queue : <strong>%1</strong>.', $block->getQueueRunnerStatus())); ?>
-            <p><?= $escaper->escapeHtml(__('Last Update : <strong>%1</strong>.', $block->getLastQueueUpdate())); ?></p>
+            <?= $escaper->escapeHtml(__('Status of the queue : <strong>%1</strong>.', $block->getQueueRunnerStatus()), $allowedTags); ?>
+            <p><?= $escaper->escapeHtml(__('Last Update : <strong>%1</strong>.', $block->getLastQueueUpdate()), $allowedTags); ?></p>
             <?php $notices = $block->getNotices() ?>
             <?php foreach ($notices as $notice): ?>
-                <p><?= $escaper->escapeHtml($notice) ?></p>
+                <p><?= $escaper->escapeHtml($notice, $allowedTags) ?></p>
             <?php endforeach; ?>
         </div>
     </div>
     <div class="indexing-queue-logs-message algoblue">
         <div class="inner">
-            <p><?= $escaper->escapeHtml(__('See how well your indexing queue is performing by viewing your %1.', '<a href="' . $block->getUrl('*/*/log') . '">indexing queue run logs</a>')) ?></p>
-            <p><?= $escaper->escapeHtml(__('Access the %1.', '<a href="' . $block->getUrl('*/queuearchive/index') . '">Queue Archive</a>')) ?></p>
+            <p><?= $escaper->escapeHtml(__('See how well your indexing queue is performing by viewing your %1.', '<a href="' . $block->getUrl('*/*/log') . '">indexing queue run logs</a>'), $allowedTags) ?></p>
+            <p><?= $escaper->escapeHtml(__('Access the %1.', '<a href="' . $block->getUrl('*/queuearchive/index') . '">Queue Archive</a>'), $allowedTags) ?></p>
         </div>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
This PR contains:
- Backport the fix from https://github.com/algolia/algoliasearch-magento-2/pull/1804 for 3.16.1