### PR TITLE
MAGE-1404: Add checks on configuration migration processed on data patches (3.15.2)

### DIFF
--- a/Setup/Patch/Data/MigrateInstantSearchConfigPatch.php
+++ b/Setup/Patch/Data/MigrateInstantSearchConfigPatch.php
@@ -47,8 +47,16 @@ class MigrateInstantSearchConfigPatch implements DataPatchInterface
         $connection = $this->moduleDataSetup->getConnection();
         foreach ($movedConfig as $from => $to) {
             $configDataTable = $this->moduleDataSetup->getTable('core_config_data');
-            $whereConfigPath = $connection->quoteInto('path = ?', $from);
-            $connection->update($configDataTable, ['path' => $to], $whereConfigPath);
+            $whereConfigPathFrom = $connection->quoteInto('path = ?', $from);
+
+            $select = $connection->select()
+                ->from($configDataTable)
+                ->where('path = ?', $to);
+            $existingValues = $connection->fetchAll($select);
+
+            if (count($existingValues) === 0) {
+                $connection->update($configDataTable, ['path' => $to], $whereConfigPathFrom);
+            }
         }
     }
 


### PR DESCRIPTION
This PR backports changes from https://github.com/algolia/algoliasearch-magento-2/pull/1817 for v 3.15.2.