### PR TITLE
MAGE-1629: Unified temporary index management for entities (3.17.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGE LOG
 
+## 3.17.5
+
+### Updates
+- Unified way to manage temporary index management for suggestions, pages and additional sections
+
+### Bug Fixes
+- Fixed pages indexing issue where settings and synonyms added on the Algolia dashboard were wiped during the process - thank you @PromInc
+- Fixed suggestions indexing issue where the index could be completely emptied during the process - thank you @its-leoeff511
+
 ## 3.17.4
 
 ### Updates

--- a/Service/AbstractIndexBuilder.php
+++ b/Service/AbstractIndexBuilder.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Service;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Magento\Framework\App\Area;
@@ -104,5 +105,20 @@ abstract class AbstractIndexBuilder
             }
         }
         return $toRealRemove;
+    }
+
+    /**
+     * @throws AlgoliaException
+     * @throws NoSuchEntityException
+     * @throws ExceededRetriesException
+     */
+    protected function moveTemporaryIndex(
+        IndexOptionsInterface $indexOptions,
+        IndexOptionsInterface $tmpIndexOptions
+    ): void
+    {
+        // Copy settings, rules and synonyms all at once
+        $this->algoliaConnector->copyIndexConfig($indexOptions, $tmpIndexOptions);
+        $this->algoliaConnector->moveIndex($tmpIndexOptions, $indexOptions);
     }
 }

--- a/Service/AdditionalSection/IndexBuilder.php
+++ b/Service/AdditionalSection/IndexBuilder.php
@@ -12,6 +12,7 @@ use Algolia\AlgoliaSearch\Service\AbstractIndexBuilder;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\IndexSettingsHandler;
 use Magento\Framework\App\Config\ScopeCodeResolver;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\App\Emulation;
@@ -26,6 +27,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
         protected AlgoliaConnector        $algoliaConnector,
         protected IndexOptionsBuilder     $indexOptionsBuilder,
         protected AdditionalSectionHelper $additionalSectionHelper,
+        protected IndexSettingsHandler    $indexSettingsHandler,
     ){
         parent::__construct(
             $configHelper,
@@ -86,7 +88,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             }
 
             $this->moveTemporaryIndex($indexOptions, $tempIndexOptions);
-            $this->algoliaConnector->setSettings(
+            $this->indexSettingsHandler->setSettings(
                 $indexOptions,
                 $this->additionalSectionHelper->getIndexSettings($storeId)
             );

--- a/Service/AdditionalSection/IndexBuilder.php
+++ b/Service/AdditionalSection/IndexBuilder.php
@@ -86,6 +86,10 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             }
 
             $this->moveTemporaryIndex($indexOptions, $tempIndexOptions);
+            $this->algoliaConnector->setSettings(
+                $indexOptions,
+                $this->additionalSectionHelper->getIndexSettings($storeId)
+            );
         }
     }
 }

--- a/Service/AdditionalSection/IndexBuilder.php
+++ b/Service/AdditionalSection/IndexBuilder.php
@@ -85,13 +85,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
                 $this->saveObjects($chunk, $tempIndexOptions);
             }
 
-            $this->algoliaConnector->copyQueryRules($indexOptions, $tempIndexOptions);
-            $this->algoliaConnector->moveIndex($tempIndexOptions, $indexOptions);
-
-            $this->algoliaConnector->setSettings(
-                $indexOptions,
-                $this->additionalSectionHelper->getIndexSettings($storeId)
-            );
+            $this->moveTemporaryIndex($indexOptions, $tempIndexOptions);
         }
     }
 }

--- a/Service/Page/BatchQueueProcessor.php
+++ b/Service/Page/BatchQueueProcessor.php
@@ -53,7 +53,7 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
                 'saveConfigurationToAlgolia',
                 [
                     'storeId' => $storeId,
-                    'useTmpIndex' => true,
+                    'useTmpIndex' => (!$entityIds),
                     'filteredEntities' => ['pages']
                 ]
             );

--- a/Service/Page/BatchQueueProcessor.php
+++ b/Service/Page/BatchQueueProcessor.php
@@ -5,8 +5,11 @@ namespace Algolia\AlgoliaSearch\Service\Page;
 use Algolia\AlgoliaSearch\Api\Processor\BatchQueueProcessorInterface;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Data;
