### PR TITLE
MAGE-1630 Upgrade guzzlehttp/guzzle to ^7.12.1 to remediate two Dependabot CVEs (3.17.5)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
             bin/setup-composer-auth
             bin/cli git clone git@github.com:magento/magento2.git .
             bin/cli git checkout tags/<< parameters.magento-version >>
-            bin/composer require "algolia/algoliasearch-magento-2:dev-${CIRCLE_BRANCH}"
+            bin/composer require --with-all-dependencies "algolia/algoliasearch-magento-2:dev-${CIRCLE_BRANCH}"
             bin/composer global require --dev phpunit/phpunit
       - run:
           name: Enable AlgoliaSearch extension
@@ -182,7 +182,7 @@ workflows:
           matrix:
             parameters:
               php-version: ["8.2"]
-              magento-version: ["2.4.6-p11", "2.4.7-p6"]
+              magento-version: ["2.4.7-p6"]
       - notify:
           context: mage-slack
 #  magento-integration-test-workflow:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "php": "~8.2|~8.3|~8.4",
     "magento/framework": "~103.0",
     "algolia/algoliasearch-client-php": "4.18.3",
-    "guzzlehttp/guzzle": "^6.3.3|^7.3.0",
+    "guzzlehttp/guzzle": "^7.12.1",
     "ext-json": "*",
     "ext-PDO": "*",
     "ext-mbstring": "*",


### PR DESCRIPTION
## Summary

Backport of the guzzle CVE remediation to the 3.17.5 patch line. Bumps the `guzzlehttp/guzzle` constraint from `^6.3.3|^7.3.0` to `^7.12.1` so the resolved version is always >= 7.12.1. The EOL guzzle 6 branch is dropped (this line requires PHP >= 8.2, where guzzle 6 is not installable anyway).

## Vulnerabilities remediated

- **GHSA-cwxw-98qj-8qjx / CVE-2026-55767** - dot-only cookie domains (`Domain=.`) match all hosts, enabling cookie injection / session fixation across a shared cookie jar.
- **GHSA-wpwq-4j6v-78m3 / CVE-2026-55568** - cURL handlers silently downgrade an `https://` proxy to cleartext on libcurl < 7.50.2, leaking proxy credentials and the CONNECT target.

Both fixed in guzzle 7.12.1. Closes Dependabot alerts #7 and #8.

## CI changes

- Added `--with-all-dependencies` to the `composer require` in `.circleci/config.yml` so Composer may promote the guzzle version locked by Magento's checked-out lockfile past the new floor.
- Dropped the `2.4.6-p11` build from the matrix: Magento 2.4.6 is end-of-life per the [version support matrix](https://github.com/algolia/algoliasearch-magento-2#magento-versions-support), and guzzle 7.12.1 requires `guzzlehttp/promises ^2.5`, which conflicts with 2.4.6's locked dependency closure. Leaves `2.4.7-p6`.

## Acceptance criteria

- [x] `composer.json` guzzle constraint resolves to >= 7.12.1
- [x] CI green on supported Magento (2.4.7-p6)
- [ ] Dependabot alerts #7 and #8 close after merge

## Notes

- Part of MAGE-1630. Companion PRs: `release/3.19.0-dev` (#1964) and `release/3.18.2-dev` (#1965).
- Broader CI matrix modernization (2.4.7-p10, 2.4.8-p5, PHP exclude matrix) tracked separately.

Jira: https://algolia.atlassian.net/browse/MAGE-1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)