### PR TITLE
MAGE-1570: Apply new settings comparator to batch processing

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -310,6 +310,7 @@ class ProductHelper extends AbstractEntityHelper
      * @throws AlgoliaException
      * @throws LocalizedException
      * @throws NoSuchEntityException
+     * @throws \Throwable
      */
     public function setSettings(
         IndexOptionsInterface $indexOptions,
@@ -322,47 +323,13 @@ class ProductHelper extends AbstractEntityHelper
         if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
             $this->logger->log('Index name: ' . $indexOptions->getIndexName());
             $this->logger->log('Settings: ' . json_encode($indexSettings));
-
             $this->algoliaConnector->waitLastTask($storeId);
+        }
 
-            if ($saveToTmpIndicesToo) {
-                // For temp index, we need to call AlgoliaConnector::setSettings() directly with explicit settings merge
-                // Main reasons:
-                //  - Temp indices never have replicas associated
-                //  - Settings rely directly on prod index so performing a diff with temporary online settings is useless
-                $this->algoliaConnector->setSettings(
-                    $indexTmpOptions,
-                    $indexSettings,
-                    false,
-                    true,
-                    $indexOptions->getIndexName()
-                );
-
-                $this->logger->log('Pushing the same settings to TMP index as well');
-                $this->algoliaConnector->waitLastTask($storeId);
-
-                try {
-                    $this->algoliaConnector->copySynonyms($indexOptions, $indexTmpOptions);
-                    $this->algoliaConnector->waitLastTask($storeId);
-                    $this->logger->log('
-                        Copying synonyms from production index to "' . $indexTmpOptions->getIndexName() . '" to not erase them with the index move.
-                    ');
-                } catch (AlgoliaException $e) {
-                    $this->logger->error('Error encountered while copying synonyms: ' . $e->getMessage());
-                }
-
-                try {
-                    $this->algoliaConnector->copyQueryRules($indexOptions, $indexTmpOptions);
-                    $this->algoliaConnector->waitLastTask($storeId);
-                    $this->logger->log('
-                        Copying query rules from production index to "' . $indexTmpOptions->getIndexName() . '" to not erase them with the index move.
-                    ');
-                } catch (AlgoliaException $e) {
-                    if ($e->getCode() !== 404) {
-                        throw $e;
-                    }
-                }
-            }
+        if ($saveToTmpIndicesToo && !$this->algoliaConnector->indexExists($indexTmpOptions->getIndexName(), $storeId)) {
+            $this->algoliaConnector->copyIndexConfig($indexOptions, $indexTmpOptions);
+            $this->logger->log('Copying the settings, synonyms and rules from production to "' . $indexTmpOptions->getIndexName() . '" index.');
+            $this->algoliaConnector->waitLastTask($storeId);
         }
 
         $this->setFacetsQueryRules($indexOptions);

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -326,7 +326,7 @@ class ProductHelper extends AbstractEntityHelper
             $this->algoliaConnector->waitLastTask($storeId);
         }
 
-        if ($saveToTmpIndicesToo && !$this->algoliaConnector->indexExists($indexTmpOptions->getIndexName(), $storeId)) {
+        if ($saveToTmpIndicesToo) {
             $this->algoliaConnector->copyIndexConfig($indexOptions, $indexTmpOptions);
             $this->logger->log('Copying the settings, synonyms and rules from production to "' . $indexTmpOptions->getIndexName() . '" index.');
             $this->algoliaConnector->waitLastTask($storeId);

--- a/Model/IndexMover.php
+++ b/Model/IndexMover.php
@@ -51,7 +51,7 @@ class IndexMover
             return;
         }
 
-        $this->indicesConfigurator->saveConfigurationToAlgolia($storeId, true);
+        $this->indicesConfigurator->saveConfigurationToAlgolia($storeId, true, ['products']);
         $this->moveIndex($tmpIndexName, $indexName, $storeId);
     }
 }

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -52,7 +52,11 @@ class IndicesConfigurator
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function saveConfigurationToAlgolia(int $storeId, bool $useTmpIndex = false): void
+    public function saveConfigurationToAlgolia(
+        int $storeId,
+        bool $useTmpIndex = false,
+        array $filteredEntities = [])
+    : void
     {
         $logEventName = 'Save configuration to Algolia for store: ' . $this->logger->getStoreName($storeId);
         $this->logger->start($logEventName, true);
@@ -70,14 +74,37 @@ class IndicesConfigurator
             return;
         }
 
