### PR TITLE
MAGE-1556 Extract SearchClientProvider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,5 +64,6 @@ CircleCI runs on branches matching `^(feat|fix|chore)/MAGE.*`. Tests against PHP
 
 - PSR-2 base with additional rules in `.php-cs-fixer.php`
 - Comments should be rare and only when logic isn't self-descriptive — prefer renaming classes/methods over adding comments
+- Do not add PHPDoc blocks that merely restate PHP type declarations. Only add PHPDoc when it provides information beyond what the type signature already conveys (e.g., `@throws`, descriptions of non-obvious behavior, or types that cannot be expressed natively such as `array<string, int>`). The `no_superfluous_phpdoc_tags` fixer rule enforces this automatically.
 - PHPStan level 1 compliance required
 - MEQP2 marketplace standard — ERRORs block merge, WARNINGs should be avoided

--- a/Api/SearchClientProviderInterface.php
+++ b/Api/SearchClientProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api;
+
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+
+interface SearchClientProviderInterface
+{
+    /**
+     * @throws AlgoliaException
+     */
+    public function getClient(?int $storeId = 0): SearchClient;
+}

--- a/Api/SendStrategyInterface.php
+++ b/Api/SendStrategyInterface.php
@@ -10,14 +10,12 @@ interface SendStrategyInterface
      * Determine if this strategy should handle send operations for the given store.
      * Only called on optional strategies - not the default fallback.
      *
-     * @param int $storeId
-     * @return bool
      */
     public function isApplicable(int $storeId): bool;
 
     /**
-     * @param IndexOptionsInterface $indexOptions
      * @param array $requests Batch requests [{action, body}, ...]
+     *
      * @return array Response from the send operation
      */
     public function send(IndexOptionsInterface $indexOptions, array $requests): array;

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -5,13 +5,12 @@ namespace Algolia\AlgoliaSearch\Service;
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
 use Algolia\AlgoliaSearch\Api\Data\SearchQueryInterface;
 use Algolia\AlgoliaSearch\Api\SearchClient;
-use Algolia\AlgoliaSearch\Configuration\SearchConfig;
+use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Model\Search\ListIndicesResponse;
 use Algolia\AlgoliaSearch\Model\Search\SettingsResponse;
-use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 use Exception;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Message\ManagerInterface;
@@ -36,9 +35,6 @@ class AlgoliaConnector
      */
     protected const ALGOLIA_API_SECURED_KEY_TIMEOUT_SECONDS = 60 * 60 * 24; // TODO: Implement as config
 
-    /** @var SearchClient[] */
-    protected array $clients = [];
-
     protected ?int $maxRecordSize = null;
 
     /** @var string[] */
@@ -46,8 +42,6 @@ class AlgoliaConnector
 
     /** @var string[] */
     protected array $nonCastableAttributes = ['sku', 'name', 'description', 'query'];
-
-    protected bool $userAgentsAdded = false;
 
     protected ?string $lastUsedIndexName = null;
 
@@ -59,7 +53,7 @@ class AlgoliaConnector
         protected ConfigHelper $config,
         protected ManagerInterface $messageManager,
         protected ConsoleOutput $consoleOutput,
-        protected AlgoliaCredentialsManager $algoliaCredentialsManager,
+        protected SearchClientProviderInterface $clientProvider,
         protected IndexNameFetcher $indexNameFetcher,
         protected IndexOptionsBuilder $indexOptionsBuilder,
         protected SendStrategyResolver $sendStrategyResolver
@@ -74,72 +68,9 @@ class AlgoliaConnector
     /**
      * @throws AlgoliaException
      */
