### PR TITLE
MAGE-1618 Preserve ingestion-owned index settings on reindex

### DIFF
--- a/Service/Index/Settings/IndexSettingsComparator.php
+++ b/Service/Index/Settings/IndexSettingsComparator.php
@@ -14,12 +14,20 @@ class IndexSettingsComparator
     ) {}
 
     /**
+     * @param array|null $algoliaSettings pre-fetched remote settings; when null they are fetched from the connector
+     *
      * @throws NoSuchEntityException
      * @throws AlgoliaException
      */
-    public function matches(IndexOptionsInterface $indexOptions, array $indexSettings): bool
-    {
-        $algoliaSettings = $this->connector->getSettings($indexOptions);
+    public function matches(
+        IndexOptionsInterface $indexOptions,
+        array $indexSettings,
+        ?array $algoliaSettings = null
+    ): bool {
+        if ($algoliaSettings === null) {
+            $algoliaSettings = $this->connector->getSettings($indexOptions);
+        }
+
         $algoliaSettings = array_intersect_key($algoliaSettings, $indexSettings);
 
         return $this->getSettingsHash($indexSettings) === $this->getSettingsHash($algoliaSettings);

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -25,8 +25,8 @@ class IndexSettingsHandler
         protected AlgoliaConnector        $connector,
         protected ConfigHelper            $config,
         protected IndexSettingsComparator $indexSettingsComparator,
+        protected IndexSettingsPreserver  $indexSettingsPreserver,
         protected AlgoliaLogger           $logger,
-        protected IndexSettingsPreserver  $indexSettingsPreserver
     ) {}
 
     /**

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -25,7 +25,8 @@ class IndexSettingsHandler
         protected AlgoliaConnector        $connector,
         protected ConfigHelper            $config,
         protected IndexSettingsComparator $indexSettingsComparator,
-        protected AlgoliaLogger           $logger
+        protected AlgoliaLogger           $logger,
+        protected IndexSettingsPreserver  $indexSettingsPreserver
     ) {}
 
     /**
@@ -34,8 +35,15 @@ class IndexSettingsHandler
      */
     public function setSettings(IndexOptionsInterface $indexOptions, array $indexSettings): bool
     {
+        // Fetch the remote settings once and thread them through both the preserver and the comparator.
+        $remoteSettings = $this->connector->getSettings($indexOptions);
+
+        // Merge back any remotely managed entries (e.g. ingestion-owned attributesForFaceting) so they
+        // survive this write. This must run before the comparison so no-op detection sees the final payload.
+        $indexSettings = $this->indexSettingsPreserver->preserve($indexSettings, $remoteSettings);
+
         // Early return if Algolia settings are already the same
-        if ($this->indexSettingsComparator->matches($indexOptions, $indexSettings)) {
+        if ($this->indexSettingsComparator->matches($indexOptions, $indexSettings, $remoteSettings)) {
             if ($this->config->isLoggingEnabled($indexOptions->getStoreId())) {
                 $this->logger->info(
                     sprintf(

--- a/Service/Index/Settings/IndexSettingsPreserver.php
+++ b/Service/Index/Settings/IndexSettingsPreserver.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Service\Index\Settings;
+
+use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
+
+/**
+ * Merges remote setting entries that are managed outside of Magento (for example the internal
+ * `attributesForFaceting` entries written by the Algolia ingestion pipeline) back into the payload
+ * Magento is about to push, so they are not clobbered on every reindex.
+ *
+ * Configured by a map of `settingKey => PCRE pattern`. For each configured key present in the proposed
+ * payload, remote entries matching the pattern are preserved (remote wins).
+ */
+class IndexSettingsPreserver
+{
+    /**
+     * Default preservation rules: setting key => PCRE pattern applied to each entry.
+     *
+     * The `attributesForFaceting` pattern matches a leading underscore, both bare (`_foo`) and inside a
+     * `FacetBuilder` decorator (`searchable(_foo)`, `filterOnly(_foo)`).
+     *
+     * @var array<string, string>
+     */
+    public const DEFAULT_RULES = [
+        'attributesForFaceting' => '/(?:^|\()_/',
+    ];
+
+    /**
+     * @param array<string, string> $rules setting key => PCRE pattern
+     */
+    public function __construct(
+        protected AlgoliaLogger $logger,
+        protected array         $rules = self::DEFAULT_RULES,
+    ) {}
+
+    /**
+     * Merge remote entries matching the configured preservation rules into the proposed payload.
+     *
+     * Pure transformation: both the proposed payload and the remote payload are supplied by the caller,
+     * so this performs no I/O. Keys not covered by a rule (or absent from the proposed payload) pass
+     * through unchanged.
+     */
+    public function preserve(array $proposed, array $remote): array
+    {
+        foreach ($this->rules as $key => $pattern) {
+            if (!array_key_exists($key, $proposed)) {
+                continue;
+            }
+
+            $proposedValues = is_array($proposed[$key]) ? $proposed[$key] : [];
+            $remoteValues = (isset($remote[$key]) && is_array($remote[$key])) ? $remote[$key] : [];
+
+            $preserved = array_filter(
+                $remoteValues,
+                fn($entry): bool => is_string($entry) && preg_match($pattern, $entry) === 1
+            );
+
+            // Remote wins: a protected entry should never originate from Magento, so drop any that does
+            // (and surface it) before merging the authoritative remote entries back in.
+            $proposedValues = array_filter(
+                $proposedValues,
+                function ($entry) use ($pattern, $key): bool {
+                    if (is_string($entry) && preg_match($pattern, $entry) === 1) {
+                        $this->logger->warning(
+                            sprintf(
+                                'IndexSettingsPreserver: dropping locally proposed protected entry "%s" for '
+                                . 'setting "%s"; the remote value is preserved instead.',
+                                $entry,
+                                $key
+                            )
+                        );
+
+                        return false;
+                    }
+
+                    return true;
+                }
+            );
+
+            $proposed[$key] = array_values(array_unique([...$proposedValues, ...$preserved]));
+        }
+
+        return $proposed;
+    }
+}

--- a/Test/Unit/Service/Index/Settings/IndexSettingsComparatorTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsComparatorTest.php
@@ -16,39 +16,39 @@ class IndexSettingsComparatorTest extends TestCase
     protected IndexSettingsComparator $indexSettingsComparator;
 
     protected array $testSettings = [
-        "searchableAttributes" => [
-            "unordered(name)",
-            "unordered(sku)",
-            "unordered(manufacturer)",
-            "unordered(categories)",
-            "unordered(categories_without_path)",
-            "unordered(color)"
+        'searchableAttributes' => [
+            'unordered(name)',
+            'unordered(sku)',
+            'unordered(manufacturer)',
+            'unordered(categories)',
+            'unordered(categories_without_path)',
+            'unordered(color)',
         ],
-        "customRanking" => [
-            "desc(in_stock)",
-            "desc(ordered_qty)",
-            "desc(created_at)",
+        'customRanking' => [
+            'desc(in_stock)',
+            'desc(ordered_qty)',
+            'desc(created_at)',
         ],
-        "unretrievableAttributes" => [
-            "in_stock",
-            "ordered_qty",
+        'unretrievableAttributes' => [
+            'in_stock',
+            'ordered_qty',
         ],
-        "attributesForFaceting" => [
-            "price.USD.default",
-            "categories",
-            "searchable(color)",
-            "searchable(activity)",
-            "categories.level0",
-            "categoryIds",
+        'attributesForFaceting' => [
+            'price.USD.default',
+            'categories',
+            'searchable(color)',
+            'searchable(activity)',
+            'categories.level0',
+            'categoryIds',
         ],
-        "maxValuesPerFacet" => 5,
-        "removeWordsIfNoResults" => "allOptional",
-        "typoTolerance" => "false",
-        "dummyAttribute" => [
-            "foo" => "bar",
-            "bar" => "foo",
-            "baz" => "foo",
-        ]
+        'maxValuesPerFacet' => 5,
+        'removeWordsIfNoResults' => 'allOptional',
+        'typoTolerance' => 'false',
+        'dummyAttribute' => [
+            'foo' => 'bar',
+            'bar' => 'foo',
+            'baz' => 'foo',
+        ],
     ];
 
     protected function setUp(): void
@@ -69,38 +69,38 @@ class IndexSettingsComparatorTest extends TestCase
     public function testWithSameSettingsButOrderedDifferently(): void
     {
         $algoliaSettings = [
-            "maxValuesPerFacet" => 5,
-            "removeWordsIfNoResults" => "allOptional",
-            "typoTolerance" => "false",
-            "dummyAttribute" => [
-                "foo" => "bar",
-                "bar" => "foo",
-                "baz" => "foo",
+            'maxValuesPerFacet' => 5,
+            'removeWordsIfNoResults' => 'allOptional',
+            'typoTolerance' => 'false',
+            'dummyAttribute' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+                'baz' => 'foo',
             ],
-            "searchableAttributes" => [
-                "unordered(name)",
-                "unordered(sku)",
-                "unordered(manufacturer)",
-                "unordered(categories)",
-                "unordered(categories_without_path)",
-                "unordered(color)"
+            'searchableAttributes' => [
+                'unordered(name)',
+                'unordered(sku)',
+                'unordered(manufacturer)',
+                'unordered(categories)',
+                'unordered(categories_without_path)',
+                'unordered(color)',
             ],
-            "unretrievableAttributes" => [
-                "in_stock",
-                "ordered_qty",
+            'unretrievableAttributes' => [
+                'in_stock',
+                'ordered_qty',
             ],
-            "attributesForFaceting" => [
-                "price.USD.default",
-                "categories",
-                "searchable(color)",
-                "searchable(activity)",
-                "categories.level0",
-                "categoryIds",
+            'attributesForFaceting' => [
+                'price.USD.default',
+                'categories',
+                'searchable(color)',
+                'searchable(activity)',
+                'categories.level0',
+                'categoryIds',
             ],
-            "customRanking" => [
-                "desc(in_stock)",
-                "desc(ordered_qty)",
-                "desc(created_at)",
+            'customRanking' => [
+                'desc(in_stock)',
+                'desc(ordered_qty)',
+                'desc(created_at)',
             ],
         ];
 
@@ -113,9 +113,9 @@ class IndexSettingsComparatorTest extends TestCase
     {
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['dummyAttribute'] = [
-            "baz" => "foo",
-            "foo" => "bar",
-            "bar" => "foo",
+            'baz' => 'foo',
+            'foo' => 'bar',
+            'bar' => 'foo',
         ];
 
         $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
@@ -167,11 +167,11 @@ class IndexSettingsComparatorTest extends TestCase
     {
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['searchableAttributes'] = [
-            "unordered(name)",
-            "unordered(sku)",
-            "unordered(manufacturer)",
-            "unordered(categories)",
-            "unordered(categories_without_path)"
+            'unordered(name)',
+            'unordered(sku)',
+            'unordered(manufacturer)',
+            'unordered(categories)',
+            'unordered(categories_without_path)',
             // removed color
         ];
 
@@ -184,13 +184,13 @@ class IndexSettingsComparatorTest extends TestCase
     {
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['searchableAttributes'] = [
-            "unordered(name)",
-            "unordered(name)",
-            "unordered(sku)",
-            "unordered(color)", // moved color
-            "unordered(manufacturer)",
-            "unordered(categories)",
-            "unordered(categories_without_path)"
+            'unordered(name)',
+            'unordered(name)',
+            'unordered(sku)',
+            'unordered(color)', // moved color
+            'unordered(manufacturer)',
+            'unordered(categories)',
+            'unordered(categories_without_path)',
         ];
 
         $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
@@ -208,5 +208,22 @@ class IndexSettingsComparatorTest extends TestCase
         $this->expectExceptionMessageMatches('/Invalid JSON/');
         // Must be different
         $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, [INF]));
+    }
+
+    public function testUsesProvidedRemoteSettingsWhenPassed(): void
+    {
+        // When remote settings are supplied, the connector must not be queried.
+        $this->connector->expects($this->never())->method('getSettings');
+
+        $this->assertTrue(
+            $this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings, $this->testSettings)
+        );
+
+        $changedRemote = $this->testSettings;
+        $changedRemote['maxValuesPerFacet'] = 10;
+
+        $this->assertFalse(
+            $this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings, $changedRemote)
+        );
     }
 }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -49,8 +49,8 @@ class IndexSettingsHandlerTest extends TestCase
             $this->connector,
             $this->config,
             $this->indexSettingsComparator,
-            $this->logger,
             $this->indexSettingsPreserver,
+            $this->logger,
         );
     }
 
@@ -379,8 +379,8 @@ class IndexSettingsHandlerTest extends TestCase
             $this->connector,
             $this->config,
             $indexSettingsComparator,
-            $this->logger,
             $this->indexSettingsPreserver,
+            $this->logger,
         );
 
         $storeId = 1;
@@ -410,7 +410,7 @@ class IndexSettingsHandlerTest extends TestCase
         $config = $this->createMock(ConfigHelper::class);
         $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger, $preserver);
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
         $this->indexOptions->method('getStoreId')->willReturn(1);
 
         $this->assertTrue($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
@@ -444,7 +444,7 @@ class IndexSettingsHandlerTest extends TestCase
         $config = $this->createMock(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger, $preserver);
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
         $this->indexOptions->method('getStoreId')->willReturn(1);
 
         $handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]);
@@ -471,7 +471,7 @@ class IndexSettingsHandlerTest extends TestCase
         $config = $this->createMock(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger, $preserver);
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
         $this->indexOptions->method('getStoreId')->willReturn(1);
 
         $this->assertFalse($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
@@ -496,7 +496,7 @@ class IndexSettingsHandlerTest extends TestCase
         $config = $this->createMock(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger, $preserver);
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
         $this->indexOptions->method('getStoreId')->willReturn(1);
 
         $this->assertFalse($handler->setSettings($this->indexOptions, $proposed));

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -8,6 +8,7 @@ use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsHandler;
+use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsPreserver;
 use Algolia\AlgoliaSearch\Test\TestCase;
 
 class IndexSettingsHandlerTest extends TestCase
@@ -16,6 +17,7 @@ class IndexSettingsHandlerTest extends TestCase
 
     protected ?ConfigHelper $config = null;
     protected ?IndexSettingsComparator $indexSettingsComparator = null;
+    protected ?IndexSettingsPreserver $indexSettingsPreserver = null;
     protected ?AlgoliaLogger $logger = null;
 
     protected ?IndexOptionsInterface $indexOptions = null;
@@ -34,6 +36,9 @@ class IndexSettingsHandlerTest extends TestCase
         $this->config = $this->createMock(ConfigHelper::class);
         $this->indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
         $this->indexSettingsComparator->method('matches')->willReturn(false);
+        $this->indexSettingsPreserver = $this->createMock(IndexSettingsPreserver::class);
+        // By default preservation is a pass-through so existing expectations operate on the original payload
+        $this->indexSettingsPreserver->method('preserve')->willReturnArgument(0);
         $this->logger = $this->createMock(AlgoliaLogger::class);
         $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
 
@@ -45,6 +50,7 @@ class IndexSettingsHandlerTest extends TestCase
             $this->config,
             $this->indexSettingsComparator,
             $this->logger,
+            $this->indexSettingsPreserver,
         );
     }
 
@@ -374,6 +380,7 @@ class IndexSettingsHandlerTest extends TestCase
             $this->config,
             $indexSettingsComparator,
             $this->logger,
+            $this->indexSettingsPreserver,
         );
 
         $storeId = 1;
@@ -385,5 +392,113 @@ class IndexSettingsHandlerTest extends TestCase
         $this->indexOptions->method('getStoreId')->willReturn($storeId);
 
         $this->assertFalse($this->handler->setSettings($this->indexOptions, $settings));
+    }
+
+    public function testGetSettingsCalledExactlyOncePerSetSettings(): void
+    {
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())
+            ->method('getSettings')
+            ->willReturn(['attributesForFaceting' => ['categories']]);
+
+        $preserver = $this->createMock(IndexSettingsPreserver::class);
+        $preserver->method('preserve')->willReturnArgument(0);
+
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->method('matches')->willReturn(false);
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger, $preserver);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $this->assertTrue($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
+    }
+
+    public function testPreserverInvokedBeforeComparator(): void
+    {
+        $order = [];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->method('getSettings')->willReturn(['attributesForFaceting' => ['categories']]);
+
+        $preserver = $this->createMock(IndexSettingsPreserver::class);
+        $preserver->expects($this->once())
+            ->method('preserve')
+            ->willReturnCallback(function ($proposed) use (&$order) {
+                $order[] = 'preserve';
+
+                return $proposed;
+            });
+
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->once())
+            ->method('matches')
+            ->willReturnCallback(function () use (&$order) {
+                $order[] = 'matches';
+
+                return true;
+            });
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('isLoggingEnabled')->willReturn(false);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger, $preserver);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]);
+
+        $this->assertSame(['preserve', 'matches'], $order);
+    }
+
+    public function testComparatorReceivesPreFetchedRemote(): void
+    {
+        $remote = ['attributesForFaceting' => ['categories', '_collections']];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $preserver = $this->createMock(IndexSettingsPreserver::class);
+        $preserver->method('preserve')->willReturnArgument(0);
+
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->once())
+            ->method('matches')
+            ->with($this->indexOptions, $this->anything(), $remote)
+            ->willReturn(true);
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('isLoggingEnabled')->willReturn(false);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger, $preserver);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $this->assertFalse($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
+    }
+
+    public function testNoOpDetectionAccountsForPreservedEntries(): void
+    {
+        $proposed = ['attributesForFaceting' => ['a', 'b']];
+        $remote = ['attributesForFaceting' => ['a', 'b', '_x']];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->method('getSettings')->willReturn($remote);
+        // The only diff was the preserved entry, so no write should be issued.
+        $connector->expects($this->never())->method('setSettings');
+
+        $preserver = $this->createMock(IndexSettingsPreserver::class);
+        $preserver->method('preserve')->willReturn(['attributesForFaceting' => ['a', 'b', '_x']]);
+
+        // Use the real comparator so the no-op detection is genuinely exercised.
+        $comparator = new IndexSettingsComparator($connector);
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('isLoggingEnabled')->willReturn(false);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger, $preserver);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $this->assertFalse($handler->setSettings($this->indexOptions, $proposed));
     }
 }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsPreserverTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsPreserverTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service\Index\Settings;
