### PR TITLE
MAGE-1422 Product URL fix for 3.16.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,10 @@ jobs:
 
 workflows:
   magento-build-and-test-workflow:
+    when:
+      matches:
+        pattern: "^(feat|fix|chore)/MAGE.*"
+        value: << pipeline.git.branch >>
     jobs:
       - magento-build:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,12 +173,6 @@ jobs:
 
 workflows:
   magento-build-and-test-workflow:
-    when:
-      or:
-        - equal: [ main, << pipeline.git.branch >> ]
-        - matches:
-            pattern: ".*release.*"
-            value: << pipeline.git.branch >>
     jobs:
       - magento-build:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ workflows:
       or:
         - equal: [ main, << pipeline.git.branch >> ]
         - matches:
-            pattern: "^release/.*"
+            pattern: ".*release.*"
             value: << pipeline.git.branch >>
     jobs:
       - magento-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
           working_directory: ~/Sites
           command: |
             bin/cli bash -c "cd ./dev/tests/integration && export $(cat .env | xargs) && ../../../vendor/bin/phpunit --debug --exclude-group problematic ../../../vendor/algolia/algoliasearch-magento-2/Test/Integration/"
-  
+
   notify:
     docker:
       - image: cimg/base:current
@@ -173,6 +173,12 @@ jobs:
 
 workflows:
   magento-build-and-test-workflow:
+    when:
+      or:
+        - equal: [ main, << pipeline.git.branch >> ]
+        - matches:
+            pattern: "^release/.*"
+            value: << pipeline.git.branch >>
     jobs:
       - magento-build:
           matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGE LOG
 
+## 3.16.1
+
+### Bug fixes 
+-  Ensure that only non-redirect URL rewrites are considered when generating product URLs - thank you @fasimana
+
 ## 3.16.0
 
 ### Features

--- a/Model/Product/Url.php
+++ b/Model/Product/Url.php
@@ -67,6 +67,7 @@ class Url extends ProductUrl
                     UrlRewrite::ENTITY_ID   => $product->getId(),
                     UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
                     UrlRewrite::STORE_ID    => $storeId,
+                    UrlRewrite::REDIRECT_TYPE => 0,
                 ];
                 if ($categoryId) {
                     $filterData[UrlRewrite::METADATA]['category_id'] = $categoryId;


### PR DESCRIPTION
**Summary**

- Includes community supplied fix from https://github.com/algolia/algoliasearch-magento-2/pull/1796
- Restricts CI to only execute on `feat`, `fix` & `chore`