### PR TITLE
Release/3.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGE LOG
 
+## 3.15.3
+
+### Bug fixes
+- Rollback change introduced in 3.15.2 regarding `store_id` sorting in Queue Job model.
+
 ## 3.15.2
 
 ### Updates

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -580,7 +580,7 @@ class Queue
                 SORT_ASC,
                 'method',
                 SORT_ASC,
-                'storeId',
+                'store_id',
                 SORT_ASC,
                 'job_id',
                 SORT_ASC

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.15.2",
+  "version": "3.15.3",
   "require": {
     "php": "~8.1|~8.2|~8.3",
     "magento/framework": "~103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.15.2">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.15.3">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
## 3.15.3

### Bug fixes
- Rollback change introduced in 3.15.2 regarding `store_id` sorting in Queue Job model.