+
+use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
+use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsPreserver;
+use Algolia\AlgoliaSearch\Test\TestCase;
+
+class IndexSettingsPreserverTest extends TestCase
+{
+    protected ?AlgoliaLogger $logger = null;
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(AlgoliaLogger::class);
+    }
+
+    public function testPreservesUnderscoreEntryAbsentFromProposed(): void
+    {
+        $this->logger->expects($this->never())->method('warning');
+        $preserver = new IndexSettingsPreserver($this->logger);
+
+        $proposed = ['attributesForFaceting' => ['categories', 'searchable(color)']];
+        $remote = ['attributesForFaceting' => ['categories', 'searchable(color)', '_collections']];
+
+        $result = $preserver->preserve($proposed, $remote);
+
+        $this->assertContains('_collections', $result['attributesForFaceting']);
+        $this->assertContains('categories', $result['attributesForFaceting']);
+        $this->assertContains('searchable(color)', $result['attributesForFaceting']);
+    }
+
+    public function testPreservesDecoratedUnderscoreEntry(): void
+    {
+        $this->logger->expects($this->never())->method('warning');
+        $preserver = new IndexSettingsPreserver($this->logger);
+
+        $proposed = ['attributesForFaceting' => ['categories']];
+        $remote = ['attributesForFaceting' => ['categories', 'filterOnly(_collections)']];
+
+        $result = $preserver->preserve($proposed, $remote);
+
+        // The decorated entry must be preserved verbatim.
+        $this->assertContains('filterOnly(_collections)', $result['attributesForFaceting']);
+    }
+
+    public function testReturnsProposedUnchangedWhenNoApplicableKey(): void
+    {
+        $this->logger->expects($this->never())->method('warning');
+        $preserver = new IndexSettingsPreserver($this->logger);
+
+        $proposed = ['replicas' => ['magento2_default_products_price_asc']];
+        $remote = ['attributesForFaceting' => ['_collections']];
+
+        $result = $preserver->preserve($proposed, $remote);
+
+        $this->assertSame($proposed, $result);
+    }
+
+    public function testRemoteWinsAndLogsWhenProposedContainsProtectedEntry(): void
+    {
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('_foo'));
+        $preserver = new IndexSettingsPreserver($this->logger);
+
+        $proposed = ['attributesForFaceting' => ['categories', '_foo']];
+        $remote = ['attributesForFaceting' => ['_foo']];
+
+        $result = $preserver->preserve($proposed, $remote);
+
+        $this->assertContains('categories', $result['attributesForFaceting']);
+        $this->assertContains('_foo', $result['attributesForFaceting']);
+        // Remote wins: the entry appears exactly once.
+        $this->assertSame(1, array_count_values($result['attributesForFaceting'])['_foo']);
+    }
+
+    public function testEmptyRemoteReturnsProposedUnchanged(): void
+    {
+        $this->logger->expects($this->never())->method('warning');
+        $preserver = new IndexSettingsPreserver($this->logger);
+
+        $proposed = ['attributesForFaceting' => ['categories', 'searchable(color)']];
+        $remote = [];
+
+        $result = $preserver->preserve($proposed, $remote);
+
+        $this->assertSame($proposed, $result);
+    }
+
+    public function testCustomRulesArgumentOverridesDefaults(): void
+    {
+        $this->logger->expects($this->never())->method('warning');
+        $preserver = new IndexSettingsPreserver($this->logger, ['searchableAttributes' => '/^algolia_/']);
+
+        $proposed = [
+            'searchableAttributes' => ['name'],
+            // The default attributesForFaceting rule must NOT apply when custom rules are supplied.
+            'attributesForFaceting' => ['categories'],
+        ];
+        $remote = [
+            'searchableAttributes' => ['name', 'algolia_internal'],
+            'attributesForFaceting' => ['categories', '_collections'],
+        ];
+
+        $result = $preserver->preserve($proposed, $remote);
+
+        $this->assertContains('algolia_internal', $result['searchableAttributes']);
+        $this->assertNotContains('_collections', $result['attributesForFaceting']);
+    }
+
+    public function testDeduplicatesWhenRemotePreservedEntryAlreadyInProposed(): void
+    {
+        $preserver = new IndexSettingsPreserver($this->logger);
+
+        $proposed = ['attributesForFaceting' => ['categories', 'filterOnly(_collections)']];
+        $remote = ['attributesForFaceting' => ['filterOnly(_collections)']];
+
+        $result = $preserver->preserve($proposed, $remote);
+
+        $this->assertSame(1, array_count_values($result['attributesForFaceting'])['filterOnly(_collections)']);
+    }
+}


