### PR TITLE
MAGE-1411 Eliminate extra hydration of products to conserve memory use

### DIFF
--- a/Console/Command/BatchingOptimizeCommand.php
+++ b/Console/Command/BatchingOptimizeCommand.php
@@ -248,6 +248,7 @@ class BatchingOptimizeCommand extends AbstractStoreCommand
         }
 
         if (!isset($this->storeCounts[$storeId])) {
+            $this->output->writeln('<info>Scanning products for store ' . $storeName . '...</info>');
             $this->setStoreCounts($storeId);
         }
 
@@ -319,8 +320,8 @@ class BatchingOptimizeCommand extends AbstractStoreCommand
         $complexProducts = $this->getProductsCollectionForStore($storeId, self::PRODUCTS_COMPLEX_TYPES);
 
         $this->storeCounts[$storeId] = [
-            'simple' => $simpleProducts->count(),
-            'complex' => $complexProducts->count()
+            'simple' => $this->getRawCount($simpleProducts),
+            'complex' => $this->getRawCount($complexProducts)
         ];
 
         $this->storeCounts[$storeId]['total'] =
@@ -373,6 +374,24 @@ class BatchingOptimizeCommand extends AbstractStoreCommand
     }
 
     /**
+     * Relying on Collection count method will unnecesarily hydrate the collection and consume memory
+     * This method will return the count of the collection without hydrating it
+     *
+     * @param Collection $collection
+     * @return int
+     */
+    protected function getRawCount(Collection $collection): int
+    {
+        $sql = $collection->getSelect()->__toString();
+
+        $connection = $collection->getConnection();
+
+        $rows = $connection->fetchAll($sql);
+
+        return count($rows);
+    }
+
+    /**
      * @param Collection $products
      * @param int $sampleSize
      * @return array
@@ -384,13 +403,10 @@ class BatchingOptimizeCommand extends AbstractStoreCommand
     protected function getProductsSizes(Collection $products, int $sampleSize): array
     {
         $stats = [];
-        $limit = 0;
+
+        $products->setPageSize($sampleSize)->setCurPage(1);
 
         foreach ($products as $product) {
-            if ($limit >= $sampleSize) {
-                break;
-            }
-
             $serializedRecord = json_encode($this->recordBuilder->buildRecord($product));
 
             if (function_exists('mb_strlen')) {
@@ -400,7 +416,6 @@ class BatchingOptimizeCommand extends AbstractStoreCommand
             }
 
             $stats[$product->getSku()] = $size;
-            $limit++;
         }
 
         return $stats;


### PR DESCRIPTION
**Summary**

Using the Magento API to build the collections for sampling requires `N` number of object hydrations (see `\Magento\Eav\Model\Entity\Collection\AbstractCollection::_loadEntities`) which can gobble up RAM and kill the process. 

This PR aims to eliminate unnecessary object hydration from:

- Counts
- Sampling

... which should allow the batch optimizer tool to work with larger data sets. Additional details in Jira.

**Result**

Using a mem tracker script via `ps` on the Magento `extra_large` performance fixture.

Before:
<img width="2048" height="948" alt="image" src="https://github.com/user-attachments/assets/adaa8cf1-3860-447a-967a-77046e31b795" />
After:
<img width="2048" height="1215" alt="image" src="https://github.com/user-attachments/assets/84169c49-0a14-40fa-8519-a0b1f2768075" />

