### PR TITLE
MAGE-1413 Fix implicit nullable types for PHP 8.4

### DIFF
--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -124,7 +124,7 @@ class Queue
      *
      * @throws Exception
      */
-    public function runCron(int $nbJobs = null, bool $force = false): void
+    public function runCron(?int $nbJobs = null, bool $force = false): void
     {
         if (!$this->configHelper->isQueueActive() && $force === false) {
             return;
@@ -394,7 +394,7 @@ class Queue
      *
      * @return Job[]
      */
-    protected function fetchJobs(int $jobsLimit, bool $fetchFullReindexJobs = false, int $lastJobId = null): array
+    protected function fetchJobs(int $jobsLimit, bool $fetchFullReindexJobs = false, ?int $lastJobId = null): array
     {
         $jobs = [];
 


### PR DESCRIPTION
Fixes issue ID'd on https://github.com/algolia/algoliasearch-magento-2/pull/1812 in version 3.16.1 (resulting from 3.17.0 backport). 