### PR TITLE
MAGE-1557: Introduce Claude testing guides 

### DIFF
--- a/.claude/skills/generate-unit-tests/SKILL.md
+++ b/.claude/skills/generate-unit-tests/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: generate-unit-tests
+description: Generates focused PHPUnit unit tests for a given PHP class in the AlgoliaSearch module, following the project's 3-layer testing guidelines (core rules → type guide → class-specific rules).
+---
+
+Generate focused PHPUnit unit tests for the file: $ARGUMENTS
+
+Follow these steps exactly:
+
+## Step 1 — Load foundation rules
+Read `.claude/testing-core.md`. These rules are non-negotiable and apply to every test you generate.
+
+## Step 2 — Load the type-specific guide
+Determine which category the target file belongs to based on its path and class name:
+
+| If the path contains…          | Read this guide                              |
+|---------------------------------|----------------------------------------------|
+| `Observer/`                     | `.claude/types/testing-observers.md`         |
+| `Service/`                      | `.claude/types/testing-services.md`          |
+| `Helper/`                       | `.claude/types/testing-helpers.md`           |
+| `Model/Indexer/` or `Indexer/`  | `.claude/types/testing-indexers.md`          |
+| anything else                   | skip — use core rules only                   |
+
+Read the matching guide before generating any test code.
+
+## Step 3 — Check for class-specific rules
+Extract the class name from the file path (e.g. `AlgoliaConnector` from `Service/AlgoliaConnector.php`) and check whether `.claude/specifics/testing-<ClassName>.md` exists. If it does, read it — its rules take precedence over the type guide for this class.
+
+## Step 4 — Read the target file
+Read the full source file at the path provided in $ARGUMENTS. Understand:
+- Constructor dependencies (these will all be mocked)
+- Public methods and their signatures
+- Guard clauses and early exits
+- Any use of `addCommitCallback`, event dispatch, or external service calls
+
+## Step 5 — Determine output path
+Mirror the module structure under `Test/Unit/`:
+- `Model/Indexer/CategoryObserver.php` → `Test/Unit/Model/Indexer/CategoryObserverTest.php`
+- `Service/Product/RecordBuilder.php` → `Test/Unit/Service/Product/RecordBuilderTest.php`
+- `Helper/ConfigHelper.php` → `Test/Unit/Helper/ConfigHelperTest.php`
+
+Check if a test file already exists at that path. If it does, read it first to avoid duplicating existing tests.
+
+## Step 6 — Generate tests
+
+Rules:
+- **Maximum 10 tests** per file
+- **Focus on user-observable behavior**: what the method returns, what exception it throws, which collaborator it calls with which arguments
+- **Do not test implementation details**: internal variable names, call counts on low-level helpers, private method logic
+- **Use `@dataProvider`** (or `#[DataProvider]` attribute) when testing the same behavior across multiple input variants
+- Each test name must read as a plain-English sentence describing the behavior: `testReturnsEmptyArrayWhenProductIsDisabled`
+- Use the nullable property pattern from core rules: `protected null|(Foo&MockObject) $foo = null;`
+- For magic `@method` docblock methods, use `getMockBuilder` + `addMethods()`
+- For `addCommitCallback` patterns, capture and invoke the closure inline
+
+## Step 7 — Write the file
+Write the generated test class to the output path determined in Step 5. The file must:
+- Extend `\Algolia\AlgoliaSearch\Test\TestCase` (not PHPUnit's TestCase directly) so inherited helpers like `invokeMethod()`, `setPrivateProperty()`, and `getPrivateProperty()` are available
+- Declare strict types
+- Use the same namespace structure as the module (e.g. `Algolia\AlgoliaSearch\Test\Unit\Model\Indexer`)
+- Import all used classes at the top
+
+After writing the file, report:
+- The output file path
+- A one-line description of each test and what behavior it covers

--- a/.claude/skills/generate-unit-tests/SKILL.md
+++ b/.claude/skills/generate-unit-tests/SKILL.md
@@ -44,10 +44,12 @@ Check if a test file already exists at that path. If it does, read it first to a
 ## Step 6 — Generate tests
 
 Rules:
-- **Maximum 10 tests** per file
+- **Generate at least one test per public method** with some exceptions such as `@deprecated` methods, or delegating methods — but only skip a delegating method when the delegation is trivial and involves no transformation, guard clause, or state change.
+- **Any additional tests per method should be driven by its cyclomatic complexity**
 - **Focus on user-observable behavior**: what the method returns, what exception it throws, which collaborator it calls with which arguments
 - **Do not test implementation details**: internal variable names, call counts on low-level helpers, private method logic
 - **Use `@dataProvider`** (or `#[DataProvider]` attribute) when testing the same behavior across multiple input variants
+- **Don't write any test that just return what we mock.**
 - Each test name must read as a plain-English sentence describing the behavior: `testReturnsEmptyArrayWhenProductIsDisabled`
 - Use the nullable property pattern from core rules: `protected null|(Foo&MockObject) $foo = null;`
 - For magic `@method` docblock methods, use `getMockBuilder` + `addMethods()`

--- a/.claude/specifics/testing-AlgoliaConnector.md
+++ b/.claude/specifics/testing-AlgoliaConnector.md
@@ -1,0 +1,14 @@
+#Testing Guidelines specific to the AlgoliaConnector Service
+
+## Component Types & Testing Approaches
+- AlgoliaConnector is a service located at Service/AlgoliaConnector.php 
+
+## Specifics
+- As mentioned in the doc/ARCHITECTURE.md file : `AlgoliaConnector` is the single gateway to the Algolia PHP API client. All API calls
+  flow through it.
+- As such, we can expect more than the expected limit of 10 tests.
+- Focus on the methods calling the client rather than utility methods
+
+## Mistakes to avoid
+- Make sure to test how we leverage the Algolia PHP Client, not the Client itself.
+- `SearchClient::generateSecuredApiKey` is a **static method** in the Algolia PHP client v4 — PHPUnit cannot mock it. Do not write tests that try to configure it on a mock object; they will throw `BadMethodCallException`.

--- a/.claude/specifics/testing-AlgoliaConnector.md
+++ b/.claude/specifics/testing-AlgoliaConnector.md
@@ -6,7 +6,6 @@
 ## Specifics
 - As mentioned in the doc/ARCHITECTURE.md file : `AlgoliaConnector` is the single gateway to the Algolia PHP API client. All API calls
   flow through it.
-- As such, we can expect more than the expected limit of 10 tests.
 - Focus on the methods calling the client rather than utility methods
 
 ## Mistakes to avoid

--- a/.claude/testing-core.md
+++ b/.claude/testing-core.md
@@ -1,0 +1,56 @@
+#Core Testing Guidelines
+
+## Informations
+- The files we are testing are located in a Magento2 module
+- The test files are located in the Test/Unit directory, create all the tests in this parent's directory
+- Follow the same structure as in the module (ex: tests for the Service/Product/RecordBuilder.php should be located in the Test/Unit/Service/Product directory)
+
+## Tech Stack
+- Use PHPUnit 10
+- PHP 8.3
+- Magento 2.4.8
+
+### Test Strategy
+- Don't test Event Manager's dispatch methods
+- Use @dataProvider annotations when it's needed
+- Do not test methods coming from the parent classes (Magento core)
+
+### Mocking Strategy
+- Instantiate the tested class in the setUp() method by mocking every object that needs to be passed in its constructor
+- Use nullable types for the testing class properties. ex:
+    - protected ?ConfigHelper $configHelper;
+      or
+    - protected null|(CategoryResourceModel&MockObject) $categoryResource = null;
+
+**DO Mock:**
+- Every object that needs to be passed in the constructor of the tested class
+
+**DON'T Mock:**
+- The tested class itself
+
+### Example
+
+```php
+class InstantSearchHelperTest extends TestCase
+{
+    protected ?InstantSearchHelper $instantSearchHelper;
+
+    protected ?ScopeConfigInterface $configInterface;
+    protected ?WriterInterface $configWriter;
+    protected ?Serializer $serializer;
+
+    protected function setUp(): void
+    {
+        $this->configInterface = $this->createMock(ScopeConfigInterface::class);
+        $this->configWriter = $this->createMock(WriterInterface::class);
+        $this->serializer = $this->createMock(Serializer::class);
+
+        $this->instantSearchHelper = new InstantSearchHelper(
+            $this->configInterface,
+            $this->configWriter,
+            $this->serializer
+        );
+    }
+//...
+}
+```

--- a/.claude/types/testing-helpers.md
+++ b/.claude/types/testing-helpers.md
@@ -1,0 +1,45 @@
+# Helper Testing Guide
+
+## What to test
+- Config value retrieval (correct scope, correct path)
+- Data formatting and transformation methods
+- Boolean flags and feature toggles
+- Methods that aggregate multiple config values
+
+## What NOT to test
+- That `ScopeConfigInterface::getValue` works (it's core)
+- Serialization/unserialization of Magento core serializers
+
+## Key patterns
+
+### Config helpers (ConfigHelper pattern)
+ConfigHelper wraps `ScopeConfigInterface`. Test that it reads from the right path and scope, and casts/transforms the value correctly.
+
+```php
+$this->scopeConfig->method('getValue')
+    ->with(ConfigHelper::APPLICATION_ID, ScopeInterface::SCOPE_STORE, $storeId)
+    ->willReturn('MY_APP_ID');
+
+$this->assertSame('MY_APP_ID', $this->configHelper->getApplicationID($storeId));
+```
+
+### Boolean flags
+```php
+$this->scopeConfig->method('isSetFlag')
+    ->with(ConfigHelper::ENABLE_INDEXING, ScopeInterface::SCOPE_STORE)
+    ->willReturn(true);
+
+$this->assertTrue($this->configHelper->isIndexingEnabled());
+```
+
+### Serialized values (arrays stored as JSON)
+```php
+$this->serializer->method('unserialize')
+    ->willReturn(['field' => 'name', 'searchable' => '1']);
+```
+
+## Focus areas
+1. Each public getter with its expected output type
+2. Default values when config is null/empty
+3. Store-scoped vs global config reads
+4. Any transformation logic (e.g. CSV to array, JSON decode, type cast)

--- a/.claude/types/testing-indexers.md
+++ b/.claude/types/testing-indexers.md
@@ -1,0 +1,53 @@
+# Indexer Testing Guide
+
+## What to test
+- That `executeFull()` triggers a full reindex via the correct service
+- That `executeList($ids)` triggers a partial reindex with the given IDs
+- Guard clauses: credentials missing, indexing disabled
+- Queue mode vs direct mode branching
+
+## What NOT to test
+- Magento's indexer framework internals
+- `IndexerInterface` implementations from Magento core
+
+## Key patterns
+
+### Full vs partial reindex
+```php
+public function testExecuteFullDelegatesToService(): void
+{
+    $this->indexingService->expects($this->once())->method('reindexAll');
+    $this->indexer->executeFull();
+}
+
+public function testExecuteListDelegatesToServiceWithIds(): void
+{
+    $ids = [1, 2, 3];
+    $this->indexingService->expects($this->once())
+        ->method('reindexList')
+        ->with($ids);
+    $this->indexer->executeList($ids);
+}
+```
+
+### Plugin/Observer pattern (addCommitCallback)
+For indexers that are actually plugins deferring work:
+```php
+$this->resource->method('addCommitCallback')
+    ->willReturnCallback(function (callable $cb) { $cb(); });
+```
+
+### IndexerRegistry with multiple indexers
+```php
+$this->indexerRegistry->method('get')
+    ->willReturnMap([
+        ['algolia_categories', $this->categoryIndexer],
+        ['algolia_products', $this->productIndexer],
+    ]);
+```
+
+## Focus areas
+1. Delegation to the right service/helper method
+2. Early exits when credentials or indexing are disabled
+3. Correct IDs passed through from observer to service
+4. Scheduled vs non-scheduled (queue) branching

--- a/.claude/types/testing-observers.md
+++ b/.claude/types/testing-observers.md
@@ -1,0 +1,36 @@
+# Observer Testing Guide
+
+## What to test
+- That the observer responds to the correct event
+- That it delegates to the right service/helper with the right arguments
+- Edge cases: missing data, disabled config, wrong store context
+
+## What NOT to test
+- `EventManager::dispatch()` calls (per core rules)
+- Internal Magento framework behavior
+- That an observer is wired to an event (that's XML config, not PHP logic)
+
+## Key patterns
+
+### Accessing the event object
+Observer methods receive a `\Magento\Framework\Event\Observer` — mock it and configure `getEvent()` to return a mock event with the right data objects.
+
+```php
+$observer = $this->createMock(\Magento\Framework\Event\Observer::class);
+$event = $this->createMock(\Magento\Framework\Event::class);
+$observer->method('getEvent')->willReturn($event);
+$event->method('getData')->with('product')->willReturn($this->product);
+```
+
+### Commit callbacks (addCommitCallback pattern)
+When the observer defers work via `$resource->addCommitCallback(...)`, capture and invoke the closure:
+
+```php
+$this->resource->method('addCommitCallback')
+    ->willReturnCallback(function (callable $cb) { $cb(); });
+```
+
+## Focus areas
+1. Happy path: observer does its work when conditions are met
+2. Guard clauses: observer exits early when config is disabled or credentials are missing
+3. Store loop: work is performed per store when multiple stores exist

--- a/.claude/types/testing-services.md
+++ b/.claude/types/testing-services.md
@@ -1,0 +1,43 @@
+# Service Testing Guide
+
+## What to test
+- Core business logic and transformations
+- Return values and data shapes
+- Thrown exceptions for invalid input
+- Conditional branching based on arguments or injected config
+
+## What NOT to test
+- That dependencies were constructed correctly
+- Framework plumbing (DI wiring, plugin loading)
+- Private helper methods directly — test them via public API
+
+## Key patterns
+
+### Testing return values
+Services typically transform input into output. Assert on the returned value, not on internal calls.
+
+```php
+$result = $this->service->buildRecord($product);
+$this->assertArrayHasKey('objectID', $result);
+$this->assertSame('SKU-001', $result['sku']);
+```
+
+### Testing exceptions
+```php
+$this->expectException(ProductReindexingException::class);
+$this->service->canProductBeReindexed($disabledProduct, $storeId);
+```
+
+### Using @dataProvider for variants
+When the same logic runs differently based on input type (e.g. simple vs configurable product):
+
+```php
+#[DataProvider('productTypeProvider')]
+public function testBuildRecordHandlesProductType(string $typeId, array $expectedKeys): void
+```
+
+## Focus areas
+1. The main transformation/computation the service is responsible for
+2. Each distinct code path (enabled/disabled, different product types, etc.)
+3. Exception paths with meaningful messages
+4. Edge cases: empty collections, null values, zero prices

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Service;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\Data\SearchQueryInterface;
 use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
@@ -398,5 +399,158 @@ class AlgoliaConnectorTest extends TestCase
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
         $this->connector->deleteRule($this->indexOptions, 'rule-1');
+    }
+
+    // ── query() ──
+
+    public function testQueryBuildsCorrectRequestStructureForClient(): void
+    {
+        $queryOptions = $this->createMock(IndexOptionsInterface::class);
+        $queryOptions->method('getIndexName')->willReturn(self::INDEX_NAME);
+        $queryOptions->method('getStoreId')->willReturn(self::STORE_ID);
+
+        $searchQuery = $this->createMock(SearchQueryInterface::class);
+        $searchQuery->method('getIndexOptions')->willReturn($queryOptions);
+        $searchQuery->method('getQuery')->willReturn('blue shirt');
+        $searchQuery->method('getParams')->willReturn(['hitsPerPage' => 10]);
+
+        $this->client->expects($this->once())
+            ->method('search')
+            ->with($this->callback(function (array $payload) {
+                $request = $payload['requests'][0];
+                $this->assertSame(self::INDEX_NAME, $request[AlgoliaConnector::ALGOLIA_API_INDEX_NAME]);
+                $this->assertSame('blue shirt', $request['query']);
+                $this->assertSame(10, $request['hitsPerPage']);
+                return true;
+            }))
+            ->willReturn(['hits' => []]);
+
+        $this->connector->query($searchQuery);
+    }
+
+    // ── getObjects() ──
+
+    public function testGetObjectsMapsObjectIdsToRequestFormatWithIndexName(): void
+    {
+        $this->client->expects($this->once())
+            ->method('getObjects')
+            ->with($this->callback(function (array $payload) {
+                $this->assertCount(2, $payload['requests']);
+                $this->assertSame(self::INDEX_NAME, $payload['requests'][0][AlgoliaConnector::ALGOLIA_API_INDEX_NAME]);
+                $this->assertSame('42', $payload['requests'][0][AlgoliaConnector::ALGOLIA_API_OBJECT_ID]);
+                $this->assertSame('99', $payload['requests'][1][AlgoliaConnector::ALGOLIA_API_OBJECT_ID]);
+                return true;
+            }))
+            ->willReturn(['results' => []]);
+
+        $this->connector->getObjects($this->indexOptions, ['42', '99']);
+    }
+
+    // ── setSettings() merge branch ──
+
+    public function testSetSettingsMergesLocalSettingsOnTopOfOnlineSettings(): void
+    {
+        $onlineSettings = ['ranking' => ['typo', 'geo'], 'attributesToIndex' => ['old_name']];
+        $localSettings  = ['searchableAttributes' => ['new_name']];
+
+        $this->client->method('getSettings')->willReturn($onlineSettings);
+        $this->client->expects($this->once())
+            ->method('setSettings')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function (array $merged) {
+                    // attributesToIndex renamed + local override applied
+                    $this->assertSame(['new_name'], $merged['searchableAttributes']);
+                    // online-only keys preserved
+                    $this->assertArrayHasKey('ranking', $merged);
+                    // original attributesToIndex key removed
+                    $this->assertArrayNotHasKey('attributesToIndex', $merged);
+                    return true;
+                }),
+                false
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->setSettings($this->indexOptions, $localSettings, false, true);
+    }
+
+    // ── waitLastTask() ──
+
+    public function testWaitLastTaskReturnsEarlyWhenNoOperationHasBeenPerformed(): void
+    {
+        $this->client->expects($this->never())->method('waitForTask');
+
+        $this->connector->waitLastTask();
+    }
+
+    public function testWaitLastTaskCallsClientWithStoreSpecificStateAfterOperation(): void
+    {
+        $objects = [['objectID' => '1', 'name' => 'A']];
+        $this->mockStrategy->method('send')
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+        $this->connector->saveObjects($this->indexOptions, $objects);
+
+        $this->client->expects($this->once())
+            ->method('waitForTask')
+            ->with(self::INDEX_NAME, self::TASK_ID);
+
+        $this->connector->waitLastTask(self::STORE_ID);
+    }
+
+    // ── castProductObject() ──
+
+    public function testCastProductObjectConvertsNumericStringToInteger(): void
+    {
+        $data = ['qty' => '5'];
+        $this->connector->castProductObject($data);
+
+        $this->assertSame(5, $data['qty']);
+    }
+
+    public function testCastProductObjectLeavesNonCastableAttributesUntouched(): void
+    {
+        $data = ['sku' => '12345', 'name' => '100 Faces'];
+        $this->connector->castProductObject($data);
+
+        $this->assertSame('12345', $data['sku']);
+        $this->assertSame('100 Faces', $data['name']);
+    }
+
+    public function testCastProductObjectSplitsPipeSeparatedStringsIntoTypedArray(): void
+    {
+        $data = ['color_ids' => '1|2|3'];
+        $this->connector->castProductObject($data);
+
+        $this->assertSame([1, 2, 3], $data['color_ids']);
+    }
+
+    // ── isValidFloat() ──
+
+    public function testIsValidFloatReturnsFalseForValuesThatEvaluateToInfinity(): void
+    {
+        $this->assertFalse($this->connector->isValidFloat('1.8e308'));
+    }
+
+    public function testIsValidFloatReturnsTrueForRegularFloatingPointValues(): void
+    {
+        $this->assertTrue($this->connector->isValidFloat('3.14'));
+    }
+
+    // ── getLastTaskId() ──
+
+    public function testGetLastTaskIdReturnsNullWhenNoOperationHasBeenPerformed(): void
+    {
+        $this->assertNull($this->connector->getLastTaskId());
+    }
+
+    public function testGetLastTaskIdReturnsStoreSpecificTaskIdAfterOperation(): void
+    {
+        $objects = [['objectID' => '1', 'name' => 'A']];
+        $this->mockStrategy->method('send')
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->saveObjects($this->indexOptions, $objects);
+
+        $this->assertSame(self::TASK_ID, $this->connector->getLastTaskId(self::STORE_ID));
     }
 }

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Service;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
@@ -21,6 +22,8 @@ class AlgoliaConnectorTest extends TestCase
     private null|(SendStrategyInterface&MockObject) $mockStrategy = null;
     private null|(ConfigHelper&MockObject) $config = null;
     private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
