### PR TITLE
MAGE-1677 Update guzzlehttp (3.19.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "php": "~8.3|~8.4|~8.5",
     "magento/framework": "~103.0",
     "algolia/algoliasearch-client-php": "^4.40.0",
-    "guzzlehttp/guzzle": "^7.12.1",
+    "guzzlehttp/guzzle": "^7.15.2",
     "ext-json": "*",
     "ext-PDO": "*",
     "ext-mbstring": "*",


### PR DESCRIPTION
**Summary**

Update `guzzlehttp/guzzle` to "7.15.2" in response to CVE-2026-69246

**Result**

<img width="1170" height="550" alt="image" src="https://github.com/user-attachments/assets/267c1f75-0e77-41e4-84e0-a4ff89f65a9a" />
<img width="1494" height="156" alt="image" src="https://github.com/user-attachments/assets/8794fc77-c21d-4498-a4f8-1c51856bd0f1" />