-    protected function createClient(int $storeId = self::ALGOLIA_DEFAULT_SCOPE): void
-    {
-        if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
-            throw new AlgoliaException('Client initialization could not be performed because Algolia credentials were not provided.');
-        }
-
-        $config = SearchConfig::create(
-            $this->config->getApplicationID($storeId),
-            $this->config->getAPIKey($storeId)
-        );
-        $config->setConnectTimeout($this->getConnectionTimeout($storeId));
-        $config->setReadTimeout($this->getReadTimeout($storeId));
-        $config->setWriteTimeout($this->config->getWriteTimeout($storeId));
-        $this->clients[$storeId] = SearchClient::createWithConfig($config);
-    }
-
-    /**
-     * Allow override by alternate connectors
-     */
-    protected function getConnectionTimeout(int $storeId): int
-    {
-        return $this->config->getConnectionTimeout($storeId);
-    }
-
-    /**
-     * Allow override by alternate connectors
-     */
-    protected function getReadTimeout(int $storeId): int
-    {
-        return $this->config->getReadTimeout($storeId);
-    }
-
-    /**
-     * @throws AlgoliaException
-     */
-    protected function addAlgoliaUserAgent(int $storeId = self::ALGOLIA_DEFAULT_SCOPE): void
-    {
-        $clientName = $this->getClient($storeId)->getClientConfig()?->getClientName();
-
-        if ($clientName) {
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento2 integration', $this->config->getExtensionVersion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'PHP', phpversion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento', $this->config->getMagentoVersion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Edition', $this->config->getMagentoEdition());
-
-            $this->userAgentsAdded = true;
-        }
-    }
-
-    /**
-     * @throws AlgoliaException
-     */
     public function getClient(?int $storeId = self::ALGOLIA_DEFAULT_SCOPE): SearchClient
     {
-        if ($storeId === null) {
-            $storeId = self::ALGOLIA_DEFAULT_SCOPE;
-        }
-
-        if (!isset($this->clients[$storeId])) {
-            $this->createClient($storeId);
-            if (!$this->userAgentsAdded) {
-                $this->addAlgoliaUserAgent($storeId);
-            }
-        }
-
-        return $this->clients[$storeId];
+        return $this->clientProvider->getClient($storeId);
     }
 
     /**

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -248,6 +248,7 @@ class AlgoliaConnector
         $strategy = $this->sendStrategyResolver->resolve($indexOptions->getStoreId());
         $response = $strategy->send($indexOptions, $requests);
         $this->setLastOperationInfo($indexOptions, $response);
+
         return $response;
     }
 

--- a/Service/DirectSendStrategy.php
+++ b/Service/DirectSendStrategy.php
@@ -3,12 +3,13 @@
 namespace Algolia\AlgoliaSearch\Service;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
 
 class DirectSendStrategy implements SendStrategyInterface
 {
     public function __construct(
-        private AlgoliaConnector $connector
+        private SearchClientProviderInterface $clientProvider
     ) {}
 
     public function isApplicable(int $storeId): bool
@@ -18,7 +19,7 @@ class DirectSendStrategy implements SendStrategyInterface
 
     public function send(IndexOptionsInterface $indexOptions, array $requests): array
     {
-        return $this->connector->getClient($indexOptions->getStoreId())
+        return $this->clientProvider->getClient($indexOptions->getStoreId())
             ->batch($indexOptions->getIndexName(), ['requests' => $requests]);
     }
 }

--- a/Service/SearchClientProvider.php
+++ b/Service/SearchClientProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
+use Algolia\AlgoliaSearch\Configuration\SearchConfig;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
+
+class SearchClientProvider implements SearchClientProviderInterface
+{
+    /** @var SearchClient[] */
+    protected array $clients = [];
+
+    protected bool $userAgentsAdded = false;
+
+    public function __construct(
+        protected ConfigHelper $config,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
+    ) {}
+
+    /**
+     * @throws AlgoliaException
+     */
+    public function getClient(?int $storeId = AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE): SearchClient
+    {
+        if ($storeId === null) {
+            $storeId = AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE;
+        }
+
+        if (!isset($this->clients[$storeId])) {
+            $this->createClient($storeId);
+            if (!$this->userAgentsAdded) {
+                $this->addAlgoliaUserAgent($storeId);
+            }
+        }
+
+        return $this->clients[$storeId];
+    }
+
+    /**
+     * @throws AlgoliaException
+     */
+    protected function createClient(int $storeId = AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE): void
+    {
+        if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
+            throw new AlgoliaException('Client initialization could not be performed because Algolia credentials were not provided.');
+        }
+
+        $config = SearchConfig::create(
+            $this->config->getApplicationID($storeId),
+            $this->config->getAPIKey($storeId)
+        );
+        $config->setConnectTimeout($this->getConnectionTimeout($storeId));
+        $config->setReadTimeout($this->getReadTimeout($storeId));
+        $config->setWriteTimeout($this->config->getWriteTimeout($storeId));
+        $this->clients[$storeId] = SearchClient::createWithConfig($config);
+    }
+
+    /**
+     * @throws AlgoliaException
+     */
+    protected function addAlgoliaUserAgent(int $storeId = AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE): void
+    {
+        $clientName = $this->getClient($storeId)->getClientConfig()?->getClientName();
+
+        if ($clientName) {
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento2 integration', $this->config->getExtensionVersion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'PHP', phpversion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento', $this->config->getMagentoVersion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Edition', $this->config->getMagentoEdition());
+
+            $this->userAgentsAdded = true;
+        }
+    }
+
+    protected function getConnectionTimeout(int $storeId): int
+    {
+        return $this->config->getConnectionTimeout($storeId);
+    }
+
+    protected function getReadTimeout(int $storeId): int
+    {
+        return $this->config->getReadTimeout($storeId);
+    }
+}

