### PR TITLE
MAGE-1676 Fix Closure serialization error on the queue job view pages

### DIFF
--- a/.claude/reference/testing/core.md
+++ b/.claude/reference/testing/core.md
@@ -1,6 +1,6 @@
 #Core Testing Guidelines
 
-## Informations
+## Information
 - The files we are testing are located in a Magento2 module
 - The test files are located in the Test/Unit directory, create all the tests in this parent's directory
 - Follow the same structure as in the module (ex: tests for the Service/Product/RecordBuilder.php should be located in the Test/Unit/Service/Product directory)

--- a/Block/Adminhtml/Job/View.php
+++ b/Block/Adminhtml/Job/View.php
@@ -2,23 +2,29 @@
 
 namespace Algolia\AlgoliaSearch\Block\Adminhtml\Job;
 
+use Algolia\AlgoliaSearch\Model\JobFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResource;
 use Magento\Backend\Block\Widget\Button;
-use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 
 class View extends Template
 {
-    /** @var SessionManagerInterface */
-    protected $backendSession;
+    /** @var JobResource */
+    protected $jobResource;
+
+    /** @var JobFactory */
+    protected $jobFactory;
 
     public function __construct(
-        Context          $context,
-        SessionManagerInterface   $backendSession,
+        Context       $context,
+        JobResource   $jobResource,
+        JobFactory    $jobFactory,
         array $data = []
     ) {
         parent::__construct($context, $data);
-        $this->backendSession = $backendSession;
+        $this->jobResource = $jobResource;
+        $this->jobFactory = $jobFactory;
     }
 
     /**
@@ -46,7 +52,12 @@ class View extends Template
      */
     public function getCurrentJob()
     {
-        return $this->backendSession->getData('current_job');
+        $currentJobId = $this->_request->getParam('id');
+
+        $job = $this->jobFactory->create();
+        $this->jobResource->load($job, $currentJobId);
+
+        return $job;
     }
 
     /**

--- a/Block/Adminhtml/Job/View.php
+++ b/Block/Adminhtml/Job/View.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Block\Adminhtml\Job;
 
+use Algolia\AlgoliaSearch\Model\Job;
 use Algolia\AlgoliaSearch\Model\JobFactory;
 use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResource;
 use Magento\Backend\Block\Widget\Button;
@@ -10,21 +11,15 @@ use Magento\Framework\View\Element\Template\Context;
 
 class View extends Template
 {
-    /** @var JobResource */
-    protected $jobResource;
-
-    /** @var JobFactory */
-    protected $jobFactory;
+    protected ?Job $currentJob = null;
 
     public function __construct(
-        Context       $context,
-        JobResource   $jobResource,
-        JobFactory    $jobFactory,
-        array $data = []
+        Context               $context,
+        protected JobFactory  $jobFactory,
+        protected JobResource $jobResource,
+        array                 $data = []
     ) {
         parent::__construct($context, $data);
-        $this->jobResource = $jobResource;
-        $this->jobFactory = $jobFactory;
     }
 
     /**
@@ -47,17 +42,18 @@ class View extends Template
         return parent::_prepareLayout();
     }
 
-    /**
-     * @return \Algolia\AlgoliaSearch\Model\Job
-     */
-    public function getCurrentJob()
+    public function getCurrentJob(): Job
     {
-        $currentJobId = $this->_request->getParam('id');
+        if ($this->currentJob !== null) {
+            return $this->currentJob;
+        }
 
         $job = $this->jobFactory->create();
-        $this->jobResource->load($job, $currentJobId);
+        $this->jobResource->load($job, (int) $this->getRequest()->getParam('id'));
 
-        return $job;
+        $this->currentJob = $job;
+
+        return $this->currentJob;
     }
 
     /**

--- a/Block/Adminhtml/QueueArchive/View.php
+++ b/Block/Adminhtml/QueueArchive/View.php
@@ -2,24 +2,23 @@
 
 namespace Algolia\AlgoliaSearch\Block\Adminhtml\QueueArchive;
 
+use Algolia\AlgoliaSearch\Api\Data\QueueArchiveInterface;
+use Algolia\AlgoliaSearch\Api\QueueArchiveRepositoryInterface;
 use Magento\Backend\Block\Widget\Button;
-use Magento\Framework\Session\SessionManagerInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 
 class View extends Template
 {
-    /** @var SessionManagerInterface */
-    protected $backendSession;
+    protected ?QueueArchiveInterface $currentJob = null;
 
     public function __construct(
-        Context          $context,
-        SessionManagerInterface   $backendSession,
-        array $data = []
+        Context                                   $context,
+        protected QueueArchiveRepositoryInterface $queueArchiveRepository,
+        array                                      $data = []
     ) {
         parent::__construct($context, $data);
-
-        $this->backendSession = $backendSession;
     }
 
     /**
@@ -43,11 +42,13 @@ class View extends Template
     }
 
     /**
-     * @return \Algolia\AlgoliaSearch\Model\QueueArchive
+     * @throws NoSuchEntityException
      */
-    public function getCurrentJob()
+    public function getCurrentJob(): QueueArchiveInterface
     {
-        return $this->backendSession->getData('current_job');
+        return $this->currentJob ??= $this->queueArchiveRepository->getById(
+            (int) $this->getRequest()->getParam('id')
+        );
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,17 @@
   - `Service\Product\RecordBuilder` now requires `Magento\Catalog\Model\ResourceModel\Product` and `Magento\Catalog\Model\Product\Gallery\ReadHandler` (12 to 14 arguments).
   - `Helper\Entity\Product\PriceManager\ProductWithoutChildren` now requires `Magento\Catalog\Api\ProductRepositoryInterface` in place of `Magento\Catalog\Model\ProductFactory`.
   - The LandingPage and Query admin controllers and edit blocks, and `Controller\Router`, gained resource-model constructor dependencies.
+  - `Controller\Adminhtml\Queue\AbstractAction` and `Controller\Adminhtml\QueueArchive\AbstractAction` no longer accept `Magento\Framework\Session\SessionManagerInterface`.
+  - `Block\Adminhtml\Job\View` now requires `Model\JobFactory` and `Model\ResourceModel\Job` in place of the session manager.
+  - `Block\Adminhtml\QueueArchive\View` now requires `Api\QueueArchiveRepositoryInterface` in place of the session manager.
 - The MSI compatibility module `algolia/algoliasearch-inventory-magento-2` extends `Service\Product\RecordBuilder`, so it requires the coordinated 1.5.0 release to stay compatible with 3.19.0. Install `algolia/algoliasearch-inventory-magento-2:^1.5.0` alongside this version.
 - `Helper\Entity\ProductHelper::addStockFilter()` now declares `ProductCollection $products` and `int $storeId`. A subclass overriding this protected method with a narrower or incompatible signature will fatal on class load; untyped or wider overrides remain valid.
 - The Recommend product template (`view/frontend/web/js/template/recommend/products.js`) now passes a single destructured options object to its methods instead of positional arguments, aligning it with the autocomplete product template. Any RequireJS mixin overriding these methods must be updated. 
 
 ### Bug fixes
 - Injected the missing `CollectionProcessorInterface` into `Model\QueueArchiveRepository`, fixing a latent runtime fatal in `getList()`.
+- Fixed `Uncaught Exception: Serialization of 'Closure' is not allowed` on the Indexing Queue and Queue Archive job view pages, caused by storing the fully hydrated model in the backend session. (thanks @angelvilaplana, [#1939](https://github.com/algolia/algoliasearch-magento-2/pull/1939))
+- Fixed a getter typo in the Queue Archive view template that left the Processed At field blank on the Queue Archive view page.
 
 ## 3.19.0-beta.1
 

--- a/Controller/Adminhtml/Queue/AbstractAction.php
+++ b/Controller/Adminhtml/Queue/AbstractAction.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Queue;
 
+use Algolia\AlgoliaSearch\Model\Job;
 use Algolia\AlgoliaSearch\Model\JobFactory;
 use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResourceModel;
 use Magento\Backend\App\Action\Context;
@@ -9,26 +10,13 @@ use Magento\Indexer\Model\IndexerFactory;
 
 abstract class AbstractAction extends \Magento\Backend\App\Action
 {
-    /** @var \Algolia\AlgoliaSearch\Model\JobFactory */
-    protected $jobFactory;
-
-    /** @var JobResourceModel */
-    protected $jobResourceModel;
-
-    /** @var IndexerFactory */
-    protected $indexerFactory;
-
     public function __construct(
-        Context $context,
-        JobFactory $jobFactory,
-        JobResourceModel $jobResourceModel,
-        IndexerFactory $indexerFactory
+        Context                    $context,
+        protected JobFactory       $jobFactory,
+        protected JobResourceModel $jobResourceModel,
+        protected IndexerFactory   $indexerFactory
     ) {
         parent::__construct($context);
-
-        $this->jobFactory       = $jobFactory;
-        $this->jobResourceModel = $jobResourceModel;
-        $this->indexerFactory   = $indexerFactory;
     }
 
     /**
@@ -39,10 +27,7 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         return $this->_authorization->isAllowed('Algolia_AlgoliaSearch::manage');
     }
 
-    /**
-     * @return \Algolia\AlgoliaSearch\Model\Job
-     */
-    protected function initJob()
+    protected function initJob(): ?Job
     {
         $jobId = (int) $this->getRequest()->getParam('id');
 
@@ -51,7 +36,7 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
             return null;
         }
 
-        /** @var \Algolia\AlgoliaSearch\Model\Job $model */
+        /** @var Job $model */
         $model = $this->jobFactory->create();
         $this->jobResourceModel->load($model, $jobId);
         if (!$model->getId()) {

--- a/Controller/Adminhtml/Queue/AbstractAction.php
+++ b/Controller/Adminhtml/Queue/AbstractAction.php
@@ -5,14 +5,10 @@ namespace Algolia\AlgoliaSearch\Controller\Adminhtml\Queue;
 use Algolia\AlgoliaSearch\Model\JobFactory;
 use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResourceModel;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Indexer\Model\IndexerFactory;
 
 abstract class AbstractAction extends \Magento\Backend\App\Action
 {
-    /** @var SessionManagerInterface */
-    protected $backendSession;
-
     /** @var \Algolia\AlgoliaSearch\Model\JobFactory */
     protected $jobFactory;
 
@@ -24,14 +20,12 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
 
     public function __construct(
         Context $context,
-        SessionManagerInterface $backendSession,
         JobFactory $jobFactory,
         JobResourceModel $jobResourceModel,
         IndexerFactory $indexerFactory
     ) {
         parent::__construct($context);
 
-        $this->backendSession   = $backendSession;
         $this->jobFactory       = $jobFactory;
         $this->jobResourceModel = $jobResourceModel;
         $this->indexerFactory   = $indexerFactory;
@@ -63,9 +57,6 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         if (!$model->getId()) {
             return null;
         }
-
-        // Register model to use later in blocks
-        $this->backendSession->setData('current_job', $model);
 
         return $model;
     }

--- a/Controller/Adminhtml/QueueArchive/AbstractAction.php
+++ b/Controller/Adminhtml/QueueArchive/AbstractAction.php
@@ -2,39 +2,21 @@
 
 namespace Algolia\AlgoliaSearch\Controller\Adminhtml\QueueArchive;
 
+use Algolia\AlgoliaSearch\Model\QueueArchive;
 use Algolia\AlgoliaSearch\Model\QueueArchiveFactory;
 use Algolia\AlgoliaSearch\Model\ResourceModel\QueueArchive as QueueArchiveResourceModel;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Indexer\Model\IndexerFactory;
 
 abstract class AbstractAction extends \Magento\Backend\App\Action
 {
-    /** @var SessionManagerInterface */
-    protected $backendSession;
-
-    /** @var \Algolia\AlgoliaSearch\Model\QueueArchiveFactory */
-    protected $queueArchiveFactory;
-
-    /** @var QueueArchiveResourceModel */
-    protected $queueArchiveResourceModel;
-
-    /** @var IndexerFactory */
-    protected $indexerFactory;
-
     public function __construct(
-        Context $context,
-        SessionManagerInterface $backendSession,
-        QueueArchiveFactory $queueArchiveFactory,
-        QueueArchiveResourceModel $queueArchiveResourceModel,
-        IndexerFactory $indexerFactory
+        Context                             $context,
+        protected QueueArchiveFactory        $queueArchiveFactory,
+        protected QueueArchiveResourceModel  $queueArchiveResourceModel,
+        protected IndexerFactory             $indexerFactory
     ) {
         parent::__construct($context);
-
-        $this->backendSession     = $backendSession;
-        $this->queueArchiveFactory       = $queueArchiveFactory;
-        $this->queueArchiveResourceModel = $queueArchiveResourceModel;
-        $this->indexerFactory   = $indexerFactory;
     }
 
     /**
@@ -45,10 +27,7 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
         return $this->_authorization->isAllowed('Algolia_AlgoliaSearch::manage');
     }
 
-    /**
-     * @return \Algolia\AlgoliaSearch\Model\QueueArchive
-     */
-    protected function initJob()
+    protected function initJob(): ?QueueArchive
     {
         $jobId = (int) $this->getRequest()->getParam('id');
 
@@ -57,15 +36,12 @@ abstract class AbstractAction extends \Magento\Backend\App\Action
             return null;
         }
 
-        /** @var \Algolia\AlgoliaSearch\Model\QueueArchive $model */
+        /** @var QueueArchive $model */
         $model = $this->queueArchiveFactory->create();
         $this->queueArchiveResourceModel->load($model, $jobId);
         if (!$model->getId()) {
             return null;
         }
-
-        // Register model to use later in blocks
-        $this->backendSession->setData('current_job', $model);
 
         return $model;
     }

--- a/Test/Unit/Block/Adminhtml/Job/ViewTest.php
+++ b/Test/Unit/Block/Adminhtml/Job/ViewTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Block\Adminhtml\Job;
+
+use Algolia\AlgoliaSearch\Block\Adminhtml\Job\View;
+use Algolia\AlgoliaSearch\Model\Job;
+use Algolia\AlgoliaSearch\Model\JobFactory;
+use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResource;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use Magento\Framework\App\RequestInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[AllowMockObjectsWithoutExpectations]
+class ViewTest extends TestCase
+{
+    protected null|(View&MockObject) $block = null;
+    protected null|(JobFactory&MockObject) $jobFactory = null;
+    protected null|(JobResource&MockObject) $jobResource = null;
+    protected null|(RequestInterface&MockObject) $request = null;
+
+    protected function setUp(): void
+    {
+        $this->jobFactory = $this->createMock(JobFactory::class);
+        $this->jobResource = $this->createMock(JobResource::class);
+        $this->request = $this->createMock(RequestInterface::class);
+
+        $this->block = $this->getMockBuilder(View::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getRequest'])
+            ->getMock();
+
+        $this->block->method('getRequest')->willReturn($this->request);
+        $this->setPrivateProperty($this->block, 'jobFactory', $this->jobFactory);
+        $this->setPrivateProperty($this->block, 'jobResource', $this->jobResource);
+    }
+
+    public function testGetCurrentJobLoadsJobUsingRequestId(): void
+    {
+        $job = $this->createMock(Job::class);
+        $this->request->method('getParam')->with('id')->willReturn(42);
+        $this->jobFactory->method('create')->willReturn($job);
+        $this->jobResource->expects($this->once())->method('load')->with($job, 42);
+
+        $this->assertSame($job, $this->block->getCurrentJob());
+    }
+
+    public function testGetCurrentJobCastsStringIdToInt(): void
+    {
+        $job = $this->createMock(Job::class);
+        $this->request->method('getParam')->with('id')->willReturn('42');
+        $this->jobFactory->method('create')->willReturn($job);
+        $this->jobResource->expects($this->once())->method('load')->with($job, 42);
+
+        $this->block->getCurrentJob();
+    }
+
+    public function testGetCurrentJobMemoizesResult(): void
+    {
+        $job = $this->createMock(Job::class);
+        $this->request->method('getParam')->with('id')->willReturn(42);
+        $this->jobFactory->expects($this->once())->method('create')->willReturn($job);
+        $this->jobResource->expects($this->once())->method('load')->with($job, 42);
+
+        $first = $this->block->getCurrentJob();
+        $second = $this->block->getCurrentJob();
+
+        $this->assertSame($first, $second);
+    }
+}

--- a/Test/Unit/Block/Adminhtml/QueueArchive/ViewTest.php
+++ b/Test/Unit/Block/Adminhtml/QueueArchive/ViewTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algolia\AlgoliaSearch\Test\Unit\Block\Adminhtml\QueueArchive;
+
+use Algolia\AlgoliaSearch\Api\Data\QueueArchiveInterface;
+use Algolia\AlgoliaSearch\Api\QueueArchiveRepositoryInterface;
+use Algolia\AlgoliaSearch\Block\Adminhtml\QueueArchive\View;
+use Algolia\AlgoliaSearch\Test\TestCase;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[AllowMockObjectsWithoutExpectations]
+class ViewTest extends TestCase
+{
+    protected null|(View&MockObject) $block = null;
+    protected null|(QueueArchiveRepositoryInterface&MockObject) $queueArchiveRepository = null;
+    protected null|(RequestInterface&MockObject) $request = null;
+
+    protected function setUp(): void
+    {
+        $this->queueArchiveRepository = $this->createMock(QueueArchiveRepositoryInterface::class);
+        $this->request = $this->createMock(RequestInterface::class);
+
+        $this->block = $this->getMockBuilder(View::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getRequest'])
+            ->getMock();
+
+        $this->block->method('getRequest')->willReturn($this->request);
+        $this->setPrivateProperty($this->block, 'queueArchiveRepository', $this->queueArchiveRepository);
+    }
+
+    public function testGetCurrentJobLoadsArchiveUsingRequestId(): void
+    {
+        $archive = $this->createMock(QueueArchiveInterface::class);
+        $this->request->method('getParam')->with('id')->willReturn(42);
+        $this->queueArchiveRepository->method('getById')->with(42)->willReturn($archive);
+
+        $this->assertSame($archive, $this->block->getCurrentJob());
+    }
+
+    public function testGetCurrentJobMemoizesResult(): void
+    {
+        $archive = $this->createMock(QueueArchiveInterface::class);
+        $this->request->method('getParam')->with('id')->willReturn(42);
+        $this->queueArchiveRepository->expects($this->once())->method('getById')->with(42)->willReturn($archive);
+
+        $first = $this->block->getCurrentJob();
+        $second = $this->block->getCurrentJob();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testGetCurrentJobPropagatesNoSuchEntityException(): void
+    {
+        $this->request->method('getParam')->with('id')->willReturn(42);
+        $this->queueArchiveRepository->method('getById')->with(42)
+            ->willThrowException(new NoSuchEntityException());
+
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->block->getCurrentJob();
+    }
+}

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -356,6 +356,8 @@ These are properties the codebase maintains by convention.
   Magento's indexer framework, CLI commands, or the admin UI.
 - No server-side rendering of search results - all search rendering is client-side JS.
 - No cross-store index sharing - each store gets its own set of indices.
+- No Magento model instance is stored in the backend session - persist a scalar id (or a plain
+  array) and reload the entity where it's needed.
 
 ## Cross-Cutting Concerns
 
@@ -410,3 +412,6 @@ rejected at execution time.
 - Reading config via `ScopeConfigInterface` - use `ConfigHelper` or a sub-helper.
 - Hardcoding store IDs or assuming single-store operation.
 - Bypassing the queue for indexing operations.
+- Storing a Magento model instance in the backend session. `Model\Job` carries an injected
+  `ObjectManagerInterface` for its handler dispatch, so serializing it at `session_write_close()`
+  fatals with "Serialization of 'Closure' is not allowed."

--- a/view/adminhtml/templates/job/view.phtml
+++ b/view/adminhtml/templates/job/view.phtml
@@ -7,7 +7,7 @@ $job = $block->getCurrentJob();
 <div class="admin__fieldset-wrapper opened algolia-setup-fieldset">
     <div class="admin__fieldset-wrapper-title">
         <strong class="title">
-            <span><?= $escaper->escapeHtml(__('Job Informations')); ?></span>
+            <span><?= $escaper->escapeHtml(__('Job Information')); ?></span>
         </strong>
     </div>
     <div class="admin__fieldset-wrapper-content">

--- a/view/adminhtml/templates/queuearchive/view.phtml
+++ b/view/adminhtml/templates/queuearchive/view.phtml
@@ -1,7 +1,7 @@
 <?php
 
 /* @var \Algolia\AlgoliaSearch\Block\Adminhtml\QueueArchive\View $block */
-/* @var \Algolia\AlgoliaSearch\Model\Queue $queue */
+/* @var \Algolia\AlgoliaSearch\Model\QueueArchive $queue */
 $queue = $block->getCurrentJob();
 ?>
 
@@ -97,7 +97,7 @@ $queue = $block->getCurrentJob();
                 <label class="admin__field-label"><span><?= $escaper->escapeHtml(__('Processed At')) ?></span></label>
                 <div class="admin__field-control">
                     <div class="admin__field admin__field-option">
-                        <?= $escaper->escapeHtml($queue->getProcssedAt()) ?>
+                        <?= $escaper->escapeHtml($queue->getProcessedAt()) ?>
                     </div>
                 </div>
             </div>

--- a/view/adminhtml/templates/queuearchive/view.phtml
+++ b/view/adminhtml/templates/queuearchive/view.phtml
@@ -8,7 +8,7 @@ $queue = $block->getCurrentJob();
 <div class="admin__fieldset-wrapper opened algolia-setup-fieldset">
     <div class="admin__fieldset-wrapper-title">
         <strong class="title">
-            <span><?= $escaper->escapeHtml(__('Queue Archive Informations')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Queue Archive Information')) ?></span>
         </strong>
     </div>
     <div class="admin__fieldset-wrapper-content">


### PR DESCRIPTION
## Summary

Opening a job detail page from the Indexing Queue or Queue Archive grids could fail with:

```
Uncaught Exception: Serialization of 'Closure' is not allowed
```

Both `Controller\Adminhtml\Queue\AbstractAction::initJob()` and its Queue Archive counterpart loaded the entity and then stashed the **fully hydrated model** in the backend session (`$this->backendSession->setData('current_job', $model)`) so the view block could pick it up. `Model\Job` carries an injected `ObjectManagerInterface` for its handler dispatch, so when Magento serializes the session at `session_write_close()`, it walks into a closure and fatals.

The fix removes the session round trip entirely. Each view block now loads the entity itself from the `id` request parameter, which is the only thing that ever needed to cross the request boundary:

- `Block\Adminhtml\Job\View` loads via `Model\JobFactory` + `Model\ResourceModel\Job`. (No repository exists at this time)
- `Block\Adminhtml\QueueArchive\View` loads via `Api\QueueArchiveRepositoryInterface`.
- Both cache the loaded entity in a local property, so repeated `getCurrentJob()` calls in the templates still hit the database once.
- `SessionManagerInterface` is dropped from both controllers and both blocks.

Also included in this PR:

- Documented the underlying invariant in `doc/ARCHITECTURE.md` (Architectural Invariants and Anti-Patterns) so this does not get reintroduced: no Magento model instance goes into the backend session, persist a scalar id and reload the entity where it is needed.
- Fixed `$queue->getProcssedAt()` to `getProcessedAt()` in the Queue Archive view template. The typo left the **Processed At** field silently blank on that page.
- Modernized both controllers and blocks to constructor property promotion, native return types, and removed the PHPDoc blocks that only restated the type declarations.
- Corrected the "Informations" label to "Information" in both view templates.
- Added `CHANGELOG.md` entries for 3.19.0, including the constructor signature changes under breaking changes.

Thanks to @angelvilaplana for the original fix in #1939 🙌 , which covered the Indexing Queue view. This PR keeps that authorship and extends the same treatment to the Queue Archive view.

**Breaking changes**

Constructor signatures changed. Anything extending these classes or instantiating them directly needs updating:

| Class | Change |
| --- | --- |
| `Controller\Adminhtml\Queue\AbstractAction` | no longer accepts `SessionManagerInterface` |
| `Controller\Adminhtml\QueueArchive\AbstractAction` | no longer accepts `SessionManagerInterface` |
| `Block\Adminhtml\Job\View` | requires `Model\JobFactory` and `Model\ResourceModel\Job` in place of `SessionManagerInterface` |
| `Block\Adminhtml\QueueArchive\View` | requires `Api\QueueArchiveRepositoryInterface` in place of `SessionManagerInterface` |

`Block\Adminhtml\QueueArchive\View::getCurrentJob()` now returns `QueueArchiveInterface` and throws `NoSuchEntityException` for an unknown id, rather than returning `null` from the session.

## Result

New unit tests cover the load path for both blocks:

- `Test/Unit/Block/Adminhtml/Job/ViewTest.php`
- `Test/Unit/Block/Adminhtml/QueueArchive/ViewTest.php`

They assert that `getCurrentJob()` loads the entity using the `id` request parameter and that the result is memoized so a second call does not re-query.

<img width="1496" height="574" alt="image" src="https://github.com/user-attachments/assets/e4e700ed-c642-4d5c-bef7-1335515be701" />


```bash
vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
  vendor/algolia/algoliasearch-magento-2/Test/Unit/Block/Adminhtml
```

Manual verification in admin:

1. Stores > Configuration > Algolia Search: enable the indexing queue.
2. Trigger a reindex so jobs land in `algoliasearch_queue`.
3. Algolia Search > Indexing Queue, click into a job. The detail page renders instead of an error.
4. Algolia Search > Queue Archive, click into an archived job. The detail page renders and **Processed At** now shows a timestamp.
5. Confirm no "Serialization of 'Closure' is not allowed" entries appear in `var/log/`.

<img width="1396" height="1064" alt="image" src="https://github.com/user-attachments/assets/4f3a5d7b-4cb0-484d-bd8b-f66710a9cb01" />

<img width="1376" height="1466" alt="image" src="https://github.com/user-attachments/assets/7243753c-4e8c-442c-a0a9-8ef17ee14941" />
