### PR TITLE
MAGE-1630 Upgrade guzzlehttp/guzzle to ^7.12.1 to remediate two Dependabot CVEs (3.19.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
             bin/setup-composer-auth
             bin/cli git clone git@github.com:magento/magento2.git .
             bin/cli git checkout tags/<< parameters.magento-version >>
-            bin/composer require "algolia/algoliasearch-magento-2:dev-${CIRCLE_BRANCH}"
+            bin/composer require --with-all-dependencies "algolia/algoliasearch-magento-2:dev-${CIRCLE_BRANCH}"
             bin/composer global require --dev phpunit/phpunit
       - run:
           name: Enable AlgoliaSearch extension

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "php": "~8.3|~8.4|~8.5",
     "magento/framework": "~103.0",
     "algolia/algoliasearch-client-php": "^4.40.0",
-    "guzzlehttp/guzzle": "^6.3.3|^7.3.0",
+    "guzzlehttp/guzzle": "^7.12.1",
     "ext-json": "*",
     "ext-PDO": "*",
     "ext-mbstring": "*",


### PR DESCRIPTION
## Summary

Bumps the `guzzlehttp/guzzle` constraint from `^6.3.3|^7.3.0` to `^7.12.1` so the resolved version is always >= 7.12.1, remediating two open Dependabot alerts. The EOL guzzle 6 branch is dropped because the fix exists only in 7.x; PHP 8.3+ and Magento 2.4.x both already require guzzle 7.

## Vulnerabilities remediated

- **GHSA-cwxw-98qj-8qjx / CVE-2026-55767** - dot-only cookie domains (`Domain=.`) match all hosts, enabling cookie injection / session fixation across a shared cookie jar.
- **GHSA-wpwq-4j6v-78m3 / CVE-2026-55568** - cURL handlers silently downgrade an `https://` proxy to cleartext on libcurl < 7.50.2, leaking proxy credentials and the CONNECT target.

Both fixed in guzzle 7.12.1. Closes Dependabot alerts #7 and #8.

## Acceptance criteria

- [x] `composer.json` guzzle constraint resolves to >= 7.12.1
- [x] CI green across the PHP/Magento matrix
- [ ] Dependabot alerts #7 and #8 close after merge

## Notes

- guzzle is a suggested/transitive dependency alongside Magento's own `^7` requirement; no conflict expected.
- Part of MAGE-1630. The same change will be backported to `release/3.18.2-dev` and `release/3.17.5-dev` via matching `fix/MAGE-1630-*` branches.

Jira: https://algolia.atlassian.net/browse/MAGE-1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)