### PR TITLE
MAGE-1413 Fix implicit nullable types for PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGE LOG
 
+## 3.17.0-beta.2
+
+### Bug fixes
+
+- Fixed 3.17 setup:upgrade on PHP 8.4
+
 ## 3.17.0-beta.1
 
 ### Features

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -124,7 +124,7 @@ class Queue
      *
      * @throws Exception
      */
-    public function runCron(int $nbJobs = null, bool $force = false): void
+    public function runCron(?int $nbJobs = null, bool $force = false): void
     {
         if (!$this->configHelper->isQueueActive() && $force === false) {
             return;
@@ -394,7 +394,7 @@ class Queue
      *
      * @return Job[]
      */
-    protected function fetchJobs(int $jobsLimit, bool $fetchFullReindexJobs = false, int $lastJobId = null): array
+    protected function fetchJobs(int $jobsLimit, bool $fetchFullReindexJobs = false, ?int $lastJobId = null): array
     {
         $jobs = [];
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.17.0-beta.1",
+  "version": "3.17.0-beta.2",
   "require": {
     "php": "~8.2|~8.3|~8.4",
     "magento/framework": "~103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.17.0-beta.1">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.17.0-beta.2">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
**Summary**

This resolves the issue with `setup:upgrade` throwing a missing interceptor exception on v3.17 on PHP 8.4.

```
Class "Algolia\AlgoliaSearch\Console\Command\Queue\ProcessQueueCommand\Interceptor" does not exist
```

**Result**

Successful `setup:upgrade` + Verified with PHPCS:

```
composer require --dev slevomat/coding-standard
vendor/bin/phpcs \
  --standard=SlevomatCodingStandard \
  --sniffs=SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue \
  --runtime-set testVersion 8.4 \
  --extensions=php \
  vendor/algolia/algoliasearch-magento-2
```

<img width="1100" height="368" alt="image" src="https://github.com/user-attachments/assets/693a5d33-0a24-4d6a-91f4-4d1505c6bae3" />