--- a/Service/SendStrategyResolver.php
+++ b/Service/SendStrategyResolver.php
@@ -22,6 +22,7 @@ class SendStrategyResolver
                 return $strategy;
             }
         }
+
         return $this->defaultStrategy;
     }
 }

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -70,6 +70,7 @@ class AlgoliaConnectorTest extends TestCase
                     $this->assertEquals('addObject', $requests[1]['action']);
                     $this->assertEquals('1', $requests[0]['body']['objectID']);
                     $this->assertEquals('2', $requests[1]['body']['objectID']);
+
                     return true;
                 })
             )
@@ -90,6 +91,7 @@ class AlgoliaConnectorTest extends TestCase
                 $this->indexOptions,
                 $this->callback(function ($requests) {
                     $this->assertEquals('partialUpdateObject', $requests[0]['action']);
+
                     return true;
                 })
             )
@@ -123,6 +125,7 @@ class AlgoliaConnectorTest extends TestCase
                     $body = $requests[0]['body'];
                     $this->assertArrayHasKey('algoliaLastUpdateAtCET', $body);
                     $this->assertGreaterThanOrEqual($beforeTime, $body['algoliaLastUpdateAtCET']);
+
                     return true;
                 })
             )
@@ -143,6 +146,7 @@ class AlgoliaConnectorTest extends TestCase
                     $body = $requests[0]['body'];
                     $this->assertSame(29.99, $body['price']);
                     $this->assertSame(5, $body['qty']);
+
                     return true;
                 })
             )
@@ -168,6 +172,7 @@ class AlgoliaConnectorTest extends TestCase
                 $this->callback(function ($requests) {
                     $this->assertCount(1, $requests);
                     $this->assertEquals('1', $requests[0]['body']['objectID']);
+
                     return true;
                 })
             )
@@ -194,6 +199,7 @@ class AlgoliaConnectorTest extends TestCase
                     $this->assertEquals('100', $requests[0]['body']['objectID']);
                     $this->assertEquals('200', $requests[1]['body']['objectID']);
                     $this->assertEquals('300', $requests[2]['body']['objectID']);
+
                     return true;
                 })
             )

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -3,10 +3,10 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Service;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
-use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Service\SendStrategyResolver;
@@ -40,7 +40,7 @@ class AlgoliaConnectorTest extends TestCase
             $this->config,
             $this->createMock(ManagerInterface::class),
             $this->createMock(ConsoleOutput::class),
-            $this->createMock(AlgoliaCredentialsManager::class),
+            $this->createMock(SearchClientProviderInterface::class),
             $this->createMock(IndexNameFetcher::class),
             $this->createMock(IndexOptionsBuilder::class),
             $mockResolver

--- a/Test/Unit/Service/DirectSendStrategyTest.php
+++ b/Test/Unit/Service/DirectSendStrategyTest.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Service;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
 use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\DirectSendStrategy;
 use Algolia\AlgoliaSearch\Test\TestCase;
