### PR TITLE
MAGE-1335: Refactor Product With Children to remove Double Conversion (3.15.2)

### DIFF
--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -58,8 +58,17 @@ abstract class ProductWithChildren extends ProductWithoutChildren
                 } else {
                     $minPrice = $specialPrice[0];
                 }
-                $price     = $minPrice ?? $this->getTaxPrice($product, $subProduct->getFinalPrice(), $withTax);
-                $basePrice = $this->getTaxPrice($product, $subProduct->getPrice(), $withTax);
+
+                $finalPrice = $subProduct->getFinalPrice();
+                $basePrice  = $subProduct->getPrice();
+
+                if ($currencyCode !== $this->baseCurrencyCode) {
+                    $finalPrice = $this->convertPrice($finalPrice, $currencyCode);
+                    $basePrice  = $this->convertPrice($basePrice, $currencyCode);
+                }
+
+                $price     = $minPrice ?? $this->getTaxPrice($product, $finalPrice, $withTax);
+                $basePrice = $this->getTaxPrice($product, $basePrice, $withTax);
                 $min = min($min, $price);
                 $original = min($original, $basePrice);
                 $max = max($max, $price);
@@ -68,14 +77,7 @@ abstract class ProductWithChildren extends ProductWithoutChildren
         } else {
             $originalMax = $original = $min = $max;
         }
-        if ($currencyCode !== $this->baseCurrencyCode) {
-            $min      = $this->convertPrice($min, $currencyCode);
-            $original = $this->convertPrice($original, $currencyCode);
-            if ($min !== $max) {
-                $max = $this->convertPrice($max, $currencyCode);
-                $originalMax = $this->convertPrice($originalMax, $currencyCode);
-            }
-        }
+
         return [$min, $max, $original, $originalMax];
     }
 


### PR DESCRIPTION
This PR backports the fix for double conversion issue on products with children from this PR : https://github.com/algolia/algoliasearch-magento-2/pull/1745 