### PR TITLE
MAGE-1576: SaveSettings store filtering when indexing is disabled

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -171,7 +171,7 @@ class Data
     public function isIndexingEnabled($storeId = null): bool
     {
         if ($this->configHelper->isIndexingEnabled($storeId) === false) {
-            $this->logger->log('INDEXING IS DISABLED FOR ' . $this->logger->getStoreName($storeId));
+            $this->logger->log('INDEXING IS DISABLED FOR STORE ' . $this->logger->getStoreName($storeId));
             return false;
         }
         return true;
@@ -221,7 +221,7 @@ class Data
     protected function buildIndexData(?StoreInterface $store = null): array
     {
         $storeId = $store?->getStoreId();
-        $currencyCode = 
+        $currencyCode =
             $store?->getCurrentCurrencyCode($storeId) ??
             $this->configHelper->getCurrencyCode();
 

--- a/Logger/DiagnosticsLogger.php
+++ b/Logger/DiagnosticsLogger.php
@@ -17,6 +17,7 @@ class DiagnosticsLogger
     /** @var array */
     protected const ALGOLIA_TAGS = ['group' => 'algolia'];
     protected const PROFILE_LOG_MESSAGES_DEFAULT = false;
+    protected const SEPARATOR_DEFAULT = false;
     protected const DEFAULT_NAMESPACE_DEPTH = 2;
 
     protected bool $isLoggerEnabled = false;
@@ -53,10 +54,13 @@ class DiagnosticsLogger
         return $storeId . ' (' . $this->storeNameFetcher->getStoreName($storeId) . ')';
     }
 
-    public function start(string $action, bool $profileMethod = self::PROFILE_LOG_MESSAGES_DEFAULT): void
-    {
+    public function start(
+        string $action,
+        bool $profileMethod = self::PROFILE_LOG_MESSAGES_DEFAULT,
+        bool $separator = self::SEPARATOR_DEFAULT
+    ): void {
         if ($this->isLoggerEnabled) {
-            $this->logger->start($action);
+            $this->logger->start($action, $separator);
         }
 
         if ($this->isProfilerEnabled && $profileMethod) {
@@ -71,10 +75,13 @@ class DiagnosticsLogger
     /**
      * @throws DiagnosticsException
      */
-    public function stop(string $action, bool $profileMethod = self::PROFILE_LOG_MESSAGES_DEFAULT): void
-    {
+    public function stop(
+        string $action,
+        bool $profileMethod = self::PROFILE_LOG_MESSAGES_DEFAULT,
+        bool $separator = self::SEPARATOR_DEFAULT
+    ): void {
         if ($this->isLoggerEnabled) {
-            $this->logger->stop($action);
+            $this->logger->stop($action, $separator);
         }
 
         if ($this->isProfilerEnabled && $profileMethod) {

--- a/Logger/TimedLogger.php
+++ b/Logger/TimedLogger.php
@@ -16,10 +16,13 @@ class TimedLogger
     )
     {}
 
-    public function start($action): void
+    public function start(string $action, bool $separator): void
     {
-        $this->log('');
-        $this->log('');
+        if ($separator) {
+            $this->log('');
+            $this->log('');
+        }
+
         $this->log('>>>>> BEGIN ' . $action);
         $this->timers[$action] = microtime(true);
     }
@@ -27,13 +30,18 @@ class TimedLogger
     /**
      * @throws DiagnosticsException
      */
-    public function stop($action): void
+    public function stop(string $action, bool $separator): void
     {
         if (false === isset($this->timers[$action])) {
             throw new DiagnosticsException(__('Algolia Logger => non existing action'));
         }
 
         $this->log('<<<<< END ' . $action . ' (' . $this->formatTime($this->timers[$action], microtime(true)) . ')');
+
+        if ($separator) {
+            $this->log('');
+            $this->log('');
+        }
     }
 
     /**

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -59,18 +59,18 @@ class IndicesConfigurator
     : void
     {
         $logEventName = 'Save configuration to Algolia for store: ' . $this->logger->getStoreName($storeId);
-        $this->logger->start($logEventName, true);
+        $this->logger->start($logEventName, true, true);
 
         if (!$this->algoliaCredentialsManager->checkCredentials($storeId)) {
             $this->logger->log('Algolia credentials are not filled.');
-            $this->logger->stop($logEventName, true);
+            $this->logger->stop($logEventName, true, true);
 
             return;
         }
 
         if ($this->baseHelper->isIndexingEnabled($storeId) === false) {
             $this->logger->log('Indexing is not enabled for the store.');
-            $this->logger->stop($logEventName, true);
+            $this->logger->stop($logEventName, true, true);
             return;
         }
 
@@ -100,7 +100,7 @@ class IndicesConfigurator
 
         $this->algoliaConnector->waitForAllCollectedTaskIds($storeId);
 
-        $this->logger->stop($logEventName, true);
+        $this->logger->stop($logEventName, true, true);
     }
 
     /**

--- a/Model/Observer/SaveSettings.php
+++ b/Model/Observer/SaveSettings.php
@@ -23,9 +23,9 @@ class SaveSettings implements ObserverInterface
 
     public function __construct(
         protected StoreManagerInterface $storeManager,
-        protected IndicesConfigurator $indicesConfigurator,
-        protected Data $helper,
-        protected ProductHelper $productHelper
+        protected IndicesConfigurator   $indicesConfigurator,
+        protected Data                  $helper,
+        protected ProductHelper         $productHelper
     ){}
 
     /**
@@ -42,6 +42,10 @@ class SaveSettings implements ObserverInterface
          try {
             $storeIds = array_keys($this->storeManager->getStores());
             foreach ($storeIds as $storeId) {
+                if (!$this->helper->isIndexingEnabled($storeId)) {
+                    continue;
+                }
+
                 $this->indicesConfigurator->saveConfigurationToAlgolia($storeId, false, $filteredEntities);
             }
         } catch (\Exception $e) {

--- a/Test/Unit/Model/Observer/SaveSettingsTest.php
+++ b/Test/Unit/Model/Observer/SaveSettingsTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Model\Observer;
+
+use Algolia\AlgoliaSearch\Helper\Data;
+use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
+use Algolia\AlgoliaSearch\Model\Observer\SaveSettings;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SaveSettingsTest extends TestCase
+{
+    private null|(StoreManagerInterface&MockObject) $storeManager = null;
+    private null|(IndicesConfigurator&MockObject) $indicesConfigurator = null;
+    private null|(Data&MockObject) $helper = null;
+    private null|(ProductHelper&MockObject) $productHelper = null;
+    private ?SaveSettings $saveSettings = null;
+
+    protected function setUp(): void
+    {
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->indicesConfigurator = $this->createMock(IndicesConfigurator::class);
+        $this->helper = $this->createMock(Data::class);
+        $this->productHelper = $this->createMock(ProductHelper::class);
+
+        $this->saveSettings = new SaveSettings(
+            $this->storeManager,
+            $this->indicesConfigurator,
+            $this->helper,
+            $this->productHelper
+        );
+    }
+
+    private function createObserver(string $eventName): Observer
+    {
+        $event = $this->createMock(Event::class);
+        $event->method('getName')->willReturn($eventName);
+
+        $observer = $this->createMock(Observer::class);
+        $observer->method('getEvent')->willReturn($event);
+
+        return $observer;
+    }
+
+    private function withStores(array $storeIds, bool $indexingEnabled = true): void
+    {
+        $stores = [];
+        foreach ($storeIds as $id) {
+            $stores[$id] = $this->createMock(StoreInterface::class);
+        }
+        $this->storeManager->method('getStores')->willReturn($stores);
+        $this->helper->method('isIndexingEnabled')->willReturn($indexingEnabled);
+    }
+
+    public function testCallsSaveConfigurationForEachEnabledStore(): void
+    {
+        $this->storeManager->method('getStores')->willReturn([
+            1 => $this->createMock(StoreInterface::class),
+            2 => $this->createMock(StoreInterface::class),
+        ]);
+        $this->helper->method('isIndexingEnabled')->willReturn(true);
+
+        $this->indicesConfigurator->expects($this->exactly(2))
+            ->method('saveConfigurationToAlgolia');
+
+        $this->saveSettings->execute($this->createObserver('some_event'));
+    }
+
+    public function testSkipsStoreWhenIndexingIsDisabled(): void
+    {
+        $this->storeManager->method('getStores')->willReturn([
+            1 => $this->createMock(StoreInterface::class),
+            2 => $this->createMock(StoreInterface::class),
+        ]);
+        $this->helper->method('isIndexingEnabled')
+            ->willReturnMap([[1, false], [2, true]]);
+
+        $this->indicesConfigurator->expects($this->once())
+            ->method('saveConfigurationToAlgolia')
+            ->with(2, false, $this->anything());
+
+        $this->saveSettings->execute($this->createObserver('some_event'));
+    }
+
+    public function testNeverCallsSaveConfigurationWhenAllStoresHaveIndexingDisabled(): void
+    {
+        $this->withStores([1, 2], false);
+
+        $this->indicesConfigurator->expects($this->never())
+            ->method('saveConfigurationToAlgolia');
+
+        $this->saveSettings->execute($this->createObserver('some_event'));
+    }
+
+    /**
+     * @dataProvider eventFilteredEntitiesProvider
+     */
+    public function testForwardsCorrectFilteredEntitiesForEvent(
+        string $eventName,
+        array $expectedEntities
+    ): void {
+        $this->withStores([1]);
+
+        $this->indicesConfigurator->expects($this->once())
+            ->method('saveConfigurationToAlgolia')
+            ->with(1, false, $expectedEntities);
+
+        $this->saveSettings->execute($this->createObserver($eventName));
+    }
+
+    public static function eventFilteredEntitiesProvider(): array
+    {
+        return [
+            'instant search section maps to products' => [
+                'admin_system_config_changed_section_algoliasearch_instant',
+                ['products'],
+            ],
+            'images section maps to products' => [
+                'admin_system_config_changed_section_algoliasearch_images',
+                ['products'],
+            ],
+            'products section maps to products' => [
+                'admin_system_config_changed_section_algoliasearch_products',
+                ['products'],
+            ],
+            'categories section maps to categories' => [
+                'admin_system_config_changed_section_algoliasearch_categories',
+                ['categories'],
+            ],
+            'unknown event maps to empty filter' => [
+                'admin_system_config_changed_section_algoliasearch_unknown',
+                [],
+            ],
+        ];
+    }
+
+    public function testAlwaysPassesFalseForUseTmpIndex(): void
+    {
+        $this->withStores([1]);
+
+        $this->indicesConfigurator->expects($this->once())
+            ->method('saveConfigurationToAlgolia')
+            ->with(1, false, $this->anything());
+
+        $this->saveSettings->execute($this->createObserver('some_event'));
+    }
+}


### PR DESCRIPTION
This PR contains:
- `SaveSettings` Observer inside store filtering when indexing is disabled 
- Added possibility to add a configurable separator in the Algolia logging so it's (hopefully) easier to read
- Added related unit tests class