@@ -12,7 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 class DirectSendStrategyTest extends TestCase
 {
     private null|(SearchClient&MockObject) $searchClient = null;
-    private null|(AlgoliaConnector&MockObject) $connector = null;
+    private null|(SearchClientProviderInterface&MockObject) $clientProvider = null;
     private ?DirectSendStrategy $strategy = null;
     private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
 
@@ -23,10 +24,10 @@ class DirectSendStrategyTest extends TestCase
     protected function setUp(): void
     {
         $this->searchClient = $this->createMock(SearchClient::class);
-        $this->connector = $this->createMock(AlgoliaConnector::class);
-        $this->connector->method('getClient')->willReturn($this->searchClient);
+        $this->clientProvider = $this->createMock(SearchClientProviderInterface::class);
+        $this->clientProvider->method('getClient')->willReturn($this->searchClient);
 
-        $this->strategy = new DirectSendStrategy($this->connector);
+        $this->strategy = new DirectSendStrategy($this->clientProvider);
 
         $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
         $this->indexOptions->method('getStoreId')->willReturn(self::STORE_ID);
@@ -47,7 +48,7 @@ class DirectSendStrategyTest extends TestCase
             ['action' => 'addObject', 'body' => ['objectID' => '2', 'name' => 'Product B']],
         ];
 
-        $this->connector->expects($this->once())
+        $this->clientProvider->expects($this->once())
             ->method('getClient')
             ->with(self::STORE_ID)
             ->willReturn($this->searchClient);

--- a/Test/Unit/Service/DirectSendStrategyTest.php
+++ b/Test/Unit/Service/DirectSendStrategyTest.php
@@ -87,6 +87,7 @@ class DirectSendStrategyTest extends TestCase
                 $this->callback(function ($batchParams) {
                     $this->assertEquals('deleteObject', $batchParams['requests'][0]['action']);
                     $this->assertEquals('100', $batchParams['requests'][0]['body']['objectID']);
+
                     return true;
                 })
             )

--- a/Test/Unit/Service/SearchClientProviderTest.php
+++ b/Test/Unit/Service/SearchClientProviderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\SearchClientProvider;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SearchClientProviderTest extends TestCase
+{
+    private null|(ConfigHelper&MockObject) $config = null;
+    private null|(AlgoliaCredentialsManager&MockObject) $credentialsManager = null;
+    private ?SearchClientProvider $provider = null;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(ConfigHelper::class);
+        $this->config->method('getExtensionVersion')->willReturn('3.19.0');
+        $this->config->method('getMagentoVersion')->willReturn('2.4.8');
+        $this->config->method('getMagentoEdition')->willReturn('Community');
+
+        $this->credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+
+        $this->provider = new SearchClientProvider(
+            $this->config,
+            $this->credentialsManager
+        );
+    }
+
+    public function testGetClientThrowsWhenCredentialsInvalid(): void
+    {
+        $this->credentialsManager->method('checkCredentials')->willReturn(false);
+
+        $this->expectException(AlgoliaException::class);
+        $this->expectExceptionMessage('Algolia credentials were not provided');
+
+        $this->provider->getClient(1);
+    }
+
+    public function testGetClientWithNullStoreIdDefaultsToZero(): void
+    {
+        $this->credentialsManager->method('checkCredentials')
+            ->with(0)
+            ->willReturn(false);
+
+        $this->expectException(AlgoliaException::class);
+
+        $this->provider->getClient(null);
+    }
+
+    public function testGetClientCachesPerStore(): void
+    {
+        $this->credentialsManager->expects($this->once())
+            ->method('checkCredentials')
+            ->with(1)
+            ->willReturn(true);
+        $this->config->method('getApplicationID')->willReturn('test-app-id');
+        $this->config->method('getAPIKey')->willReturn('test-api-key');
+        $this->config->method('getConnectionTimeout')->willReturn(5);
+        $this->config->method('getReadTimeout')->willReturn(10);
+        $this->config->method('getWriteTimeout')->willReturn(30);
+
+        $client1 = $this->provider->getClient(1);
+        $client1Again = $this->provider->getClient(1);
+
+        $this->assertSame($client1, $client1Again);
+    }
+
+    public function testGetClientReturnsDifferentClientsPerStore(): void
+    {
+        $storeIds = [];
+        $this->credentialsManager->expects($this->exactly(2))
+            ->method('checkCredentials')
+            ->with($this->callback(function (int $storeId) use (&$storeIds) {
+                $storeIds[] = $storeId;
+                return true;
+            }))
+            ->willReturn(true);
+        $this->config->method('getApplicationID')->willReturn('test-app-id');
+        $this->config->method('getAPIKey')->willReturn('test-api-key');
+        $this->config->method('getConnectionTimeout')->willReturn(5);
+        $this->config->method('getReadTimeout')->willReturn(10);
+        $this->config->method('getWriteTimeout')->willReturn(30);
+
+        $client1 = $this->provider->getClient(1);
+        $client2 = $this->provider->getClient(2);
+
+        $this->assertNotSame($client1, $client2);
+        $this->assertEquals([1, 2], $storeIds);
+    }
+}

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -330,8 +330,11 @@ in `Model/Backend/`.
   sub-directory with a consistent set of classes: IndexBuilder, RecordBuilder,
   BatchQueueProcessor. New entities should follow this pattern.
 
