### PR TITLE
MAGE-1569: conditional `SetSettings()` calls applied to `saveConfigurationToAlgolia()`

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -319,17 +319,51 @@ class ProductHelper extends AbstractEntityHelper
     ): void {
         $indexSettings = $this->getIndexSettings($storeId);
 
-        $this->indexSettingsHandler->setSettings($indexOptions, $indexSettings);
+        if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
+            $logEventName = 'Pushing settings for products indices.';
+            $this->logger->start($logEventName, true);
+            $this->logger->log('Index name: ' . $indexOptions->getIndexName());
+            $this->logger->log('Settings: ' . json_encode($indexSettings));
+            $this->logger->stop($logEventName, true);
 
-        $this->logger->log('Settings: ' . json_encode($indexSettings));
-        if ($saveToTmpIndicesToo) {
-            $this->indexSettingsHandler->setSettings(
-                $indexTmpOptions,
-                $indexSettings,
-                $indexOptions->getIndexName()
-            );
+            $this->algoliaConnector->waitLastTask($storeId);
 
-            $this->logger->log('Pushing the same settings to TMP index as well');
+            if ($saveToTmpIndicesToo) {
+                $this->indexSettingsHandler->setSettings($indexTmpOptions, $indexSettings, $indexOptions->getIndexName());
+
+                $logEventName = 'Pushing the same settings to TMP index as well';
+                $this->logger->start($logEventName, true);
+                $this->logger->log('Index name: ' . $indexOptions->getIndexName());
+                $this->logger->log('TMP Index name: ' . $indexTmpOptions->getIndexName());
+                $this->logger->log('Settings: ' . json_encode($indexSettings));
+                $this->logger->stop($logEventName, true);
+
+                $this->algoliaConnector->waitLastTask($storeId);
+            }
+
+            if ($saveToTmpIndicesToo) {
+                try {
+                    $this->algoliaConnector->copySynonyms($indexOptions, $indexTmpOptions);
+                    $this->algoliaConnector->waitLastTask($storeId);
+                    $this->logger->log('
+                        Copying synonyms from production index to "' . $indexTmpOptions->getIndexName() . '" to not erase them with the index move.
+                    ');
+                } catch (AlgoliaException $e) {
+                    $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
+                }
+
+                try {
+                    $this->algoliaConnector->copyQueryRules($indexOptions, $indexTmpOptions);
+                    $this->algoliaConnector->waitLastTask($storeId);
+                    $this->logger->log('
+                        Copying query rules from production index to "' . $indexTmpOptions->getIndexName() . '" to not erase them with the index move.
+                    ');
+                } catch (AlgoliaException $e) {
+                    if ($e->getCode() !== 404) {
+                        throw $e;
+                    }
+                }
+            }
         }
 
         $this->setFacetsQueryRules($indexOptions);
@@ -341,30 +375,6 @@ class ProductHelper extends AbstractEntityHelper
         }
 
         $this->replicaManager->syncReplicasToAlgolia($storeId, $indexSettings);
-
-        if ($saveToTmpIndicesToo) {
-            try {
-                $this->algoliaConnector->copySynonyms($indexOptions, $indexTmpOptions);
-                $this->algoliaConnector->waitLastTask($storeId);
-                $this->logger->log('
-                        Copying synonyms from production index to "' . $indexTmpOptions->getIndexName() . '" to not erase them with the index move.
-                    ');
-            } catch (AlgoliaException $e) {
-                $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
-            }
-
-            try {
-                $this->algoliaConnector->copyQueryRules($indexOptions, $indexTmpOptions);
-                $this->algoliaConnector->waitLastTask($storeId);
-                $this->logger->log('
-                        Copying query rules from production index to "' . $indexTmpOptions->getIndexName() . '" to not erase them with the index move.
-                    ');
-            } catch (AlgoliaException $e) {
-                if ($e->getCode() !== 404) {
-                    throw $e;
-                }
-            }
-        }
     }
 
     /**

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -320,28 +320,16 @@ class ProductHelper extends AbstractEntityHelper
         $indexSettings = $this->getIndexSettings($storeId);
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
-            $logEventName = 'Pushing settings for products indices.';
-            $this->logger->start($logEventName, true);
             $this->logger->log('Index name: ' . $indexOptions->getIndexName());
             $this->logger->log('Settings: ' . json_encode($indexSettings));
-            $this->logger->stop($logEventName, true);
 
             $this->algoliaConnector->waitLastTask($storeId);
 
             if ($saveToTmpIndicesToo) {
                 $this->indexSettingsHandler->setSettings($indexTmpOptions, $indexSettings, $indexOptions->getIndexName());
-
-                $logEventName = 'Pushing the same settings to TMP index as well';
-                $this->logger->start($logEventName, true);
-                $this->logger->log('Index name: ' . $indexOptions->getIndexName());
-                $this->logger->log('TMP Index name: ' . $indexTmpOptions->getIndexName());
-                $this->logger->log('Settings: ' . json_encode($indexSettings));
-                $this->logger->stop($logEventName, true);
-
+                $this->logger->log('Pushing the same settings to TMP index as well');
                 $this->algoliaConnector->waitLastTask($storeId);
-            }
 
-            if ($saveToTmpIndicesToo) {
                 try {
                     $this->algoliaConnector->copySynonyms($indexOptions, $indexTmpOptions);
                     $this->algoliaConnector->waitLastTask($storeId);

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -327,6 +327,9 @@ class ProductHelper extends AbstractEntityHelper
 
             if ($saveToTmpIndicesToo) {
                 // For temp index, we need to call AlgoliaConnector::setSettings() directly with explicit settings merge
+                // Main reasons:
+                //  - Temp indices never have replicas associated
+                //  - Settings rely directly on prod index so performing a diff with temporary online settings is useless
                 $this->algoliaConnector->setSettings(
                     $indexTmpOptions,
                     $indexSettings,
@@ -491,7 +494,7 @@ class ProductHelper extends AbstractEntityHelper
      * @throws AlgoliaException
      * @throws NoSuchEntityException
      */
-    public function setFacetsQueryRules(IndexOptionsInterface $indexOptions, bool $waitLastTask = false): void
+    protected function setFacetsQueryRules(IndexOptionsInterface $indexOptions, bool $waitLastTask = false): void
     {
         $this->clearFacetsQueryRules($indexOptions);
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -326,7 +326,15 @@ class ProductHelper extends AbstractEntityHelper
             $this->algoliaConnector->waitLastTask($storeId);
 
             if ($saveToTmpIndicesToo) {
-                $this->indexSettingsHandler->setSettings($indexTmpOptions, $indexSettings, $indexOptions->getIndexName());
+                // For temp index, we need to call AlgoliaConnector::setSettings() directly with explicit settings merge
+                $this->algoliaConnector->setSettings(
+                    $indexTmpOptions,
+                    $indexSettings,
+                    false,
+                    true,
+                    $indexOptions->getIndexName()
+                );
+
                 $this->logger->log('Pushing the same settings to TMP index as well');
                 $this->algoliaConnector->waitLastTask($storeId);
 

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -355,11 +355,9 @@ class ProductHelper extends AbstractEntityHelper
         }
 
         $this->setFacetsQueryRules($indexOptions);
-        $this->algoliaConnector->waitLastTask($storeId);
 
         if ($saveToTmpIndicesToo) {
             $this->setFacetsQueryRules($indexTmpOptions);
-            $this->algoliaConnector->waitLastTask($storeId);
         }
 
         $this->replicaManager->syncReplicasToAlgolia($storeId, $indexSettings);
@@ -480,11 +478,12 @@ class ProductHelper extends AbstractEntityHelper
 
     /**
      * @param IndexOptionsInterface $indexOptions
+     * @param bool $waitLastTask
      * @return void
      * @throws AlgoliaException
      * @throws NoSuchEntityException
      */
-    protected function setFacetsQueryRules(IndexOptionsInterface $indexOptions)
+    public function setFacetsQueryRules(IndexOptionsInterface $indexOptions, bool $waitLastTask = false): void
     {
         $this->clearFacetsQueryRules($indexOptions);
 
@@ -522,6 +521,10 @@ class ProductHelper extends AbstractEntityHelper
             $this->logger->log('Setting facets query rules to "' . $indexOptions->getIndexName() . '" index: ' . json_encode($rules));
 
             $this->algoliaConnector->saveRules($indexOptions, $rules, true);
+
+            if ($waitLastTask) {
+                $this->algoliaConnector->waitLastTask($indexOptions->getStoreId());
+            }
         }
     }
 

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -181,18 +181,10 @@ class IndicesConfigurator
      */
     protected function setProductsSettings(int $storeId, bool $useTmpIndex): void
     {
-        $logEventName = 'Pushing settings for products indices.';
-        $this->logger->start($logEventName, true);
-
         $indexOptions = $this->productIndexOptionsBuilder->buildEntityIndexOptions($storeId);
         $indexTmpOptions = $this->productIndexOptionsBuilder->buildEntityIndexOptions($storeId, true);
 
-        $this->logger->log('Index name: ' . $indexOptions->getIndexName());
-        $this->logger->log('TMP Index name: ' . $indexTmpOptions->getIndexName());
-
         $this->productHelper->setSettings($indexOptions, $indexTmpOptions, $storeId, $useTmpIndex);
-
-        $this->logger->stop($logEventName, true);
     }
 
     /**

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -239,10 +239,16 @@ class IndicesConfigurator
                             true
                         );
 
-                        if ($this->indexSettingsHandler->setSettings($indexTempOptions, $extraSettings)) {
-                            $this->logSettingsPush($indexTempOptions, $extraSettings);
-                            $this->algoliaConnector->waitLastTask($storeId);
-                        }
+                        // Direct call to AlgoliaConnector::setSettings() (see ProductHelper::setSettings())
+                        $this->algoliaConnector->setSettings(
+                            $indexTempOptions,
+                            $extraSettings,
+                            false,
+                            true,
+                            $indexOptions->getIndexName()
+                        );
+                        $this->logSettingsPush($indexTempOptions, $extraSettings);
+                        $this->algoliaConnector->waitLastTask($storeId);
                     }
                 }
             } catch (AlgoliaException $e) {

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Model;
 
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
 use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
@@ -70,31 +71,20 @@ class IndicesConfigurator
         }
 
         $this->setCategoriesSettings($storeId);
-        $this->algoliaConnector->waitLastTask($storeId);
-
-        /* Check if we want to index CMS pages */
-        if ($this->configHelper->isPagesIndexEnabled($storeId)) {
-            $this->setPagesSettings($storeId);
-            $this->algoliaConnector->waitLastTask($storeId);
-        } else {
-            $this->logger->log('CMS Page Indexing is not enabled for the store.');
-        }
-
-        //Check if we want to index Query Suggestions
-        if ($this->configHelper->isQuerySuggestionsIndexEnabled($storeId)) {
-            $this->setQuerySuggestionsSettings($storeId);
-            $this->algoliaConnector->waitLastTask($storeId);
-        } else {
-            $this->logger->log('Query Suggestions Indexing is not enabled for the store.');
-        }
-
+        $this->setPagesSettings($storeId);
+        $this->setQuerySuggestionsSettings($storeId);
         $this->setAdditionalSectionsSettings($storeId);
-        $this->algoliaConnector->waitLastTask($storeId);
-
         $this->setProductsSettings($storeId, $useTmpIndex);
-
         $this->setExtraSettings($storeId, $useTmpIndex);
 
+        $this->logger->stop($logEventName, true);
+    }
+
+    protected function logSettingsPush(string $logEventName, IndexOptionsInterface $indexOptions, array $settings): void
+    {
+        $this->logger->start($logEventName, true);
+        $this->logger->log('Index name: ' . $indexOptions->getIndexName());
+        $this->logger->log('Settings: ' . json_encode($settings));
         $this->logger->stop($logEventName, true);
     }
 
@@ -103,17 +93,13 @@ class IndicesConfigurator
      */
     protected function setCategoriesSettings(int $storeId): void
     {
-        $logEventName = 'Pushing settings for categories indices.';
-        $this->logger->start($logEventName, true);
-
         $settings = $this->categoryHelper->getIndexSettings($storeId);
         $indexOptions = $this->categoryIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
-        $this->indexSettingsHandler->setSettings($indexOptions, $settings);
-
-        $this->logger->log('Index name: ' . $indexOptions->getIndexName());
-        $this->logger->log('Settings: ' . json_encode($settings));
-        $this->logger->stop($logEventName, true);
+        if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
+            $this->logSettingsPush('Pushing settings for categories indices.', $indexOptions, $settings);
+            $this->algoliaConnector->waitLastTask($storeId);
+        }
     }
 
     /**
@@ -121,17 +107,19 @@ class IndicesConfigurator
      */
     protected function setPagesSettings(int $storeId): void
     {
-        $logEventName = 'Pushing settings for CMS pages indices.';
-        $this->logger->start($logEventName, true);
+        /* Check if we want to index CMS pages */
+        if (!$this->configHelper->isPagesIndexEnabled($storeId)) {
+            $this->logger->log('CMS Page Indexing is not enabled for the store.');
+            return;
+        }
 
         $settings = $this->pageHelper->getIndexSettings($storeId);
         $indexOptions = $this->pageIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
-        $this->indexSettingsHandler->setSettings($indexOptions, $settings);
-
-        $this->logger->log('Index name: ' . $indexOptions->getIndexName());
-        $this->logger->log('Settings: ' . json_encode($settings));
-        $this->logger->stop($logEventName, true);
+        if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
+            $this->logSettingsPush('Pushing settings for CMS pages indices.', $indexOptions, $settings);
+            $this->algoliaConnector->waitLastTask($storeId);
+        }
     }
 
     /**
@@ -139,17 +127,23 @@ class IndicesConfigurator
      */
     protected function setQuerySuggestionsSettings(int $storeId): void
     {
-        $logEventName = 'Pushing settings for query suggestions indices.';
-        $this->logger->start($logEventName, true);
+        //Check if we want to index Query Suggestions
+        if (!$this->configHelper->isQuerySuggestionsIndexEnabled($storeId)) {
+            $this->logger->log('Query Suggestions Indexing is not enabled for the store.');
+            return;
+        }
 
         $settings = $this->suggestionHelper->getIndexSettings($storeId);
         $indexOptions = $this->suggestionIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
-        $this->indexSettingsHandler->setSettings($indexOptions, $settings);
-
-        $this->logger->log('Index name: ' . $indexOptions->getIndexName());
-        $this->logger->log('Settings: ' . json_encode($settings));
-        $this->logger->stop($logEventName, true);
+        if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
+            $this->logSettingsPush(
+                'Pushing settings for query suggestions indices.',
+                $indexOptions,
+                $settings
+            );
+            $this->algoliaConnector->waitLastTask($storeId);
+        }
     }
 
     /**
@@ -157,9 +151,6 @@ class IndicesConfigurator
      */
     protected function setAdditionalSectionsSettings(int $storeId): void
     {
-        $logEventName = 'Pushing settings for additional section indices.';
-        $this->logger->start($logEventName, true);
-
         $protectedSections = ['products', 'categories', 'pages', 'suggestions'];
         foreach ($this->autocompleteHelper->getAdditionalSections($storeId) as $section) {
             if (in_array($section['name'], $protectedSections, true)) {
@@ -172,14 +163,15 @@ class IndicesConfigurator
             $settings = $this->additionalSectionHelper->getIndexSettings($storeId);
             $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
-            $this->indexSettingsHandler->setSettings($indexOptions, $settings);
-
-            $this->logger->log('Index name: ' . $indexName);
-            $this->logger->log('Settings: ' . json_encode($settings));
-            $this->logger->log('Pushed settings for "' . $section['name'] . '" section.');
+            if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
+                $this->logSettingsPush(
+                    'Pushing settings for additional section "' . $section['name'] . '".',
+                    $indexOptions,
+                    $settings
+                );
+                $this->algoliaConnector->waitLastTask($storeId);
+            }
         }
-
-        $this->logger->stop($logEventName, true);
     }
 
     /**
@@ -208,16 +200,6 @@ class IndicesConfigurator
      */
     protected function setExtraSettings(int $storeId, bool $saveToTmpIndicesToo): void
     {
-        $logEventName = 'Pushing extra settings.';
-        $this->logger->start($logEventName, true);
-
-        $sections = [
-            'products' => $this->productHelper->getIndexName($storeId),
-            'categories' => $this->categoryHelper->getIndexName($storeId),
-            'pages' => $this->pageHelper->getIndexName($storeId),
-            'suggestions' => $this->suggestionHelper->getIndexName($storeId),
-            'additional_sections' => $this->additionalSectionHelper->getIndexName($storeId)
-        ];
         $sections = [
             'products',
             'categories',
@@ -233,19 +215,16 @@ class IndicesConfigurator
 
                 if ($extraSettings) {
                     $extraSettings = json_decode($extraSettings, true);
-
                     $indexOptions = $this->indexOptionsBuilder->buildWithComputedIndex('_' . $section, $storeId);
 
-                    $this->logger->log('Index name: ' . $indexOptions->getIndexName());
-                    $this->logger->log('Extra settings: ' . json_encode($extraSettings));
-
-                    $this->algoliaConnector->setSettings(
-                        $indexOptions,
-                        $extraSettings,
-                        true,
-                        false
-                    );
-                    $this->algoliaConnector->waitLastTask($storeId);
+                    if ($this->indexSettingsHandler->setSettings($indexOptions, $extraSettings)) {
+                        $this->logSettingsPush(
+                            'Pushing extra settings',
+                            $indexOptions,
+                            $extraSettings
+                        );
+                        $this->algoliaConnector->waitLastTask($storeId);
+                    }
 
                     if ($section === 'products' && $saveToTmpIndicesToo) {
                         $indexTempOptions = $this->indexOptionsBuilder->buildWithComputedIndex(
@@ -254,14 +233,14 @@ class IndicesConfigurator
                             true
                         );
 
-                        $this->logger->log('Index name: ' . $indexTempOptions->getIndexName());
-                        $this->logger->log('Extra settings: ' . json_encode($extraSettings));
-
-                        $this->algoliaConnector->setSettings(
-                            $indexTempOptions,
-                            $extraSettings,
-                            true
-                        );
+                        if ($this->indexSettingsHandler->setSettings($indexTempOptions, $extraSettings)) {
+                            $this->logSettingsPush(
+                                'Pushing extra settings on product temporary index.',
+                                $indexTempOptions,
+                                $extraSettings
+                            );
+                            $this->algoliaConnector->waitLastTask($storeId);
+                        }
                     }
                 }
             } catch (AlgoliaException $e) {
@@ -280,7 +259,5 @@ class IndicesConfigurator
         if ($error) {
             throw new AlgoliaException('<br>' . implode('<br> ', $error));
         }
-
-        $this->logger->stop($logEventName, true);
     }
 }

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -80,12 +80,10 @@ class IndicesConfigurator
         $this->logger->stop($logEventName, true);
     }
 
