### PR TITLE
MAGE-1536 unit tests

### DIFF
--- a/Service/IndexNameFetcher.php
+++ b/Service/IndexNameFetcher.php
@@ -54,6 +54,18 @@ class IndexNameFetcher
     }
 
     /**
+     * If the index is a temporary index, return the original index name
+     * Otherwise, return the index name as is
+     */
+    public function getOriginalIndexName(string $indexName): string
+    {
+        if (!$this->isTempIndex($indexName)) {
+            return $indexName;
+        }
+        return substr($indexName, 0, -strlen(self::INDEX_TEMP_SUFFIX));
+    }
+
+    /**
      * This is the default index name format for query suggestions but it can be overridden
      * This is a temporary workaround for delete index operations
      * TODO: Revisit this approach when a QuerySuggestionsClient is implemented in algoliasearch-client-php

--- a/Test/Unit/Service/SendStrategyResolverTest.php
+++ b/Test/Unit/Service/SendStrategyResolverTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
+use Algolia\AlgoliaSearch\Service\SendStrategyResolver;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SendStrategyResolverTest extends TestCase
+{
+    private const STORE_ID = 1;
+
+    private null|(SendStrategyInterface&MockObject) $defaultStrategy = null;
+
+    protected function setUp(): void
+    {
+        $this->defaultStrategy = $this->createMock(SendStrategyInterface::class);
+    }
+
+    public function testResolveReturnsDefaultStrategyWhenNoStrategiesConfigured(): void
+    {
+        $resolver = new SendStrategyResolver($this->defaultStrategy);
+
+        $this->assertSame($this->defaultStrategy, $resolver->resolve(self::STORE_ID));
+    }
+
+    public function testResolveReturnsDefaultStrategyWhenNoStrategyIsApplicable(): void
+    {
+        $inapplicable = $this->createMock(SendStrategyInterface::class);
+        $inapplicable->method('isApplicable')->willReturn(false);
+
+        $resolver = new SendStrategyResolver($this->defaultStrategy, [$inapplicable]);
+
+        $this->assertSame($this->defaultStrategy, $resolver->resolve(self::STORE_ID));
+    }
+
+    public function testResolveReturnsFirstApplicableStrategy(): void
+    {
+        $applicable = $this->createMock(SendStrategyInterface::class);
+        $applicable->method('isApplicable')->with(self::STORE_ID)->willReturn(true);
+
+        $resolver = new SendStrategyResolver($this->defaultStrategy, [$applicable]);
+
+        $this->assertSame($applicable, $resolver->resolve(self::STORE_ID));
+    }
+
+    public function testResolveReturnsFirstApplicableWhenMultipleMatch(): void
+    {
+        $first = $this->createMock(SendStrategyInterface::class);
+        $first->method('isApplicable')->willReturn(true);
+
+        $second = $this->createMock(SendStrategyInterface::class);
+        $second->method('isApplicable')->willReturn(true);
+
+        $resolver = new SendStrategyResolver($this->defaultStrategy, [$first, $second]);
+
+        $this->assertSame($first, $resolver->resolve(self::STORE_ID));
+    }
+
+    public function testResolveSkipsInapplicableAndReturnsFirstApplicable(): void
+    {
+        $inapplicable = $this->createMock(SendStrategyInterface::class);
+        $inapplicable->method('isApplicable')->willReturn(false);
+
+        $applicable = $this->createMock(SendStrategyInterface::class);
+        $applicable->method('isApplicable')->willReturn(true);
+
+        $resolver = new SendStrategyResolver($this->defaultStrategy, [$inapplicable, $applicable]);
+
+        $this->assertSame($applicable, $resolver->resolve(self::STORE_ID));
+    }
+
+    public function testResolvePassesStoreIdToIsApplicable(): void
+    {
+        $storeId = 42;
+
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $strategy->expects($this->once())
+            ->method('isApplicable')
+            ->with($storeId)
+            ->willReturn(false);
+
+        $resolver = new SendStrategyResolver($this->defaultStrategy, [$strategy]);
+        $resolver->resolve($storeId);
+    }
+
+    public function testResolveDoesNotCallIsApplicableOnDefaultStrategy(): void
+    {
+        $this->defaultStrategy->expects($this->never())->method('isApplicable');
+
+        $resolver = new SendStrategyResolver($this->defaultStrategy);
+        $resolver->resolve(self::STORE_ID);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -301,12 +301,22 @@
     </type>
 
 
+    <virtualType name="Algolia\AlgoliaSearch\Logger\Processor\PsrLogMessageProcessorWithoutUsedContext"
+                 type="Monolog\Processor\PsrLogMessageProcessor">
+        <arguments>
+            <argument name="removeUsedContextFields" xsi:type="boolean">true</argument>
+        </arguments>
+    </virtualType>
+
     <type name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger">
         <arguments>
             <argument name="name" xsi:type="string">algolia</argument>
             <argument name="handlers" xsi:type="array">
                 <item name="system" xsi:type="object">Algolia\AlgoliaSearch\Logger\Handler\SystemLoggerHandler</item>
                 <item name="custom" xsi:type="object">Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler</item>
+            </argument>
+            <argument name="processors" xsi:type="array">
+                <item name="psr_log_message" xsi:type="object">Algolia\AlgoliaSearch\Logger\Processor\PsrLogMessageProcessorWithoutUsedContext</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
**Summary**

- Add `SendStrategyResolver` unit tests covering resolution order, default fallback, store ID forwarding, and edge cases 
- Add `IndexNameFetcher::getOriginalIndexName()` helper to strip the `_tmp` suffix from temporary index names, needed by send strategy logic to identify the target index 
- Configure `AlgoliaLogger` with a `PsrLogMessageProcessor` virtual type that removes used context fields, enabling clean PSR-3 placeholder substitution in log messages 

**Result**
Unit tests:
<img width="1482" height="262" alt="image" src="https://github.com/user-attachments/assets/cd9a72c3-a271-475f-aca4-76972b9b0f60" />
