### PR TITLE
MAGE-1573: Collect task ids and wait once during save settings (also MAGE-1574 and MAGE-1575)

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -329,7 +329,7 @@ class ProductHelper extends AbstractEntityHelper
         if ($saveToTmpIndicesToo) {
             $this->algoliaConnector->copyIndexConfig($indexOptions, $indexTmpOptions);
             $this->logger->log('Copying the settings, synonyms and rules from production to "' . $indexTmpOptions->getIndexName() . '" index.');
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexTmpOptions);
+            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->setFacetsQueryRules($indexOptions);
@@ -456,12 +456,12 @@ class ProductHelper extends AbstractEntityHelper
 
     /**
      * @param IndexOptionsInterface $indexOptions
-     * @param bool $waitLastTask
+     * @param bool $collectTaskId
      * @return void
      * @throws AlgoliaException
      * @throws NoSuchEntityException
      */
-    protected function setFacetsQueryRules(IndexOptionsInterface $indexOptions, bool $waitLastTask = false): void
+    protected function setFacetsQueryRules(IndexOptionsInterface $indexOptions, bool $collectTaskId = false): void
     {
         $this->clearFacetsQueryRules($indexOptions);
 
@@ -500,7 +500,7 @@ class ProductHelper extends AbstractEntityHelper
 
             $this->algoliaConnector->saveRules($indexOptions, $rules, true);
 
-            if ($waitLastTask) {
+            if ($collectTaskId) {
                 $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
             }
         }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -323,13 +323,13 @@ class ProductHelper extends AbstractEntityHelper
         if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
             $this->logger->log('Index name: ' . $indexOptions->getIndexName());
             $this->logger->log('Settings: ' . json_encode($indexSettings));
-            $this->algoliaConnector->waitLastTask($storeId);
+            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         if ($saveToTmpIndicesToo) {
             $this->algoliaConnector->copyIndexConfig($indexOptions, $indexTmpOptions);
             $this->logger->log('Copying the settings, synonyms and rules from production to "' . $indexTmpOptions->getIndexName() . '" index.');
-            $this->algoliaConnector->waitLastTask($storeId);
+            $this->algoliaConnector->collectTaskIdToWaitFor($indexTmpOptions);
         }
 
         $this->setFacetsQueryRules($indexOptions);
@@ -501,7 +501,7 @@ class ProductHelper extends AbstractEntityHelper
             $this->algoliaConnector->saveRules($indexOptions, $rules, true);
 
             if ($waitLastTask) {
-                $this->algoliaConnector->waitLastTask($indexOptions->getStoreId());
+                $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
             }
         }
     }

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -456,12 +456,11 @@ class ProductHelper extends AbstractEntityHelper
 
     /**
      * @param IndexOptionsInterface $indexOptions
-     * @param bool $collectTaskId
      * @return void
      * @throws AlgoliaException
      * @throws NoSuchEntityException
      */
-    protected function setFacetsQueryRules(IndexOptionsInterface $indexOptions, bool $collectTaskId = false): void
+    protected function setFacetsQueryRules(IndexOptionsInterface $indexOptions): void
     {
         $this->clearFacetsQueryRules($indexOptions);
 
@@ -499,10 +498,6 @@ class ProductHelper extends AbstractEntityHelper
             $this->logger->log('Setting facets query rules to "' . $indexOptions->getIndexName() . '" index: ' . json_encode($rules));
 
             $this->algoliaConnector->saveRules($indexOptions, $rules, true);
-
-            if ($collectTaskId) {
-                $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
-            }
         }
     }
 

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -98,6 +98,8 @@ class IndicesConfigurator
 
         $this->setExtraSettings($storeId, $useTmpIndex, $filteredEntities);
 
+        $this->algoliaConnector->waitForAllCollectedTaskIds($storeId);
+
         $this->logger->stop($logEventName, true);
     }
 
@@ -135,7 +137,7 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->waitLastTask($storeId);
+            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -160,7 +162,7 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->waitLastTask($storeId);
+            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -185,7 +187,7 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->waitLastTask($storeId);
+            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -213,7 +215,7 @@ class IndicesConfigurator
 
             if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
                 $this->logSettingsPush($indexOptions, $settings);
