### PR TITLE
MAGE-1420: Fix store id for queue job (3.15.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 3.15.2
 
 ### Bug fixes
--  Ensure that only non-redirect URL rewrites are considered when generating product URLs - thank you @fasimana
+- Ensure that only non-redirect URL rewrites are considered when generating product URLs - thank you @fasimana
+- Fix store id for queue jobs merging and sorting - thank you @pikulsky
 
 ## 3.15.1
 

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -94,8 +94,8 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
 
             $this->setDecodedData($decodedData);
 
-            if (isset($decodedData['store_id'])) {
-                $this->setStoreId($decodedData['store_id']);
+            if (isset($decodedData['storeId'])) {
+                $this->setStoreId($decodedData['storeId']);
             }
         }
 

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -580,7 +580,7 @@ class Queue
                 SORT_ASC,
                 'method',
                 SORT_ASC,
-                'store_id',
+                'storeId',
                 SORT_ASC,
                 'job_id',
                 SORT_ASC


### PR DESCRIPTION
This PR contains changes from @pikulsky in their original PR:  https://github.com/algolia/algoliasearch-magento-2/pull/1769

- Follow camel case for store ID
- Fix using queue job's store ID for jobs sorting
