### PR TITLE
MAGE-1631 Add per-store resolution unit test

### DIFF
--- a/Test/Unit/Service/SendStrategyResolverTest.php
+++ b/Test/Unit/Service/SendStrategyResolverTest.php
@@ -94,4 +94,18 @@ class SendStrategyResolverTest extends TestCase
         $resolver = new SendStrategyResolver($this->defaultStrategy);
         $resolver->resolve(self::STORE_ID);
     }
+
+    public function testResolveIsPerStoreForTheSameStrategy(): void
+    {
+        $storeSpecific = $this->createMock(SendStrategyInterface::class);
+        $storeSpecific->method('isApplicable')->willReturnMap([
+            [self::STORE_ID, true],
+            [self::STORE_ID + 1, false],
+        ]);
+
+        $resolver = new SendStrategyResolver($this->defaultStrategy, [$storeSpecific]);
+
+        $this->assertSame($storeSpecific, $resolver->resolve(self::STORE_ID));
+        $this->assertSame($this->defaultStrategy, $resolver->resolve(self::STORE_ID + 1));
+    }
 }


### PR DESCRIPTION
**Summary**

This PR addresses one missing acceptance criteria for the unit test class:
- Per-store resolution (a strategy applicable for one store but not another).

**Result**
<img width="1494" height="260" alt="image" src="https://github.com/user-attachments/assets/f83429d6-3c3f-48a4-9ed8-06f7c459d5ec" />

