### PR TITLE
MAGE-1658 Add conflicts declaration for 3.19 MSI compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - `Helper\Entity\Product\PriceManager\ProductWithoutChildren` now requires `Magento\Catalog\Api\ProductRepositoryInterface` in place of `Magento\Catalog\Model\ProductFactory`.
   - The LandingPage and Query admin controllers and edit blocks, and `Controller\Router`, gained resource-model constructor dependencies.
 - The MSI compatibility module `algolia/algoliasearch-inventory-magento-2` extends `Service\Product\RecordBuilder`, so it requires the coordinated 1.5.0 release to stay compatible with 3.19.0. Install `algolia/algoliasearch-inventory-magento-2:^1.5.0` alongside this version.
+- `Helper\Entity\ProductHelper::addStockFilter()` now declares `ProductCollection $products` and `int $storeId`. A subclass overriding this protected method with a narrower or incompatible signature will fatal on class load; untyped or wider overrides remain valid.
 - The Recommend product template (`view/frontend/web/js/template/recommend/products.js`) now passes a single destructured options object to its methods instead of positional arguments, aligning it with the autocomplete product template. Any RequireJS mixin overriding these methods must be updated. 
 
 ### Bug fixes

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -205,8 +205,10 @@ class ProductHelper extends AbstractEntityHelper
         return $products;
     }
 
-    protected function addStockFilter($products, $storeId): void
-    {
+    protected function addStockFilter(
+        ProductCollection $products,
+        int               $storeId
+    ): void {
         if ($this->configHelper->getShowOutOfStock($storeId) === false) {
             $this->stockHelper->addInStockFilterToCollection($products);
         }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "ext-dom": "*"
   },
   "conflict": {
-    "algolia/algoliasearch-adapter-magento-2": "<0.10.0"
+    "algolia/algoliasearch-adapter-magento-2": "<0.10.0",
+    "algolia/algoliasearch-inventory-magento-2": "<1.5.0"
   },
   "suggest": {
       "algolia/algoliasearch-inventory-magento-2": "Algolia Search Inventory module for Magento 2.3.x,2.4.x and Algolia Search 1.12+ extension"


### PR DESCRIPTION
## Summary

This PR aligns the core module's dependency requirements with https://github.com/algolia/algoliasearch-inventory-magento-2/pull/39 for upcoming 3.19.0.