### PR TITLE
Fix serialization of Closure error in Job Queue view

### DIFF
--- a/Block/Adminhtml/Job/View.php
+++ b/Block/Adminhtml/Job/View.php
@@ -2,28 +2,35 @@
 
 namespace Algolia\AlgoliaSearch\Block\Adminhtml\Job;
 
+use Algolia\AlgoliaSearch\Model\JobFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResource;
 use Magento\Backend\Block\Widget\Button;
-use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 
 class View extends Template
 {
-    /** @var SessionManagerInterface */
-    protected $backendSession;
+    /** @var JobResource */
+    protected $jobResource;
+
+    /** @var JobFactory */
+    protected $jobFactory;
 
     /**
      * @param Context $context
-     * @param SessionManagerInterface $backendSession
+     * @param JobResource $jobResource
+     * @param JobFactory $jobFactory
      * @param array $data
      */
     public function __construct(
-        Context          $context,
-        SessionManagerInterface   $backendSession,
+        Context       $context,
+        JobResource   $jobResource,
+        JobFactory    $jobFactory,
         array $data = []
     ) {
         parent::__construct($context, $data);
-        $this->backendSession = $backendSession;
+        $this->jobResource = $jobResource;
+        $this->jobFactory = $jobFactory;
     }
 
     /** @inheritdoc */
@@ -47,7 +54,12 @@ class View extends Template
     /** @return \Algolia\AlgoliaSearch\Model\Job */
     public function getCurrentJob()
     {
-        return $this->backendSession->getData('current_job');
+        $currentJobId = $this->_request->getParam('id');
+
+        $job = $this->jobFactory->create();
+        $this->jobResource->load($job, $currentJobId);
+
+        return $job;
     }
 
     /**  @return string */

--- a/Controller/Adminhtml/Queue/AbstractAction.php
+++ b/Controller/Adminhtml/Queue/AbstractAction.php
@@ -5,14 +5,10 @@ namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Queue;
 use Algolia\AlgoliaSearch\Model\JobFactory;
 use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResourceModel;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Indexer\Model\IndexerFactory;
 
 abstract class AbstractAction extends \Magento\Backend\App\Action
 {
-    /** @var SessionManagerInterface */
-    protected $backendSession;
-
     /** @var \Algolia\AlgoliaSearch\Model\JobFactory */
     protected $jobFactory;
 
@@ -24,21 +20,18 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
 
     /**
      * @param Context          $context
-     * @param SessionManagerInterface          $backendSession
      * @param JobFactory       $jobFactory
      * @param JobResourceModel $jobResourceModel
      * @param IndexerFactory   $indexerFactory
      */
     public function __construct(
         Context $context,
-        SessionManagerInterface $backendSession,
         JobFactory $jobFactory,
         JobResourceModel $jobResourceModel,
         IndexerFactory $indexerFactory
     ) {
         parent::__construct($context);
 
-        $this->backendSession   = $backendSession;
         $this->jobFactory       = $jobFactory;
         $this->jobResourceModel = $jobResourceModel;
         $this->indexerFactory   = $indexerFactory;
@@ -66,9 +59,6 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         if (!$model->getId()) {
             return null;
         }
-
-        // Register model to use later in blocks
-        $this->backendSession->setData('current_job', $model);
 
         return $model;
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR fixes a "Uncaught Exception: Serialization of 'Closure' is not allowed" error that occurs when viewing specific jobs in Indexing Queue.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Previously, the AbstractAction was saving the entire Job model into the backend session. In Magento 2, models often contain dependencies (via plugins or resource models) that include anonymous functions (Closures). 

Since PHP cannot serialize Closures, the SessionManager would crash during session_write_close(). Because session writing occurs at the end of the PHP lifecycle, the Job View page would load the main content successfully, but then throw the exception in the footer/bottom of the page, preventing a clean response.

<img width="1917" height="959" alt="image" src="https://github.com/user-attachments/assets/5272ab03-e3d4-4399-8bb9-f57564d13df2" />

<br>

Changes:
- Removed SessionManagerInterface dependency from View block and AbstractAction.
- Modified getCurrentJob() in the View block to load the model dynamically using the id parameter from the Request.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

The Job View page now loads successfully without triggering a session serialization exceptions.

Testing performed:

1. Navigated to Stores > Algolia Search > Indexing Queue
2. Clicked on "View" for an existing job.
3. Verified the page renders correctly and the job details are displayed without errors.

Commands run:

- `bin/magento setup:di:compile` (to verify constructor injection)
- `bin/magento cache:clean`