-    protected function logSettingsPush(string $logEventName, IndexOptionsInterface $indexOptions, array $settings): void
+    protected function logSettingsPush(IndexOptionsInterface $indexOptions, array $settings): void
     {
-        $this->logger->start($logEventName, true);
         $this->logger->log('Index name: ' . $indexOptions->getIndexName());
         $this->logger->log('Settings: ' . json_encode($settings));
-        $this->logger->stop($logEventName, true);
     }
 
     /**
@@ -93,13 +91,18 @@ class IndicesConfigurator
      */
     protected function setCategoriesSettings(int $storeId): void
     {
+        $logEventName = 'Pushing settings for categories indices.';
+        $this->logger->start($logEventName, true);
+
         $settings = $this->categoryHelper->getIndexSettings($storeId);
         $indexOptions = $this->categoryIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
-            $this->logSettingsPush('Pushing settings for categories indices.', $indexOptions, $settings);
+            $this->logSettingsPush($indexOptions, $settings);
             $this->algoliaConnector->waitLastTask($storeId);
         }
+
+        $this->logger->stop($logEventName, true);
     }
 
     /**
@@ -113,13 +116,18 @@ class IndicesConfigurator
             return;
         }
 
+        $logEventName = 'Pushing settings for CMS pages indices.';
+        $this->logger->start($logEventName, true);
+
         $settings = $this->pageHelper->getIndexSettings($storeId);
         $indexOptions = $this->pageIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
-            $this->logSettingsPush('Pushing settings for CMS pages indices.', $indexOptions, $settings);
+            $this->logSettingsPush($indexOptions, $settings);
             $this->algoliaConnector->waitLastTask($storeId);
         }
+
+        $this->logger->stop($logEventName, true);
     }
 
     /**
@@ -133,17 +141,18 @@ class IndicesConfigurator
             return;
         }
 
+        $logEventName = 'Pushing settings for query suggestions indices.';
+        $this->logger->start($logEventName, true);
+
         $settings = $this->suggestionHelper->getIndexSettings($storeId);
         $indexOptions = $this->suggestionIndexOptionsBuilder->buildEntityIndexOptions($storeId);
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
-            $this->logSettingsPush(
-                'Pushing settings for query suggestions indices.',
-                $indexOptions,
-                $settings
-            );
+            $this->logSettingsPush($indexOptions, $settings);
             $this->algoliaConnector->waitLastTask($storeId);
         }
+
+        $this->logger->stop($logEventName, true);
     }
 
     /**
@@ -151,6 +160,9 @@ class IndicesConfigurator
      */
     protected function setAdditionalSectionsSettings(int $storeId): void
     {
+        $logEventName = 'Pushing settings for query suggestions indices.';
+        $this->logger->start($logEventName, true);
+
         $protectedSections = ['products', 'categories', 'pages', 'suggestions'];
         foreach ($this->autocompleteHelper->getAdditionalSections($storeId) as $section) {
             if (in_array($section['name'], $protectedSections, true)) {
@@ -164,14 +176,12 @@ class IndicesConfigurator
             $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
             if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
-                $this->logSettingsPush(
-                    'Pushing settings for additional section "' . $section['name'] . '".',
-                    $indexOptions,
-                    $settings
-                );
+                $this->logSettingsPush($indexOptions, $settings);
                 $this->algoliaConnector->waitLastTask($storeId);
             }
         }
+
+        $this->logger->stop($logEventName, true);
     }
 
     /**
@@ -181,17 +191,25 @@ class IndicesConfigurator
      */
     protected function setProductsSettings(int $storeId, bool $useTmpIndex): void
     {
+        $logEventName = 'Pushing settings for products indices.';
+        $this->logger->start($logEventName, true);
+
         $indexOptions = $this->productIndexOptionsBuilder->buildEntityIndexOptions($storeId);
         $indexTmpOptions = $this->productIndexOptionsBuilder->buildEntityIndexOptions($storeId, true);
 
         $this->productHelper->setSettings($indexOptions, $indexTmpOptions, $storeId, $useTmpIndex);
+
+        $this->logger->stop($logEventName, true);
     }
 
     /**
-     * @throws AlgoliaException|NoSuchEntityException|DiagnosticsException
+     * @throws AlgoliaException|NoSuchEntityException
      */
     protected function setExtraSettings(int $storeId, bool $saveToTmpIndicesToo): void
     {
+        $logEventName = 'Pushing extra settings.';
+        $this->logger->start($logEventName, true);
+
         $sections = [
             'products',
             'categories',
@@ -210,11 +228,7 @@ class IndicesConfigurator
                     $indexOptions = $this->indexOptionsBuilder->buildWithComputedIndex('_' . $section, $storeId);
 
                     if ($this->indexSettingsHandler->setSettings($indexOptions, $extraSettings)) {
-                        $this->logSettingsPush(
-                            'Pushing extra settings',
-                            $indexOptions,
-                            $extraSettings
-                        );
+                        $this->logSettingsPush($indexOptions, $extraSettings);
                         $this->algoliaConnector->waitLastTask($storeId);
                     }
 
@@ -226,11 +240,7 @@ class IndicesConfigurator
                         );
 
                         if ($this->indexSettingsHandler->setSettings($indexTempOptions, $extraSettings)) {
-                            $this->logSettingsPush(
-                                'Pushing extra settings on product temporary index.',
-                                $indexTempOptions,
-                                $extraSettings
-                            );
+                            $this->logSettingsPush($indexTempOptions, $extraSettings);
                             $this->algoliaConnector->waitLastTask($storeId);
                         }
                     }
