### PR TITLE
MAGE-1530: updating PHP Client to v 4.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGE LOG
 
+## 3.19.0-dev
+
+### Updates
+- Update Algolia PHP Client to version 4.40.0. 
+
 ## 3.18.0-beta.1
 
 ### Features

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": "~8.2|~8.3|~8.4",
     "magento/framework": "~103.0",
-    "algolia/algoliasearch-client-php": "4.18.3",
+    "algolia/algoliasearch-client-php": "^4.40.0",
     "guzzlehttp/guzzle": "^6.3.3|^7.3.0",
     "ext-json": "*",
     "ext-PDO": "*",


### PR DESCRIPTION
This PR updates the PHP Client to v [4.40.0](https://github.com/algolia/algoliasearch-client-php/releases/tag/4.40.0) .

Updated from version 4.18.3 which includes the following changes: https://github.com/algolia/algoliasearch-client-php/compare/4.18.3...4.40.0

The following clients currently used in the extension have been tested successfully:
- SearchClient
- AnalyticsClient
- InsightsClient
- RecommendClient



PHP related changes:

**4.32.0**
- feat(php): add `setWaitTaskTimeBeforeRetry` method for Search and Ingestion clients (PR:  https://github.com/algolia/api-clients-automation/pull/5514)

**4.38.0**
- feat(php): added `withHttpInfo` methods to PHP (PR: https://github.com/algolia/api-clients-automation/pull/5852)
- feat(php): Implement retry strategy (PR: https://github.com/algolia/api-clients-automation/pull/5891)

**4.40.0**
- feat(php): added gzip compression (PR: https://github.com/algolia/api-clients-automation/pull/6051 )


Unit tests:
<img width="998" height="276" alt="image" src="https://github.com/user-attachments/assets/2bc57e5c-4fc6-4531-b908-f49f09a7ae65" />

Integration tests:
<img width="978" height="160" alt="image" src="https://github.com/user-attachments/assets/58adfa64-6106-43cd-85ea-7a13a84fce8b" />