+    private null|(SearchClientProviderInterface&MockObject) $clientProvider = null;
+    private null|(SearchClient&MockObject) $client = null;
 
     private const STORE_ID = 1;
     private const INDEX_NAME = 'magento2_default_products';
@@ -36,11 +39,15 @@ class AlgoliaConnectorTest extends TestCase
         $this->config->method('getNonCastableAttributes')->willReturn([]);
         $this->config->method('getMaxRecordSizeLimit')->willReturn(10000);
 
+        $this->client = $this->createMock(SearchClient::class);
+        $this->clientProvider = $this->createMock(SearchClientProviderInterface::class);
+        $this->clientProvider->method('getClient')->willReturn($this->client);
+
         $this->connector = new AlgoliaConnector(
             $this->config,
             $this->createMock(ManagerInterface::class),
             $this->createMock(ConsoleOutput::class),
-            $this->createMock(SearchClientProviderInterface::class),
+            $this->clientProvider,
             $this->createMock(IndexNameFetcher::class),
             $this->createMock(IndexOptionsBuilder::class),
             $mockResolver
@@ -251,5 +258,145 @@ class AlgoliaConnectorTest extends TestCase
         ]);
 
         $this->assertEquals($expectedResponse, $result);
+    }
+
+    // ── getSettings() ──
+
+    public function testGetSettingsReturnsEmptyArrayWhenIndexDoesNotExist(): void
+    {
+        $this->client->method('getSettings')
+            ->willThrowException(new \Exception('Not Found', 404));
+
+        $this->assertSame([], $this->connector->getSettings($this->indexOptions));
+    }
+
+    public function testGetSettingsRethrowsNon404Exceptions(): void
+    {
+        $this->client->method('getSettings')
+            ->willThrowException(new \Exception('Internal Server Error', 500));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionCode(500);
+
+        $this->connector->getSettings($this->indexOptions);
+    }
+
+    // ── setSettings() ──
+
+    public function testSetSettingsForwardsSettingsToClient(): void
+    {
+        $settings = ['searchableAttributes' => ['name', 'description']];
+
+        $this->client->expects($this->once())
+            ->method('setSettings')
+            ->with(self::INDEX_NAME, $settings, false)
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->setSettings($this->indexOptions, $settings);
+    }
+
+    // ── deleteIndex() ──
+
+    public function testDeleteIndexDelegatesToClient(): void
+    {
+        $this->client->expects($this->once())
+            ->method('deleteIndex')
+            ->with(self::INDEX_NAME)
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->deleteIndex($this->indexOptions);
+    }
+
+    // ── moveIndex() ──
+
+    public function testMoveIndexCallsOperationIndexWithMoveOperation(): void
+    {
+        $toIndexOptions = $this->createMock(IndexOptionsInterface::class);
+        $toIndexOptions->method('getIndexName')->willReturn('magento2_default_products_tmp');
+        $toIndexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+
+        $this->client->expects($this->once())
+            ->method('operationIndex')
+            ->with(self::INDEX_NAME, [
+                'operation'   => 'move',
+                'destination' => 'magento2_default_products_tmp',
+            ])
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->moveIndex($this->indexOptions, $toIndexOptions);
+    }
+
+    // ── clearIndex() ──
+
+    public function testClearIndexCallsClearObjectsOnClient(): void
+    {
+        $this->client->expects($this->once())
+            ->method('clearObjects')
+            ->with(self::INDEX_NAME)
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->clearIndex($this->indexOptions);
+    }
+
+    // ── copySynonyms() / copyQueryRules() ──
+
+    public function testCopySynonymsUsesOperationIndexWithSynonymsScope(): void
+    {
+        $toIndexOptions = $this->createMock(IndexOptionsInterface::class);
+        $toIndexOptions->method('getIndexName')->willReturn('magento2_default_products_replica');
+        $toIndexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+
+        $this->client->expects($this->once())
+            ->method('operationIndex')
+            ->with(self::INDEX_NAME, [
+                'operation'   => 'copy',
+                'destination' => 'magento2_default_products_replica',
+                'scope'       => ['synonyms'],
+            ])
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->copySynonyms($this->indexOptions, $toIndexOptions);
+    }
+
+    public function testCopyQueryRulesUsesOperationIndexWithRulesScope(): void
+    {
+        $toIndexOptions = $this->createMock(IndexOptionsInterface::class);
+        $toIndexOptions->method('getIndexName')->willReturn('magento2_default_products_replica');
+        $toIndexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+
+        $this->client->expects($this->once())
+            ->method('operationIndex')
+            ->with(self::INDEX_NAME, [
+                'operation'   => 'copy',
+                'destination' => 'magento2_default_products_replica',
+                'scope'       => ['rules'],
+            ])
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->copyQueryRules($this->indexOptions, $toIndexOptions);
+    }
+
+    // ── saveRule() / deleteRule() ──
+
+    public function testSaveRuleDelegatesToClientWithCorrectArguments(): void
+    {
+        $rule = [AlgoliaConnector::ALGOLIA_API_OBJECT_ID => 'rule-1', 'condition' => []];
+
+        $this->client->expects($this->once())
+            ->method('saveRule')
+            ->with(self::INDEX_NAME, 'rule-1', $rule, false)
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->saveRule($rule, $this->indexOptions);
+    }
+
+    public function testDeleteRuleDelegatesToClientWithCorrectArguments(): void
+    {
+        $this->client->expects($this->once())
+            ->method('deleteRule')
+            ->with(self::INDEX_NAME, 'rule-1', false)
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->deleteRule($this->indexOptions, 'rule-1');
     }
 }


### PR DESCRIPTION
This PR contains:
- Introduced Claude testing guides:
  - `testing-core.md `which contains universal rules for all tests
  - `types/testing-*.md `for all type related rules
  - `specifics/testing-<ClassName>.md` for class specific rules
- Added /`generate-unit-tests <ClassName> `skill to automatically generate tests for a given class.
- Generated `AlgoliaConnectorTest.php` class as an example.