### PR TITLE
MAGE-1611: Added missing CDATA tag in system.xml

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -669,7 +669,9 @@
                     <label>Include non visible products in index</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>
-                        Include non visible products in index. Default value is <strong>No</strong>
+                        <![CDATA[
+                            Include non visible products in index. Default value is <strong>No</strong>
+                        ]]>
                     </comment>
                 </field>
             </group>


### PR DESCRIPTION
This PR contains:
- Added missing `<![CDATA[]]>` tag in `system.xml` that was causing an error when executing `bin/magento` with Magento 2.4.9