### PR TITLE
MAGE-1070: Add FPT compatibility

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -18,6 +18,7 @@ use Magento\Framework\DataObject;
 use Magento\Framework\Locale\Currency;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Weee\Helper\Data as WeeeHelper;
 
 class ConfigHelper
 {
@@ -117,6 +118,7 @@ class ConfigHelper
     public const REMOVE_IF_NO_RESULT = 'algoliasearch_advanced/advanced/remove_words_if_no_result';
     public const PARTIAL_UPDATES = 'algoliasearch_advanced/advanced/partial_update';
     public const CUSTOMER_GROUPS_ENABLE = 'algoliasearch_advanced/advanced/customer_groups_enable';
+    public const FPT_ENABLE = 'algoliasearch_advanced/advanced/fpt_enable';
     public const REMOVE_PUB_DIR_IN_URL = 'algoliasearch_advanced/advanced/remove_pub_dir_in_url';
     public const REMOVE_BRANDING = 'algoliasearch_advanced/advanced/remove_branding';
     public const IDX_PRODUCT_ON_CAT_PRODUCTS_UPD = 'algoliasearch_advanced/advanced/index_product_on_category_products_update';
@@ -172,7 +174,8 @@ class ConfigHelper
         protected CookieHelper                                          $cookieHelper,
         protected AutocompleteHelper                                    $autocompleteConfig,
         protected InstantSearchHelper                                   $instantSearchConfig,
-        protected QueueHelper                                           $queueHelper
+        protected QueueHelper                                           $queueHelper,
+        protected WeeeHelper                                            $weeeHelper
     )
     {}
 
@@ -1171,6 +1174,16 @@ class ConfigHelper
     public function isCustomerGroupsEnabled($storeId = null): bool
     {
         return $this->configInterface->isSetFlag(self::CUSTOMER_GROUPS_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * @param $storeId
+     * @return bool
+     */
+    public function isFptEnabled($storeId = null): bool
+    {
+        return $this->weeeHelper->isEnabled($storeId) &&
+            $this->configInterface->isSetFlag(self::FPT_ENABLE, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     public function setCustomerGroupsEnabled(bool $val, ?string $scope = null, ?int $scopeId = null): void

--- a/Helper/Entity/Product/PriceManager/ProductWithChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithChildren.php
@@ -69,6 +69,11 @@ abstract class ProductWithChildren extends ProductWithoutChildren
 
                 $price     = $minPrice ?? $this->getTaxPrice($product, $finalPrice, $withTax);
                 $basePrice = $this->getTaxPrice($product, $basePrice, $withTax);
+
+                if ($this->configHelper->isFptEnabled($subProduct->getStoreId())) {
+                    $basePrice += $this->weeeTax->getWeeeAmount($subProduct);
+                }
+
                 $min = min($min, $price);
                 $original = min($original, $basePrice);
                 $max = max($max, $price);

--- a/Test/Unit/Helper/ConfigHelperTest.php
+++ b/Test/Unit/Helper/ConfigHelperTest.php
@@ -17,8 +17,8 @@ use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Locale\Currency;
 use Magento\Framework\Module\ResourceInterface;
-
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Weee\Helper\Data as WeeeHelper;
 use PHPUnit\Framework\TestCase;
 
 class ConfigHelperTest extends TestCase
@@ -41,6 +41,8 @@ class ConfigHelperTest extends TestCase
     protected ?InstantSearchHelper $instantSearchHelper;
     protected ?QueueHelper $queueHelper;
 
+    protected ?WeeeHelper $weeeHelper;
+
     protected function setUp(): void
     {
         $this->configInterface = $this->createMock(ScopeConfigInterface::class);
@@ -59,6 +61,7 @@ class ConfigHelperTest extends TestCase
         $this->autocompleteHelper = $this->createMock(AutocompleteHelper::class);
         $this->instantSearchHelper = $this->createMock(InstantSearchHelper::class);
         $this->queueHelper = $this->createMock(QueueHelper::class);
+        $this->weeeHelper = $this->createMock(WeeeHelper::class);
 
         $this->configHelper = new ConfigHelperTestable(
             $this->configInterface,
@@ -76,7 +79,8 @@ class ConfigHelperTest extends TestCase
             $this->cookieHelper,
             $this->autocompleteHelper,
             $this->instantSearchHelper,
-            $this->queueHelper
+            $this->queueHelper,
+            $this->weeeHelper
         );
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1454,6 +1454,16 @@
                         ]]>
                     </comment>
                 </field>
+                <field id="fpt_enable" translate="label comment" type="select" sortOrder="22" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Enable FPT</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                            Do you want to take into account Fixed Product Tax (FPT) configured on your products?
+                            <br><span class="algolia-config-warning">&#9888;</span> The extension will only take into account global FPT per country (state scoped FPT are not supported).
+                        ]]>
+                    </comment>
+                </field>
                 <field id="remove_pub_dir_in_url" translate="label comment" type="select" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Remove pub/ from image URLs</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>


### PR DESCRIPTION
This PR contains:
- Added (limited) compatibility with FPT Magento feature (as suggested in this earlier PR: https://github.com/algolia/algoliasearch-magento-2/pull/1619) (thanks @aissyass)
⚠️ : We only support FPT set at country level (not state scoped ones)
- Added Configuration in the "Advanced" section of the extension's configuration to enable/disable this feature (FPT also has to be enabled in the default **Sales > Tax > Fixed Product Taxes** section).