### PR TITLE
MAGE-1404: Add checks on configuration migration processed on data patches

### DIFF
--- a/Setup/Patch/Data/MigrateBatchSizeConfigPatch.php
+++ b/Setup/Patch/Data/MigrateBatchSizeConfigPatch.php
@@ -3,12 +3,15 @@
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Setup\Patch\DataMigrationTrait;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
 
 class MigrateBatchSizeConfigPatch implements DataPatchInterface
 {
+    use DataMigrationTrait;
+
     public function __construct(
         protected ModuleDataSetupInterface $moduleDataSetup,
     ) {}
@@ -35,14 +38,9 @@ class MigrateBatchSizeConfigPatch implements DataPatchInterface
     {
         $movedConfig = [
             'algoliasearch_advanced/queue/number_of_element_by_page' => ConfigHelper::NUMBER_OF_ELEMENT_BY_PAGE,
-       ];
+        ];
 
-        $connection = $this->moduleDataSetup->getConnection();
-        foreach ($movedConfig as $from => $to) {
-            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
-            $whereConfigPath = $connection->quoteInto('path = ?', $from);
-            $connection->update($configDataTable, ['path' => $to], $whereConfigPath);
-        }
+        $this->migrateConfig($movedConfig);
     }
 
     /**

--- a/Setup/Patch/Data/MigrateIndexingConfigPatch.php
+++ b/Setup/Patch/Data/MigrateIndexingConfigPatch.php
@@ -3,12 +3,15 @@
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Setup\Patch\DataMigrationTrait;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
 
 class MigrateIndexingConfigPatch implements DataPatchInterface
 {
+    use DataMigrationTrait;
+
     public function __construct(
         protected ModuleDataSetupInterface $moduleDataSetup,
     ) {}
@@ -39,12 +42,7 @@ class MigrateIndexingConfigPatch implements DataPatchInterface
             'algoliasearch_credentials/credentials/enable_pages_index'             => ConfigHelper::ENABLE_PAGES_INDEX,
         ];
 
-        $connection = $this->moduleDataSetup->getConnection();
-        foreach ($movedConfig as $from => $to) {
-            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
-            $whereConfigPath = $connection->quoteInto('path = ?', $from);
-            $connection->update($configDataTable, ['path' => $to], $whereConfigPath);
-        }
+        $this->migrateConfig($movedConfig);
     }
 
     /**

--- a/Setup/Patch/Data/MigrateInstantSearchConfigPatch.php
+++ b/Setup/Patch/Data/MigrateInstantSearchConfigPatch.php
@@ -2,12 +2,15 @@
 
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
+use Algolia\AlgoliaSearch\Setup\Patch\DataMigrationTrait;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
 
 class MigrateInstantSearchConfigPatch implements DataPatchInterface
 {
+    use DataMigrationTrait;
+
     public function __construct(
         protected ModuleDataSetupInterface $moduleDataSetup,
     ) {}
@@ -44,12 +47,8 @@ class MigrateInstantSearchConfigPatch implements DataPatchInterface
             'algoliasearch_instant/instant/infinite_scroll_enable'             => 'algoliasearch_instant/instant_options/infinite_scroll_enable',
             'algoliasearch_instant/instant/hide_pagination'                    => 'algoliasearch_instant/instant_options/hide_pagination'
         ];
-        $connection = $this->moduleDataSetup->getConnection();
-        foreach ($movedConfig as $from => $to) {
-            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
-            $whereConfigPath = $connection->quoteInto('path = ?', $from);
-            $connection->update($configDataTable, ['path' => $to], $whereConfigPath);
-        }
+
+        $this->migrateConfig($movedConfig);
     }
 
     /**

--- a/Setup/Patch/DataMigrationTrait.php
+++ b/Setup/Patch/DataMigrationTrait.php
@@ -14,11 +14,10 @@ trait DataMigrationTrait
         foreach ($configurations as $from => $to) {
             $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
             $whereConfigPathFrom = $connection->quoteInto('path = ?', $from);
-            $whereConfigPathTo = $connection->quoteInto('path = ?', $to);
 
             $select = $connection->select()
                 ->from($configDataTable)
-                ->where($whereConfigPathTo);
+                ->where('path = ?', $to);
             $existingValues = $connection->fetchAll($select);
 
             if (count($existingValues) === 0) {

--- a/Setup/Patch/DataMigrationTrait.php
+++ b/Setup/Patch/DataMigrationTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Setup\Patch;
+
+trait DataMigrationTrait
+{
+    /**
+     * @param array $configurations
+     * @return void
+     */
+    public function migrateConfig(array $configurations): void
+    {
+        $connection = $this->moduleDataSetup->getConnection();
+        foreach ($configurations as $from => $to) {
+            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
+            $whereConfigPathFrom = $connection->quoteInto('path = ?', $from);
+            $whereConfigPathTo = $connection->quoteInto('path = ?', $to);
+
+            $select = $connection->select()
+                ->from($configDataTable)
+                ->where($whereConfigPathTo);
+            $existingValues = $connection->fetchAll($select);
+
+            if (count($existingValues) === 0) {
+                $connection->update($configDataTable, ['path' => $to], $whereConfigPathFrom);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR contains:
- Added a `DataMigrationTrait.php` class which handles the data migration in the `core_config_data` table in the data patches.
- Introduced a check before performing the update statement, which should prevent some "Integrity constraint violation" issues which can occur in some circumstances.