### PR TITLE
MAGE-1420: Fix store id for queue job (3.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@
 ## 3.16.1
 
 ### Bug fixes
--  Ensure that only non-redirect URL rewrites are considered when generating product URLs - thank you @fasimana
+- Ensure that only non-redirect URL rewrites are considered when generating product URLs - thank you @fasimana
+- Fix store id for queue jobs sorting - thank you @pikulsky
+
 
 ## 3.16.0
 

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -578,7 +578,7 @@ class Queue
                 SORT_ASC,
                 'method',
                 SORT_ASC,
-                'store_id',
+                'storeId',
                 SORT_ASC,
                 'job_id',
                 SORT_ASC


### PR DESCRIPTION
This PR contains changes from @pikulsky in their original PR:  https://github.com/algolia/algoliasearch-magento-2/pull/1769

- Fix using queue job's store ID for jobs sorting