+        if (count($filteredEntities) > 0) {
+            $this->logger->log('Filtered entities: ' . implode(',', $filteredEntities));
+
+            if (in_array('products', $filteredEntities)) {
+                $this->setProductsSettings($storeId, $useTmpIndex);
+            }
+            if (in_array('categories', $filteredEntities)) {
+                $this->setCategoriesSettings($storeId);
+            }
+        } else {
+            $this->setAllEntitiesSettings($storeId, $useTmpIndex);
+        }
+
+        $this->setExtraSettings($storeId, $useTmpIndex, $filteredEntities);
+
+        $this->logger->stop($logEventName, true);
+    }
+
+    /**
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     * @throws DiagnosticsException
+     * @throws AlgoliaException
+     */
+    protected function setAllEntitiesSettings(int $storeId, bool $useTmpIndex = false): void
+    {
         $this->setCategoriesSettings($storeId);
         $this->setPagesSettings($storeId);
         $this->setQuerySuggestionsSettings($storeId);
         $this->setAdditionalSectionsSettings($storeId);
         $this->setProductsSettings($storeId, $useTmpIndex);
-        $this->setExtraSettings($storeId, $useTmpIndex);
-
-        $this->logger->stop($logEventName, true);
     }
 
     protected function logSettingsPush(IndexOptionsInterface $indexOptions, array $settings): void
@@ -203,9 +230,9 @@ class IndicesConfigurator
     }
 
     /**
-     * @throws AlgoliaException|NoSuchEntityException
+     * @throws AlgoliaException|NoSuchEntityException|DiagnosticsException
      */
-    protected function setExtraSettings(int $storeId, bool $saveToTmpIndicesToo): void
+    protected function setExtraSettings(int $storeId, bool $saveToTmpIndicesToo, ?array $filteredEntities): void
     {
         $logEventName = 'Pushing extra settings.';
         $this->logger->start($logEventName, true);
@@ -217,6 +244,10 @@ class IndicesConfigurator
             'suggestions',
             'additional_sections'
         ];
+
+        if (count($filteredEntities) > 0) {
+            $sections = array_intersect($sections, $filteredEntities);
+        }
 
         $error = [];
         foreach ($sections as $section) {

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -83,6 +83,15 @@ class IndicesConfigurator
             if (in_array('categories', $filteredEntities)) {
                 $this->setCategoriesSettings($storeId);
             }
+            if (in_array('pages', $filteredEntities)) {
+                $this->setPagesSettings($storeId);
+            }
+            if (in_array('suggestions', $filteredEntities)) {
+                $this->setQuerySuggestionsSettings($storeId);
+            }
+            if (in_array('additional_sections', $filteredEntities)) {
+                $this->setAdditionalSectionsSettings($storeId);
+            }
         } else {
             $this->setAllEntitiesSettings($storeId, $useTmpIndex);
         }
@@ -232,7 +241,7 @@ class IndicesConfigurator
     /**
      * @throws AlgoliaException|NoSuchEntityException|DiagnosticsException
      */
