### PR TITLE
MAGE-1589: PHPStan static-analysis cleanup

### DIFF
--- a/Block/Adminhtml/LandingPage/Edit/AbstractButton.php
+++ b/Block/Adminhtml/LandingPage/Edit/AbstractButton.php
@@ -9,34 +9,12 @@ use Magento\Backend\Block\Widget\Context;
 
 abstract class AbstractButton
 {
-    /** @var Context */
-    protected $context;
-
-    /** @var LandingPageFactory */
-    protected $landingPageFactory;
-
-    /** @var UrlBuilder */
-    protected $frontendUrlBuilder;
-
-    /** @var LandingPageResource */
-    protected $landingPageResource;
-
-    /**
-     * PHP Constructor
-     *
-     *
-     * @return AbstractButton
-     */
     public function __construct(
-        Context $context,
-        LandingPageFactory $landingPageFactory,
-        UrlBuilder $frontendUrlBuilder,
-        LandingPageResource $landingPageResource
+        protected Context             $context,
+        protected LandingPageFactory  $landingPageFactory,
+        protected UrlBuilder          $frontendUrlBuilder,
+        protected LandingPageResource $landingPageResource
     ) {
-        $this->context = $context;
-        $this->landingPageFactory = $landingPageFactory;
-        $this->frontendUrlBuilder = $frontendUrlBuilder;
-        $this->landingPageResource = $landingPageResource;
     }
 
     /**

--- a/Block/Adminhtml/LandingPage/Edit/AbstractButton.php
+++ b/Block/Adminhtml/LandingPage/Edit/AbstractButton.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Block\Adminhtml\LandingPage\Edit;
 
 use Algolia\AlgoliaSearch\Block\Adminhtml\LandingPage\Renderer\UrlBuilder;
 use Algolia\AlgoliaSearch\Model\LandingPageFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\LandingPage as LandingPageResource;
 use Magento\Backend\Block\Widget\Context;
 
 abstract class AbstractButton
@@ -17,6 +18,9 @@ abstract class AbstractButton
     /** @var UrlBuilder */
     protected $frontendUrlBuilder;
 
+    /** @var LandingPageResource */
+    protected $landingPageResource;
+
     /**
      * PHP Constructor
      *
@@ -26,11 +30,13 @@ abstract class AbstractButton
     public function __construct(
         Context $context,
         LandingPageFactory $landingPageFactory,
-        UrlBuilder $frontendUrlBuilder
+        UrlBuilder $frontendUrlBuilder,
+        LandingPageResource $landingPageResource
     ) {
         $this->context = $context;
         $this->landingPageFactory = $landingPageFactory;
         $this->frontendUrlBuilder = $frontendUrlBuilder;
+        $this->landingPageResource = $landingPageResource;
     }
 
     /**
@@ -46,7 +52,7 @@ abstract class AbstractButton
             $modelId = $this->context->getRequest()->getParam('id');
             /** @var \Algolia\AlgoliaSearch\Model\LandingPage $landingPage */
             $landingPage = $this->landingPageFactory->create();
-            $landingPage->getResource()->load($landingPage, $modelId);
+            $this->landingPageResource->load($landingPage, $modelId);
 
             return $landingPage;
         } catch (\Magento\Framework\Exception\NoSuchEntityException) {

--- a/Block/Adminhtml/LandingPage/Edit/ViewButton.php
+++ b/Block/Adminhtml/LandingPage/Edit/ViewButton.php
@@ -16,6 +16,8 @@ class ViewButton extends AbstractButton implements ButtonProviderInterface
                 'sort_order' => 50,
             ];
         }
+
+        return [];
     }
 
     /**

--- a/Block/Adminhtml/Query/Edit/AbstractButton.php
+++ b/Block/Adminhtml/Query/Edit/AbstractButton.php
@@ -4,33 +4,17 @@ namespace Algolia\AlgoliaSearch\Block\Adminhtml\Query\Edit;
 
 use Algolia\AlgoliaSearch\Block\Adminhtml\LandingPage\Renderer\UrlBuilder;
 use Algolia\AlgoliaSearch\Model\QueryFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\Query as QueryResource;
 use Magento\Backend\Block\Widget\Context;
 
 abstract class AbstractButton
 {
-    /** @var Context */
-    protected $context;
-
-    /** @var QueryFactory */
-    protected $queryFactory;
-
-    /** @var UrlBuilder */
-    protected $frontendUrlBuilder;
-
-    /**
-     * PHP Constructor
-     *
-     *
-     * @return AbstractButton
-     */
     public function __construct(
-        Context $context,
-        QueryFactory $queryFactory,
-        UrlBuilder $frontendUrlBuilder
+        protected Context       $context,
+        protected QueryFactory  $queryFactory,
+        protected UrlBuilder    $frontendUrlBuilder,
+        protected QueryResource $queryResource
     ) {
-        $this->context = $context;
-        $this->queryFactory = $queryFactory;
-        $this->frontendUrlBuilder = $frontendUrlBuilder;
     }
 
     /**
@@ -46,7 +30,7 @@ abstract class AbstractButton
             $modelId = $this->context->getRequest()->getParam('id');
             /** @var \Algolia\AlgoliaSearch\Model\Query $query */
             $query = $this->queryFactory->create();
-            $query->getResource()->load($query, $modelId);
+            $this->queryResource->load($query, $modelId);
 
             return $query;
         } catch (\Magento\Framework\Exception\NoSuchEntityException) {

--- a/Block/Adminhtml/Query/Edit/ViewButton.php
+++ b/Block/Adminhtml/Query/Edit/ViewButton.php
@@ -16,6 +16,8 @@ class ViewButton extends AbstractButton implements ButtonProviderInterface
                 'sort_order' => 50,
             ];
         }
+
+        return [];
     }
 
     /**

--- a/Block/Widget/LookingSimilar.php
+++ b/Block/Widget/LookingSimilar.php
@@ -13,6 +13,9 @@ class LookingSimilar extends Template implements BlockInterface
     /** @var ConfigHelper */
     protected $configHelper;
 
