### PR TITLE
Feat/mage 1304 performance testing

### DIFF
--- a/Console/Command/BatchingOptimizeCommand.php
+++ b/Console/Command/BatchingOptimizeCommand.php
@@ -295,7 +295,7 @@ class BatchingOptimizeCommand extends AbstractStoreCommand
             'This will override your "Maximum number of records sent per indexing request" configuration to <info>' . $recommendedBatchCount . '</info> for store "' . $storeName . '".');
         $this->output->writeln(' ');
 
-        if ($this->confirmOperation()) {
+        if ($this->confirmOperation('Applying optimized batching configuration', 'Batching optimization cancelled - settings were NOT changed', true)) {
             $this->configWriter->save(
                 ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE,
                 $recommendedBatchCount,

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -96,14 +96,19 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex($storeId);
         $collection = $this->productHelper->getProductCollectionQuery($storeId, $entityIds, $onlyVisible);
 
-        $this->buildIndexPage(
-            $storeId,
-            $collection,
-            $options['page'] ?? 1,
-            $options['pageSize'] ?? $this->configHelper->getNumberOfElementByPage($storeId),
-            $entityIds,
-            $options['useTmpIndex'] ?? false
-        );
+        try {
+            $this->buildIndexPage(
+                $storeId,
+                $collection,
+                $options['page'] ?? 1,
+                $options['pageSize'] ?? $this->configHelper->getNumberOfElementByPage($storeId),
+                $entityIds,
+                $options['useTmpIndex'] ?? false
+            );
+        } finally {
+            $collection->walk('clearInstance');
+            $collection->clear();
+        }
 
         $this->stopEmulation();
     }

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -96,19 +96,14 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex($storeId);
         $collection = $this->productHelper->getProductCollectionQuery($storeId, $entityIds, $onlyVisible);
 
-        try {
-            $this->buildIndexPage(
-                $storeId,
-                $collection,
-                $options['page'] ?? 1,
-                $options['pageSize'] ?? $this->configHelper->getNumberOfElementByPage($storeId),
-                $entityIds,
-                $options['useTmpIndex'] ?? false
-            );
-        } finally {
-            $collection->walk('clearInstance');
-            $collection->clear();
-        }
+        $this->buildIndexPage(
+            $storeId,
+            $collection,
+            $options['page'] ?? 1,
+            $options['pageSize'] ?? $this->configHelper->getNumberOfElementByPage($storeId),
+            $entityIds,
+            $options['useTmpIndex'] ?? false
+        );
 
         $this->stopEmulation();
     }


### PR DESCRIPTION
**Summary**

This contains two small changes:

- A tweak to the batch optimizer to support automated testing with non-interactive mode
- An experiment on eager memory cleanup for performance testing (mixed results - pending team review)

**Result**

You'll observe that with collection cloning removed we gain a bump in performance across the board in all scenarios as much as 37% at times on smaller data sets. (First scenario comparison.) Note that this relies on PHP's garbage collection.

With eager memory cleanup I can eke out a little more performance in some scenarios (up to 42% or more) but we lose some performance on other scenarios.
<img width="2794" height="1416" alt="image" src="https://github.com/user-attachments/assets/3b74d802-3674-4d9e-8459-a53b571ef9a1" />

Both versions of 3.17.0 are faster than 3.16.0 with the last table showing a comparison of the third scenario (this branch) against the baseline (3.16.0)