### PR TITLE
Copy settings and synonyms on pages full reindex

### DIFF
--- a/Service/Page/IndexBuilder.php
+++ b/Service/Page/IndexBuilder.php
@@ -10,6 +10,7 @@ use Algolia\AlgoliaSearch\Helper\Entity\PageHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AbstractIndexBuilder;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\Page\IndexOptionsBuilder as PageIndexOptionsBuilder;
 use Magento\Framework\App\Config\ScopeCodeResolver;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\App\Emulation;
@@ -17,13 +18,14 @@ use Magento\Store\Model\App\Emulation;
 class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
 {
     public function __construct(
-        protected ConfigHelper        $configHelper,
-        protected DiagnosticsLogger   $logger,
-        protected Emulation           $emulation,
-        protected ScopeCodeResolver   $scopeCodeResolver,
-        protected AlgoliaConnector    $algoliaConnector,
-        protected IndexOptionsBuilder $indexOptionsBuilder,
-        protected PageHelper          $pageHelper
+        protected ConfigHelper            $configHelper,
+        protected DiagnosticsLogger       $logger,
+        protected Emulation               $emulation,
+        protected ScopeCodeResolver       $scopeCodeResolver,
+        protected AlgoliaConnector        $algoliaConnector,
+        protected PageIndexOptionsBuilder $pageIndexOptionsBuilder,
+        protected IndexOptionsBuilder     $indexOptionsBuilder,
+        protected PageHelper              $pageHelper
     ){
         parent::__construct(
             $configHelper,
@@ -32,6 +34,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             $scopeCodeResolver,
             $algoliaConnector
         );
+        $this->pageIndexOptionsBuilder = $pageIndexOptionsBuilder;
     }
 
     /**
@@ -106,7 +109,10 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
 
         if ($isFullReindex) {
             $tempIndexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, true);
+            $indexOptions = $this->pageIndexOptionsBuilder->buildEntityIndexOptions($storeId);
+            $indexSettings = $this->algoliaConnector->getSettings($indexOptions);
 
+            $this->algoliaConnector->setSettings($indexOptions, $indexSettings);
             $this->algoliaConnector->copyQueryRules($indexOptions, $tempIndexOptions);
             $this->algoliaConnector->copySynonyms($indexName, $tempIndexName, $storeId);
             $this->algoliaConnector->moveIndex($tempIndexOptions, $indexOptions);

--- a/Service/Page/IndexBuilder.php
+++ b/Service/Page/IndexBuilder.php
@@ -108,6 +108,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             $tempIndexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, true);
 
             $this->algoliaConnector->copyQueryRules($indexOptions, $tempIndexOptions);
+            $this->algoliaConnector->copySynonyms($indexName, $tempIndexName, $storeId);
             $this->algoliaConnector->moveIndex($tempIndexOptions, $indexOptions);
         }
         $this->algoliaConnector->setSettings(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

When doing a full reindex on Pages, the settings and synonyms configured in Algolia do not copy over to the new index - thus they are lost.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Settings and Synonyms should not be wiped of the Algolia `_pages` index


**Steps to Recreate**
1. Set custom settings (ie. custom ranking) in Algolia for a `_pages` index
2. Create synonyms in Algolia for a `_pages` index
3. 4. Trigger a reindex from Magento `php bin/magento indexer:reindex algolia_pages`
5. Wait till complete
6. Observe in Algolia that settings and synonyms have been deleted