### PR TITLE
MAGE-1531 Introduce SendStrategy pattern to AlgoliaConnector 

### DIFF
--- a/Api/SendStrategyInterface.php
+++ b/Api/SendStrategyInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+
+interface SendStrategyInterface
+{
+    /**
+     * Determine if this strategy should handle send operations for the given store.
+     * Only called on optional strategies - not the default fallback.
+     *
+     * @param int $storeId
+     * @return bool
+     */
+    public function isApplicable(int $storeId): bool;
+
+    /**
+     * @param IndexOptionsInterface $indexOptions
+     * @param array $requests Batch requests [{action, body}, ...]
+     * @return array Response from the send operation
+     */
+    public function send(IndexOptionsInterface $indexOptions, array $requests): array;
+}

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -79,7 +79,8 @@ class AlgoliaConnector
         protected ConsoleOutput $consoleOutput,
         protected AlgoliaCredentialsManager $algoliaCredentialsManager,
         protected IndexNameFetcher $indexNameFetcher,
-        protected IndexOptionsBuilder $indexOptionsBuilder
+        protected IndexOptionsBuilder $indexOptionsBuilder,
+        protected SendStrategyResolver $sendStrategyResolver
     ) {
         // Merge non castable attributes set in config
         $this->nonCastableAttributes = array_merge(
@@ -272,12 +273,9 @@ class AlgoliaConnector
      */
     protected function performBatchOperation(IndexOptionsInterface $indexOptions, array $requests): array
     {
-        $indexName = $indexOptions->getIndexName();
-
-        $response = $this->getClient($indexOptions->getStoreId())->batch($indexName, [ 'requests' => $requests ] );
-
+        $strategy = $this->sendStrategyResolver->resolve($indexOptions->getStoreId());
+        $response = $strategy->send($indexOptions, $requests);
         $this->setLastOperationInfo($indexOptions, $response);
-
         return $response;
     }
 

--- a/Service/DirectSendStrategy.php
+++ b/Service/DirectSendStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
+
+class DirectSendStrategy implements SendStrategyInterface
+{
+    public function __construct(
+        private AlgoliaConnector $connector
+    ) {}
+
+    public function isApplicable(int $storeId): bool
+    {
+        return true;
+    }
+
+    public function send(IndexOptionsInterface $indexOptions, array $requests): array
+    {
+        return $this->connector->getClient($indexOptions->getStoreId())
+            ->batch($indexOptions->getIndexName(), ['requests' => $requests]);
+    }
+}

--- a/Service/SendStrategyResolver.php
+++ b/Service/SendStrategyResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
+
+class SendStrategyResolver
+{
+    /**
+     * @param SendStrategyInterface $defaultStrategy DirectSendStrategy - always-on fallback
+     * @param SendStrategyInterface[] $strategies Optional strategies injected by satellite modules
+     */
+    public function __construct(
+        private SendStrategyInterface $defaultStrategy,
+        private array $strategies = []
+    ) {}
+
+    public function resolve(int $storeId): SendStrategyInterface
+    {
+        foreach ($this->strategies as $strategy) {
+            if ($strategy->isApplicable($storeId)) {
+                return $strategy;
+            }
+        }
+        return $this->defaultStrategy;
+    }
+}

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use Magento\Framework\Message\ManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class AlgoliaConnectorTest extends TestCase
+{
+    private ?AlgoliaConnector $connector = null;
+    private null|(SearchClient&MockObject) $searchClient = null;
+    private null|(ConfigHelper&MockObject) $config = null;
+    private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
+
+    private const STORE_ID = 1;
+    private const INDEX_NAME = 'magento2_default_products';
+    private const TASK_ID = 12345;
+
+    protected function setUp(): void
+    {
+        $this->searchClient = $this->createMock(SearchClient::class);
+        $this->config = $this->createMock(ConfigHelper::class);
+
+        $this->config->method('getNonCastableAttributes')->willReturn([]);
+        $this->config->method('getMaxRecordSizeLimit')->willReturn(10000);
+
+        $this->connector = new AlgoliaConnector(
+            $this->config,
+            $this->createMock(ManagerInterface::class),
+            $this->createMock(ConsoleOutput::class),
+            $this->createMock(AlgoliaCredentialsManager::class),
+            $this->createMock(IndexNameFetcher::class),
+            $this->createMock(IndexOptionsBuilder::class)
+        );
+
+        // Inject mock SearchClient directly into the clients array
+        $this->setPrivateProperty($this->connector, 'clients', [self::STORE_ID => $this->searchClient]);
+
+        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
+        $this->indexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->indexOptions->method('getIndexName')->willReturn(self::INDEX_NAME);
+    }
+
+    // ── saveObjects() ──
+
+    public function testSaveObjectsCallsBatchWithAddObjectAction(): void
+    {
+        $objects = [
+            ['objectID' => '1', 'name' => 'Product A'],
+            ['objectID' => '2', 'name' => 'Product B'],
+        ];
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function ($batchParams) {
+                    $requests = $batchParams['requests'];
+                    $this->assertCount(2, $requests);
+                    $this->assertEquals('addObject', $requests[0]['action']);
+                    $this->assertEquals('addObject', $requests[1]['action']);
+                    $this->assertEquals('1', $requests[0]['body']['objectID']);
+                    $this->assertEquals('2', $requests[1]['body']['objectID']);
+                    return true;
+                })
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->saveObjects($this->indexOptions, $objects);
+    }
+
+    public function testSaveObjectsWithPartialUpdateCallsBatchWithPartialUpdateAction(): void
+    {
+        $objects = [
+            ['objectID' => '1', 'price' => '29.99'],
+        ];
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function ($batchParams) {
+                    $this->assertEquals('partialUpdateObject', $batchParams['requests'][0]['action']);
+                    return true;
+                })
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->saveObjects($this->indexOptions, $objects, true);
+    }
+
+    public function testSaveObjectsTracksLastOperationInfo(): void
+    {
+        $objects = [['objectID' => '1', 'name' => 'Product A']];
+
+        $this->searchClient->method('batch')
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->saveObjects($this->indexOptions, $objects);
+
+        $this->assertEquals(self::TASK_ID, $this->connector->getLastTaskId(self::STORE_ID));
+    }
+
+
+    public function testSaveObjectsSetsAlgoliaLastUpdateTimestamp(): void
+    {
+        $objects = [['objectID' => '1', 'name' => 'Product A']];
+        $beforeTime = strtotime('now');
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function ($batchParams) use ($beforeTime) {
+                    $body = $batchParams['requests'][0]['body'];
+                    $this->assertArrayHasKey('algoliaLastUpdateAtCET', $body);
+                    $this->assertGreaterThanOrEqual($beforeTime, $body['algoliaLastUpdateAtCET']);
+                    return true;
+                })
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->saveObjects($this->indexOptions, $objects);
+    }
+
+    public function testSaveObjectsCastsNumericValues(): void
+    {
+        $objects = [['objectID' => '1', 'price' => '29.99', 'qty' => '5']];
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function ($batchParams) {
+                    $body = $batchParams['requests'][0]['body'];
+                    $this->assertSame(29.99, $body['price']);
+                    $this->assertSame(5, $body['qty']);
+                    return true;
+                })
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->saveObjects($this->indexOptions, $objects);
+    }
+
+    public function testSaveObjectsSkipsOversizedRecords(): void
+    {
+        // Set max size large enough for small records but too small for the bloated one
+        $this->setPrivateProperty($this->connector, 'maxRecordSize', 200);
+
+        $objects = [
+            ['objectID' => '1', 'name' => 'Small'],
+            ['objectID' => '2', 'name' => str_repeat('x', 10000)],
+        ];
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function ($batchParams) {
+                    $requests = $batchParams['requests'];
+                    // Only the small record should survive
+                    $this->assertCount(1, $requests);
+                    $this->assertEquals('1', $requests[0]['body']['objectID']);
+                    return true;
+                })
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->saveObjects($this->indexOptions, $objects);
+    }
+
+    // ── deleteObjects() ──
+
+    public function testDeleteObjectsCallsBatchWithDeleteObjectAction(): void
+    {
+        $ids = ['100', '200', '300'];
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function ($batchParams) {
+                    $requests = $batchParams['requests'];
+                    $this->assertCount(3, $requests);
+                    foreach ($requests as $request) {
+                        $this->assertEquals('deleteObject', $request['action']);
+                    }
+                    $this->assertEquals('100', $requests[0]['body']['objectID']);
+                    $this->assertEquals('200', $requests[1]['body']['objectID']);
+                    $this->assertEquals('300', $requests[2]['body']['objectID']);
+                    return true;
+                })
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->deleteObjects($ids, $this->indexOptions);
+    }
+
+    public function testDeleteObjectsTracksLastOperationInfo(): void
+    {
+        $ids = ['100'];
+
+        $this->searchClient->method('batch')
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->deleteObjects($ids, $this->indexOptions);
+
+        $this->assertEquals(self::TASK_ID, $this->connector->getLastTaskId(self::STORE_ID));
+    }
+
+    // ── performBatchOperation()  ──
+
+    public function testPerformBatchOperationDelegatesToClientBatch(): void
+    {
+        $requests = [
+            ['action' => 'addObject', 'body' => ['objectID' => '1', 'name' => 'Test']],
+        ];
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(self::INDEX_NAME, ['requests' => $requests])
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->invokeMethod($this->connector, 'performBatchOperation', [$this->indexOptions, $requests]);
+    }
+
+    public function testPerformBatchOperationReturnsClientResponse(): void
+    {
+        $expectedResponse = [
+            AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID,
+            'objectIDs' => ['1', '2'],
+        ];
+
+        $this->searchClient->method('batch')->willReturn($expectedResponse);
+
+        $result = $this->invokeMethod($this->connector, 'performBatchOperation', [
+            $this->indexOptions,
+            [['action' => 'addObject', 'body' => ['objectID' => '1']]],
+        ]);
+
+        $this->assertEquals($expectedResponse, $result);
+    }
+}

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -3,12 +3,13 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Service;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
-use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\SendStrategyResolver;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\Message\ManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -17,7 +18,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 class AlgoliaConnectorTest extends TestCase
 {
     private ?AlgoliaConnector $connector = null;
-    private null|(SearchClient&MockObject) $searchClient = null;
+    private null|(SendStrategyInterface&MockObject) $mockStrategy = null;
     private null|(ConfigHelper&MockObject) $config = null;
     private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
 
@@ -27,9 +28,11 @@ class AlgoliaConnectorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->searchClient = $this->createMock(SearchClient::class);
-        $this->config = $this->createMock(ConfigHelper::class);
+        $this->mockStrategy = $this->createMock(SendStrategyInterface::class);
+        $mockResolver = $this->createMock(SendStrategyResolver::class);
+        $mockResolver->method('resolve')->willReturn($this->mockStrategy);
 
+        $this->config = $this->createMock(ConfigHelper::class);
         $this->config->method('getNonCastableAttributes')->willReturn([]);
         $this->config->method('getMaxRecordSizeLimit')->willReturn(10000);
 
@@ -39,11 +42,9 @@ class AlgoliaConnectorTest extends TestCase
             $this->createMock(ConsoleOutput::class),
             $this->createMock(AlgoliaCredentialsManager::class),
             $this->createMock(IndexNameFetcher::class),
-            $this->createMock(IndexOptionsBuilder::class)
+            $this->createMock(IndexOptionsBuilder::class),
+            $mockResolver
         );
