### PR TITLE
MAGE-1623: update 3.19.0-dev for compatibilty with 2.4.9 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
           working_directory: ~/Sites
           command: |
             bin/cli bash -c "cd ./dev/tests/integration && export $(cat .env | xargs) && ../../../vendor/bin/phpunit --debug --exclude-group problematic ../../../vendor/algolia/algoliasearch-magento-2/Test/Integration/"
-  
+
   notify:
     docker:
       - image: cimg/base:current
@@ -181,8 +181,8 @@ workflows:
       - magento-build:
           matrix:
             parameters:
-              php-version: ["8.2"]
-              magento-version: ["2.4.6-p11", "2.4.7-p6"]
+              php-version: ["8.3"]
+              magento-version: ["2.4.7-p6"]
       - notify:
           context: mage-slack
 #  magento-integration-test-workflow:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Updates
 - Update Algolia PHP Client to version 4.40.0.
+- Ensured compatibility of the extension with Magento 2.4.9 and PHP 8.5
 
 ## 3.18.0
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Algolia Search & Discovery extension for Magento 2
 ![Latest version](https://img.shields.io/badge/latest-3.18.0-green)
 ![Magento 2](https://img.shields.io/badge/Magento-2.4.7+-orange)
 
-![PHP](https://img.shields.io/badge/PHP-8.1%2C8.2%2C8.3%2C8.4-blue)
+![PHP](https://img.shields.io/badge/PHP-8.3%2C8.4%2C8.5-blue)
 
 [![CircleCI](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/main.svg?style=svg)](https://circleci.com/gh/algolia/algoliasearch-magento-2/tree/main)
 
@@ -59,6 +59,8 @@ We support the 2 or 3 latest patch versions of Magento depending on releases ove
 | v3.16.x           | 5/15/2026   | `~2.4.7\|\|~2.4.8`           | `~8.2.0\|\|~8.3.0\|\|~8.4.0`           |
 | v3.17.x           | N/A         | `~2.4.7\|\|~2.4.8`           | `~8.2.0\|\|~8.3.0\|\|~8.4.0`           |
 | v3.18.x           | N/A         | `~2.4.7\|\|~2.4.8`           | `~8.2.0\|\|~8.3.0\|\|~8.4.0`           |
+| >=v3.18.1         | N/A         | `~2.4.7\|\|~2.4.8\|\|~2.4.9` | `~8.2.0\|\|~8.3.0\|\|~8.4.0\|\|~8.5.0` |
+| v3.19.x           | N/A         | `~2.4.7\|\|~2.4.8\|\|~2.4.9` | `~8.3.0\|\|~8.4.0\|\|~8.5.0`           |
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": ["MIT"],
   "version": "3.19.0-dev",
   "require": {
-    "php": "~8.2|~8.3|~8.4",
+    "php": "~8.3|~8.4|~8.5",
     "magento/framework": "~103.0",
     "algolia/algoliasearch-client-php": "^4.40.0",
     "guzzlehttp/guzzle": "^6.3.3|^7.3.0",
@@ -25,7 +25,7 @@
   ],
   "require-dev": {
     "phpcompatibility/php-compatibility": "^9.2",
-    "phpunit/phpunit": "^9.5|^10.5"
+    "phpunit/phpunit": "^9.5|^10.5|^12.0"
   },
   "autoload": {
     "files": [ "registration.php" ],

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -669,7 +669,9 @@
                     <label>Include non visible products in index</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>
-                        Include non visible products in index. Default value is <strong>No</strong>
+                        <![CDATA[
+                            Include non visible products in index. Default value is <strong>No</strong>
+                        ]]>
                     </comment>
                 </field>
             </group>


### PR DESCRIPTION
This PR contains changes from https://github.com/algolia/algoliasearch-magento-2/pull/1954 and https://github.com/algolia/algoliasearch-magento-2/pull/1953 applied to `3.19.0-dev` .