@@ -251,5 +261,7 @@ class IndicesConfigurator
         if ($error) {
             throw new AlgoliaException('<br>' . implode('<br> ', $error));
         }
+
+        $this->logger->stop($logEventName, true);
     }
 }

--- a/Service/IndexSettingsHandler.php
+++ b/Service/IndexSettingsHandler.php
@@ -33,11 +33,7 @@ class IndexSettingsHandler
      * @throws NoSuchEntityException
      * @throws AlgoliaException
      */
-    public function setSettings(
-        IndexOptionsInterface $indexOptions,
-        array $indexSettings,
-        string $mergeSettingsFrom = ''
-    ): bool
+    public function setSettings(IndexOptionsInterface $indexOptions, array $indexSettings): bool
     {
         // Early return if Algolia settings are already the same
         if ($this->indexSettingsComparator->matches($indexOptions, $indexSettings)) {
@@ -56,30 +52,31 @@ class IndexSettingsHandler
             $this->connector->setSettings(
                 $indexOptions,
                 $indexSettings,
-                false,
-                true,
-                $mergeSettingsFrom
+                false
             );
             return true;
         }
 
+        // If we should forward to replicas, we need to remove settings which we don't want to send
+        // such as customRanking and ranking (managed by each replica separately)
         [$forward, $noForward] = $this->splitSettings($indexSettings);
+
+        // FORWARDED: $settings without excluded attributes
         if ($forward) {
             $this->connector->setSettings(
                 $indexOptions,
                 $forward,
-                true,
-                false
+                true
             );
             $this->connector->waitLastTask($indexOptions->getStoreId());
         }
+
+        // NOT FORWARDED: array containing excluded attributes only
         if ($noForward) {
             $this->connector->setSettings(
                 $indexOptions,
                 $noForward,
-                false,
-                true,
-                $mergeSettingsFrom
+                false
             );
         }
 

--- a/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Config;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Configuration\InstantSearchHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Test\Integration\Indexing\Config\Traits\ConfigAssertionsTrait;
 use Algolia\AlgoliaSearch\Test\Integration\Indexing\MultiStoreTestCase;
 
@@ -89,6 +90,13 @@ class MultiStoreConfigTest extends MultiStoreTestCase
 
         $this->indicesConfigurator->saveConfigurationToAlgolia($fixtureSecondStore->getId());
 
+        $defaultIndexOptions = $this->getIndexOptions('products', $defaultStore->getId());
+        $fixtureIndexOptions = $this->getIndexOptions('products', $fixtureSecondStore->getId());
+
+        $productHelper = $this->objectManager->get(ProductHelper::class);
+        $productHelper->setFacetsQueryRules($defaultIndexOptions, true);
+        $productHelper->setFacetsQueryRules($fixtureIndexOptions, true);
+
         $defaultCategoryIndexOptions = $this->getIndexOptions('categories', $defaultStore->getId());
         $defaultCategoryIndexSettings = $this->algoliaConnector->getSettings($defaultCategoryIndexOptions);
 
@@ -103,10 +111,7 @@ class MultiStoreConfigTest extends MultiStoreTestCase
         $this->assertNotContains($rankingFromConfig, $defaultCategoryIndexSettings['customRanking']);
         $this->assertContains($rankingFromConfig, $fixtureCategoryIndexSettings['customRanking']);
 
-        $defaultIndexOptions = $this->getIndexOptions('products', $defaultStore->getId());
         $defaultProductIndexRules = $this->algoliaConnector->searchRules($defaultIndexOptions);
-
-        $fixtureIndexOptions = $this->getIndexOptions('products', $fixtureSecondStore->getId());
         $fixtureProductIndexRules = $this->algoliaConnector->searchRules($fixtureIndexOptions);
 
         // Check that the Rule has only been created for the fixture store

--- a/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
@@ -94,8 +94,8 @@ class MultiStoreConfigTest extends MultiStoreTestCase
         $fixtureIndexOptions = $this->getIndexOptions('products', $fixtureSecondStore->getId());
 
         $productHelper = $this->objectManager->get(ProductHelper::class);
-        $productHelper->setFacetsQueryRules($defaultIndexOptions, true);
-        $productHelper->setFacetsQueryRules($fixtureIndexOptions, true);
+        $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$defaultIndexOptions, true]);
+        $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$fixtureIndexOptions, true]);
 
         $defaultCategoryIndexOptions = $this->getIndexOptions('categories', $defaultStore->getId());
         $defaultCategoryIndexSettings = $this->algoliaConnector->getSettings($defaultCategoryIndexOptions);

