### PR TITLE
MAGE-1535 Centralize default store scope constant

### DIFF
--- a/Api/ClientProviderInterface.php
+++ b/Api/ClientProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Api;
+
+interface ClientProviderInterface
+{
+    public const ALGOLIA_DEFAULT_SCOPE = 0;
+}

--- a/Api/SearchClientProviderInterface.php
+++ b/Api/SearchClientProviderInterface.php
@@ -4,10 +4,10 @@ namespace Algolia\AlgoliaSearch\Api;
 
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 
-interface SearchClientProviderInterface
+interface SearchClientProviderInterface extends ClientProviderInterface
 {
     /**
      * @throws AlgoliaException
      */
-    public function getClient(?int $storeId = 0): SearchClient;
+    public function getClient(?int $storeId = self::ALGOLIA_DEFAULT_SCOPE): SearchClient;
 }

--- a/Controller/Adminhtml/IndexingManager/Reindex.php
+++ b/Controller/Adminhtml/IndexingManager/Reindex.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Api\ClientProviderInterface;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use Magento\Backend\App\Action;
@@ -43,7 +43,7 @@ class Reindex extends Action
     public function execute()
     {
         $params = $this->getRequest()->getParams();
-        $storeIds = !isset($params['store_id']) || $params['store_id'] === (string) AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE ?
+        $storeIds = !isset($params['store_id']) || $params['store_id'] === (string) ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE ?
             array_keys($this->storeManager->getStores()) :
             [(int) $params['store_id']];
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AdditionalSection\IndexBuilder as AdditionalSectionIndexBuilder;
-use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Api\ClientProviderInterface;
 use Algolia\AlgoliaSearch\Service\Category\IndexBuilder as CategoryIndexBuilder;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\Page\IndexBuilder as PageIndexBuilder;
@@ -182,7 +182,7 @@ class Data
     public function getIndexDataByStoreIds(): array
     {
         $indexNames = [];
-        $indexNames[AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE] = $this->buildIndexData();
+        $indexNames[ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE] = $this->buildIndexData();
         foreach ($this->storeManager->getStores() as $store) {
             $indexNames[$store->getId()] = $this->buildIndexData($store);
         }

--- a/Service/AbstractClientProvider.php
+++ b/Service/AbstractClientProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service;
+
+use Algolia\AlgoliaSearch\Api\ClientProviderInterface;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
+
+abstract class AbstractClientProvider
+{
+    protected bool $userAgentsAdded = false;
+
+    /**
+     * @throws AlgoliaException
+     */
+    protected function addAlgoliaUserAgent(int $storeId = ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE): void
+    {
+        $clientName = $this->getClient($storeId)->getClientConfig()?->getClientName();
+
+        if ($clientName) {
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento2 integration', $this->config->getExtensionVersion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'PHP', phpversion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento', $this->config->getMagentoVersion());
+            AlgoliaAgent::addAlgoliaAgent($clientName, 'Edition', $this->config->getMagentoEdition());
+
+            $this->userAgentsAdded = true;
+        }
+    }
+
+    /**
+     * @throws AlgoliaException
+     */
+    protected function createClientByStore(?int $storeId): void
+    {
+        if ($storeId === null) {
+            $storeId = ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE;
+        }
+
+        if (!isset($this->clients[$storeId])) {
+            $this->createClient($storeId);
+            if (!$this->userAgentsAdded) {
+                $this->addAlgoliaUserAgent($storeId);
+            }
+        }
+    }
+
+    protected function getConnectionTimeout(int $storeId): int
+    {
+        return $this->config->getConnectionTimeout($storeId);
+    }
+
+    protected function getReadTimeout(int $storeId): int
+    {
+        return $this->config->getReadTimeout($storeId);
+    }
+}

--- a/Service/AbstractClientProvider.php
+++ b/Service/AbstractClientProvider.php
@@ -10,6 +10,8 @@ abstract class AbstractClientProvider
 {
     protected bool $userAgentsAdded = false;
 
+    abstract protected function createClient(int $storeId = ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE): void;
+
     /**
      * @throws AlgoliaException
      */

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Service;
 
+use Algolia\AlgoliaSearch\Api\ClientProviderInterface;
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
 use Algolia\AlgoliaSearch\Api\Data\SearchQueryInterface;
 use Algolia\AlgoliaSearch\Api\SearchClient;
@@ -27,8 +28,11 @@ class AlgoliaConnector
     /** @var string */
     public const ALGOLIA_API_TASK_ID = 'taskID';
 
-    /** @var int */
-    public const ALGOLIA_DEFAULT_SCOPE = 0;
+    /**
+     * @deprecated Use ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE
+     * @var int
+     */
+    public const ALGOLIA_DEFAULT_SCOPE = ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE;
 
     /** @var int This value should be configured based on system/full_page_cache/ttl
      *           (which is by default 86400) and/or the configuration block TTL
@@ -68,7 +72,7 @@ class AlgoliaConnector
     /**
      * @throws AlgoliaException
      */
-    public function getClient(?int $storeId = self::ALGOLIA_DEFAULT_SCOPE): SearchClient
+    public function getClient(?int $storeId = ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE): SearchClient
     {
         return $this->clientProvider->getClient($storeId);
     }
@@ -545,7 +549,7 @@ class AlgoliaConnector
         }
 
         if ($storeId === null) {
-            $storeId = self::ALGOLIA_DEFAULT_SCOPE;
+            $storeId = ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE;
         }
 
         $this->getClient($storeId)->waitForTask($lastUsedIndexName, $lastTaskId);

--- a/Service/SearchClientProvider.php
+++ b/Service/SearchClientProvider.php
@@ -7,14 +7,11 @@ use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Configuration\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 
-class SearchClientProvider implements SearchClientProviderInterface
+class SearchClientProvider extends AbstractClientProvider implements SearchClientProviderInterface
 {
     /** @var SearchClient[] */
     protected array $clients = [];
-
-    protected bool $userAgentsAdded = false;
 
     public function __construct(
         protected ConfigHelper $config,
@@ -26,18 +23,9 @@ class SearchClientProvider implements SearchClientProviderInterface
      */
     public function getClient(?int $storeId = self::ALGOLIA_DEFAULT_SCOPE): SearchClient
     {
-        if ($storeId === null) {
-            $storeId = self::ALGOLIA_DEFAULT_SCOPE;
-        }
+        $this->createClientByStore($storeId);
 
-        if (!isset($this->clients[$storeId])) {
-            $this->createClient($storeId);
-            if (!$this->userAgentsAdded) {
-                $this->addAlgoliaUserAgent($storeId);
-            }
-        }
-
-        return $this->clients[$storeId];
+        return $this->clients[$storeId ?: self::ALGOLIA_DEFAULT_SCOPE];
     }
 
     /**
@@ -57,32 +45,5 @@ class SearchClientProvider implements SearchClientProviderInterface
         $config->setReadTimeout($this->getReadTimeout($storeId));
         $config->setWriteTimeout($this->config->getWriteTimeout($storeId));
         $this->clients[$storeId] = SearchClient::createWithConfig($config);
-    }
-
-    /**
-     * @throws AlgoliaException
-     */
-    protected function addAlgoliaUserAgent(int $storeId = self::ALGOLIA_DEFAULT_SCOPE): void
-    {
-        $clientName = $this->getClient($storeId)->getClientConfig()?->getClientName();
-
-        if ($clientName) {
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento2 integration', $this->config->getExtensionVersion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'PHP', phpversion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Magento', $this->config->getMagentoVersion());
-            AlgoliaAgent::addAlgoliaAgent($clientName, 'Edition', $this->config->getMagentoEdition());
-
-            $this->userAgentsAdded = true;
-        }
-    }
-
-    protected function getConnectionTimeout(int $storeId): int
-    {
-        return $this->config->getConnectionTimeout($storeId);
-    }
-
-    protected function getReadTimeout(int $storeId): int
-    {
-        return $this->config->getReadTimeout($storeId);
     }
 }

--- a/Service/SearchClientProvider.php
+++ b/Service/SearchClientProvider.php
@@ -24,10 +24,10 @@ class SearchClientProvider implements SearchClientProviderInterface
     /**
      * @throws AlgoliaException
      */
-    public function getClient(?int $storeId = AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE): SearchClient
+    public function getClient(?int $storeId = self::ALGOLIA_DEFAULT_SCOPE): SearchClient
     {
         if ($storeId === null) {
-            $storeId = AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE;
+            $storeId = self::ALGOLIA_DEFAULT_SCOPE;
         }
 
         if (!isset($this->clients[$storeId])) {
@@ -43,7 +43,7 @@ class SearchClientProvider implements SearchClientProviderInterface
     /**
      * @throws AlgoliaException
      */
-    protected function createClient(int $storeId = AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE): void
+    protected function createClient(int $storeId = self::ALGOLIA_DEFAULT_SCOPE): void
     {
         if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
             throw new AlgoliaException('Client initialization could not be performed because Algolia credentials were not provided.');
@@ -62,7 +62,7 @@ class SearchClientProvider implements SearchClientProviderInterface
     /**
      * @throws AlgoliaException
      */
-    protected function addAlgoliaUserAgent(int $storeId = AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE): void
+    protected function addAlgoliaUserAgent(int $storeId = self::ALGOLIA_DEFAULT_SCOPE): void
     {
         $clientName = $this->getClient($storeId)->getClientConfig()?->getClientName();
 

--- a/Test/TestCase.php
+++ b/Test/TestCase.php
@@ -43,6 +43,22 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Get a private property of a class
+     *
+     * @param object $obj The object to get the property from
+     * @param string $prop The name of the property to get the value for
+     * @return mixed The value of the property
+     *
+     * @throws \ReflectionException
+     */
+    protected function getPrivateProperty(object $obj, string $prop): mixed
+    {
+        $reflection = new \ReflectionClass($obj);
+
+        return $reflection->getProperty($prop)->getValue($obj);
+    }
+
+    /**
      * Mock a private property of a class
      *
      * @param object $object The object to mock the property for


### PR DESCRIPTION
**Summary**

This PR provides some small refactoring to help support the ingestion module:

- Introduces `ClientProviderInterface` as a centralized home for the `ALGOLIA_DEFAULT_SCOPE` constant (previously defined on `AlgoliaConnector`), making it available across the API layer without coupling consumers to a concrete service class
- Eliminates hardcoded 0 defaults from both `SearchClientProviderInterface` and `IngestionClientProviderInterface` in new ingestion module
- Updates all existing usages (`AlgoliaConnector`, `SearchClientProvider`, `Helper/Data`, `Controller/Adminhtml/IndexingManager/Reindex`) to reference `ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE`.
- Deprecates `AlgoliaConnector::ALGOLIA_DEFAULT_SCOPE` with a backward-compatible alias pointing to the new canonical location.
- Adds a `getPrivateProperty()` reflection utility to the base TestCase class for use in unit tests.
 