### PR TITLE
MAGE-1565 remove deprecated template beforecontent.phtml (3.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Bug Fixes
 - Fixed undefined property `indexerRegistry` exception on `CategoryObserver`
 
+### Updates
+- Removed the deprecated `beforecontent.phtml` template and its block declaration in `algolia_search_handle.xml` (deprecated in v3.16).
+
 ## 3.17.3
 
 ### Updates

--- a/view/frontend/layout/algolia_search_handle.xml
+++ b/view/frontend/layout/algolia_search_handle.xml
@@ -12,10 +12,6 @@
             <block class="Algolia\AlgoliaSearch\Block\Configuration" name="algolia.internals.configuration" template="Algolia_AlgoliaSearch::internals/configuration.phtml"/>
         </referenceBlock>
 
-        <referenceContainer name="main.content">
-            <block class="Magento\Framework\View\Element\Template" before="-" name="algolia.beforecontent" template="Algolia_AlgoliaSearch::internals/beforecontent.phtml"/>
-        </referenceContainer>
-
         <referenceContainer name="before.body.end">
             <!-- Instant search results page templates -->
             <block class="Algolia\AlgoliaSearch\Block\Instant\Wrapper" name="algolia.instant.wrapper" template="Algolia_AlgoliaSearch::instant/wrapper.phtml"/>

--- a/view/frontend/templates/internals/beforecontent.phtml
+++ b/view/frontend/templates/internals/beforecontent.phtml
@@ -1,4 +1,0 @@
- <!--
-DEPRECATED: This template will be removed in version 3.17
-If you're overriding or referencing this file, please update your layout and customizations accordingly.
--->


### PR DESCRIPTION
**Summary**

Removes the deprecated `beforecontent.phtml` template, originally deprecated in v3.16.

The template body has been empty since v3.16, so removing it has no runtime behavior change. Anyone still overriding the template path may see a logged Magento layout warning.