### PR TITLE
MAGE-1612: Update versioning files for Magento 2.4.9 and PHP 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.18.1
 
 ### Updates
+- Ensured compatibility of the extension with Magento 2.4.9 and PHP 8.5
 - Added improvements on `setSettings` operations sent during indexing and configuration saving:
   - Introduced `IndexSettingsComparator` service to compare settings with the Algolia Dashboard.
   - Added diff check for both configuration save and batch processing.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Algolia Search & Discovery extension for Magento 2
 ![Latest version](https://img.shields.io/badge/latest-3.18.1-green)
 ![Magento 2](https://img.shields.io/badge/Magento-2.4.7+-orange)
 
-![PHP](https://img.shields.io/badge/PHP-8.1%2C8.2%2C8.3%2C8.4-blue)
+![PHP](https://img.shields.io/badge/PHP-8.2%2C8.3%2C8.4%2C8.5-blue)
 
 [![CircleCI](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/main.svg?style=svg)](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/main)
 
@@ -58,7 +58,8 @@ We support the 2 or 3 latest patch versions of Magento depending on releases ove
 | v3.15.x           | 12/1/2025   | `~2.4.6\|\|~2.4.7`           | `~8.1.0\|\|~8.2.0\|\|~8.3.0`           |
 | v3.16.x           | 5/15/2026   | `~2.4.7\|\|~2.4.8`           | `~8.2.0\|\|~8.3.0\|\|~8.4.0`           |
 | v3.17.x           | N/A         | `~2.4.7\|\|~2.4.8`           | `~8.2.0\|\|~8.3.0\|\|~8.4.0`           |
-| v3.18.x           | N/A         | `~2.4.7\|\|~2.4.8`           | `~8.2.0\|\|~8.3.0\|\|~8.4.0`           |
+| v3.18.0           | N/A         | `~2.4.7\|\|~2.4.8`           | `~8.2.0\|\|~8.3.0\|\|~8.4.0`           |
+| >=v3.18.1         | N/A         | `~2.4.7\|\|~2.4.8\|\|~2.4.9` | `~8.2.0\|\|~8.3.0\|\|~8.4.0\|\|~8.5.0` |
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": ["MIT"],
   "version": "3.18.1",
   "require": {
-    "php": "~8.2|~8.3|~8.4",
+    "php": "~8.2|~8.3|~8.4|~8.5",
     "magento/framework": "~103.0",
     "algolia/algoliasearch-client-php": "4.18.3",
     "guzzlehttp/guzzle": "^6.3.3|^7.3.0",
@@ -25,7 +25,7 @@
   ],
   "require-dev": {
     "phpcompatibility/php-compatibility": "^9.2",
-    "phpunit/phpunit": "^9.5|^10.5"
+    "phpunit/phpunit": "^9.5|^10.5|^12.0"
   },
   "autoload": {
     "files": [ "registration.php" ],


### PR DESCRIPTION
This PR contains:
- Updated versioning files for Magento 2.4.9 and PHP 8.5