+use Algolia\AlgoliaSearch\Helper\Entity\PageHelper;
+use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Model\Queue;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Service\Page\IndexBuilder as PageIndexBuilder;
 use Magento\Framework\Exception\NoSuchEntityException;
 
@@ -16,6 +19,9 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
         protected Data $dataHelper,
         protected ConfigHelper $configHelper,
         protected Queue $queue,
+        protected PageHelper $pageHelper,
+        protected IndexSettingsComparator $indexSettingsComparator,
+        protected IndexOptionsBuilder $indexOptionsBuilder,
         protected AlgoliaCredentialsManager $algoliaCredentialsManager
     ){}
 
@@ -36,6 +42,23 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
 
             return;
         }
+
+        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $pageSettings = $this->pageHelper->getIndexSettings($storeId);
+
+        if (!$this->indexSettingsComparator->matches($indexOptions, $pageSettings)) {
+            /** @uses IndicesConfigurator::saveConfigurationToAlgolia() */
+            $this->queue->addToQueue(
+                IndicesConfigurator::class,
+                'saveConfigurationToAlgolia',
+                [
+                    'storeId' => $storeId,
+                    'useTmpIndex' => true,
+                    'filteredEntities' => ['pages']
+                ]
+            );
+        }
+
 
         if ($this->isPagesInAdditionalSections($storeId)) {
             $data = ['storeId' => $storeId];

--- a/Service/Page/IndexBuilder.php
+++ b/Service/Page/IndexBuilder.php
@@ -69,6 +69,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
 
         $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
 
+
         $this->startEmulation($storeId);
 
         $pages = $this->pageHelper->getPages($storeId, $entityIds);
@@ -78,9 +79,10 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
         // if there are pageIds defined, do not index to _tmp
         $isFullReindex = (!$entityIds);
 
+        $toIndexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, $isFullReindex);
+
         if (isset($pages['toIndex']) && count($pages['toIndex'])) {
             $pagesToIndex = $pages['toIndex'];
-            $toIndexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, $isFullReindex);
 
             foreach (array_chunk($pagesToIndex, 100) as $chunk) {
                 try {
@@ -89,9 +91,6 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
                     $this->logger->log($e->getMessage());
                     continue;
                 }
-            }
-            if ($isFullReindex) {
-                $this->moveTemporaryIndex($indexOptions, $toIndexOptions);
             }
         }
 
@@ -105,6 +104,10 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
                     continue;
                 }
             }
+        }
+
+        if ($isFullReindex) {
+            $this->moveTemporaryIndex($indexOptions, $toIndexOptions);
         }
     }
 }

--- a/Service/Page/IndexBuilder.php
+++ b/Service/Page/IndexBuilder.php
@@ -90,6 +90,9 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
                     continue;
                 }
             }
+            if ($isFullReindex) {
+                $this->moveTemporaryIndex($indexOptions, $toIndexOptions);
+            }
         }
 
         if (!$isFullReindex && isset($pages['toRemove']) && count($pages['toRemove'])) {
@@ -103,16 +106,5 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
                 }
             }
         }
-
-        if ($isFullReindex) {
-            $tempIndexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, true);
-
-            $this->algoliaConnector->copyQueryRules($indexOptions, $tempIndexOptions);
-            $this->algoliaConnector->moveIndex($tempIndexOptions, $indexOptions);
-        }
-        $this->algoliaConnector->setSettings(
-            $indexOptions,
-            $this->pageHelper->getIndexSettings($storeId)
-        );
     }
 }

--- a/Service/Suggestion/BatchQueueProcessor.php
+++ b/Service/Suggestion/BatchQueueProcessor.php
@@ -4,8 +4,11 @@ namespace Algolia\AlgoliaSearch\Service\Suggestion;
 
 use Algolia\AlgoliaSearch\Api\Processor\BatchQueueProcessorInterface;
 use Algolia\AlgoliaSearch\Helper\Data;
+use Algolia\AlgoliaSearch\Helper\Entity\SuggestionHelper;
+use Algolia\AlgoliaSearch\Model\IndicesConfigurator;
 use Algolia\AlgoliaSearch\Model\Queue;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Service\Suggestion\IndexBuilder as SuggestionIndexBuilder;
 
 class BatchQueueProcessor implements BatchQueueProcessorInterface
