### PR TITLE
MAGE-1532 Version bump for downstream dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.18.0-beta.1",
+  "version": "3.19.0-dev",
   "require": {
     "php": "~8.2|~8.3|~8.4",
     "magento/framework": "~103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.18.0-beta.1">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.19.0-dev">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
**Summary**

Bumps version for `Algolia_Ingestion` which requires 3.19.

**Result**

<img width="2048" height="730" alt="image" src="https://github.com/user-attachments/assets/fe5b20f7-77dc-49b3-be85-c76556a4757a" />