--- a/Test/Integration/Indexing/Queue/QueueTest.php
+++ b/Test/Integration/Indexing/Queue/QueueTest.php
@@ -111,6 +111,15 @@ class QueueTest extends TestCase
 
         $this->assertTrue($existsDefaultTmpIndex, 'Default products production index does not exists and it should');
 
+        $indexOptions = $this->getIndexOptions('products', 1);
+        $settings = $this->algoliaConnector->getSettings($indexOptions);
+
+        $indexOptionsTmp = $this->getIndexOptions('products', 1 , true);
+        $settingsTmp = $this->algoliaConnector->getSettings($indexOptionsTmp);
+
+        // Asserts that the prod settings have been copied successfully to tmp
+        $this->assertEquals($settings, $settingsTmp);
+
         // Run the last move - move
         $queue->runCron(2, true);
 

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Helper\Entity;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\IndexSettingsHandler;
+use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
+use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use Magento\Catalog\Api\Data\ProductInterfaceFactory;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\CatalogInventory\Helper\Stock;
+use Magento\Eav\Model\Config;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ProductHelperTest extends TestCase
+{
+    private array $defaultSettings = ['searchableAttributes' => [], 'customRanking' => []];
+    private int $storeId = 1;
+
+    private null|(Config&MockObject) $eavConfig = null;
+    private null|(ConfigHelper&MockObject) $configHelper = null;
+    private null|(AlgoliaConnector&MockObject) $algoliaConnector = null;
+    private null|(IndexOptionsBuilder&MockObject) $indexOptionsBuilder = null;
+    private null|(DiagnosticsLogger&MockObject) $logger = null;
+    private null|(StoreManagerInterface&MockObject) $storeManager = null;
+    private null|(ManagerInterface&MockObject) $eventManager = null;
+    private null|(Visibility&MockObject) $visibility = null;
+    private null|(Stock&MockObject) $stockHelper = null;
+    private null|(Type&MockObject) $productType = null;
+    private null|(CollectionFactory&MockObject) $productCollectionFactory = null;
+    private null|(IndexNameFetcher&MockObject) $indexNameFetcher = null;
+    private null|(ReplicaManagerInterface&MockObject) $replicaManager = null;
+    private null|(ProductInterfaceFactory&MockObject) $productFactory = null;
+    private null|(ProductRecordBuilder&MockObject) $productRecordBuilder = null;
+    private null|(FacetBuilder&MockObject) $facetBuilder = null;
+    private null|(IndexSettingsHandler&MockObject) $indexSettingsHandler = null;
+    private null|(ProductHelper&MockObject) $productHelper = null;
+    private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
+    private null|(IndexOptionsInterface&MockObject) $indexTmpOptions = null;
+
+    protected function setUp(): void
+    {
+        $this->eavConfig = $this->createMock(Config::class);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->algoliaConnector = $this->createMock(AlgoliaConnector::class);
+        $this->indexOptionsBuilder = $this->createMock(IndexOptionsBuilder::class);
+        $this->logger = $this->createMock(DiagnosticsLogger::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->eventManager = $this->createMock(ManagerInterface::class);
+        $this->visibility = $this->createMock(Visibility::class);
+        $this->stockHelper = $this->createMock(Stock::class);
+        $this->productType = $this->createMock(Type::class);
+        $this->productCollectionFactory = $this->createMock(CollectionFactory::class);
+        $this->indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $this->replicaManager = $this->createMock(ReplicaManagerInterface::class);
+        $this->productFactory = $this->createMock(ProductInterfaceFactory::class);
+        $this->productRecordBuilder = $this->createMock(ProductRecordBuilder::class);
+        $this->facetBuilder = $this->createMock(FacetBuilder::class);
+        $this->indexSettingsHandler = $this->createMock(IndexSettingsHandler::class);
+
+        // Partial mock: stub getIndexSettings and the protected setFacetsQueryRules
+        // so setSettings() tests remain isolated from their implementations
+        $this->productHelper = $this->getMockBuilder(ProductHelper::class)
+            ->setConstructorArgs([
+                $this->eavConfig,
+                $this->configHelper,
+                $this->algoliaConnector,
+                $this->indexOptionsBuilder,
+                $this->logger,
+                $this->storeManager,
+                $this->eventManager,
+                $this->visibility,
+                $this->stockHelper,
+                $this->productType,
+                $this->productCollectionFactory,
+                $this->indexNameFetcher,
+                $this->replicaManager,
+                $this->productFactory,
+                $this->productRecordBuilder,
+                $this->facetBuilder,
+                $this->indexSettingsHandler,
+            ])
+            ->onlyMethods(['getIndexSettings', 'setFacetsQueryRules'])
+            ->getMock();
+
+        $this->productHelper->method('getIndexSettings')->willReturn($this->defaultSettings);
+
+        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
+        $this->indexOptions->method('getIndexName')->willReturn('prod_index');
+
+        $this->indexTmpOptions = $this->createMock(IndexOptionsInterface::class);
+        $this->indexTmpOptions->method('getIndexName')->willReturn('prod_index_tmp');
+    }
+
+    public function testSkipsAlgoliaConnectorUpdateWhenSettingsUnchanged(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+
+        $this->algoliaConnector->expects($this->never())->method('waitLastTask');
+        $this->algoliaConnector->expects($this->never())->method('setSettings');
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+    }
+
+    public function testWaitsForLastTaskWhenSettingsChanged(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+
+        $this->algoliaConnector->expects($this->atLeastOnce())->method('waitLastTask')->with($this->storeId);
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+    }
+
+    public function testDoesNotPushSettingsToTmpIndexWhenFlagIsFalse(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+
+        $this->algoliaConnector->expects($this->never())->method('setSettings');
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, false);
+    }
+
+    public function testPushesSettingsToTmpIndexWithMergeParametersWhenFlagIsTrue(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+
+        $this->algoliaConnector->expects($this->once())
+            ->method('setSettings')
+            ->with(
+                $this->indexTmpOptions,
+                $this->defaultSettings,
+                false,
+                true,
+                'prod_index'
+            );
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
+    }
+
+    public function testCopiesSynonymsAndQueryRulesFromProdToTmpIndex(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+
+        $this->algoliaConnector->expects($this->once())
+            ->method('copySynonyms')
+            ->with($this->indexOptions, $this->indexTmpOptions);
+
+        $this->algoliaConnector->expects($this->once())
+            ->method('copyQueryRules')
+            ->with($this->indexOptions, $this->indexTmpOptions);
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
+    }
+
+    public function testLogsSynonymCopyErrorAndContinuesWhenCopySynonymsFails(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+
+        $this->algoliaConnector->method('copySynonyms')
+            ->willThrowException(new AlgoliaException('Synonyms API error'));
+
+        $this->logger->expects($this->atLeastOnce())->method('error');
+
+        // copyQueryRules must still be reached after the synonym failure
+        $this->algoliaConnector->expects($this->once())->method('copyQueryRules');
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
+    }
+
+    public function testRethrowsNon404ExceptionFromCopyQueryRules(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+
+        $this->algoliaConnector->method('copyQueryRules')
+            ->willThrowException(new AlgoliaException('Internal error', 500));
+
+        $this->expectException(AlgoliaException::class);
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
+    }
+
+    public function testAlwaysCallsSetFacetsQueryRulesForMainIndexEvenWhenSettingsUnchanged(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+
+        $this->productHelper->expects($this->atLeastOnce())
+            ->method('setFacetsQueryRules')
+            ->with($this->indexOptions);
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+    }
+
+    public function testCallsSetFacetsQueryRulesForTmpIndexWhenSaveToTmpIsTrue(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+
+        $this->productHelper->expects($this->exactly(2))
+            ->method('setFacetsQueryRules')
+            ->willReturnCallback(function (IndexOptionsInterface $opts) {
+                static $calls = [];
+                $calls[] = $opts->getIndexName();
+                return null;
+            });
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
+    }
+
+    public function testDoesNotCallSetFacetsQueryRulesForTmpIndexWhenFlagIsFalse(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+
+        $this->productHelper->expects($this->once())
+            ->method('setFacetsQueryRules')
+            ->with($this->indexOptions);
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, false);
+    }
+
+    public function testAlwaysSyncsReplicasToAlgoliaWithIndexSettings(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+
+        $this->replicaManager->expects($this->once())
+            ->method('syncReplicasToAlgolia')
+            ->with($this->storeId, $this->defaultSettings);
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+    }
+}

