### PR TITLE
MAGE-1677 Update guzzlehttp (3.18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed pages indexing issue where settings and synonyms added on the Algolia dashboard were wiped during the process - thank you @PromInc
 - Fixed suggestions indexing issue where the index could be completely emptied during the process - thank you @its-leoeff511
 - Prevented semanticSearch echo back to Algolia when extra settings are enabled 
+- Upgraded guzzlehttp/guzzle to ^7.15.2 to remediate [CVE-2026-69246](https://github.com/advisories/GHSA-v5mv-p594-2x33)
 
 ## 3.18.1
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "php": "~8.2|~8.3|~8.4|~8.5",
     "magento/framework": "~103.0",
     "algolia/algoliasearch-client-php": "4.18.3",
-    "guzzlehttp/guzzle": "^7.12.1",
+    "guzzlehttp/guzzle": "^7.15.2",
     "ext-json": "*",
     "ext-PDO": "*",
     "ext-mbstring": "*",


### PR DESCRIPTION
**Summary**

Update `guzzlehttp/guzzle` to "7.15.2" in response to CVE-2026-69246

Backports #1981 for 3.18.2