### PR TITLE
Fix suggestions reindex always results in empty index

### DIFF
--- a/Service/Suggestion/IndexBuilder.php
+++ b/Service/Suggestion/IndexBuilder.php
@@ -84,7 +84,8 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
                     $storeId,
                     $collection,
                     $page,
-                    $this->configHelper->getNumberOfElementByPage($storeId)
+                    $this->configHelper->getNumberOfElementByPage($storeId),
+                    true
                 );
                 $page++;
             }
@@ -98,11 +99,12 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
      * @param QueryCollection $collectionDefault
      * @param int $page
      * @param int $pageSize
+     * @param bool $useTmpIndex
      * @return void
      * @throws NoSuchEntityException
      * @throws \Exception
      */
-    protected function rebuildStoreSuggestionIndexPage(int $storeId, QueryCollection $collectionDefault, int $page, int $pageSize): void
+    protected function rebuildStoreSuggestionIndexPage(int $storeId, QueryCollection $collectionDefault, int $page, int $pageSize, bool $useTmpIndex = true): void
     {
         if ($this->isIndexingEnabled($storeId) === false) {
             return;
@@ -111,7 +113,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
         $collection = clone $collectionDefault;
         $collection->setCurPage($page)->setPageSize($pageSize);
         $collection->load();
-        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, $useTmpIndex);
         $indexData = [];
 
         /** @var Query $suggestion */


### PR DESCRIPTION
## Problem

Running `bin/magento algolia:reindex:suggestions` completes without error but the `_suggestions` index in Algolia always ends up empty.

## Steps to Reproduce

1. Ensure `algoliasearch_indexing_manager/algolia_indexing/enable_query_suggestions_index = 1`
2. Ensure `search_query` table has records meeting the minimum popularity/results thresholds
3. Run `bin/magento algolia:reindex:suggestions` - pass in store_id if preferred
4. Check the `_suggestions` index in Algolia — 0 records

## Root Cause

`rebuildStoreSuggestionIndexPage` saves records directly to the final index (e.g. `magento2_default_suggestions`) instead of the temporary index. 

The subsequent `moveStoreSuggestionIndex` call then:

1. Copies query rules from the final index -> `_tmp` (creating an empty `_tmp`)
2. Moves the empty `_tmp` over the final index essentially **wiping all records just saved**

This breaks the intended pattern used by the product `IndexBuilder`, where records are built in `_tmp` and moved to final in one operation.

## Fix

Pass `$useTmpIndex` to `buildEntityIndexOptions` in `rebuildStoreSuggestionIndexPage`.

To align with the product builder's pattern, `$useTmpIndex` is passed as a parameter from `buildIndex` ->  `rebuildStoreSuggestionIndexPage` rather than hardcoding `true`.

## Affected Versions

Confirmed in v3.16.1 and I believe through v3.17.3.