--- a/Test/Unit/Service/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/IndexSettingsHandlerTest.php
@@ -120,7 +120,7 @@ class IndexSettingsHandlerTest extends TestCase
                         case 2:
                             $this->assertEquals(['customRanking' => ['desc(price)']], $indexSettings);
                             $this->assertFalse($forwardToReplicas);
-                            $this->assertTrue($mergeSettings);
+                            $this->assertFalse($mergeSettings);
                             break;
                 }
             });
@@ -148,9 +148,7 @@ class IndexSettingsHandlerTest extends TestCase
             ->with(
                 $this->indexOptions,
                 $settings,
-                false,
-                true,
-                ''
+                false
             );
 
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
@@ -176,8 +174,7 @@ class IndexSettingsHandlerTest extends TestCase
             ->with(
                 $this->indexOptions,
                 $settings,
-                true,
-                false
+                true
             );
 
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
@@ -202,9 +199,7 @@ class IndexSettingsHandlerTest extends TestCase
             ->with(
                 $this->indexOptions,
                 $settings,
-                false,
-                true,
-                ''
+                false
             );
 
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));


### PR DESCRIPTION
This PR contains:
- `saveConfigurationToAlgolia()`and `ProductHelper::getSettings()` now perform `setSettings()`operations based on the results from the `IndexSettingsComparator`.
- `waitLastTask()` is now only call when `setSettings()`operations are performed
- Refactored the whole `IndicesConfigurator` class so it's now easier to read
- Refactoring Diagnostic logging as a result