-
-        // Inject mock SearchClient directly into the clients array
-        $this->setPrivateProperty($this->connector, 'clients', [self::STORE_ID => $this->searchClient]);
 
         $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
         $this->indexOptions->method('getStoreId')->willReturn(self::STORE_ID);
@@ -59,12 +60,11 @@ class AlgoliaConnectorTest extends TestCase
             ['objectID' => '2', 'name' => 'Product B'],
         ];
 
-        $this->searchClient->expects($this->once())
-            ->method('batch')
+        $this->mockStrategy->expects($this->once())
+            ->method('send')
             ->with(
-                self::INDEX_NAME,
-                $this->callback(function ($batchParams) {
-                    $requests = $batchParams['requests'];
+                $this->indexOptions,
+                $this->callback(function ($requests) {
                     $this->assertCount(2, $requests);
                     $this->assertEquals('addObject', $requests[0]['action']);
                     $this->assertEquals('addObject', $requests[1]['action']);
@@ -84,12 +84,12 @@ class AlgoliaConnectorTest extends TestCase
             ['objectID' => '1', 'price' => '29.99'],
         ];
 
-        $this->searchClient->expects($this->once())
-            ->method('batch')
+        $this->mockStrategy->expects($this->once())
+            ->method('send')
             ->with(
-                self::INDEX_NAME,
-                $this->callback(function ($batchParams) {
-                    $this->assertEquals('partialUpdateObject', $batchParams['requests'][0]['action']);
+                $this->indexOptions,
+                $this->callback(function ($requests) {
+                    $this->assertEquals('partialUpdateObject', $requests[0]['action']);
                     return true;
                 })
             )
@@ -102,7 +102,7 @@ class AlgoliaConnectorTest extends TestCase
     {
         $objects = [['objectID' => '1', 'name' => 'Product A']];
 
-        $this->searchClient->method('batch')
+        $this->mockStrategy->method('send')
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
         $this->connector->saveObjects($this->indexOptions, $objects);
@@ -110,18 +110,17 @@ class AlgoliaConnectorTest extends TestCase
         $this->assertEquals(self::TASK_ID, $this->connector->getLastTaskId(self::STORE_ID));
     }
 
-
     public function testSaveObjectsSetsAlgoliaLastUpdateTimestamp(): void
     {
         $objects = [['objectID' => '1', 'name' => 'Product A']];
         $beforeTime = strtotime('now');
 
-        $this->searchClient->expects($this->once())
-            ->method('batch')
+        $this->mockStrategy->expects($this->once())
+            ->method('send')
             ->with(
-                self::INDEX_NAME,
-                $this->callback(function ($batchParams) use ($beforeTime) {
-                    $body = $batchParams['requests'][0]['body'];
+                $this->indexOptions,
+                $this->callback(function ($requests) use ($beforeTime) {
+                    $body = $requests[0]['body'];
                     $this->assertArrayHasKey('algoliaLastUpdateAtCET', $body);
                     $this->assertGreaterThanOrEqual($beforeTime, $body['algoliaLastUpdateAtCET']);
                     return true;
@@ -136,12 +135,12 @@ class AlgoliaConnectorTest extends TestCase
     {
         $objects = [['objectID' => '1', 'price' => '29.99', 'qty' => '5']];
 
-        $this->searchClient->expects($this->once())
-            ->method('batch')
+        $this->mockStrategy->expects($this->once())
+            ->method('send')
             ->with(
-                self::INDEX_NAME,
-                $this->callback(function ($batchParams) {
-                    $body = $batchParams['requests'][0]['body'];
+                $this->indexOptions,
+                $this->callback(function ($requests) {
+                    $body = $requests[0]['body'];
                     $this->assertSame(29.99, $body['price']);
                     $this->assertSame(5, $body['qty']);
                     return true;
@@ -162,13 +161,11 @@ class AlgoliaConnectorTest extends TestCase
             ['objectID' => '2', 'name' => str_repeat('x', 10000)],
         ];
 
-        $this->searchClient->expects($this->once())
-            ->method('batch')
+        $this->mockStrategy->expects($this->once())
+            ->method('send')
             ->with(
-                self::INDEX_NAME,
-                $this->callback(function ($batchParams) {
-                    $requests = $batchParams['requests'];
-                    // Only the small record should survive
+                $this->indexOptions,
+                $this->callback(function ($requests) {
                     $this->assertCount(1, $requests);
                     $this->assertEquals('1', $requests[0]['body']['objectID']);
                     return true;
@@ -185,12 +182,11 @@ class AlgoliaConnectorTest extends TestCase
     {
         $ids = ['100', '200', '300'];
 
-        $this->searchClient->expects($this->once())
-            ->method('batch')
+        $this->mockStrategy->expects($this->once())
+            ->method('send')
             ->with(
-                self::INDEX_NAME,
-                $this->callback(function ($batchParams) {
-                    $requests = $batchParams['requests'];
+                $this->indexOptions,
+                $this->callback(function ($requests) {
                     $this->assertCount(3, $requests);
                     foreach ($requests as $request) {
                         $this->assertEquals('deleteObject', $request['action']);
@@ -210,7 +206,7 @@ class AlgoliaConnectorTest extends TestCase
     {
         $ids = ['100'];
 
-        $this->searchClient->method('batch')
+        $this->mockStrategy->method('send')
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
         $this->connector->deleteObjects($ids, $this->indexOptions);
@@ -218,30 +214,30 @@ class AlgoliaConnectorTest extends TestCase
         $this->assertEquals(self::TASK_ID, $this->connector->getLastTaskId(self::STORE_ID));
     }
 
-    // ── performBatchOperation()  ──
+    // ── performBatchOperation() ──
 
-    public function testPerformBatchOperationDelegatesToClientBatch(): void
+    public function testPerformBatchOperationDelegatesToStrategy(): void
     {
         $requests = [
             ['action' => 'addObject', 'body' => ['objectID' => '1', 'name' => 'Test']],
         ];
 
-        $this->searchClient->expects($this->once())
-            ->method('batch')
-            ->with(self::INDEX_NAME, ['requests' => $requests])
+        $this->mockStrategy->expects($this->once())
+            ->method('send')
+            ->with($this->indexOptions, $requests)
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
         $this->invokeMethod($this->connector, 'performBatchOperation', [$this->indexOptions, $requests]);
     }
 
-    public function testPerformBatchOperationReturnsClientResponse(): void
+    public function testPerformBatchOperationReturnsStrategyResponse(): void
     {
         $expectedResponse = [
             AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID,
             'objectIDs' => ['1', '2'],
         ];
 
-        $this->searchClient->method('batch')->willReturn($expectedResponse);
+        $this->mockStrategy->method('send')->willReturn($expectedResponse);
 
         $result = $this->invokeMethod($this->connector, 'performBatchOperation', [
             $this->indexOptions,

--- a/Test/Unit/Service/DirectSendStrategyTest.php
+++ b/Test/Unit/Service/DirectSendStrategyTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\DirectSendStrategy;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class DirectSendStrategyTest extends TestCase
+{
+    private null|(SearchClient&MockObject) $searchClient = null;
+    private null|(AlgoliaConnector&MockObject) $connector = null;
+    private ?DirectSendStrategy $strategy = null;
+    private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
+
+    private const STORE_ID = 1;
+    private const INDEX_NAME = 'magento2_default_products';
+    private const TASK_ID = 12345;
+
+    protected function setUp(): void
+    {
+        $this->searchClient = $this->createMock(SearchClient::class);
+        $this->connector = $this->createMock(AlgoliaConnector::class);
+        $this->connector->method('getClient')->willReturn($this->searchClient);
+
+        $this->strategy = new DirectSendStrategy($this->connector);
+
+        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
+        $this->indexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->indexOptions->method('getIndexName')->willReturn(self::INDEX_NAME);
+    }
+
+    public function testIsApplicableAlwaysReturnsTrue(): void
+    {
+        $this->assertTrue($this->strategy->isApplicable(self::STORE_ID));
+        $this->assertTrue($this->strategy->isApplicable(0));
+        $this->assertTrue($this->strategy->isApplicable(99));
+    }
+
+    public function testSendCallsClientBatchWithCorrectIndexNameAndRequests(): void
+    {
+        $requests = [
+            ['action' => 'addObject', 'body' => ['objectID' => '1', 'name' => 'Product A']],
+            ['action' => 'addObject', 'body' => ['objectID' => '2', 'name' => 'Product B']],
+        ];
+
+        $this->connector->expects($this->once())
+            ->method('getClient')
+            ->with(self::STORE_ID)
+            ->willReturn($this->searchClient);
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(self::INDEX_NAME, ['requests' => $requests])
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->strategy->send($this->indexOptions, $requests);
+    }
+
+    public function testSendReturnsClientResponse(): void
+    {
+        $expectedResponse = [
+            AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID,
+            'objectIDs' => ['1', '2'],
+        ];
+
+        $this->searchClient->method('batch')->willReturn($expectedResponse);
+
+        $result = $this->strategy->send($this->indexOptions, []);
+
+        $this->assertEquals($expectedResponse, $result);
+    }
+
+    public function testSendWithDeleteObjectAction(): void
+    {
+        $requests = [
+            ['action' => 'deleteObject', 'body' => ['objectID' => '100']],
+        ];
+
+        $this->searchClient->expects($this->once())
+            ->method('batch')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function ($batchParams) {
+                    $this->assertEquals('deleteObject', $batchParams['requests'][0]['action']);
+                    $this->assertEquals('100', $batchParams['requests'][0]['body']['objectID']);
+                    return true;
+                })
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->strategy->send($this->indexOptions, $requests);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -39,6 +39,22 @@
     <preference for="Algolia\AlgoliaSearch\Api\Data\SearchQueryInterface" type="Algolia\AlgoliaSearch\Model\Data\SearchQuery" />
     <preference for="Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface" type="Algolia\AlgoliaSearch\Model\Data\IndexOptions" />
 
+    <!-- Send strategy -->
+    <preference for="Algolia\AlgoliaSearch\Api\SendStrategyInterface"
+                type="Algolia\AlgoliaSearch\Service\DirectSendStrategy"/>
+    <type name="Algolia\AlgoliaSearch\Service\DirectSendStrategy">
+        <arguments>
+            <!-- Temporary proxy to address circular dependency - TODO: Refactor this -->
+            <argument name="connector" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaConnector\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Algolia\AlgoliaSearch\Service\SendStrategyResolver">
+        <arguments>
+            <argument name="defaultStrategy" xsi:type="object">Algolia\AlgoliaSearch\Service\DirectSendStrategy</argument>
+            <argument name="strategies" xsi:type="array"/>
+        </arguments>
+    </type>
+
     <!-- Algolia services -->
     <preference for="Algolia\AlgoliaSearch\Api\Insights\EventProcessorInterface" type="Algolia\AlgoliaSearch\Service\Insights\EventProcessor"/>
     <preference for="Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface" type="Algolia\AlgoliaSearch\Service\Product\ReplicaManager"/>


### PR DESCRIPTION
**Summary**

This PR introduces a "strategy pattern" for record delivery in `AlgoliaConnector`, enabling satellite modules (e.g., upcoming `Algolia_Ingestion` module) to replace the default `SearchClient::batch()` call without modifying core extension code.

(Targeting the linting PR https://github.com/algolia/algoliasearch-magento-2/pull/1923 to cleanly separate these change sets)

Note that there is ***no behavioral change***. `DirectSendStrategy` produces the same `batch()` call with the same payload shape as before.

- **`Api/SendStrategyInterface`** (public API) - defines interface for external implementations
- **`Service/DirectSendStrategy`** - default implementation; wraps the existing `SearchClient::batch()` call extracted from `performBatchOperation()`. Behavior should be identical to before.
- **`Service/SendStrategyResolver`** - iterates optional strategies (injected by satellite modules via `di.xml`); falls back to `DirectSendStrategy`
- **`AlgoliaConnector::performBatchOperation()`** - delegates to the resolved strategy instead of calling the client directly.
- **`di.xml`** - and uses `AlgoliaConnector\Proxy` on `DirectSendStrategy` to break the resulting circular dependency. 

> [!NOTE]
The circular dependency is not ideal even with the proxy. I have scoped a new task to break down the composition of `AlgoliaConnector` to address this issue. 

**Result**

`AlgoliaConnectorTest` was introduced for baseline testing and then via a red-green-refactor, the mock injection point was moved from `SearchClient` (in `clients` array) to `SendStrategyInterface` (via mock resolver). All existing payload assertions are preserved.

Added a new `DirectSendStrategyTest` to cover the extracted `batch()` delegation directly.

<img width="1489" height="516" alt="image" src="https://github.com/user-attachments/assets/12b03f9a-2611-44ed-a02c-28b235affe24" />
