### PR TITLE
MAGE-1648 Strip semanticSearch from mergeSettings (3.19.0)

### DIFF
--- a/Service/AlgoliaConnector.php
+++ b/Service/AlgoliaConnector.php
@@ -330,7 +330,7 @@ class AlgoliaConnector
      */
     protected function getSettingsToRemove(array $onlineSettings): array
     {
-        $removals = ['slaves', 'replicas', 'decompoundedAttributes'];
+        $removals = ['slaves', 'replicas', 'decompoundedAttributes', 'semanticSearch'];
 
         if (isset($onlineSettings['mode']) && $onlineSettings['mode'] == 'neuralSearch') {
             $removals[] = 'mode';

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -476,6 +476,69 @@ class AlgoliaConnectorTest extends TestCase
         $this->connector->setSettings($this->indexOptions, $localSettings, false, true);
     }
 
+    /**
+     * Online settings containing `semanticSearch` must not appear in
+     * the payload passed to the client's setSettings() during the temp-index
+     * merge. An empty `semanticSearch` object round-trips through PHP as an
+     * empty array and re-encodes as a JSON array, which the API rejects.
+     */
+    public function testSetSettingsStripsSemanticSearchFromMergedOnlineSettings(): void
+    {
+        $onlineSettings = [
+            'searchableAttributes' => ['name', 'description'],
+            'customRanking'        => ['desc(popularity)'],
+            'semanticSearch'       => [], // empty object as returned by getSettings; the offending value
+        ];
+        $localSettings = ['attributesToSnippet' => ['description:10']];
+
+        // Merge source: the live production index.
+        $this->client->method('getSettings')
+            ->with('magento2_default_products')
+            ->willReturn($onlineSettings);
+
+        $this->client->expects($this->once())
+            ->method('setSettings')
+            ->with(
+                self::INDEX_NAME,
+                $this->callback(function (array $merged) {
+                    $this->assertArrayNotHasKey(
+                        'semanticSearch',
+                        $merged,
+                        'semanticSearch must be stripped before the temp-index settings write'
+                    );
+                    // Other online settings and the local override still pass through.
+                    $this->assertArrayHasKey('searchableAttributes', $merged);
+                    $this->assertArrayHasKey('customRanking', $merged);
+                    $this->assertArrayHasKey('attributesToSnippet', $merged);
+
+                    return true;
+                }),
+                false
+            )
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $this->connector->setSettings(
+            $this->indexOptions,
+            $localSettings,
+            false,
+            true,
+            'magento2_default_products'
+        );
+    }
+
+    /**
+     * Pins the strip list directly so the regression cannot be reintroduced by
+     * an edit to getSettingsToRemove() that drops the semanticSearch entry.
+     *
+     * @throws \ReflectionException
+     */
+    public function testGetSettingsToRemoveIncludesSemanticSearch(): void
+    {
+        $removals = $this->invokeMethod($this->connector, 'getSettingsToRemove', [[]]);
+
+        $this->assertContains('semanticSearch', $removals);
+    }
+
     // ── waitLastTask() ──
 
     public function testWaitLastTaskReturnsEarlyWhenNoOperationHasBeenPerformed(): void


### PR DESCRIPTION
## Summary

Ports the 3.18 fix on #1971 to 3.19.

## Result

Unit tests:
<img width="1492" height="263" alt="image" src="https://github.com/user-attachments/assets/5843c93f-2b88-405e-973d-e528137bb365" />

NeuralSearch settings preservation confirmed via manual testing. 