-- **Single API gateway.** All Algolia PHP client usage goes through `AlgoliaConnector`.
-  Other classes never instantiate the client directly.
+- **Single API gateway.** `SearchClient` instantiation is managed by `SearchClientProvider`
+  (via `SearchClientProviderInterface`). All index operations go through `AlgoliaConnector`,
+  which delegates client access to the provider. Other classes never instantiate `SearchClient`
+  directly or bypass the connector for index operations. Other Algolia API clients (e.g.,
+  `IngestionClient`) follow the same provider pattern with their own dedicated providers.
 
 - **Frontend config bridge.** Server-side config is serialized once in
   `Block/Configuration.php`. There is no REST API for frontend config - JS reads from
@@ -345,7 +348,9 @@ in `Model/Backend/`.
 
 These are properties the codebase maintains by convention.
 
-- No direct Algolia API client usage outside `AlgoliaConnector`.
+- No direct `SearchClient` instantiation outside `SearchClientProvider`. Each Algolia API
+  client type has its own dedicated provider.
+- No direct Algolia index operations outside `AlgoliaConnector`.
 - No direct `ScopeConfigInterface` reads outside `Helper/`.
 - No REST/GraphQL endpoints for indexing control - indexing is triggered only through
   Magento's indexer framework, CLI commands, or the admin UI.

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -39,15 +39,13 @@
     <preference for="Algolia\AlgoliaSearch\Api\Data\SearchQueryInterface" type="Algolia\AlgoliaSearch\Model\Data\SearchQuery" />
     <preference for="Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface" type="Algolia\AlgoliaSearch\Model\Data\IndexOptions" />
 
+    <!-- Client provider -->
+    <preference for="Algolia\AlgoliaSearch\Api\SearchClientProviderInterface"
+                type="Algolia\AlgoliaSearch\Service\SearchClientProvider"/>
+
     <!-- Send strategy -->
     <preference for="Algolia\AlgoliaSearch\Api\SendStrategyInterface"
                 type="Algolia\AlgoliaSearch\Service\DirectSendStrategy"/>
-    <type name="Algolia\AlgoliaSearch\Service\DirectSendStrategy">
-        <arguments>
-            <!-- Temporary proxy to address circular dependency - TODO: Refactor this -->
-            <argument name="connector" xsi:type="object">Algolia\AlgoliaSearch\Service\AlgoliaConnector\Proxy</argument>
-        </arguments>
-    </type>
     <type name="Algolia\AlgoliaSearch\Service\SendStrategyResolver">
         <arguments>
             <argument name="defaultStrategy" xsi:type="object">Algolia\AlgoliaSearch\Service\DirectSendStrategy</argument>


### PR DESCRIPTION
**Summary**

This PR decomposes `AlgoliaConnector` so that search client provisioning can be invoked independently and relieves the original connector of this responsibility. This is especially useful for supporting the strategy pattern introduced on https://github.com/algolia/algoliasearch-magento-2/pull/1924. 

- Lifecycle management (creation, caching, credentials, user agent) has been moved from `AlgoliaConnector` into a new `SearchClientProvider` class behind a `SearchClientProviderInterface`)
- Eliminates the circular dependency discovered during introduction of the send strategy (`AlgoliaConnector -> SendStrategyResolver -> DirectSendStrategy -> AlgoliaConnector`) that required a Magento proxy as a temporary workaround in `di.xml`
- `DirectSendStrategy` now depends on the narrow `SearchClientProviderInterface` instead of the full `AlgoliaConnector`
- Updates `ARCHITECTURE.md` with new design pattern
- Unit tests updated / added 

The change is intended to be purely architectural and should represent no behavioral change.

**Result**
Unit tests:
<img width="1489" height="260" alt="image" src="https://github.com/user-attachments/assets/7e761313-dc08-4e14-b047-e9e502834155" />
Integration tests:
<img width="982" height="209" alt="image" src="https://github.com/user-attachments/assets/1c3020ea-454a-4a56-8ca9-f746a9dda729" />
