### PR TITLE
MAGE-1426 dynamic faceting fixes (also MAGE-1427)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 .php_cs.cache
 .vscode
 .idea
+node_modules

--- a/Service/IndexSettingsHandler.php
+++ b/Service/IndexSettingsHandler.php
@@ -55,6 +55,7 @@ class IndexSettingsHandler
                 true,
                 false
             );
+            $this->connector->waitLastTask($indexOptions->getStoreId());
         }
         if ($noForward) {
             $this->connector->setSettings(

--- a/Service/Product/FacetBuilder.php
+++ b/Service/Product/FacetBuilder.php
@@ -95,7 +95,7 @@ class FacetBuilder
     {
         return array_combine(
             $attributes,
-            array_fill(0, count($attributes), [ 'sortRemainingBy' => 'alpha' ])
+            array_fill(0, count($attributes), [ 'sortRemainingBy' => 'count' ])
         );
     }
 

--- a/Test/Unit/Service/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/IndexSettingsHandlerTest.php
@@ -18,17 +18,80 @@ class IndexSettingsHandlerTest extends TestCase
 
     private ?IndexSettingsHandler $handler = null;
 
+    /**
+     * State machine to track pending operations per store ID
+     * Format: [storeId => ['totalCalls' => int, 'waitCalled' => bool, 'batchesCompleted' => int]]
+     */
+    private array $operationState = [];
+
     protected function setUp(): void
     {
         $this->connector = $this->createMock(AlgoliaConnector::class);
         $this->config = $this->createMock(ConfigHelper::class);
         $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
 
+        // Configure the mock to use our state machine
+        $this->setupStateMachineMock();
+
         $this->handler = new IndexSettingsHandlerTestable($this->connector, $this->config);
+    }
+
+    private function setupStateMachineMock(): void
+    {
+        $this->connector->method('setSettings')
+            ->willReturnCallback(function($indexOptions, $settings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') {
+                $storeId = $indexOptions->getStoreId();
+                
+                // Initialize state if not exists
+                if (!isset($this->operationState[$storeId])) {
+                    $this->operationState[$storeId] = [
+                        'totalCalls' => 0,
+                        'waitCalled' => false,
+                        'batchesCompleted' => 0
+                    ];
+                }
+                
+                // Check if we have completed batches that haven't been waited for
+                if ($this->operationState[$storeId]['batchesCompleted'] > 0 && 
+                    !$this->operationState[$storeId]['waitCalled']) {
+                    throw new \RuntimeException(
+                        "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
+                    );
+                }
+                
+                // Increment call count
+                $this->operationState[$storeId]['totalCalls']++;
+                $this->operationState[$storeId]['waitCalled'] = false;
+            });
+
+        $this->connector->method('waitLastTask')
+            ->willReturnCallback(function($storeId = null) {
+                if ($storeId !== null && isset($this->operationState[$storeId])) {
+                    // Mark that wait has been called
+                    $this->operationState[$storeId]['waitCalled'] = true;
+                }
+            });
+    }
+
+    /**
+     * Call this after IndexSettingsHandler.setSettings() completes to mark the batch as done
+     */
+    private function markBatchCompleted(int $storeId): void
+    {
+        if (isset($this->operationState[$storeId])) {
+            $this->operationState[$storeId]['batchesCompleted']++;
+        }
+    }
+
+    private function resetOperationState(): void
+    {
+        $this->operationState = [];
     }
 
     public function testSetSettingsWithForwardingEnabledAndMixedSettings(): void
     {
+        $this->resetOperationState();
+        
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
@@ -44,7 +107,7 @@ class IndexSettingsHandlerTest extends TestCase
         $this->connector->expects($this->exactly(2))
             ->method('setSettings')
             ->willReturnCallback(
-                function($indexOptions, $indexSettings, $forwardToReplicas, $mergeSettings, $mergeFrom) use (&$invocationCount) {
+                function($indexOptions, $indexSettings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') use (&$invocationCount) {
                     $invocationCount++;
 
                     switch ($invocationCount) {
@@ -62,10 +125,13 @@ class IndexSettingsHandlerTest extends TestCase
             });
 
         $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyExcludedSettings(): void
     {
+        $this->resetOperationState();
+        
         $storeId = 1;
         $settings = [
             'ranking' => ['asc(name)'],
@@ -88,10 +154,13 @@ class IndexSettingsHandlerTest extends TestCase
             );
 
         $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyForwardableSettings(): void
     {
+        $this->resetOperationState();
+        
         $storeId = 1;
         $settings = [
             'attributesToHighlight' => ['title'],
@@ -113,10 +182,13 @@ class IndexSettingsHandlerTest extends TestCase
             );
 
         $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
     }
 
     public function testSetSettingsWithForwardingDisabled(): void
     {
+        $this->resetOperationState();
+        
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
@@ -138,10 +210,13 @@ class IndexSettingsHandlerTest extends TestCase
             );
 
         $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
     }
 
     public function testForwardSettingsWithEmptyInput(): void
     {
+        $this->resetOperationState();
+        
         $storeId = 1;
         $settings = [];
 
@@ -153,6 +228,7 @@ class IndexSettingsHandlerTest extends TestCase
         $this->connector->expects($this->never())->method('setSettings');
 
         $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
     }
 
 
@@ -171,5 +247,110 @@ class IndexSettingsHandlerTest extends TestCase
             'customRanking' => ['desc(price)'],
             'ranking' => ['asc(name)']
         ], $noForward);
+    }
+
+    public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
+    {
+        $this->resetOperationState();
+        
+        $storeId = 1;
+        $settings = ['attributesToRetrieve' => ['name']];
+
+        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->willReturn(false);
+
+        // First call should succeed
+        $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
+        
+        // Second call without wait should throw exception
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
+        
+        $this->handler->setSettings($this->indexOptions, $settings);
+    }
+
+    public function testSubsequentSetSettingsAfterWaitSucceeds(): void
+    {
+        $this->resetOperationState();
+        
+        $storeId = 1;
+        $settings = ['attributesToRetrieve' => ['name']];
+
+        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->willReturn(false);
+
+        // Configure connector to expect two setSettings calls and one waitLastTask call
+        $this->connector->expects($this->exactly(2))
+            ->method('setSettings');
+        
+        $this->connector->expects($this->once())
+            ->method('waitLastTask')
+            ->with($storeId);
+
+        // First call should succeed
+        $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
+        
+        // Wait for the task
+        $this->connector->waitLastTask($storeId);
+        
+        // Second call after wait should succeed
+        $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
+    }
+
+    public function testDifferentStoreIdsDontInterfere(): void
+    {
+        $this->resetOperationState();
+        
+        $storeId1 = 1;
+        $storeId2 = 2;
+        $settings = ['attributesToRetrieve' => ['name']];
+
+        $indexOptions1 = $this->createMock(IndexOptionsInterface::class);
+        $indexOptions1->method('getStoreId')->willReturn($storeId1);
+        
+        $indexOptions2 = $this->createMock(IndexOptionsInterface::class);
+        $indexOptions2->method('getStoreId')->willReturn($storeId2);
+
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->willReturn(false);
+
+        // Both calls should succeed as they use different store IDs
+        $this->connector->expects($this->exactly(2))
+            ->method('setSettings');
+
+        $this->handler->setSettings($indexOptions1, $settings);
+        $this->markBatchCompleted($storeId1);
+        $this->handler->setSettings($indexOptions2, $settings);
+        $this->markBatchCompleted($storeId2);
+    }
+
+    public function testForwardingEnabledMultipleCallsRequireWait(): void
+    {
+        $this->resetOperationState();
+        
+        $storeId = 1;
+        $settings = [
+            'customRanking' => ['desc(price)'],
+            'attributesToRetrieve' => ['name']
+        ];
+
+        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+            ->willReturn(true);
+
+        // First call makes two internal setSettings calls
+        $this->handler->setSettings($this->indexOptions, $settings);
+        $this->markBatchCompleted($storeId);
+        
+        // Second call should fail because no wait was called
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
+        
+        $this->handler->setSettings($this->indexOptions, $settings);
     }
 }

--- a/view/frontend/web/js/instantsearch.js
+++ b/view/frontend/web/js/instantsearch.js
@@ -663,14 +663,21 @@ define([
         },
 
         getRefinementListOptions(facet) {
-            return {
+            const options = {
                 container   : this.getFacetContainer(facet),
                 attribute   : facet.attribute,
                 limit       : algoliaConfig.maxValuesPerFacet,
                 templates   : this.getRefinementsListTemplates(),
-                sortBy      : ['count:desc', 'name:asc'],
                 panelOptions: this.getRefinementFacetPanelOptions(facet)
             };
+            if (!algoliaConfig.instant.isDynamicFacetsEnabled) {
+                options['sortBy'] = this.getFacetSortBy()
+            }
+            return options;
+        },
+
+        getFacetSortBy() {
+            return ['count:desc', 'name:asc'];
         },
 
         getRefinementFacetPanelOptions(facet) {


### PR DESCRIPTION
**Summary**

This PR aims to correct two issues:

1. Replica forwarding necessary to support alternate sorts with dynamic faceting can abort if async operation fails to complete in time
2. Local InstantSearch widgets can override facet sorting behavior in merchandising rules

**Result**

Unit tests and integration tests have been added to catch the replica forwarded settings issue in the future.

Unit tests with missing wait op (fails as expected):
<img width="2048" height="822" alt="image" src="https://github.com/user-attachments/assets/8e8e5c0a-839e-482c-b71c-58186a374851" />
Unit tests with wait op:
<img width="2048" height="346" alt="image" src="https://github.com/user-attachments/assets/b3449b4a-807d-40df-94e2-85ef392000a2" />

Integration tests on PHPUnit 10 (For Magento 2.4.8):
<img width="1486" height="369" alt="image" src="https://github.com/user-attachments/assets/be02e219-7344-4da0-aee9-1ed1793fc21a" />

For sorting via dynamic facet merch rules:

<img width="902" height="971" alt="2025-09-19_17-58-49" src="https://github.com/user-attachments/assets/c86c30e0-49d5-4185-a261-c387cc29d349" />
<img width="1238" height="569" alt="2025-09-19_18-05-30" src="https://github.com/user-attachments/assets/ea49c063-525f-43b6-9c8f-9fc50551f68e" />
<img width="673" height="820" alt="2025-09-19_17-59-32" src="https://github.com/user-attachments/assets/95c324c9-f6dd-43c6-8759-7b3419750214" />