### PR DESCRIPTION
**Summary**

A problem was identified where the Magento integration clobbers `attributesForFaceting` entries that are managed _outside_ of the extension (notably the internal underscore-prefixed entries written by the Algolia ingestion pipeline for Collections) every time it pushes index settings during a reindex or from the admin. This PR makes those remotely managed entries survive a Magento integration settings write.

This is PR 2 - stacked on the `Service/Index/` reorganization that already merged via #1956.

Noteworthy changes:

- **Adds `IndexSettingsPreserver`** - a pure transformation keyed by a `settingKey => PCRE pattern` rule map. For each configured key present in the payload Magento is about to push, remote entries matching the pattern are merged back in (remote wins). The default rule preserves leading-underscore entries on `attributesForFaceting`, both bare (`_foo`) and inside a `FacetBuilder` decorator (`searchable(_foo)`, `filterOnly(_foo)`). A locally proposed entry that collides with a protected pattern is dropped and logged as a warning rather than overwriting the remote value.
- **Restructures the settings write path** - `IndexSettingsHandler::setSettings` now fetches the remote settings once, runs preservation, then threads that same payload into the comparator. `IndexSettingsComparator::matches` gained an optional pre-fetched `$algoliaSettings` argument (falls back to fetching when null), so the remote settings are read exactly once per write instead of twice. Preservation runs before the no-op comparison so that diff detection sees the **final payload** and a write whose only difference was a preserved entry is correctly skipped. (This prevents a regression of the no-op de-prioritization that was addressed in 3.18.1 and 3.17.4)
- **Added unit tests**

**Result**

Full unit test suite green:

<img width="1492" height="256" alt="image" src="https://github.com/user-attachments/assets/13d052d1-bb89-435f-b790-4f10024e19a3" />

Full reindex with ingestion enabled:
<img width="1452" height="188" alt="image" src="https://github.com/user-attachments/assets/47a80db8-8377-4ef4-b5c0-b733b1827b76" />
<img width="2968" height="316" alt="image" src="https://github.com/user-attachments/assets/3e82fe19-4b20-424d-a673-1c5fe7d88a5d" />

Collections remain stable:
<img width="2714" height="796" alt="image" src="https://github.com/user-attachments/assets/12ec0004-78bc-426d-b922-b6b5f35bdd2f" />
Data in tact:
<img width="2142" height="1700" alt="image" src="https://github.com/user-attachments/assets/6e43dc21-5c93-4ed8-b7b9-06a34694e6e7" />
<img width="2676" height="1578" alt="image" src="https://github.com/user-attachments/assets/f7a71f47-c5af-487f-8e17-36732bfca265" />

Front end renders the Collection:

<img width="1544" height="774" alt="image" src="https://github.com/user-attachments/assets/b75bff8a-7ff6-4917-a328-758ea1e87162" />