-    protected function setExtraSettings(int $storeId, bool $saveToTmpIndicesToo, ?array $filteredEntities): void
+    protected function setExtraSettings(int $storeId, bool $saveToTmpIndicesToo, ?array $filteredEntities = []): void
     {
         $logEventName = 'Pushing extra settings.';
         $this->logger->start($logEventName, true);

--- a/Model/Observer/SaveSettings.php
+++ b/Model/Observer/SaveSettings.php
@@ -8,10 +8,19 @@ use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 
 class SaveSettings implements ObserverInterface
 {
+    public const EVENTS = [
+        'admin_system_config_changed_section_algoliasearch_instant'    => ['products'],
+        'admin_system_config_changed_section_algoliasearch_images'     => ['products'],
+        'admin_system_config_changed_section_algoliasearch_products'   => ['products'],
+        'admin_system_config_changed_section_algoliasearch_categories' => ['categories']
+    ];
+
     public function __construct(
         protected StoreManagerInterface $storeManager,
         protected IndicesConfigurator $indicesConfigurator,
@@ -23,13 +32,17 @@ class SaveSettings implements ObserverInterface
      * @param Observer $observer
      *
      * @throws AlgoliaException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
     public function execute(Observer $observer)
     {
+        $filteredEntities = self::EVENTS[$observer->getEvent()->getName()] ?? [];
+
          try {
             $storeIds = array_keys($this->storeManager->getStores());
             foreach ($storeIds as $storeId) {
-                $this->indicesConfigurator->saveConfigurationToAlgolia($storeId);
+                $this->indicesConfigurator->saveConfigurationToAlgolia($storeId, false, $filteredEntities);
             }
         } catch (\Exception $e) {
             if ($e->getCode() !== 404) {

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -570,16 +570,11 @@ class AlgoliaConnector
         $this->setLastOperationInfo($indexOptions, $res);
     }
 
-    /**
-     * Warning: This method can't be performed across two different applications
-     *
-     * @param IndexOptionsInterface $fromIndexOptions
-     * @param IndexOptionsInterface $toIndexOptions
-     * @return void
-     * @throws AlgoliaException
-     * @throws NoSuchEntityException
-     */
-    public function copySynonyms(IndexOptionsInterface $fromIndexOptions, IndexOptionsInterface $toIndexOptions): void
+    protected function copyIndexScopes(
+        IndexOptionsInterface $fromIndexOptions,
+        IndexOptionsInterface $toIndexOptions,
+        ?array $scopes = []
+    ): void
     {
         $fromIndexName = $fromIndexOptions->getIndexName();
         $toIndexName = $toIndexOptions->getIndexName();
@@ -589,10 +584,22 @@ class AlgoliaConnector
             [
                 'operation'   => 'copy',
                 'destination' => $toIndexName,
-                'scope'       => ['synonyms']
+                'scope'       => $scopes
             ]
         );
         $this->setLastOperationInfo($fromIndexOptions, $response);
+    }
+
+    /**
+     * Warning: This method can't be performed across two different applications
+     *
+     * @param IndexOptionsInterface $fromIndexOptions
+     * @param IndexOptionsInterface $toIndexOptions
+     * @return void
+     */
+    public function copySynonyms(IndexOptionsInterface $fromIndexOptions, IndexOptionsInterface $toIndexOptions): void
+    {
+        $this->copyIndexScopes($fromIndexOptions, $toIndexOptions, ['synonyms']);
     }
 
     /**
@@ -609,23 +616,22 @@ class AlgoliaConnector
      * @param IndexOptionsInterface $fromIndexOptions
      * @param IndexOptionsInterface $toIndexOptions
      * @return void
-     * @throws AlgoliaException
-     * @throws NoSuchEntityException
      */
     public function copyQueryRules(IndexOptionsInterface $fromIndexOptions, IndexOptionsInterface $toIndexOptions): void
     {
-        $fromIndexName = $fromIndexOptions->getIndexName();
-        $toIndexName = $toIndexOptions->getIndexName();
+        $this->copyIndexScopes($fromIndexOptions, $toIndexOptions, ['rules']);
+    }
 
-        $response = $this->getClient($fromIndexOptions->getStoreId())->operationIndex(
-            $fromIndexName,
-            [
-                'operation'   => 'copy',
-                'destination' => $toIndexName,
-                'scope'       => ['rules']
-            ]
-        );
-        $this->setLastOperationInfo($fromIndexOptions, $response);
+    /**
+     * Warning: This method can't be performed across two different applications
+     *
+     * @param IndexOptionsInterface $fromIndexOptions
+     * @param IndexOptionsInterface $toIndexOptions
+     * @return void
+     */
+    public function copyIndexConfig(IndexOptionsInterface $fromIndexOptions, IndexOptionsInterface $toIndexOptions): void
+    {
+        $this->copyIndexScopes($fromIndexOptions, $toIndexOptions, ['settings', 'synonyms', 'rules']);
     }
 
     /**

--- a/Service/Category/BatchQueueProcessor.php
+++ b/Service/Category/BatchQueueProcessor.php
@@ -10,17 +10,20 @@ use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Model\Queue;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Service\Category\IndexBuilder as CategoryIndexBuilder;
+use Algolia\AlgoliaSearch\Service\IndexSettingsComparator;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 class BatchQueueProcessor implements BatchQueueProcessorInterface
 {
     public function __construct(
-        protected Data $dataHelper,
-        protected ConfigHelper $configHelper,
-        protected Queue $queue,
-        protected CategoryHelper $categoryHelper,
-        protected AlgoliaCredentialsManager $algoliaCredentialsManager
+        protected Data                      $dataHelper,
+        protected ConfigHelper              $configHelper,
+        protected Queue                     $queue,
+        protected CategoryHelper            $categoryHelper,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager,
+        protected IndexOptionsBuilder       $indexOptionsBuilder,
+        protected IndexSettingsComparator   $indexSettingsComparator
     ){}
 
     /**
@@ -82,8 +85,21 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
      */
     protected function processFullReindex(int $storeId, int $categoriesPerPage): void
     {
-        /** @uses IndicesConfigurator::saveConfigurationToAlgolia() */
-        $this->queue->addToQueue(IndicesConfigurator::class, 'saveConfigurationToAlgolia', ['storeId' => $storeId]);
+        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $categoriesSettings = $this->categoryHelper->getIndexSettings($storeId);
+
+        if (!$this->indexSettingsComparator->matches($indexOptions, $categoriesSettings)) {
+            /** @uses IndicesConfigurator::saveConfigurationToAlgolia() */
+            $this->queue->addToQueue(
+                IndicesConfigurator::class,
+                'saveConfigurationToAlgolia',
+                [
+                    'storeId' => $storeId,
+                    'useTmpIndex' => false,
+                    'filteredEntities' => ['categories']
+                ]
+            );
+        }
 
         $collection = $this->categoryHelper->getCategoryCollectionQuery($storeId);
         $size = $collection->getSize();

--- a/Service/Product/BatchQueueProcessor.php
+++ b/Service/Product/BatchQueueProcessor.php
@@ -91,6 +91,10 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
         $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, $useTmpIndex);
         $productSettings = $this->productHelper->getIndexSettings($storeId);
 
+        // $useTmpIndex needs to be checked here because we need to ensure proper creation of the tmp index at this point
+        // (tmp index needs to be initialized in the setSettings operation even if the settings are matching ALgolia dashboard)
+        // => If no setSettings is performed before the first batch, this will result in the creation
+        // of a tmp index without any settings, rules or synonyms.
         if (!$useTmpIndex && $this->indexSettingsComparator->matches($indexOptions, $productSettings)) {
             return;
         }

--- a/Service/Product/BatchQueueProcessor.php
+++ b/Service/Product/BatchQueueProcessor.php
@@ -15,6 +15,7 @@ use Algolia\AlgoliaSearch\Model\IndexMover;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Model\Queue;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Service\Product\IndexBuilder as ProductIndexBuilder;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -22,15 +23,17 @@ use Magento\Framework\Exception\NoSuchEntityException;
 class BatchQueueProcessor implements BatchQueueProcessorInterface
 {
     public function __construct(
-        protected Data $dataHelper,
-        protected ConfigHelper $configHelper,
-        protected ProductHelper $productHelper,
-        protected QueueHelper $queueHelper,
-        protected Queue $queue,
-        protected DiagnosticsLogger $diag,
+        protected Data                      $dataHelper,
+        protected ConfigHelper              $configHelper,
+        protected ProductHelper             $productHelper,
+        protected QueueHelper               $queueHelper,
+        protected Queue                     $queue,
+        protected DiagnosticsLogger         $diag,
         protected AlgoliaCredentialsManager $algoliaCredentialsManager,
-        protected ProductIndexBuilder $productIndexBuilder,
-        protected IndexCollectionSize $indexCollectionSizeCache
+        protected ProductIndexBuilder       $productIndexBuilder,
+        protected IndexCollectionSize       $indexCollectionSizeCache,
+        protected IndexOptionsBuilder       $indexOptionsBuilder,
+        protected IndexSettingsComparator   $indexSettingsComparator
     ){}
 
     /**
@@ -85,10 +88,18 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
 
     protected function syncAlgoliaSettings(int $storeId, bool $useTmpIndex): void
     {
+        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, $useTmpIndex);
+        $productSettings = $this->productHelper->getIndexSettings($storeId);
+
+        if (!$useTmpIndex && $this->indexSettingsComparator->matches($indexOptions, $productSettings)) {
+            return;
+        }
+
         /** @uses IndicesConfigurator::saveConfigurationToAlgolia() */
         $this->queue->addToQueue(IndicesConfigurator::class, 'saveConfigurationToAlgolia', [
             'storeId' => $storeId,
             'useTmpIndex' => $useTmpIndex,
+            'filteredEntities' => ['products']
         ], 1, true);
     }
 

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -7,11 +7,13 @@ use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Algolia\AlgoliaSearch\Exception\ProductReindexingException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\ProductDataArray;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AbstractIndexBuilder;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\IndexSettingsHandler;
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\App\Config\ScopeCodeResolver;
@@ -29,6 +31,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
 
     public function __construct(
         protected ConfigHelper             $configHelper,
+        protected QueueHelper              $queueHelper,
         protected DiagnosticsLogger        $logger,
         protected Emulation                $emulation,
         protected ScopeCodeResolver        $scopeCodeResolver,
@@ -39,6 +42,7 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         protected ResourceConnection       $resource,
         protected ManagerInterface         $eventManager,
         protected MissingPriceIndexHandler $missingPriceIndexHandler,
+        protected IndexSettingsHandler     $indexSettingsHandler,
         IndexerRegistry                    $indexerRegistry
     ){
         parent::__construct(
@@ -91,6 +95,11 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             return;
         }
 
+        // Before pushing the records, check settings and update them if needed (only when queue is active)
+        if ($this->queueHelper->isQueueActive($storeId)) {
+            $this->updateSettings($storeId);
+        }
+
         $this->startEmulation($storeId);
 
         $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex($storeId);
@@ -106,6 +115,18 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         );
 
         $this->stopEmulation();
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws AlgoliaException
+     * @throws LocalizedException
+     */
+    protected function updateSettings(int $storeId): void
+    {
+        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $settings = $this->productHelper->getIndexSettings($storeId);
+        $this->indexSettingsHandler->setSettings($indexOptions, $settings);
     }
 
     /**

--- a/Service/Product/IndexBuilder.php
+++ b/Service/Product/IndexBuilder.php
@@ -7,13 +7,11 @@ use Algolia\AlgoliaSearch\Exception\DiagnosticsException;
 use Algolia\AlgoliaSearch\Exception\ProductReindexingException;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
-use Algolia\AlgoliaSearch\Helper\Configuration\QueueHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Helper\ProductDataArray;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AbstractIndexBuilder;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
-use Algolia\AlgoliaSearch\Service\IndexSettingsHandler;
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\App\Config\ScopeCodeResolver;
@@ -31,7 +29,6 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
 
     public function __construct(
         protected ConfigHelper             $configHelper,
-        protected QueueHelper              $queueHelper,
         protected DiagnosticsLogger        $logger,
         protected Emulation                $emulation,
         protected ScopeCodeResolver        $scopeCodeResolver,
@@ -42,7 +39,6 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         protected ResourceConnection       $resource,
         protected ManagerInterface         $eventManager,
         protected MissingPriceIndexHandler $missingPriceIndexHandler,
-        protected IndexSettingsHandler     $indexSettingsHandler,
         IndexerRegistry                    $indexerRegistry
     ){
         parent::__construct(
@@ -95,11 +91,6 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
             return;
         }
 
-        // Before pushing the records, check settings and update them if needed (only when queue is active)
-        if ($this->queueHelper->isQueueActive($storeId)) {
-            $this->updateSettings($storeId);
-        }
-
         $this->startEmulation($storeId);
 
         $onlyVisible = !$this->configHelper->includeNonVisibleProductsInIndex($storeId);
@@ -115,18 +106,6 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
         );
 
         $this->stopEmulation();
-    }
-
-    /**
-     * @throws NoSuchEntityException
-     * @throws AlgoliaException
-     * @throws LocalizedException
-     */
-    protected function updateSettings(int $storeId): void
-    {
-        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
-        $settings = $this->productHelper->getIndexSettings($storeId);
-        $this->indexSettingsHandler->setSettings($indexOptions, $settings);
     }
 
     /**

--- a/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
@@ -88,7 +88,11 @@ class MultiStoreConfigTest extends MultiStoreTestCase
             scopeCode: $fixtureSecondStore->getCode()
         );
 
-        $this->indicesConfigurator->saveConfigurationToAlgolia($fixtureSecondStore->getId());
+        $this->indicesConfigurator->saveConfigurationToAlgolia(
+            $fixtureSecondStore->getId(),
+            false,
+            ['products', 'categories']
+        );
 
         $defaultIndexOptions = $this->getIndexOptions('products', $defaultStore->getId());
         $fixtureIndexOptions = $this->getIndexOptions('products', $fixtureSecondStore->getId());

--- a/Test/Integration/Indexing/Product/MultiStoreReplicaTest.php
+++ b/Test/Integration/Indexing/Product/MultiStoreReplicaTest.php
@@ -230,7 +230,7 @@ class MultiStoreReplicaTest extends MultiStoreTestCase
         );
 
         $this->assertSortingAttribute($attr, $dir);
-        $this->indicesConfigurator->saveConfigurationToAlgolia($store->getId());
+        $this->indicesConfigurator->saveConfigurationToAlgolia($store->getId(), false, ['products']);
         $this->algoliaConnector->waitLastTask($store->getId());
     }
 

--- a/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
@@ -65,7 +65,7 @@ class ReplicaIndexingTest extends TestCase
         $sortDir = 'desc';
         $this->assertSortingAttribute($sortAttr, $sortDir);
 
-        $this->indicesConfigurator->saveConfigurationToAlgolia(1);
+        $this->indicesConfigurator->saveConfigurationToAlgolia(1, false, ['products']);
         $this->algoliaConnector->waitLastTask();
 
         // Assert replica config created
@@ -121,7 +121,7 @@ class ReplicaIndexingTest extends TestCase
         // Cannot use config fixture because we have disabled db isolation
         $this->setConfig(InstantSearchHelper::IS_ENABLED, 1);
 
-        $this->indicesConfigurator->saveConfigurationToAlgolia(1);
+        $this->indicesConfigurator->saveConfigurationToAlgolia(1,false, ['products']);
         $this->algoliaConnector->waitLastTask();
 
         // Assert replica config created

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -140,58 +140,23 @@ class ProductHelperTest extends TestCase
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 
         $this->algoliaConnector->expects($this->once())
-            ->method('setSettings')
+            ->method('copyIndexConfig')
             ->with(
-                $this->indexTmpOptions,
-                $this->defaultSettings,
-                false,
-                true,
-                'prod_index'
+                $this->indexOptions,
+                $this->indexTmpOptions
             );
 
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
     }
 
-    public function testCopiesSynonymsAndQueryRulesFromProdToTmpIndex(): void
+    public function testNoPushSettingsToTmpIndexWithMergeParametersWhenFlagIsFalse(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->once())
-            ->method('copySynonyms')
-            ->with($this->indexOptions, $this->indexTmpOptions);
+        $this->algoliaConnector->expects($this->never())
+            ->method('copyIndexConfig');
 
-        $this->algoliaConnector->expects($this->once())
-            ->method('copyQueryRules')
-            ->with($this->indexOptions, $this->indexTmpOptions);
-
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
-    }
-
-    public function testLogsSynonymCopyErrorAndContinuesWhenCopySynonymsFails(): void
-    {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
-
-        $this->algoliaConnector->method('copySynonyms')
-            ->willThrowException(new AlgoliaException('Synonyms API error'));
-
-        $this->logger->expects($this->atLeastOnce())->method('error');
-
-        // copyQueryRules must still be reached after the synonym failure
-        $this->algoliaConnector->expects($this->once())->method('copyQueryRules');
-
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
-    }
-
-    public function testRethrowsNon404ExceptionFromCopyQueryRules(): void
-    {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
-
-        $this->algoliaConnector->method('copyQueryRules')
-            ->willThrowException(new AlgoliaException('Internal error', 500));
-
-        $this->expectException(AlgoliaException::class);
-
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, false);
     }
 
     public function testAlwaysCallsSetFacetsQueryRulesForMainIndexEvenWhenSettingsUnchanged(): void

--- a/Test/Unit/Model/IndicesConfiguratorTest.php
+++ b/Test/Unit/Model/IndicesConfiguratorTest.php
@@ -90,7 +90,16 @@ class IndicesConfiguratorTest extends TestCase
                 $this->indexSettingsHandler,
                 $this->logger,
             ])
-            ->onlyMethods(['setAllEntitiesSettings', 'setProductsSettings', 'setCategoriesSettings', 'setExtraSettings'])
+            ->onlyMethods(
+                [
+                    'setAllEntitiesSettings',
+                    'setProductsSettings',
+                    'setCategoriesSettings',
+                    'setPagesSettings',
+                    'setQuerySuggestionsSettings',
+                    'setExtraSettings'
+                ]
+            )
             ->getMock();
 
         $this->logger->method('getStoreName')->willReturn('Default Store');
@@ -197,13 +206,17 @@ class IndicesConfiguratorTest extends TestCase
     {
         $this->allowPassingGuards();
 
-        // 'pages' and 'suggestions' have no dedicated dispatch in the filter branch;
-        // they are handled exclusively through setExtraSettings
+        $this->configurator->expects($this->once())->method('setPagesSettings');
+        $this->configurator->expects($this->once())->method('setQuerySuggestionsSettings');
         $this->configurator->expects($this->never())->method('setProductsSettings');
         $this->configurator->expects($this->never())->method('setCategoriesSettings');
         $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId, false, ['pages', 'suggestions']);
+        $this->configurator->saveConfigurationToAlgolia(
+            $this->storeId,
+            false,
+            ['pages', 'suggestions', 'foo', 'bar']
+        );
     }
 
     public function testForwardsAllParametersToSetExtraSettings(): void

--- a/Test/Unit/Model/IndicesConfiguratorTest.php
+++ b/Test/Unit/Model/IndicesConfiguratorTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Model;
+
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Configuration\AutocompleteHelper;
+use Algolia\AlgoliaSearch\Helper\Data;
+use Algolia\AlgoliaSearch\Helper\Entity\AdditionalSectionHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\PageHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\SuggestionHelper;
+use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\Category\IndexOptionsBuilder as CategoryIndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\IndexSettingsHandler;
+use Algolia\AlgoliaSearch\Service\Page\IndexOptionsBuilder as PageIndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder as ProductIndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\Suggestion\IndexOptionsBuilder as SuggestionIndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class IndicesConfiguratorTest extends TestCase
+{
+    private int $storeId = 1;
+
+    private null|(Data&MockObject) $baseHelper = null;
+    private null|(IndexOptionsBuilder&MockObject) $indexOptionsBuilder = null;
+    private null|(CategoryIndexOptionsBuilder&MockObject) $categoryIndexOptionsBuilder = null;
+    private null|(PageIndexOptionsBuilder&MockObject) $pageIndexOptionsBuilder = null;
+    private null|(ProductIndexOptionsBuilder&MockObject) $productIndexOptionsBuilder = null;
+    private null|(SuggestionIndexOptionsBuilder&MockObject) $suggestionIndexOptionsBuilder = null;
+    private null|(AlgoliaConnector&MockObject) $algoliaConnector = null;
+    private null|(ConfigHelper&MockObject) $configHelper = null;
+    private null|(AutocompleteHelper&MockObject) $autocompleteHelper = null;
+    private null|(ProductHelper&MockObject) $productHelper = null;
+    private null|(CategoryHelper&MockObject) $categoryHelper = null;
+    private null|(PageHelper&MockObject) $pageHelper = null;
+    private null|(SuggestionHelper&MockObject) $suggestionHelper = null;
+    private null|(AdditionalSectionHelper&MockObject) $additionalSectionHelper = null;
+    private null|(AlgoliaCredentialsManager&MockObject) $algoliaCredentialsManager = null;
+    private null|(IndexSettingsHandler&MockObject) $indexSettingsHandler = null;
+    private null|(DiagnosticsLogger&MockObject) $logger = null;
+    private null|(IndicesConfigurator&MockObject) $configurator = null;
+
+    protected function setUp(): void
+    {
+        $this->baseHelper = $this->createMock(Data::class);
+        $this->indexOptionsBuilder = $this->createMock(IndexOptionsBuilder::class);
+        $this->categoryIndexOptionsBuilder = $this->createMock(CategoryIndexOptionsBuilder::class);
+        $this->pageIndexOptionsBuilder = $this->createMock(PageIndexOptionsBuilder::class);
+        $this->productIndexOptionsBuilder = $this->createMock(ProductIndexOptionsBuilder::class);
+        $this->suggestionIndexOptionsBuilder = $this->createMock(SuggestionIndexOptionsBuilder::class);
+        $this->algoliaConnector = $this->createMock(AlgoliaConnector::class);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->autocompleteHelper = $this->createMock(AutocompleteHelper::class);
+        $this->productHelper = $this->createMock(ProductHelper::class);
+        $this->categoryHelper = $this->createMock(CategoryHelper::class);
+        $this->pageHelper = $this->createMock(PageHelper::class);
+        $this->suggestionHelper = $this->createMock(SuggestionHelper::class);
+        $this->additionalSectionHelper = $this->createMock(AdditionalSectionHelper::class);
+        $this->algoliaCredentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $this->indexSettingsHandler = $this->createMock(IndexSettingsHandler::class);
+        $this->logger = $this->createMock(DiagnosticsLogger::class);
+
+        // Partial mock: stub protected routing methods so saveConfigurationToAlgolia
+        // can be tested in isolation without pulling in each entity's full dependency chain
+        $this->configurator = $this->getMockBuilder(IndicesConfigurator::class)
+            ->setConstructorArgs([
+                $this->baseHelper,
+                $this->indexOptionsBuilder,
+                $this->categoryIndexOptionsBuilder,
+                $this->pageIndexOptionsBuilder,
+                $this->productIndexOptionsBuilder,
+                $this->suggestionIndexOptionsBuilder,
+                $this->algoliaConnector,
+                $this->configHelper,
+                $this->autocompleteHelper,
+                $this->productHelper,
+                $this->categoryHelper,
+                $this->pageHelper,
+                $this->suggestionHelper,
+                $this->additionalSectionHelper,
+                $this->algoliaCredentialsManager,
+                $this->indexSettingsHandler,
+                $this->logger,
+            ])
+            ->onlyMethods(['setAllEntitiesSettings', 'setProductsSettings', 'setCategoriesSettings', 'setExtraSettings'])
+            ->getMock();
+
+        $this->logger->method('getStoreName')->willReturn('Default Store');
+    }
+
+    private function allowPassingGuards(): void
+    {
+        $this->algoliaCredentialsManager->method('checkCredentials')->willReturn(true);
+        $this->baseHelper->method('isIndexingEnabled')->willReturn(true);
+    }
+
+    public function testReturnsEarlyWhenCredentialCheckFails(): void
+    {
+        $this->algoliaCredentialsManager->method('checkCredentials')->willReturn(false);
+
+        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+        $this->configurator->expects($this->never())->method('setProductsSettings');
+        $this->configurator->expects($this->never())->method('setCategoriesSettings');
+        $this->configurator->expects($this->never())->method('setExtraSettings');
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId);
+    }
+
+    public function testReturnsEarlyWhenIndexingIsDisabled(): void
+    {
+        $this->algoliaCredentialsManager->method('checkCredentials')->willReturn(true);
+        $this->baseHelper->method('isIndexingEnabled')->willReturn(false);
+
+        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+        $this->configurator->expects($this->never())->method('setProductsSettings');
+        $this->configurator->expects($this->never())->method('setCategoriesSettings');
+        $this->configurator->expects($this->never())->method('setExtraSettings');
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId);
+    }
+
+    public function testCallsAllEntitiesSettingsWhenNoFilterProvided(): void
+    {
+        $this->allowPassingGuards();
+
+        $this->configurator->expects($this->once())->method('setAllEntitiesSettings');
+        $this->configurator->expects($this->never())->method('setProductsSettings');
+        $this->configurator->expects($this->never())->method('setCategoriesSettings');
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId);
+    }
+
+    public function testForwardsUseTmpIndexToAllEntitiesSettings(): void
+    {
+        $this->allowPassingGuards();
+
+        $this->configurator->expects($this->once())
+            ->method('setAllEntitiesSettings')
+            ->with($this->storeId, true);
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId, true);
+    }
+
+    public function testCallsOnlyProductsSettingsWhenFilterContainsProducts(): void
+    {
+        $this->allowPassingGuards();
+
+        $this->configurator->expects($this->once())->method('setProductsSettings');
+        $this->configurator->expects($this->never())->method('setCategoriesSettings');
+        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId, false, ['products']);
+    }
+
+    public function testForwardsUseTmpIndexToProductsSettings(): void
+    {
+        $this->allowPassingGuards();
+
+        $this->configurator->expects($this->once())
+            ->method('setProductsSettings')
+            ->with($this->storeId, true);
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId, true, ['products']);
+    }
+
+    public function testCallsOnlyCategoriesSettingsWhenFilterContainsCategories(): void
+    {
+        $this->allowPassingGuards();
+
+        $this->configurator->expects($this->once())->method('setCategoriesSettings');
+        $this->configurator->expects($this->never())->method('setProductsSettings');
+        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId, false, ['categories']);
+    }
+
+    public function testCallsBothProductsAndCategoriesWhenBothInFilter(): void
+    {
+        $this->allowPassingGuards();
+
+        $this->configurator->expects($this->once())->method('setProductsSettings');
+        $this->configurator->expects($this->once())->method('setCategoriesSettings');
+        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId, false, ['products', 'categories']);
+    }
+
+    public function testSkipsUnrecognizedEntitiesInFilterBranch(): void
+    {
+        $this->allowPassingGuards();
+
+        // 'pages' and 'suggestions' have no dedicated dispatch in the filter branch;
+        // they are handled exclusively through setExtraSettings
+        $this->configurator->expects($this->never())->method('setProductsSettings');
+        $this->configurator->expects($this->never())->method('setCategoriesSettings');
+        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId, false, ['pages', 'suggestions']);
+    }
+
+    public function testForwardsAllParametersToSetExtraSettings(): void
+    {
+        $this->allowPassingGuards();
+
+        $filteredEntities = ['products', 'categories'];
+
+        $this->configurator->expects($this->once())
+            ->method('setExtraSettings')
+            ->with($this->storeId, true, $filteredEntities);
+
+        $this->configurator->saveConfigurationToAlgolia($this->storeId, true, $filteredEntities);
+    }
+}

--- a/Test/Unit/Service/Product/BatchQueueProcessorTest.php
+++ b/Test/Unit/Service/Product/BatchQueueProcessorTest.php
@@ -13,8 +13,10 @@ use Algolia\AlgoliaSearch\Model\IndexMover;
 use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Model\Queue;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Service\Product\BatchQueueProcessor;
 use Algolia\AlgoliaSearch\Service\Product\IndexBuilder;
+use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\Exception\NoSuchEntityException;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +33,8 @@ class BatchQueueProcessorTest extends TestCase
     protected ?IndexBuilder $indexBuilder;
     protected ?IndexCollectionSize $indexCollectionSizeCache;
     protected ?BatchQueueProcessor $processor;
+    protected ?IndexOptionsBuilder $indexOptionsBuilder;
+    protected IndexSettingsComparator $indexSettingsComparator;
 
     protected function setUp(): void
     {
@@ -43,6 +47,8 @@ class BatchQueueProcessorTest extends TestCase
         $this->indexBuilder = $this->createMock(IndexBuilder::class);
         $this->indexCollectionSizeCache = $this->createMock(IndexCollectionSize::class);
         $this->queueHelper = $this->createMock(QueueHelper::class);
+        $this->indexOptionsBuilder = $this->createMock(IndexOptionsBuilder::class);
+        $this->indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
 
         $this->processor = new BatchQueueProcessor(
             $this->dataHelper,
@@ -53,7 +59,9 @@ class BatchQueueProcessorTest extends TestCase
             $this->diag,
             $this->algoliaCredentialsManager,
             $this->indexBuilder,
-            $this->indexCollectionSizeCache
+            $this->indexCollectionSizeCache,
+            $this->indexOptionsBuilder,
+            $this->indexSettingsComparator
         );
     }
 

--- a/Ui/Component/Listing/Column/Data.php
+++ b/Ui/Component/Listing/Column/Data.php
@@ -44,7 +44,7 @@ class Data extends \Magento\Ui\Component\Listing\Columns\Column
             $stringKey = '- <strong>' . $key . '</strong>';
 
             if (is_array($value)) {
-                if ($key === 'entityIds') {
+                if ($key === 'entityIds' || $key === 'filteredEntities') {
                     $formattedData .=
                         str_repeat('&nbsp;&nbsp;&nbsp;', $depth ) . $stringKey . ' : '  . implode(', ', $value) . '<br>';
                 } else {


### PR DESCRIPTION
This PR contains:
- Add `IndexSettingsComparator` to batch processing for entities that are performing `setSettings` operation on full indexing (products and categories) : a settings comparison is now performed before adding `saveConfigurationToAlgolia` operations in the queue process (and direct indexing when queue is disabled). 
- When queue is enabled `Product/IndexBuilder` now checks settings each time records are pushed to ensure they are up-to-date with Algolia's dashboard. (Since `saveConfigurationToAlgolia` can be skipped at the beginning of the process).
- `IndicesConfigurator::saveConfigurationToAlgolia` now has a third optional parameter `$filteredEntities` which allows to only save configuration for given entities to avoid updating all settings indices each time. (to ensure backward compatibility with 3.18.0, if this parameter is not specified, legacy behavior still applies).
- As a result, product and category `IndexBuilder` only push settings for their related indices (same for `IndexMover` which is only related to products)
- `SaveSettings` Observer now also leverages this parameter:
   - saving config on products, instantsearch and images sections now only push product index settings
   - saving config on category section now only push category index settings
   - saving config on any other section still push settings on all indices
- Settings, Rules and Synonyms are now copied to temporary index with one single `operation` call 
- Added unit tests for `IndicesConfigurator`
- Updated integration test with the `$filteredEntities` param