### PR TITLE
MAGE-1648 Strip semanticSearch from mergeSettings (3.18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 - Fixed pages indexing issue where settings and synonyms added on the Algolia dashboard were wiped during the process - thank you @PromInc
 - Fixed suggestions indexing issue where the index could be completely emptied during the process - thank you @its-leoeff511
+- Prevented semanticSearch echo back to Algolia when extra settings are enabled 
 
 ## 3.18.1
 

--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -438,7 +438,7 @@ class AlgoliaConnector
      */
     protected function getSettingsToRemove(array $onlineSettings): array
     {
-        $removals = ['slaves', 'replicas', 'decompoundedAttributes'];
+        $removals = ['slaves', 'replicas', 'decompoundedAttributes', 'semanticSearch'];
 
         if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
             $removals[] = 'mode';

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Service;
+
+use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
+use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use Magento\Framework\Message\ManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionException;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+/**
+ * The temp-index settings merge must strip `semanticSearch` from the
+ * online (production) settings before writing them back. An empty
+ * `semanticSearch` object round-trips through PHP as an empty array and
+ * re-encodes as a JSON array, which the API rejects with a BadRequestException
+ * ("cannot unmarshal array into ... semanticSearch").
+ *
+ * Scope: this 3.18.x patch ships only the semanticSearch coverage. The full
+ * AlgoliaConnector unit suite will land with 3.19. 
+ *
+ * The client is mocked and injected into the protected `clients` cache so that
+ * getClient() returns it without opening a real connection or validating
+ * credentials.
+ */
+class AlgoliaConnectorTest extends TestCase
+{
+    private ?AlgoliaConnector $connector = null;
+    private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
+    private null|(SearchClient&MockObject) $client = null;
+
+    private const STORE_ID = 1;
+    private const INDEX_NAME = 'magento2_default_products';
+    private const TASK_ID = 12345;
+
+    protected function setUp(): void
+    {
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('getNonCastableAttributes')->willReturn([]);
+
+        $this->connector = new AlgoliaConnector(
+            $config,
+            $this->createMock(ManagerInterface::class),
+            $this->createMock(ConsoleOutput::class),
+            $this->createMock(AlgoliaCredentialsManager::class),
+            $this->createMock(IndexNameFetcher::class),
+            $this->createMock(IndexOptionsBuilder::class)
+        );
+
+        // Inject a mocked client so getClient() short-circuits creation.
+        $this->client = $this->createMock(SearchClient::class);
+        $this->setPrivateProperty(
+            $this->connector,
+            'clients',
+            [self::STORE_ID => $this->client]
+        );
+
+        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
+        $this->indexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+        $this->indexOptions->method('getIndexName')->willReturn(self::INDEX_NAME);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connector = null;
+        $this->indexOptions = null;
+        $this->client = null;
+    }
+
+    /**
+     * Online settings containing `semanticSearch` must not appear in the
+     * payload passed to the client's setSettings() during the temp-index merge.
+     */
+    public function testSetSettingsStripsSemanticSearchFromMergedOnlineSettings(): void
+    {
+        $onlineSettings = [
+            'searchableAttributes' => ['name', 'description'],
+            'customRanking'        => ['desc(popularity)'],
+            'semanticSearch'       => [], // empty object as returned by getSettings; the offending value
+        ];
+        $localSettings = ['attributesToSnippet' => ['description:10']];
+
+        // Merge source: the live production index.
+        $this->client->method('getSettings')
+            ->with('magento2_default_products')
+            ->willReturn($onlineSettings);
+
+        $this->client->expects($this->once())
+            ->method('setSettings')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function (array $merged) {
+                    $this->assertArrayNotHasKey(
+                        'semanticSearch',
+                        $merged,
+                        'semanticSearch must be stripped before the temp-index settings write'
+                    );
+                    // Other online settings and the local override still pass through.
+                    $this->assertArrayHasKey('searchableAttributes', $merged);
+                    $this->assertArrayHasKey('customRanking', $merged);
+                    $this->assertArrayHasKey('attributesToSnippet', $merged);
+
+                    return true;
+                }),
+                false
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->setSettings(
+            $this->indexOptions,
+            $localSettings,
+            false,
+            true,
+            'magento2_default_products'
+        );
+    }
+
+    /**
+     * Pins the strip list directly so the regression cannot be reintroduced by
+     * an edit to getSettingsToRemove() that drops the semanticSearch entry.
+     *
+     * @throws ReflectionException
+     */
+    public function testGetSettingsToRemoveIncludesSemanticSearch(): void
+    {
+        $removals = $this->invokeMethod($this->connector, 'getSettingsToRemove', [[]]);
+
+        $this->assertContains('semanticSearch', $removals);
+    }
+}


### PR DESCRIPTION
## Summary

During a full reindex, `saveConfigurationToAlgolia` fails with a server-side `BadRequestException`:

```
Request body parsing: json: cannot unmarshal array into Go struct field
Alias.semanticSearch of type neuralengine.SemanticSearchSettings
```

This extension never sets `semanticSearch` itself. The value is echoed back from the live production index through the products temp-index merge. `semanticSearch` however is not played back on the standard `getSettings` path.  An empty `semanticSearch` object decodes in PHP to an empty array `[]`, and `json_encode([])` emits a JSON array, which the API rejects because `SemanticSearchSettings` must be an object.

Preconditions for this scenario: the live prod index has `semanticSearch` configured, and the merchant has non-empty products Extra Settings JSON (opening the `if ($extraSettings)` branch that triggers the merge).

This PR adds `'semanticSearch'` to the `$removals` array in`AlgoliaConnector::getSettingsToRemove()` so it is stripped from online settings before the merge round-trip.

This is a targeted patch but the merge machinery this bug lives in is to be removed entirely in a future refactor. This fix is intentionally throwaway but targeted unit tests are supplied for this version. 

The comprehensive `AlgoliaConnectorTest` suite lands with 3.19.

## Result

Unit tests:
<img width="1483" height="263" alt="image" src="https://github.com/user-attachments/assets/5362419c-1627-4d76-994c-64bca64376be" />

NeuralSearch settings preservation confirmed via manual testing. 

