### PR TITLE
MAGE-1404: Add checks on configuration migration processed on data patches (3.16.1)

### DIFF
--- a/Setup/Patch/Data/MigrateIndexingConfigPatch.php
+++ b/Setup/Patch/Data/MigrateIndexingConfigPatch.php
@@ -3,12 +3,15 @@
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Setup\Patch\DataMigrationTrait;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
 
 class MigrateIndexingConfigPatch implements DataPatchInterface
 {
+    use DataMigrationTrait;
+
     public function __construct(
         protected ModuleDataSetupInterface $moduleDataSetup,
     ) {}
@@ -39,12 +42,7 @@ class MigrateIndexingConfigPatch implements DataPatchInterface
             'algoliasearch_credentials/credentials/enable_pages_index'             => ConfigHelper::ENABLE_PAGES_INDEX,
         ];
 
-        $connection = $this->moduleDataSetup->getConnection();
-        foreach ($movedConfig as $from => $to) {
-            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
-            $whereConfigPath = $connection->quoteInto('path = ?', $from);
-            $connection->update($configDataTable, ['path' => $to], $whereConfigPath);
-        }
+        $this->migrateConfig($movedConfig);
     }
 
     /**

--- a/Setup/Patch/Data/MigrateInstantSearchConfigPatch.php
+++ b/Setup/Patch/Data/MigrateInstantSearchConfigPatch.php
@@ -2,12 +2,15 @@
 
 namespace Algolia\AlgoliaSearch\Setup\Patch\Data;
 
+use Algolia\AlgoliaSearch\Setup\Patch\DataMigrationTrait;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchInterface;
 
 class MigrateInstantSearchConfigPatch implements DataPatchInterface
 {
+    use DataMigrationTrait;
+
     public function __construct(
         protected ModuleDataSetupInterface $moduleDataSetup,
     ) {}
@@ -44,12 +47,8 @@ class MigrateInstantSearchConfigPatch implements DataPatchInterface
             'algoliasearch_instant/instant/infinite_scroll_enable'             => 'algoliasearch_instant/instant_options/infinite_scroll_enable',
             'algoliasearch_instant/instant/hide_pagination'                    => 'algoliasearch_instant/instant_options/hide_pagination'
         ];
-        $connection = $this->moduleDataSetup->getConnection();
-        foreach ($movedConfig as $from => $to) {
-            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
-            $whereConfigPath = $connection->quoteInto('path = ?', $from);
-            $connection->update($configDataTable, ['path' => $to], $whereConfigPath);
-        }
+
+        $this->migrateConfig($movedConfig);
     }
 
     /**

--- a/Setup/Patch/DataMigrationTrait.php
+++ b/Setup/Patch/DataMigrationTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Setup\Patch;
+
+trait DataMigrationTrait
+{
+    /**
+     * @param array $configurations
+     * @return void
+     */
+    public function migrateConfig(array $configurations): void
+    {
+        $connection = $this->moduleDataSetup->getConnection();
+        foreach ($configurations as $from => $to) {
+            $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
+            $whereConfigPathFrom = $connection->quoteInto('path = ?', $from);
+
+            $select = $connection->select()
+                ->from($configDataTable)
+                ->where('path = ?', $to);
+            $existingValues = $connection->fetchAll($select);
+
+            if (count($existingValues) === 0) {
+                $connection->update($configDataTable, ['path' => $to], $whereConfigPathFrom);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR backports changes from https://github.com/algolia/algoliasearch-magento-2/pull/1817 for v 3.16.1.