@@ -13,6 +16,9 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
     public function __construct(
         protected Data $dataHelper,
         protected Queue $queue,
+        protected SuggestionHelper $suggestionHelper,
+        protected IndexSettingsComparator $indexSettingsComparator,
+        protected IndexOptionsBuilder $indexOptionsBuilder,
         protected AlgoliaCredentialsManager $algoliaCredentialsManager
     ){}
 
@@ -26,6 +32,22 @@ class BatchQueueProcessor implements BatchQueueProcessorInterface
             $this->algoliaCredentialsManager->displayErrorMessage(self::class, $storeId);
 
             return;
+        }
+
+        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $suggestionSettings = $this->suggestionHelper->getIndexSettings($storeId);
+
+        if (!$this->indexSettingsComparator->matches($indexOptions, $suggestionSettings)) {
+            /** @uses IndicesConfigurator::saveConfigurationToAlgolia() */
+            $this->queue->addToQueue(
+                IndicesConfigurator::class,
+                'saveConfigurationToAlgolia',
+                [
+                    'storeId' => $storeId,
+                    'useTmpIndex' => true,
+                    'filteredEntities' => ['suggestions']
+                ]
+            );
         }
 
         /** @uses SuggestionIndexBuilder::buildIndexFull() */

--- a/Service/Suggestion/IndexBuilder.php
+++ b/Service/Suggestion/IndexBuilder.php
@@ -88,9 +88,12 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
                 );
                 $page++;
             }
-            unset($indexData);
         }
-        $this->moveStoreSuggestionIndex($storeId);
+
+        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $tmpIndexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, true);
+
+        $this->moveTemporaryIndex($indexOptions, $tmpIndexOptions);
     }
 
     /**
@@ -111,7 +114,7 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
         $collection = clone $collectionDefault;
         $collection->setCurPage($page)->setPageSize($pageSize);
         $collection->load();
-        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $tmpIndexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, true);
         $indexData = [];
 
         /** @var Query $suggestion */
@@ -123,32 +126,12 @@ class IndexBuilder extends AbstractIndexBuilder implements IndexBuilderInterface
             }
         }
         if (count($indexData) > 0) {
-            $this->saveObjects($indexData, $indexOptions);
+            $this->saveObjects($indexData, $tmpIndexOptions);
         }
 
         unset($indexData);
         $collection->walk('clearInstance');
         $collection->clear();
         unset($collection);
-    }
-
-    /**
-     * @param int $storeId
-     * @return void
-     * @throws AlgoliaException
-     * @throws NoSuchEntityException
-     * @throws ExceededRetriesException
-     */
-    protected function moveStoreSuggestionIndex(int $storeId): void
-    {
-        if ($this->isIndexingEnabled($storeId) === false) {
-            return;
-        }
-
-        $tmpIndexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, true);
-        $indexOptions = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
-
-        $this->algoliaConnector->copyQueryRules($indexOptions, $tmpIndexOptions);
-        $this->algoliaConnector->moveIndex($tmpIndexOptions, $indexOptions);
     }
 }

--- a/Test/Integration/Indexing/Page/PagesIndexingTest.php
+++ b/Test/Integration/Indexing/Page/PagesIndexingTest.php
@@ -78,7 +78,6 @@ class PagesIndexingTest extends IndexingTestCase
             'content',
             'algoliaLastUpdateAtCET',
             '_highlightResult',
-            '_snippetResult',
         ];
 
         foreach ($defaultAttributes as $attribute) {

--- a/Test/Integration/Indexing/Page/PagesIndexingTest.php
+++ b/Test/Integration/Indexing/Page/PagesIndexingTest.php
@@ -78,6 +78,7 @@ class PagesIndexingTest extends IndexingTestCase
             'content',
             'algoliaLastUpdateAtCET',
             '_highlightResult',
+            '_snippetResult',
         ];
 
         foreach ($defaultAttributes as $attribute) {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.17.4",
+  "version": "3.17.5-dev",
   "require": {
     "php": "~8.2|~8.3|~8.4",
     "magento/framework": "~103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.17.4">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.17.5-dev">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
This PR contains:
- Backported changes from https://github.com/algolia/algoliasearch-magento-2/pull/1960 for 3.17.5