-                $this->algoliaConnector->waitLastTask($storeId);
+                $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
             }
         }
 
@@ -269,7 +271,7 @@ class IndicesConfigurator
 
                     if ($this->indexSettingsHandler->setSettings($indexOptions, $extraSettings)) {
                         $this->logSettingsPush($indexOptions, $extraSettings);
-                        $this->algoliaConnector->waitLastTask($storeId);
+                        $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
                     }
 
                     if ($section === 'products' && $saveToTmpIndicesToo) {
@@ -288,7 +290,7 @@ class IndicesConfigurator
                             $indexOptions->getIndexName()
                         );
                         $this->logSettingsPush($indexTempOptions, $extraSettings);
-                        $this->algoliaConnector->waitLastTask($storeId);
+                        $this->algoliaConnector->collectTaskIdToWaitFor($indexTempOptions);
                     }
                 }
             } catch (AlgoliaException $e) {

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -202,15 +202,19 @@ class IndicesConfigurator
         $this->logger->start($logEventName, true);
 
         $protectedSections = ['products', 'categories', 'pages', 'suggestions'];
-        foreach ($this->autocompleteHelper->getAdditionalSections($storeId) as $section) {
+        $configSections = $this->autocompleteHelper->getAdditionalSections($storeId);
+
+        $settings = count($configSections) > 0 ?
+            $this->additionalSectionHelper->getIndexSettings($storeId) :
+            [];
+
+        foreach ($configSections as $section) {
             if (in_array($section['name'], $protectedSections, true)) {
                 continue;
             }
 
             $indexName = $this->additionalSectionHelper->getIndexName($storeId);
             $indexName = $indexName . '_' . $section['name'];
-
-            $settings = $this->additionalSectionHelper->getIndexSettings($storeId);
             $indexOptions = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
             if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -703,22 +703,23 @@ class AlgoliaConnector
 
     public function collectTaskIdToWaitFor(IndexOptionsInterface $indexOptions): void
     {
-        $this->taskIdsToWaitFor[$indexOptions->getIndexName()][] = $this->getLastTaskId($indexOptions->getStoreId());
+        $this->taskIdsToWaitFor[$indexOptions->getStoreId()][$indexOptions->getIndexName()][] =
+            $this->getLastTaskId($indexOptions->getStoreId());
     }
 
     public function waitForAllCollectedTaskIds(int $storeId): void
     {
-        if (empty($this->taskIdsToWaitFor)) {
+        if (empty($this->taskIdsToWaitFor) || !isset($this->taskIdsToWaitFor[$storeId])) {
             return;
         }
 
-        foreach ($this->taskIdsToWaitFor as $indexName => $taskIds) {
+        foreach ($this->taskIdsToWaitFor[$storeId] as $indexName => $taskIds) {
             foreach($taskIds as $taskId) {
                 $this->waitLastTask($storeId, $indexName, $taskId);
             }
         }
 
-        $this->taskIdsToWaitFor = [];
+        unset($this->taskIdsToWaitFor[$storeId]);
     }
 
     /**

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -73,6 +73,8 @@ class AlgoliaConnector
      */
     protected ?array $lastTaskInfoByStore = null;
 
+    protected array $taskIdsToWaitFor = [];
+
     public function __construct(
         protected ConfigHelper $config,
         protected ManagerInterface $messageManager,
@@ -697,6 +699,26 @@ class AlgoliaConnector
         }
 
         $this->getClient($storeId)->waitForTask($lastUsedIndexName, $lastTaskId);
+    }
+
+    public function collectTaskIdToWaitFor(IndexOptionsInterface $indexOptions): void
+    {
+        $this->taskIdsToWaitFor[$indexOptions->getIndexName()][] = $this->getLastTaskId($indexOptions->getStoreId());
+    }
+
+    public function waitForAllCollectedTaskIds(int $storeId): void
+    {
+        if (empty($this->taskIdsToWaitFor)) {
+            return;
+        }
+
+        foreach ($this->taskIdsToWaitFor as $indexName => $taskIds) {
+            foreach($taskIds as $taskId) {
+                $this->waitLastTask($storeId, $indexName, $taskId);
+            }
+        }
+
+        $this->taskIdsToWaitFor = [];
     }
 
     /**

--- a/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
@@ -101,6 +101,9 @@ class MultiStoreConfigTest extends MultiStoreTestCase
         $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$defaultIndexOptions, true]);
         $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$fixtureIndexOptions, true]);
 
+        $this->algoliaConnector->waitForAllCollectedTaskIds($defaultIndexOptions->getStoreId());
+        $this->algoliaConnector->waitForAllCollectedTaskIds($fixtureIndexOptions->getStoreId());
+
         $defaultCategoryIndexOptions = $this->getIndexOptions('categories', $defaultStore->getId());
         $defaultCategoryIndexSettings = $this->algoliaConnector->getSettings($defaultCategoryIndexOptions);
 

--- a/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
@@ -99,9 +99,9 @@ class MultiStoreConfigTest extends MultiStoreTestCase
 
         $productHelper = $this->objectManager->get(ProductHelper::class);
         $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$defaultIndexOptions, true]);
-        $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$fixtureIndexOptions, true]);
-
         $this->algoliaConnector->waitForAllCollectedTaskIds($defaultIndexOptions->getStoreId());
+
+        $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$fixtureIndexOptions, true]);
         $this->algoliaConnector->waitForAllCollectedTaskIds($fixtureIndexOptions->getStoreId());
 
         $defaultCategoryIndexOptions = $this->getIndexOptions('categories', $defaultStore->getId());

--- a/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
@@ -102,6 +102,7 @@ class MultiStoreConfigTest extends MultiStoreTestCase
         $this->algoliaConnector->waitForAllCollectedTaskIds($defaultIndexOptions->getStoreId());
 
         $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$fixtureIndexOptions, true]);
+        $this->algoliaConnector->collectTaskIdToWaitFor($fixtureIndexOptions);
         $this->algoliaConnector->waitForAllCollectedTaskIds($fixtureIndexOptions->getStoreId());
 
         $defaultCategoryIndexOptions = $this->getIndexOptions('categories', $defaultStore->getId());

--- a/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
+++ b/Test/Integration/Indexing/Config/MultiStoreConfigTest.php
@@ -98,10 +98,10 @@ class MultiStoreConfigTest extends MultiStoreTestCase
         $fixtureIndexOptions = $this->getIndexOptions('products', $fixtureSecondStore->getId());
 
         $productHelper = $this->objectManager->get(ProductHelper::class);
-        $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$defaultIndexOptions, true]);
+        $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$defaultIndexOptions]);
         $this->algoliaConnector->waitForAllCollectedTaskIds($defaultIndexOptions->getStoreId());
 
-        $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$fixtureIndexOptions, true]);
+        $this->invokeMethod($productHelper, 'setFacetsQueryRules', [$fixtureIndexOptions]);
         $this->algoliaConnector->collectTaskIdToWaitFor($fixtureIndexOptions);
         $this->algoliaConnector->waitForAllCollectedTaskIds($fixtureIndexOptions->getStoreId());
 

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -121,7 +121,7 @@ class ProductHelperTest extends TestCase
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->atLeastOnce())->method('waitLastTask')->with($this->storeId);
+        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
 
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }


### PR DESCRIPTION
This PR contains:
- Removed all `waitLastTask` occurrences in `saveConfigurationToAlgolia`
- Instead we now collect all task ids and wait for each of them at the end of the process
- As a result, AlgoliaConnector has been improved with a `collectTaskIdToWaitFor` method which adds the last task id of a given index into an array and a `waitForAllCollectedTaskIds` method which iterates over this array and wait for all task ids listed this way
- Removed unnecessary `getSettings` occurrences in the additional sections config loo. 
- Updated related unit tests
- Updated related integration tests

**Note**: This PR covers MAGE-1573, MAGE-1574 and MAGE-1575