### PR TITLE
MAGE-1418 Backport 3.16.0 IS fix

### DIFF
--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -373,7 +373,7 @@ define([
                 allWidgetConfiguration.infiniteHits = {
                     container     : '#instant-search-results-container',
                     templates     : {
-                        empty       : '',
+                        empty       : '<div></div>',
                         item        : $('#instant-hit-template').html(),
                         showMoreText: algoliaConfig.translations.showMore,
                     },
@@ -403,7 +403,7 @@ define([
                 allWidgetConfiguration.hits = {
                     container     : '#instant-search-results-container',
                     templates     : {
-                        empty: '',
+                        empty: '<div></div>',
                         item : $('#instant-hit-template').html(),
                     },
                     transformItems: function (items, {results}) {


### PR DESCRIPTION
This PR backports the [fix](https://github.com/algolia/algoliasearch-magento-2/pull/1709/commits/13ed96d3bdef72e2ce904b372d43114adcb88cf6) applied on 3.16.0 to 3.15.x for the issue referenced on https://github.com/algolia/algoliasearch-magento-2/pull/1776. 