+    /** @var Random */
+    protected $mathRandom;
+
     protected $_template = 'recommend/widget/looking-similar.phtml';
 
     public function __construct(

--- a/Block/Widget/TrendsItem.php
+++ b/Block/Widget/TrendsItem.php
@@ -13,6 +13,9 @@ class TrendsItem extends Template implements BlockInterface
     /** @var ConfigHelper */
     protected $configHelper;
 
+    /** @var Random */
+    protected $mathRandom;
+
     protected $_template = 'recommend/widget/trends-item.phtml';
 
     public function __construct(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # CHANGE LOG
 
+## 3.19.0
+
+### Updates
+- Completed a PHPStan (`magento2-analyse`) static-analysis cleanup so analyzer reports zero file errors.
+- `AlgoliaLogger` now extends `Magento\Framework\Logger\Monolog` instead of `Monolog\Logger` directly, resolving the "extends @final class" violation introduced by Monolog 3.x, with no behavior change.
+- Replaced deprecated `getResource()` / `_getResource()` usage in the LandingPage and Query merchandising admin controllers and blocks by injecting the resource models directly.
+- `Controller\Router` now resolves the landing page identifier through `ResourceModel\LandingPage` directly; the `Model\LandingPage::checkIdentifier()` passthrough was removed.
+- Replaced the deprecated product reload in the bundle and downloadable price managers with `ProductRepositoryInterface::getById()`.
+- Replaced the deprecated `media_gallery` attribute reload in `Service\Product\RecordBuilder` with the catalog gallery `ReadHandler`, and resolved product and category attributes through injected resource models.
+- Removed the unused `Model\Job::saveError()` method. The one remaining `Model\Job::save()` deprecation is temporarily suppressed via a scoped, documented `phpstan.neon` entry pending a dedicated JobProcessor refactor.
+
+### Breaking Changes
+- Several constructor signatures changed. Any class extending these must update its `parent::__construct()` call:
+  - `Service\Product\RecordBuilder` now requires `Magento\Catalog\Model\ResourceModel\Product` and `Magento\Catalog\Model\Product\Gallery\ReadHandler` (12 to 14 arguments).
+  - `Helper\Entity\Product\PriceManager\ProductWithoutChildren` now requires `Magento\Catalog\Api\ProductRepositoryInterface` in place of `Magento\Catalog\Model\ProductFactory`.
+  - The LandingPage and Query admin controllers and edit blocks, and `Controller\Router`, gained resource-model constructor dependencies.
+- The MSI compatibility module `algolia/algoliasearch-inventory-magento-2` extends `Service\Product\RecordBuilder`, so it requires the coordinated 1.5.0 release to stay compatible with 3.19.0. Install `algolia/algoliasearch-inventory-magento-2:^1.5.0` alongside this version.
+
+### Bug fixes
+- Injected the missing `CollectionProcessorInterface` into `Model\QueueArchiveRepository`, fixing a latent runtime fatal in `getList()`.
+
 ## 3.19.0-beta.1
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Replaced the deprecated product reload in the bundle and downloadable price managers with `ProductRepositoryInterface::getById()`.
 - Replaced the deprecated `media_gallery` attribute reload in `Service\Product\RecordBuilder` with the catalog gallery `ReadHandler`, and resolved product and category attributes through injected resource models.
 - Removed the unused `Model\Job::saveError()` method. The one remaining `Model\Job::save()` deprecation is temporarily suppressed via a scoped, documented `phpstan.neon` entry pending a dedicated JobProcessor refactor.
+- `Logger\Handler\AlgoliaLoggerHandler` now accepts the log level and file name as constructor arguments, allowing developers to tune `var/log/algolia.log` verbosity via `di.xml` (defaults to `INFO`, previously hard-coded to `DEBUG`).
 
 ### Breaking Changes
 - Several constructor signatures changed. Any class extending these must update its `parent::__construct()` call:

--- a/Controller/Adminhtml/Analytics/Update.php
+++ b/Controller/Adminhtml/Analytics/Update.php
@@ -18,9 +18,12 @@ class Update extends AbstractAction
         $layout = $this->layoutFactory->create();
 
         $block = $layout
-            ->createBlock(Template::class)
+            ->createBlock(
+                Template::class,
+                '',
+                ['data' => ['template' => 'Algolia_AlgoliaSearch::analytics/overview.phtml']]
+            )
             ->setData('view_model', $this->_objectManager->create(Overview::class))
-            ->setTemplate('Algolia_AlgoliaSearch::analytics/overview.phtml')
             ->toHtml();
 
         $response->setData(['html_content' => $block]);

--- a/Controller/Adminhtml/Landingpage/AbstractAction.php
+++ b/Controller/Adminhtml/Landingpage/AbstractAction.php
@@ -11,36 +11,15 @@ use Magento\Store\Model\StoreManagerInterface;
 
 abstract class AbstractAction extends \Magento\Backend\App\Action
 {
-    /** @var SessionManagerInterface */
-    protected $backendSession;
-
-    /** @var LandingPageFactory */
-    protected $landingPageFactory;
-
-    /** @var MerchandisingHelper */
-    protected $merchandisingHelper;
-
-    /** @var StoreManagerInterface */
-    protected $storeManager;
-
-    /** @var LandingPageResource */
-    protected $landingPageResource;
-
     public function __construct(
-        Context $context,
-        SessionManagerInterface $backendSession,
-        LandingPageFactory $landingPageFactory,
-        MerchandisingHelper $merchandisingHelper,
-        StoreManagerInterface $storeManager,
-        LandingPageResource $landingPageResource
+        Context                           $context,
+        protected SessionManagerInterface $backendSession,
+        protected LandingPageFactory      $landingPageFactory,
+        protected MerchandisingHelper     $merchandisingHelper,
+        protected StoreManagerInterface   $storeManager,
+        protected LandingPageResource     $landingPageResource
     ) {
         parent::__construct($context);
-
-        $this->backendSession = $backendSession;
-        $this->landingPageFactory = $landingPageFactory;
-        $this->merchandisingHelper = $merchandisingHelper;
-        $this->storeManager = $storeManager;
-        $this->landingPageResource = $landingPageResource;
     }
 
     /**

--- a/Controller/Adminhtml/Landingpage/AbstractAction.php
+++ b/Controller/Adminhtml/Landingpage/AbstractAction.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Landingpage;
 
 use Algolia\AlgoliaSearch\Helper\MerchandisingHelper;
 use Algolia\AlgoliaSearch\Model\LandingPageFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\LandingPage as LandingPageResource;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -22,12 +23,16 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
     /** @var StoreManagerInterface */
     protected $storeManager;
 
+    /** @var LandingPageResource */
+    protected $landingPageResource;
+
     public function __construct(
         Context $context,
         SessionManagerInterface $backendSession,
         LandingPageFactory $landingPageFactory,
         MerchandisingHelper $merchandisingHelper,
-        StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        LandingPageResource $landingPageResource
     ) {
         parent::__construct($context);
 
@@ -35,6 +40,7 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         $this->landingPageFactory = $landingPageFactory;
         $this->merchandisingHelper = $merchandisingHelper;
         $this->storeManager = $storeManager;
+        $this->landingPageResource = $landingPageResource;
     }
 
     /**
@@ -56,7 +62,7 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         $landingPage = $this->landingPageFactory->create();
 
         if ($landingPageId) {
-            $landingPage->getResource()->load($landingPage, $landingPageId);
+            $this->landingPageResource->load($landingPage, $landingPageId);
             if (!$landingPage->getId()) {
                 return null;
             }

--- a/Controller/Adminhtml/Landingpage/Delete.php
+++ b/Controller/Adminhtml/Landingpage/Delete.php
@@ -20,8 +20,8 @@ class Delete extends AbstractAction
             try {
                 /** @var LandingPage $landingPage */
                 $landingPage = $this->landingPageFactory->create();
-                $landingPage->getResource()->load($landingPage, $landingPageId);
-                $landingPage->getResource()->delete($landingPage);
+                $this->landingPageResource->load($landingPage, $landingPageId);
+                $this->landingPageResource->delete($landingPage);
                 $this->deleteQueryRules($landingPage);
 
                 $this->messageManager->addSuccessMessage(__('The landing page has been deleted.'));

--- a/Controller/Adminhtml/Landingpage/Duplicate.php
+++ b/Controller/Adminhtml/Landingpage/Duplicate.php
@@ -26,7 +26,7 @@ class Duplicate extends AbstractAction
 
         /** @var LandingPage $landingPage */
         $landingPage = $this->landingPageFactory->create();
-        $landingPage->getResource()->load($landingPage, $landingPageId);
+        $this->landingPageResource->load($landingPage, $landingPageId);
 
         if ($landingPage === null) {
             $this->messageManager->addErrorMessage(__('This landing page does not exists.'));
@@ -37,7 +37,7 @@ class Duplicate extends AbstractAction
         $newLandingPage = $this->duplicateLandingPage($landingPage);
 
         try {
-            $newLandingPage->getResource()->save($newLandingPage);
+            $this->landingPageResource->save($newLandingPage);
             $this->copyQueryRules($landingPage->getId(), $newLandingPage->getId());
             $this->backendSession->setData('algoliasearch_landing_page', $newLandingPage);
             $this->messageManager->addSuccessMessage(__('The duplicated landing page has been saved.'));

--- a/Controller/Adminhtml/Landingpage/Save.php
+++ b/Controller/Adminhtml/Landingpage/Save.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Landingpage;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\MerchandisingHelper;
 use Algolia\AlgoliaSearch\Model\LandingPageFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\LandingPage as LandingPageResource;
 use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\Controller\ResultFactory;
@@ -39,7 +40,8 @@ class Save extends AbstractAction
         StoreManagerInterface $storeManager,
         DataPersistorInterface $dataPersistor,
         CollectionFactory $customerGroupCollectionFactory,
-        ConfigHelper $configHelper
+        ConfigHelper $configHelper,
+        LandingPageResource $landingPageResource
     ) {
         $this->dataPersistor = $dataPersistor;
         $this->customerGroupCollectionFactory = $customerGroupCollectionFactory;
@@ -49,7 +51,8 @@ class Save extends AbstractAction
             $backendSession,
             $landingPageFactory,
             $merchandisingHelper,
-            $storeManager
+            $storeManager,
+            $landingPageResource
         );
     }
 
@@ -75,7 +78,7 @@ class Save extends AbstractAction
             $landingPage = $this->landingPageFactory->create();
 
             if ($landingPageId) {
-                $landingPage->getResource()->load($landingPage, $landingPageId);
+                $this->landingPageResource->load($landingPage, $landingPageId);
 
                 if (!$landingPage->getId()) {
                     $this->messageManager->addErrorMessage(__('This landing page does not exist.'));
@@ -109,7 +112,7 @@ class Save extends AbstractAction
             $landingPage->setData($data);
 
             try {
-                $landingPage->getResource()->save($landingPage);
+                $this->landingPageResource->save($landingPage);
 
                 if (isset($data['algolia_merchandising_positions']) && $data['algolia_merchandising_positions'] != '') {
                     $this->manageQueryRules($landingPage->getId(), $data);

--- a/Controller/Adminhtml/Landingpage/Save.php
+++ b/Controller/Adminhtml/Landingpage/Save.php
@@ -15,37 +15,17 @@ use Magento\Customer\Model\ResourceModel\Group\CollectionFactory;
 
 class Save extends AbstractAction
 {
-    /** @var DataPersistorInterface */
-    protected $dataPersistor;
-
-    /** @var CollectionFactory */
-    protected $customerGroupCollectionFactory;
-
-    /** @var ConfigHelper */
-    protected $configHelper;
-
-    /** @var SessionManagerInterface */
-    protected $backendSession;
-
-    /**
-     * PHP Constructor
-     *
-     * @return Save
-     */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        SessionManagerInterface $backendSession,
-        LandingPageFactory $landingPageFactory,
-        MerchandisingHelper $merchandisingHelper,
-        StoreManagerInterface $storeManager,
-        DataPersistorInterface $dataPersistor,
-        CollectionFactory $customerGroupCollectionFactory,
-        ConfigHelper $configHelper,
-        LandingPageResource $landingPageResource
+        SessionManagerInterface             $backendSession,
+        LandingPageFactory                  $landingPageFactory,
+        MerchandisingHelper                 $merchandisingHelper,
+        StoreManagerInterface               $storeManager,
+        LandingPageResource                 $landingPageResource,
+        protected DataPersistorInterface    $dataPersistor,
+        protected CollectionFactory         $customerGroupCollectionFactory,
+        protected ConfigHelper              $configHelper
     ) {
-        $this->dataPersistor = $dataPersistor;
-        $this->customerGroupCollectionFactory = $customerGroupCollectionFactory;
-        $this->configHelper = $configHelper;
         parent::__construct(
             $context,
             $backendSession,

--- a/Controller/Adminhtml/Query/AbstractAction.php
+++ b/Controller/Adminhtml/Query/AbstractAction.php
@@ -4,37 +4,22 @@ namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Query;
 
 use Algolia\AlgoliaSearch\Helper\MerchandisingHelper;
 use Algolia\AlgoliaSearch\Model\QueryFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\Query as QueryResource;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 abstract class AbstractAction extends \Magento\Backend\App\Action
 {
-    /** @var SessionManagerInterface */
-    protected $backendSession;
-
-    /** @var QueryFactory */
-    protected $queryFactory;
-
-    /** @var MerchandisingHelper */
-    protected $merchandisingHelper;
-
-    /** @var StoreManagerInterface */
-    protected $storeManager;
-
     public function __construct(
-        Context $context,
-        SessionManagerInterface $backendSession,
-        QueryFactory $queryFactory,
-        MerchandisingHelper $merchandisingHelper,
-        StoreManagerInterface $storeManager
+        Context                           $context,
+        protected SessionManagerInterface $backendSession,
+        protected QueryFactory            $queryFactory,
+        protected MerchandisingHelper     $merchandisingHelper,
+        protected StoreManagerInterface   $storeManager,
+        protected QueryResource           $queryResource
     ) {
         parent::__construct($context);
-
-        $this->backendSession = $backendSession;
-        $this->queryFactory = $queryFactory;
-        $this->merchandisingHelper = $merchandisingHelper;
-        $this->storeManager = $storeManager;
     }
 
     /**
@@ -56,7 +41,7 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         $query = $this->queryFactory->create();
 
         if ($queryId) {
-            $query->getResource()->load($query, $queryId);
+            $this->queryResource->load($query, $queryId);
             if (!$query->getId()) {
                 return null;
             }

--- a/Controller/Adminhtml/Query/Delete.php
+++ b/Controller/Adminhtml/Query/Delete.php
@@ -20,8 +20,8 @@ class Delete extends AbstractAction
             try {
                 /** @var Query $query */
                 $query = $this->queryFactory->create();
-                $query->getResource()->load($query, $queryId);
-                $query->getResource()->delete($query);
+                $this->queryResource->load($query, $queryId);
+                $this->queryResource->delete($query);
                 $this->deleteQueryRules($query);
 
                 $this->messageManager->addSuccessMessage(__('The query has been deleted.'));

--- a/Controller/Adminhtml/Query/Save.php
+++ b/Controller/Adminhtml/Query/Save.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\MerchandisingHelper;
 use Algolia\AlgoliaSearch\Model\ImageUploader;
 use Algolia\AlgoliaSearch\Model\QueryFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\Query as QueryResource;
 use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\Controller\ResultFactory;
@@ -14,44 +15,24 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class Save extends AbstractAction
 {
-    /** @var DataPersistorInterface */
-    protected $dataPersistor;
-
-    /** @var ConfigHelper */
-    protected $configHelper;
-
-    /** @var ImageUploader */
-    protected $imageUploader;
-
-    /** @var SessionManagerInterface */
-    protected $backendSession;
-
-    /**
-     * PHP Constructor
-     *
-     *
-     * @return Save
-     */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        SessionManagerInterface $backendSession,
-        QueryFactory $queryFactory,
-        MerchandisingHelper $merchandisingHelper,
-        StoreManagerInterface $storeManager,
-        DataPersistorInterface $dataPersistor,
-        ConfigHelper $configHelper,
-        ImageUploader $imageUploader
+        SessionManagerInterface             $backendSession,
+        QueryFactory                        $queryFactory,
+        MerchandisingHelper                 $merchandisingHelper,
+        StoreManagerInterface               $storeManager,
+        QueryResource                       $queryResource,
+        protected DataPersistorInterface    $dataPersistor,
+        protected ConfigHelper              $configHelper,
+        protected ImageUploader             $imageUploader
     ) {
-        $this->dataPersistor = $dataPersistor;
-        $this->configHelper = $configHelper;
-        $this->imageUploader = $imageUploader;
-
         parent::__construct(
             $context,
             $backendSession,
             $queryFactory,
             $merchandisingHelper,
-            $storeManager
+            $storeManager,
+            $queryResource
         );
     }
 
@@ -77,7 +58,7 @@ class Save extends AbstractAction
             $query = $this->queryFactory->create();
 
             if ($queryId) {
-                $query->getResource()->load($query, $queryId);
+                $this->queryResource->load($query, $queryId);
 
                 if (!$query->getId()) {
                     $this->messageManager->addErrorMessage(__('This query does not exist.'));
@@ -101,7 +82,7 @@ class Save extends AbstractAction
             $storeId = isset($data['store_id']) && $data['store_id'] != 0 ? $data['store_id'] : null;
 
             try {
-                $query->getResource()->save($query);
+                $this->queryResource->save($query);
 
                 if (isset($data['algolia_merchandising_positions']) && $data['algolia_merchandising_positions'] != ''
                     || $data['banner_image'] !== null) {

--- a/Controller/Router.php
+++ b/Controller/Router.php
@@ -2,7 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Controller;
 
-use Algolia\AlgoliaSearch\Model\LandingPageFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\LandingPage as LandingPageResource;
 use Magento\Framework\App\ActionFactory;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
@@ -13,33 +13,13 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class Router implements \Magento\Framework\App\RouterInterface
 {
-    /** @var ActionFactory */
-    protected $actionFactory;
-
-    /** @var StoreManagerInterface */
-    protected $storeManager;
-
-    /** @var TimezoneInterface */
-    protected $localeDate;
-
-    /** @var DateTime */
-    protected $dateTime;
-
-    /** @var LandingPageFactory */
-    protected $landingPageFactory;
-
     public function __construct(
-        ActionFactory $actionFactory,
-        LandingPageFactory $landingPageFactory,
-        TimezoneInterface $localeDate,
-        DateTime $dateTime,
-        StoreManagerInterface $storeManager
+        protected ActionFactory         $actionFactory,
+        protected LandingPageResource   $landingPageResource,
+        protected TimezoneInterface     $localeDate,
+        protected DateTime              $dateTime,
+        protected StoreManagerInterface $storeManager
     ) {
-        $this->actionFactory = $actionFactory;
-        $this->landingPageFactory = $landingPageFactory;
-        $this->localeDate = $localeDate;
-        $this->dateTime = $dateTime;
-        $this->storeManager = $storeManager;
     }
 
     /**
@@ -52,11 +32,9 @@ class Router implements \Magento\Framework\App\RouterInterface
     {
         $identifier = trim($request->getPathInfo(), '/');
 
-        /** @var \Algolia\AlgoliaSearch\Model\LandingPage $landingPage */
-        $landingPage = $this->landingPageFactory->create();
         $storeId = $this->storeManager->getStore()->getId();
         $date = $this->dateTime->formatDate($this->localeDate->scopeTimeStamp($storeId), false);
-        $pageId = $landingPage->checkIdentifier($identifier, $storeId, $date);
+        $pageId = $this->landingPageResource->checkIdentifier($identifier, $storeId, $date);
 
         if (!$pageId) {
             return null;

--- a/Helper/Entity/Product/PriceManager/Bundle.php
+++ b/Helper/Entity/Product/PriceManager/Bundle.php
@@ -34,7 +34,7 @@ class Bundle extends ProductWithChildren
      */
     protected function getMinMaxPrices(Product $product, $withTax, $subProducts, $currencyCode)
     {
-        $productWithPrice = $this->productloader->create()->load($product->getId());
+        $productWithPrice = $this->productRepository->getById($product->getId(), false, $product->getStoreId(), true);
         $productWithPrice->setData('website_id', $product->getStore()->getWebsiteId());
         $minPrice = $productWithPrice->getPriceInfo()->getPrice('final_price')->getMinimalPrice()->getValue();
         $minOriginalPrice = $productWithPrice->getPriceInfo()->getPrice('regular_price')->getMinimalPrice()->getValue();

--- a/Helper/Entity/Product/PriceManager/Configurable.php
+++ b/Helper/Entity/Product/PriceManager/Configurable.php
@@ -15,7 +15,10 @@ class Configurable extends ProductWithChildren
         $typeInstance = $product->getTypeInstance();
 
         if (!$typeInstance instanceof \Magento\ConfigurableProduct\Model\Product\Type\Configurable) {
-            $this->logger->log('Unexpected product type encountered, reverting to default price calculation. Where Product Id is ' .$product->getId(). ' and Group Id is ' .$groupId);
+            $this->logger->debug(
+                'Sub product iteration within configurable, reverting to default price calculation.',
+                [ 'entity_id' => $product->getId(), 'group_id' => $groupId ]
+            );
 
             return parent::getRulePrice($groupId, $product, $subProducts);
         }

--- a/Helper/Entity/Product/PriceManager/Downloadable.php
+++ b/Helper/Entity/Product/PriceManager/Downloadable.php
@@ -15,7 +15,7 @@ class Downloadable extends ProductWithoutChildren
         /** @var Group $group */
         foreach ($this->groups as $group) {
             $groupId = (int) $group->getData('customer_group_id');
-            $product = $this->productloader->create()->load($product->getId());
+            $product = $this->productRepository->getById($product->getId(), false, $product->getStoreId(), true);
             $product->setData('customer_group_id', $groupId);
             $product->setData('website_id', $product->getStore()->getWebsiteId());
             $discountedPrice = $product->getPriceInfo()->getPrice('final_price')->getValue();

--- a/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
+++ b/Helper/Entity/Product/PriceManager/ProductWithoutChildren.php
@@ -5,10 +5,10 @@ namespace Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use DateTime;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Api\ScopedProductTierPriceManagementInterface;
 use Magento\Catalog\Helper\Data as CatalogHelper;
 use Magento\Catalog\Model\Product;
-use Magento\Catalog\Model\ProductFactory;
 use Magento\CatalogRule\Model\ResourceModel\Rule;
 use Magento\Customer\Api\Data\GroupInterface;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
@@ -21,32 +21,6 @@ use Magento\Tax\Model\Config as TaxConfig;
 
 abstract class ProductWithoutChildren
 {
-    /** @var ConfigHelper */
-    protected $configHelper;
-    /** @var CollectionFactory */
-    protected $customerGroupCollectionFactory;
-    /** @var PriceCurrencyInterface */
-    protected $priceCurrency;
-    /** @var CatalogHelper */
-    protected $catalogHelper;
-    /** @var TaxHelper */
-    protected $taxHelper;
-    /** @var WeeeTax */
-    protected $weeeTax;
-    /** @var Rule */
-    protected $rule;
-    /** @var ProductFactory */
-    protected $productloader;
-
-    /** @var GroupExcludedWebsiteRepositoryInterface */
-    protected $groupExcludedWebsiteRepository;
-
-    /** @var ScopedProductTierPriceManagementInterface */
-    private $productTierPrice;
-
-    /** @var DiagnosticsLogger */
-    protected $logger;
-
     protected $store;
     protected $baseCurrencyCode;
     protected $groups;
@@ -54,29 +28,18 @@ abstract class ProductWithoutChildren
     protected $customData = [];
 
     public function __construct(
-        ConfigHelper $configHelper,
-        CollectionFactory $customerGroupCollectionFactory,
-        GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository,
-        PriceCurrencyInterface $priceCurrency,
-        CatalogHelper $catalogHelper,
-        TaxHelper $taxHelper,
-        WeeeTax $weeeTax,
-        Rule $rule,
-        ProductFactory $productloader,
-        ScopedProductTierPriceManagementInterface $productTierPrice,
-        DiagnosticsLogger $logger
+        protected ConfigHelper                              $configHelper,
+        protected CollectionFactory                         $customerGroupCollectionFactory,
+        protected GroupExcludedWebsiteRepositoryInterface   $groupExcludedWebsiteRepository,
+        protected PriceCurrencyInterface                    $priceCurrency,
+        protected CatalogHelper                             $catalogHelper,
+        protected TaxHelper                                 $taxHelper,
+        protected WeeeTax                                   $weeeTax,
+        protected Rule                                      $rule,
+        protected ProductRepositoryInterface                $productRepository,
+        protected ScopedProductTierPriceManagementInterface $productTierPrice,
+        protected DiagnosticsLogger                         $logger
     ) {
-        $this->configHelper = $configHelper;
-        $this->customerGroupCollectionFactory = $customerGroupCollectionFactory;
-        $this->groupExcludedWebsiteRepository = $groupExcludedWebsiteRepository;
-        $this->priceCurrency = $priceCurrency;
-        $this->catalogHelper = $catalogHelper;
-        $this->taxHelper = $taxHelper;
-        $this->weeeTax = $weeeTax;
-        $this->rule = $rule;
-        $this->productloader = $productloader;
-        $this->productTierPrice = $productTierPrice;
-        $this->logger = $logger;
     }
 
     /**

--- a/Helper/LandingPageHelper.php
+++ b/Helper/LandingPageHelper.php
@@ -7,6 +7,8 @@ use Algolia\AlgoliaSearch\Model\LandingPageFactory;
 use Algolia\AlgoliaSearch\Model\ResourceModel\LandingPage as LandingPageResource;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\Registry;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Landing Page Helper
@@ -17,45 +19,18 @@ use Magento\Framework\Registry;
  */
 class LandingPageHelper extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    /** @var LandingPage */
-    protected $landingPage;
-
-    /** @var \Magento\Store\Model\StoreManagerInterface */
-    protected $storeManager;
-
-    /** @var LandingPageFactory */
-    protected $landingPageFactory;
-
-    /** @var \Magento\Framework\View\Result\PageFactory */
-    protected $resultPageFactory;
-
-    /** @var Registry */
-    private $registry;
-
-    /** @var LandingPageResource */
-    protected $landingPageResource;
-
     /**
-     * Constructor
-     *
-     *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        LandingPage $landingPage,
-        LandingPageFactory $landingPageFactory,
-        Registry $registry,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory,
-        LandingPageResource $landingPageResource
+        protected LandingPage                 $landingPage,
+        protected LandingPageFactory          $landingPageFactory,
+        private Registry                      $registry,
+        protected StoreManagerInterface       $storeManager,
+        protected PageFactory                 $resultPageFactory,
+        protected LandingPageResource         $landingPageResource
     ) {
-        $this->landingPage = $landingPage;
-        $this->landingPageFactory = $landingPageFactory;
-        $this->registry = $registry;
-        $this->storeManager = $storeManager;
-        $this->resultPageFactory = $resultPageFactory;
-        $this->landingPageResource = $landingPageResource;
         parent::__construct($context);
     }
 

--- a/Helper/LandingPageHelper.php
+++ b/Helper/LandingPageHelper.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearch\Helper;
 
 use Algolia\AlgoliaSearch\Model\LandingPage;
 use Algolia\AlgoliaSearch\Model\LandingPageFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\LandingPage as LandingPageResource;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\Registry;
 
@@ -31,6 +32,9 @@ class LandingPageHelper extends \Magento\Framework\App\Helper\AbstractHelper
     /** @var Registry */
     private $registry;
 
+    /** @var LandingPageResource */
+    protected $landingPageResource;
+
     /**
      * Constructor
      *
@@ -43,13 +47,15 @@ class LandingPageHelper extends \Magento\Framework\App\Helper\AbstractHelper
         LandingPageFactory $landingPageFactory,
         Registry $registry,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory
+        \Magento\Framework\View\Result\PageFactory $resultPageFactory,
+        LandingPageResource $landingPageResource
     ) {
         $this->landingPage = $landingPage;
         $this->landingPageFactory = $landingPageFactory;
         $this->registry = $registry;
         $this->storeManager = $storeManager;
         $this->resultPageFactory = $resultPageFactory;
+        $this->landingPageResource = $landingPageResource;
         parent::__construct($context);
     }
 
@@ -57,7 +63,7 @@ class LandingPageHelper extends \Magento\Framework\App\Helper\AbstractHelper
     {
         if ($pageId !== null && $pageId !== $this->landingPage->getId()) {
             $this->landingPage->setStoreId($this->storeManager->getStore()->getId());
-            if (!$this->landingPage->load($pageId)) {
+            if (!$this->landingPageResource->load($this->landingPage, $pageId)) {
                 return false;
             }
             $this->registry->register('current_landing_page', $this->landingPage);

--- a/Logger/AlgoliaLogger.php
+++ b/Logger/AlgoliaLogger.php
@@ -3,6 +3,6 @@
 namespace Algolia\AlgoliaSearch\Logger;
 
 use Algolia\AlgoliaSearch\Api\LoggerInterface;
-use Monolog\Logger;
+use Magento\Framework\Logger\Monolog;
 
-class AlgoliaLogger extends Logger implements LoggerInterface {}
+class AlgoliaLogger extends Monolog implements LoggerInterface {}

--- a/Logger/DiagnosticsLogger.php
+++ b/Logger/DiagnosticsLogger.php
@@ -136,9 +136,12 @@ class DiagnosticsLogger
      */
     public function error(string $message, array $context = []): void
     {
-        if ($this->isLoggerEnabled) {
-            $this->logger->log($message, Logger::ERROR, $context);
-        }
+        $this->logger->log($message, Logger::ERROR, $context);
+    }
+
+    public function debug(string $message, array $context = []): void
+    {
+        $this->logger->log($message, Logger::DEBUG, $context);
     }
 
     /**

--- a/Logger/Handler/AlgoliaLoggerHandler.php
+++ b/Logger/Handler/AlgoliaLoggerHandler.php
@@ -2,11 +2,21 @@
 
 namespace Algolia\AlgoliaSearch\Logger\Handler;
 
+use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Logger\Handler\Base;
 use Monolog\Logger;
 
 class AlgoliaLoggerHandler extends Base
 {
-    protected $fileName = '/var/log/algolia.log';
-    protected $loggerType = Logger::DEBUG; // Default
+    protected const FILE_NAME = '/var/log/algolia.log';
+
+    public function __construct(
+        DriverInterface $filesystem,
+        ?string $filePath = null,
+        ?string $fileName = self::FILE_NAME,
+        int $loggerType = Logger::INFO // DEBUG = 100, INFO = 200, WARNING = 300
+    ) {
+        $this->loggerType = $loggerType;
+        parent::__construct($filesystem, $filePath, $fileName);
+    }
 }

--- a/Model/Backend/Sorts.php
+++ b/Model/Backend/Sorts.php
@@ -17,6 +17,8 @@ use Magento\Framework\Serialize\Serializer\Json;
 
 class Sorts extends ArraySerialized
 {
+    protected Json $serializer;
+
     public function __construct(
         Context                 $context,
         Registry                $registry,

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -5,7 +5,6 @@ namespace Algolia\AlgoliaSearch\Model;
 use Algolia\AlgoliaSearch\Api\Data\JobInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Magento\Framework\Data\Collection\AbstractDb;
-use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\ObjectManagerInterface;
@@ -228,19 +227,6 @@ class Job extends \Magento\Framework\Model\AbstractModel implements JobInterface
         }
 
         return $status;
-    }
-
-    /**
-     *
-     * @throws AlreadyExistsException
-     *
-     */
-    public function saveError(\Exception $e): Job
-    {
-        $this->setErrorLog($e->getMessage());
-        $this->getResource()->save($this);
-
-        return $this;
     }
 
     /**

--- a/Model/LandingPage.php
+++ b/Model/LandingPage.php
@@ -268,18 +268,4 @@ class LandingPage extends \Magento\Framework\Model\AbstractModel implements Iden
         return $this->setData(self::FIELD_CUSTOM_CSS, (string) $value);
     }
 
-    /**
-     * Check if landing page url key exists for specific store
-     * return page id if landing page exists
-     *
-     * @param string $identifier
-     * @param int $storeId
-     * @param string $date
-     *
-     * @return int
-     */
-    public function checkIdentifier($identifier, $storeId, $date)
-    {
-        return $this->_getResource()->checkIdentifier($identifier, $storeId, $date);
-    }
 }

--- a/Model/QueueArchiveRepository.php
+++ b/Model/QueueArchiveRepository.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Api\QueueArchiveRepositoryInterface;
 use Algolia\AlgoliaSearch\Api\Data\QueueArchiveInterface;
 use Algolia\AlgoliaSearch\Model\ResourceModel\QueueArchive as QueueArchiveResource;
 use Algolia\AlgoliaSearch\Model\ResourceModel\QueueArchive\CollectionFactory;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Api\SearchResultsInterface;
 use Magento\Framework\Api\SearchResultsInterfaceFactory;
@@ -27,17 +28,22 @@ class QueueArchiveRepository implements QueueArchiveRepositoryInterface
     /** @var SearchResultsInterfaceFactory */
     private $searchResultsFactory;
 
+    /** @var CollectionProcessorInterface */
+    private $collectionProcessor;
+
     public function __construct(
         QueueArchiveResource          $resource,
         QueueArchiveFactory           $queueArchiveFactory,
         CollectionFactory             $collectionFactory,
-        SearchResultsInterfaceFactory $searchResultsFactory
+        SearchResultsInterfaceFactory $searchResultsFactory,
+        CollectionProcessorInterface  $collectionProcessor
     )
     {
         $this->resource = $resource;
         $this->queueArchiveFactory = $queueArchiveFactory;
         $this->collectionFactory = $collectionFactory;
         $this->searchResultsFactory = $searchResultsFactory;
+        $this->collectionProcessor = $collectionProcessor;
     }
 
     /**

--- a/Observer/ReindexProductOnLastItemPurchase.php
+++ b/Observer/ReindexProductOnLastItemPurchase.php
@@ -53,6 +53,7 @@ class ReindexProductOnLastItemPurchase implements ObserverInterface
             $isSingleMode = $this->objectManager->create(\Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface::class);
             $defaultSourceProvider = $this->objectManager->create(\Magento\InventoryCatalogApi\Api\DefaultSourceProviderInterface::class);
 
+            $sourceCode = null;
             if (!empty($shipment->getExtensionAttributes())
                 && !empty($shipment->getExtensionAttributes()->getSourceCode())) {
                 $sourceCode = $shipment->getExtensionAttributes()->getSourceCode();

--- a/Service/AbstractClientProvider.php
+++ b/Service/AbstractClientProvider.php
@@ -4,11 +4,24 @@ namespace Algolia\AlgoliaSearch\Service;
 
 use Algolia\AlgoliaSearch\Api\ClientProviderInterface;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 
 abstract class AbstractClientProvider
 {
     protected bool $userAgentsAdded = false;
+
+    public function __construct(
+        protected ConfigHelper $config,
+        protected AlgoliaCredentialsManager $algoliaCredentialsManager
+    ) {}
+
+    /**
+     * The concrete client type is implementation-specific (e.g. SearchClient, IngestionClient),
+     * and those clients share no common interface, so no return type is declared here; each
+     * subclass declares its own.
+     */
+    abstract public function getClient(?int $storeId = ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE);
 
     abstract protected function createClient(int $storeId = ClientProviderInterface::ALGOLIA_DEFAULT_SCOPE): void;
 

--- a/Service/Category/IndexBuilder.php
+++ b/Service/Category/IndexBuilder.php
@@ -116,7 +116,6 @@ class IndexBuilder extends AbstractIndexBuilder implements UpdatableIndexBuilder
                     );
                     $page++;
                 }
-                unset($indexData);
             }
         } catch (\Exception $e) {
             $this->stopEmulation();

--- a/Service/Category/RecordBuilder.php
+++ b/Service/Category/RecordBuilder.php
@@ -101,10 +101,7 @@ class RecordBuilder implements RecordBuilderInterface
         foreach ($this->configHelper->getCategoryAdditionalAttributes($storeId) as $attribute) {
             $value = $category->getData($attribute['attribute']);
 
-            /** @var CategoryResource $resource */
-            $resource = $category->getResource();
-
-            $attributeResource = $resource->getAttribute($attribute['attribute']);
+            $attributeResource = $this->categoryResource->getAttribute($attribute['attribute']);
             if ($attributeResource) {
                 $value = $attributeResource->getFrontend()->getValue($category);
             }

--- a/Service/Product/RecordBuilder.php
+++ b/Service/Product/RecordBuilder.php
@@ -22,9 +22,11 @@ use Magento\Bundle\Model\Product\Type as BundleProductType;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Gallery\ReadHandler as GalleryReadHandler;
 use Magento\Catalog\Model\Product\Url as ProductUrl;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeResource;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\DataObject;
@@ -55,6 +57,8 @@ class RecordBuilder implements RecordBuilderInterface
         protected StockRegistryInterface $stockRegistry,
         protected PriceManager           $priceManager,
         protected ProductUrl             $productUrl,
+        protected ProductResource        $productResource,
+        protected GalleryReadHandler     $galleryReadHandler,
     ){}
 
     /**
@@ -233,7 +237,7 @@ class RecordBuilder implements RecordBuilderInterface
             $customData['image_url'] = $this->imageHelper->getUrl();
 
             if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery')) {
-                $product->load($product->getId(), 'media_gallery');
+                $this->galleryReadHandler->execute($product);
 
                 $customData['media_gallery'] = [];
 
@@ -287,11 +291,8 @@ class RecordBuilder implements RecordBuilderInterface
                 continue;
             }
 
-            /** @var \Magento\Catalog\Model\ResourceModel\Product $resource */
-            $resource = $product->getResource();
-
             /** @var AttributeResource $attributeResource */
-            $attributeResource = $resource->getAttribute($attributeName);
+            $attributeResource = $this->productResource->getAttribute($attributeName);
             if (!$attributeResource) {
                 continue;
             }

--- a/Service/SearchClientProvider.php
+++ b/Service/SearchClientProvider.php
@@ -6,17 +6,11 @@ use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Configuration\SearchConfig;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
-use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 
 class SearchClientProvider extends AbstractClientProvider implements SearchClientProviderInterface
 {
     /** @var SearchClient[] */
     protected array $clients = [];
-
-    public function __construct(
-        protected ConfigHelper $config,
-        protected AlgoliaCredentialsManager $algoliaCredentialsManager
-    ) {}
 
     /**
      * @throws AlgoliaException

--- a/Setup/Patch/Schema/AutocompleteConfigPatch.php
+++ b/Setup/Patch/Schema/AutocompleteConfigPatch.php
@@ -38,6 +38,8 @@ class AutocompleteConfigPatch implements SchemaPatchInterface
             }
         }
         $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
     }
 
     /**

--- a/Test/Integration/Indexing/Product/PricingTest.php
+++ b/Test/Integration/Indexing/Product/PricingTest.php
@@ -4,8 +4,8 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Product;
 
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
-use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
@@ -21,7 +21,7 @@ class PricingTest extends ProductsIndexingTestCase
 
     protected const PRODUCT_ID_CONFIGURABLE_CATALOG_PRICE_RULE = 1903;
 
-    public const SPECIAL_PRICE_TEST_PRODUCT_ID = 9;
+    protected const PRODUCT_ID_SPECIAL_PRICE = 9;
 
     /** @var array<int, float> */
     protected const ASSERT_PRODUCT_PRICES = [
@@ -30,13 +30,13 @@ class PricingTest extends ProductsIndexingTestCase
         self::PRODUCT_ID_CONFIGURABLE_CATALOG_PRICE_RULE => 39.2,
     ];
 
-    protected ProductResource $productResource;
+    protected ProductRepositoryInterface $productRepository;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->productResource = $this->objectManager->get(ProductResource::class);
+        $this->productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
 
         $this->indexerRegistry->get('catalogrule_product')->reindexAll();
         $this->indexerRegistry->get('catalogrule_rule')->reindexAll();
@@ -146,70 +146,77 @@ class PricingTest extends ProductsIndexingTestCase
 
     public function testSpecialPrice(): void
     {
-        $this->productBatchQueueProcessor->processBatch(1, [self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
-        $this->algoliaConnector->waitLastTask();
+        $date = new \DateTimeImmutable();
+        // For special price to apply, it must be within current date range
+        $specialPriceTestData = [
+            'special_price'     => 29.00,
+            'special_from_date' => $date->modify('-2 day')->getTimestamp(),
+            'special_to_date'   => $date->modify('+2 day')->getTimestamp()
+        ];
+        $regularPrice = 32.00;
 
         $indexOptions = $this->getIndexOptions('products');
 
+        // First index with default
+        $this->productBatchQueueProcessor->processBatch(1, [self::PRODUCT_ID_SPECIAL_PRICE]);
+        $this->algoliaConnector->waitLastTask();
+
         $res = $this->algoliaConnector->getObjects(
             $indexOptions,
-            [(string) self::SPECIAL_PRICE_TEST_PRODUCT_ID]
+            [(string) self::PRODUCT_ID_SPECIAL_PRICE]
         );
         $algoliaProduct = reset($res['results']);
 
         if (!$algoliaProduct || !array_key_exists('price', $algoliaProduct)) {
-            $this->markTestIncomplete('Hit was not returned correctly from Algolia. No Hit to run assetions.');
+            $this->markTestIncomplete('Hit was not returned correctly from Algolia. No Hit to run assertions.');
         }
 
-        $this->assertEquals(32, $algoliaProduct['price']['USD']['default']);
-        $this->assertEquals('', $algoliaProduct['price']['USD']['special_from_date']);
-        $this->assertEquals('', $algoliaProduct['price']['USD']['special_to_date']);
-
-        $specialPrice = 29;
-        $fromDatetime = new \DateTime();
-        $toDatetime = new \DateTime();
-        $priceFrom = $fromDatetime->modify('-2 day')->format('Y-m-d H:i:s');
-        $priceTo = $toDatetime->modify('+2 day')->format('Y-m-d H:i:s');
-
-        $product = $this->objectManager->create(Product::class);
-        $this->productResource->load($product, self::SPECIAL_PRICE_TEST_PRODUCT_ID);
-
-        $product->setCustomAttributes([
-            'special_price' => $specialPrice,
-            'special_from_date' => date($priceFrom),
-            'special_to_date' => date($priceTo),
-        ]);
-        $this->productResource->save($product);
-
-        $this->productBatchQueueProcessor->processBatch(1, [self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
-        $this->algoliaConnector->waitLastTask();
-
-        $indexOptions = $this->getIndexOptions('products');
-        $res = $this->algoliaConnector->getObjects(
-            $indexOptions,
-            [(string) self::SPECIAL_PRICE_TEST_PRODUCT_ID]
+        $this->assertEquals($regularPrice, $algoliaProduct['price']['USD']['default']);
+        $this->assertNotEquals(
+            $specialPriceTestData['special_from_date'],
+            $algoliaProduct['price']['USD']['special_from_date']
         );
-        $algoliaProduct = reset($res['results']);
+        $this->assertNotEquals(
+            $specialPriceTestData['special_to_date'],
+            $algoliaProduct['price']['USD']['special_to_date']
+        );
 
-        $this->assertEquals($specialPrice, $algoliaProduct['price']['USD']['default']);
-        $this->assertEquals('$32.00', $algoliaProduct['price']['USD']['default_original_formated']);
-    }
+        // Modify with test data
+        $product = $this->productRepository->getById(self::PRODUCT_ID_SPECIAL_PRICE);
+        $originalAttributes = [
+            'special_price' => $product->getData('special_price'),
+            'special_from_date' => $product->getData('special_from_date'),
+            'special_to_date' => $product->getData('special_to_date'),
+        ];
 
-    protected function tearDown(): void
-    {
-        /** @var Product $product */
-        $product = $this->objectManager->create(Product::class);
-        $this->productResource->load($product, self::SPECIAL_PRICE_TEST_PRODUCT_ID);
+        try {
+            $product->setCustomAttributes($specialPriceTestData);
+            $this->productRepository->save($product);
 
-        $product->setCustomAttributes([
-            'special_price' => null,
-            'special_from_date' => null,
-            'special_to_date' => null,
-        ]);
-        $this->productResource->saveAttribute($product, 'special_price');
-        $this->productResource->save($product);
+            $this->productBatchQueueProcessor->processBatch(1, [self::PRODUCT_ID_SPECIAL_PRICE]);
+            $this->algoliaConnector->waitLastTask();
 
-        parent::tearDown();
+            $res = $this->algoliaConnector->getObjects(
+                $indexOptions,
+                [(string) self::PRODUCT_ID_SPECIAL_PRICE]
+            );
+            $algoliaProduct = reset($res['results']);
+
+            $this->assertEquals($specialPriceTestData['special_price'], $algoliaProduct['price']['USD']['default']);
+            $this->assertEquals('$32.00', $algoliaProduct['price']['USD']['default_original_formated']);
+            $this->assertEquals(
+                $specialPriceTestData['special_from_date'],
+                $algoliaProduct['price']['USD']['special_from_date']
+            );
+            $this->assertEquals(
+                $specialPriceTestData['special_to_date'],
+                $algoliaProduct['price']['USD']['special_to_date']
+            );
+        } finally {
+            $product = $this->productRepository->getById(self::PRODUCT_ID_SPECIAL_PRICE, false, null, true);
+            $product->setCustomAttributes($originalAttributes);
+            $this->productRepository->save($product);
+        }
     }
 
 }

--- a/Test/Integration/Indexing/Product/PricingTest.php
+++ b/Test/Integration/Indexing/Product/PricingTest.php
@@ -5,6 +5,7 @@ namespace Algolia\AlgoliaSearch\Test\Integration\Indexing\Product;
 use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
@@ -29,9 +30,13 @@ class PricingTest extends ProductsIndexingTestCase
         self::PRODUCT_ID_CONFIGURABLE_CATALOG_PRICE_RULE => 39.2,
     ];
 
+    protected ProductResource $productResource;
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->productResource = $this->objectManager->get(ProductResource::class);
 
         $this->indexerRegistry->get('catalogrule_product')->reindexAll();
         $this->indexerRegistry->get('catalogrule_rule')->reindexAll();
@@ -167,14 +172,14 @@ class PricingTest extends ProductsIndexingTestCase
         $priceTo = $toDatetime->modify('+2 day')->format('Y-m-d H:i:s');
 
         $product = $this->objectManager->create(Product::class);
-        $product->load(self::SPECIAL_PRICE_TEST_PRODUCT_ID);
+        $this->productResource->load($product, self::SPECIAL_PRICE_TEST_PRODUCT_ID);
 
         $product->setCustomAttributes([
             'special_price' => $specialPrice,
             'special_from_date' => date($priceFrom),
             'special_to_date' => date($priceTo),
         ]);
-        $product->save();
+        $this->productResource->save($product);
 
         $this->productBatchQueueProcessor->processBatch(1, [self::SPECIAL_PRICE_TEST_PRODUCT_ID]);
         $this->algoliaConnector->waitLastTask();
@@ -194,15 +199,15 @@ class PricingTest extends ProductsIndexingTestCase
     {
         /** @var Product $product */
         $product = $this->objectManager->create(Product::class);
-        $product->load(self::SPECIAL_PRICE_TEST_PRODUCT_ID);
+        $this->productResource->load($product, self::SPECIAL_PRICE_TEST_PRODUCT_ID);
 
         $product->setCustomAttributes([
             'special_price' => null,
             'special_from_date' => null,
             'special_to_date' => null,
         ]);
-        $product->getResource()->saveAttribute($product, 'special_price');
-        $product->save();
+        $this->productResource->saveAttribute($product, 'special_price');
+        $this->productResource->save($product);
 
         parent::tearDown();
     }

--- a/Test/Unit/Logger/Handler/AlgoliaLoggerHandlerTest.php
+++ b/Test/Unit/Logger/Handler/AlgoliaLoggerHandlerTest.php
@@ -33,7 +33,7 @@ class AlgoliaLoggerHandlerTest extends AbstractHandlerTestCase
             'Should log'
         );
 
-        $this->assertTrue($this->handler->isHandling($debugRecord), 'DEBUG should be handled');
+        $this->assertFalse($this->handler->isHandling($debugRecord), 'DEBUG should not be handled unless overridden by DI');
         $this->assertTrue($this->handler->isHandling($infoRecord), 'INFO should be handled');
         $this->assertTrue($this->handler->isHandling($errorRecord), 'ERROR should be handled');
     }

--- a/Test/Unit/Service/RenderingManagerTest.php
+++ b/Test/Unit/Service/RenderingManagerTest.php
@@ -9,7 +9,6 @@ use Algolia\AlgoliaSearch\Service\RenderingManager;
 use Magento\Catalog\Model\Category;
 use Magento\Framework\View\Layout;
 use Magento\Framework\View\Layout\ProcessorInterface;
-use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -20,7 +19,6 @@ class RenderingManagerTest extends TestCase
     protected ?AutocompleteHelper $autocompleteConfigHelper;
     protected ?InstantSearchHelper $instantSearchConfigHelper;
     protected ?CurrentCategory $category;
-    protected ?StoreManagerInterface $storeManager;
 
     protected ?RenderingManager $renderingManager;
 
@@ -29,13 +27,11 @@ class RenderingManagerTest extends TestCase
         $this->autocompleteConfigHelper = $this->createMock(AutocompleteHelper::class);
         $this->instantSearchConfigHelper = $this->createMock(InstantSearchHelper::class);
         $this->category = $this->createMock(CurrentCategory::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
 
         $this->renderingManager = new RenderingManager(
             $this->autocompleteConfigHelper,
             $this->instantSearchConfigHelper,
-            $this->category,
-            $this->storeManager
+            $this->category
         );
     }
 

--- a/ViewModel/Adminhtml/Analytics/Overview.php
+++ b/ViewModel/Adminhtml/Analytics/Overview.php
@@ -413,8 +413,11 @@ class Overview implements \Magento\Framework\View\Element\Block\ArgumentInterfac
      */
     public function getDailyChartHtml()
     {
-        $block = $this->getBackendView()->getLayout()->createBlock(\Magento\Backend\Block\Template::class);
-        $block->setTemplate('Algolia_AlgoliaSearch::analytics/graph.phtml');
+        $block = $this->getBackendView()->getLayout()->createBlock(
+            \Magento\Backend\Block\Template::class,
+            '',
+            ['data' => ['template' => 'Algolia_AlgoliaSearch::analytics/graph.phtml']]
+        );
         $block->setData('analytics', $this->getDailySearchData());
 
         return $block->toHtml();

--- a/ViewModel/Adminhtml/BackendView.php
+++ b/ViewModel/Adminhtml/BackendView.php
@@ -101,9 +101,12 @@ class BackendView
     public function getTooltipHtml($message)
     {
         /** @var Template $block */
-        $block = $this->getLayout()->createBlock(Template::class);
+        $block = $this->getLayout()->createBlock(
+            Template::class,
+            '',
+            ['data' => ['template' => 'Algolia_AlgoliaSearch::ui/tooltip.phtml']]
+        );
 
-        $block->setTemplate('Algolia_AlgoliaSearch::ui/tooltip.phtml');
         $block->setData('message', $message);
 
         return $block->toHtml();

--- a/ViewModel/Adminhtml/Support/Overview.php
+++ b/ViewModel/Adminhtml/Support/Overview.php
@@ -34,9 +34,12 @@ class Overview implements \Magento\Framework\View\Element\Block\ArgumentInterfac
     public function getLegacyVersionHtml()
     {
         /** @var Template $block */
-        $block = $this->backendView->getLayout()->createBlock(Template::class);
+        $block = $this->backendView->getLayout()->createBlock(
+            Template::class,
+            '',
+            ['data' => ['template' => 'Algolia_AlgoliaSearch::support/components/legacy-version.phtml']]
+        );
 
-        $block->setTemplate('Algolia_AlgoliaSearch::support/components/legacy-version.phtml');
         $block->setData('extension_version', $this->supportHelper->getExtensionVersion());
 
         return $block->toHtml();

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -308,6 +308,12 @@
         </arguments>
     </virtualType>
 
+    <type name="Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler">
+        <arguments>
+            <argument name="loggerType" xsi:type="const">Monolog\Logger::INFO</argument>
+        </arguments>
+    </type>
+
     <type name="Algolia\AlgoliaSearch\Logger\AlgoliaLogger">
         <arguments>
             <argument name="name" xsi:type="string">algolia</argument>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,8 @@ parameters:
         # Temporary: attribute exists only in PHPUnit 12, which the extension supports but is not yet
         # the analysis/CI runtime. Remove once the PHPUnit 12 upgrade lands (tracked separately).
         - '#Attribute class PHPUnit\\Framework\\Attributes\\AllowMockObjectsWithoutExpectations does not exist.#'
+        # Model\Job self-persists via the deprecated save() inside its own execute(). 
+        # This violates SRP as the entity also drives job processing so the fix is to extract a
+        # JobProcessor from the persistence layer rather than inject a resource model into the model.
+        # That refactor is deferred to a future release (see MAGE-1589 notes). Remove this then.
+        - '#Use service contracts to persist entities in favour of \$this\(Algolia\\AlgoliaSearch\\Model\\Job\)::save\(\) method#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
         - dev
     ignoreErrors:
         - '#Call to static method getObjectManager\(\) on an unknown class Magento\\TestFramework\\Helper\\Bootstrap.#'
+        # Temporary: attribute exists only in PHPUnit 12, which the extension supports but is not yet
+        # the analysis/CI runtime. Remove once the PHPUnit 12 upgrade lands (tracked separately).
+        - '#Attribute class PHPUnit\\Framework\\Attributes\\AllowMockObjectsWithoutExpectations does not exist.#'


### PR DESCRIPTION
## Summary

This PR resolves the PHPStan static-analysis errors that surfaced during our release process quality gate enforcement. The gate now reports `status: pass` with **0 errors across 0 files** (down from an initial live count of 106 errors across 87 files). This was completed in two waves and is a release blocker for 3.19.0.

## What changed

**Genuine defect fixes**

- Injected a missing `CollectionProcessorInterface` in `QueueArchiveRepository` (a latent runtime fatal in `getList()`).
- Declared undefined properties (`$mathRandom`, `$serializer`, `$sourceCode`) and added missing return statements across several Block, Model, and Setup classes.
- Reworked `AbstractClientProvider` so shared dependencies are hoisted and `getClient()` is properly abstract (coordinated with the ingestion package's `IngestionClientProvider` - see https://github.com/algolia/algoliasearch-ingestion-magento-2/pull/24).

**Deprecation removal**

- Replaced deprecated `setTemplate()` calls with the `createBlock(..., ['data' => ['template' => ...]])` form.
- `AlgoliaLogger` now extends Magento's `Framework\Logger\Monolog` wrapper rather than `Monolog\Logger` directly.
- Merchandising controllers/blocks/helpers now inject the `LandingPage` and `Query` resource models instead of using deprecated `getResource()->load/save/delete`.
- `PriceManager` and the Product/Category `RecordBuilder`s use `ProductRepositoryInterface` and injected resource models in place of deprecated factory/reload patterns.

**Tests**

- Integration `PricingTest` switched to `ProductRepositoryInterface` with a localized save/restore of original special-price values.
- Adjusted unit test constructor arity to match refactored classes.

**Scoped suppressions (temporary, commented)**

- `#[AllowMockObjectsWithoutExpectations]` (55 errors): a PHPUnit 12-only attribute unavailable under the analyzed PHPUnit 10.5. Suppressed pending the PHPUnit 12 upgrade (out of scope here).
- `Model\Job::save()`: single scoped ignore pending the JobProcessor refactor (MAGE-1657).

Also adopts PHP 8 constructor property promotion as a standing convention for touched constructors.

## Results

- PHPStan gate: 0 errors / 0 files.
- 435 unit tests pass.
- DI-graph smoke test instantiated every refactored class.
- Full `algolia_products` reindex (2054 products x 4 stores) processed via queue with zero errors; media gallery and attribute reads confirmed correct on live products.
- Merchandising CRUD (save/load/checkIdentifier/delete) confirmed against resource models.

PHPStan happiness
<img width="977" height="185" alt="image" src="https://github.com/user-attachments/assets/7eca1641-ca9d-4870-a8b6-e9057828629a" />

Unit tests
<img width="1488" height="324" alt="image" src="https://github.com/user-attachments/assets/aa422699-152d-45cd-9b99-9122b64f62e7" />

Pricing integration test updates
<img width="2994" height="586" alt="image" src="https://github.com/user-attachments/assets/ae3a36c7-bb89-4c69-b34b-efa5d20ea973" />

> [!IMPORTANT]
> ⚠️ The `RecordBuilder` constructor grew from 12 to 14 args, which breaks the MSI module's `InventoryProductRecordBuilder`. This requires a **coordinated `algolia/algoliasearch-inventory-magento-2` 1.5.0 release** Tracked as **MAGE-1658**.