### PR TITLE
MAGE-1656 Prepare release 3.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,45 +2,11 @@
 
 ## 3.19.0
 
-### Updates
-- Completed a PHPStan (`magento2-analyse`) static-analysis cleanup so analyzer reports zero file errors.
-- `AlgoliaLogger` now extends `Magento\Framework\Logger\Monolog` instead of `Monolog\Logger` directly, resolving the "extends @final class" violation introduced by Monolog 3.x, with no behavior change.
-- Replaced deprecated `getResource()` / `_getResource()` usage in the LandingPage and Query merchandising admin controllers and blocks by injecting the resource models directly.
-- `Controller\Router` now resolves the landing page identifier through `ResourceModel\LandingPage` directly; the `Model\LandingPage::checkIdentifier()` passthrough was removed.
-- Replaced the deprecated product reload in the bundle and downloadable price managers with `ProductRepositoryInterface::getById()`.
-- Replaced the deprecated `media_gallery` attribute reload in `Service\Product\RecordBuilder` with the catalog gallery `ReadHandler`, and resolved product and category attributes through injected resource models.
-- Removed the unused `Model\Job::saveError()` method. The one remaining `Model\Job::save()` deprecation is temporarily suppressed via a scoped, documented `phpstan.neon` entry pending a dedicated JobProcessor refactor.
-- `Logger\Handler\AlgoliaLoggerHandler` now accepts the log level and file name as constructor arguments, allowing developers to tune `var/log/algolia.log` verbosity via `di.xml` (defaults to `INFO`, previously hard-coded to `DEBUG`).
-- Upgraded the bundled `algoliasearch` JavaScript client from v4.24.0 to the v5.56.0 "lite" build ahead of the v4 August 2026 deprecation.
-- Bumped InstantSearch.js to 4.106.0 and Autocomplete.js to 1.19.9 for optimal v5 peer compatibility.
-- Migrated the frontend Recommend surfaces (Frequently Bought Together, Related Products, Trending Items, Looking Similar) from the standalone `@algolia/recommend` and `@algolia/recommend-js` v4 bundles to the InstantSearch.js recommend widgets running on the v5 lite client. Widgets are lazy-loaded via `IntersectionObserver` so their weight stays off the PDP and cart critical path.
-- The Recommend product template (`view/frontend/web/js/template/recommend/products.js`) received a new `getNoResultHtml({html})` method so integrators can customize it via the same mixin mechanism.
-- Upgraded guzzlehttp/guzzle to ^7.15.2 to remediate [CVE-2026-69246](https://github.com/advisories/GHSA-v5mv-p594-2x33)
-
-### Breaking Changes
-- Several constructor signatures changed. Any class extending these must update its `parent::__construct()` call:
-  - `Service\Product\RecordBuilder` now requires `Magento\Catalog\Model\ResourceModel\Product` and `Magento\Catalog\Model\Product\Gallery\ReadHandler` (12 to 14 arguments).
-  - `Helper\Entity\Product\PriceManager\ProductWithoutChildren` now requires `Magento\Catalog\Api\ProductRepositoryInterface` in place of `Magento\Catalog\Model\ProductFactory`.
-  - The LandingPage and Query admin controllers and edit blocks, and `Controller\Router`, gained resource-model constructor dependencies.
-  - `Controller\Adminhtml\Queue\AbstractAction` and `Controller\Adminhtml\QueueArchive\AbstractAction` no longer accept `Magento\Framework\Session\SessionManagerInterface`.
-  - `Block\Adminhtml\Job\View` now requires `Model\JobFactory` and `Model\ResourceModel\Job` in place of the session manager.
-  - `Block\Adminhtml\QueueArchive\View` now requires `Api\QueueArchiveRepositoryInterface` in place of the session manager.
-- The MSI compatibility module `algolia/algoliasearch-inventory-magento-2` extends `Service\Product\RecordBuilder`, so it requires the coordinated 1.5.0 release to stay compatible with 3.19.0. Install `algolia/algoliasearch-inventory-magento-2:^1.5.0` alongside this version.
-- `Helper\Entity\ProductHelper::addStockFilter()` now declares `ProductCollection $products` and `int $storeId`. A subclass overriding this protected method with a narrower or incompatible signature will fatal on class load; untyped or wider overrides remain valid.
-- The Recommend product template (`view/frontend/web/js/template/recommend/products.js`) now passes a single destructured options object to its methods instead of positional arguments, aligning it with the autocomplete product template. Any RequireJS mixin overriding these methods must be updated. 
-
-### Bug fixes
-- Injected the missing `CollectionProcessorInterface` into `Model\QueueArchiveRepository`, fixing a latent runtime fatal in `getList()`.
-- Fixed `Uncaught Exception: Serialization of 'Closure' is not allowed` on the Indexing Queue and Queue Archive job view pages, caused by storing the fully hydrated model in the backend session. (thanks @angelvilaplana, [#1939](https://github.com/algolia/algoliasearch-magento-2/pull/1939))
-- Fixed a getter typo in the Queue Archive view template that left the Processed At field blank on the Queue Archive view page.
-
-## 3.19.0-beta.1
-
 ### Security
-- Upgraded `guzzlehttp/guzzle` to `^7.12.1` to remediate two Dependabot CVEs (dot-only cookie domains matching all hosts, and silent HTTPS-proxy downgrade to cleartext); dropped the EOL `^6.3.3` branch ([#1964](https://github.com/algolia/algoliasearch-magento-2/pull/1964)).
+- Raised the `guzzlehttp/guzzle` floor to `^7.15.2` and dropped the EOL `^6.3.3` branch, remediating three CVEs: dot-only cookie domains matching all hosts, silent HTTPS-proxy downgrade to cleartext, and [CVE-2026-69246](https://github.com/advisories/GHSA-v5mv-p594-2x33) ([#1964](https://github.com/algolia/algoliasearch-magento-2/pull/1964), [#1981](https://github.com/algolia/algoliasearch-magento-2/pull/1981), [#1984](https://github.com/algolia/algoliasearch-magento-2/pull/1984)).
 
 ### Features
-- Added support for the new Algolia Ingestion module (algolia/algoliasearch-ingestion-magento-2), which routes product indexing through the Algolia Ingestion API to unlock pre-indexing JavaScript transformations, low-latency Collections, and per-operation observability ([#1919](https://github.com/algolia/algoliasearch-magento-2/pull/1919)).
+- Added support for the new Algolia Ingestion module ([algolia/algoliasearch-ingestion-magento-2](https://github.com/algolia/algoliasearch-ingestion-magento-2)), which routes product indexing through the Algolia Ingestion API to unlock pre-indexing JavaScript transformations, low-latency Collections, and per-operation observability. This release ships in lockstep with Ingestion module 0.2.0 ([#1919](https://github.com/algolia/algoliasearch-magento-2/pull/1919), [#1967](https://github.com/algolia/algoliasearch-magento-2/pull/1967)).
 - Introduced a per-store `SendStrategy` resolver on `AlgoliaConnector`, enabling alternative indexing backends to be selected at the store scope while direct indexing remains the default ([#1924](https://github.com/algolia/algoliasearch-magento-2/pull/1924), [#1923](https://github.com/algolia/algoliasearch-magento-2/pull/1923)).
 - Added `SearchClientProvider` and `AbstractClientProvider`, extracting Algolia client construction behind `ClientProviderInterface` / `SearchClientProviderInterface` so satellite modules can supply their own clients ([#1926](https://github.com/algolia/algoliasearch-magento-2/pull/1926), [#1928](https://github.com/algolia/algoliasearch-magento-2/pull/1928)).
 
@@ -49,16 +15,50 @@
 - Added `IndexSettingsPreserver` to retain ingestion-owned index settings across a full reindex, and reorganized the `Service/Index*` class family into `Service/Index/` and `Service/Index/Settings/` (no behavior change) ([#1961](https://github.com/algolia/algoliasearch-magento-2/pull/1961), [#1956](https://github.com/algolia/algoliasearch-magento-2/pull/1956)).
 - Updated the Algolia PHP API Client to version 4.40.0 ([#1922](https://github.com/algolia/algoliasearch-magento-2/pull/1922)).
 - Centralized the default store scope constant and added a reflection utility in preparation for the Ingestion task service ([#1927](https://github.com/algolia/algoliasearch-magento-2/pull/1927)).
-- Added an `AlgoliaLogger` virtual type for PSR-3 substitution and a helper for resolving the original (production) name of a temporary index.
+- Added an `AlgoliaLogger` virtual type for PSR-3 substitution and a helper for resolving the original (production) name of a temporary index ([#1932](https://github.com/algolia/algoliasearch-magento-2/pull/1932)).
+- Completed a PHPStan (`magento2-analyse`) static-analysis cleanup so analyzer reports zero file errors ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- `AlgoliaLogger` now extends `Magento\Framework\Logger\Monolog` instead of `Monolog\Logger` directly, resolving the "extends @final class" violation introduced by Monolog 3.x, with no behavior change ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- Replaced deprecated `getResource()` / `_getResource()` usage in the LandingPage and Query merchandising admin controllers and blocks by injecting the resource models directly ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- `Controller\Router` now resolves the landing page identifier through `ResourceModel\LandingPage` directly; the `Model\LandingPage::checkIdentifier()` passthrough was removed ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- Replaced the deprecated product reload in the bundle and downloadable price managers with `ProductRepositoryInterface::getById()` ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- Replaced the deprecated `media_gallery` attribute reload in `Service\Product\RecordBuilder` with the catalog gallery `ReadHandler`, and resolved product and category attributes through injected resource models ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- Removed the unused `Model\Job::saveError()` method. The one remaining `Model\Job::save()` deprecation is temporarily suppressed via a scoped, documented `phpstan.neon` entry pending a dedicated JobProcessor refactor ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- `Logger\Handler\AlgoliaLoggerHandler` now accepts the log level and file name as constructor arguments, allowing developers to tune `var/log/algolia.log` verbosity via `di.xml` (defaults to `INFO`, previously hard-coded to `DEBUG`) ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- Upgraded the bundled `algoliasearch` JavaScript client from v4.24.0 to the v5.56.0 "lite" build ahead of the v4 August 2026 deprecation ([#1970](https://github.com/algolia/algoliasearch-magento-2/pull/1970)).
+- Bumped InstantSearch.js to 4.106.0 and Autocomplete.js to 1.19.9 for optimal v5 peer compatibility ([#1970](https://github.com/algolia/algoliasearch-magento-2/pull/1970)).
+- Migrated the frontend Recommend surfaces (Frequently Bought Together, Related Products, Trending Items, Looking Similar) from the standalone `@algolia/recommend` and `@algolia/recommend-js` v4 bundles to the InstantSearch.js recommend widgets running on the v5 lite client. Widgets are lazy-loaded via `IntersectionObserver` so their weight stays off the PDP and cart critical path ([#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
+- The Recommend product template (`view/frontend/web/js/template/recommend/products.js`) received a new `getNoResultHtml({html})` method so integrators can customize it via the same mixin mechanism ([#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
+- `Cron\ProcessQueue` now resolves the queue-active and built-in-cron conditions through `Helper\Configuration\QueueHelper` instead of the deprecated `ConfigHelper` equivalents. The evaluated configuration paths are unchanged ([#1977](https://github.com/algolia/algoliasearch-magento-2/pull/1977)).
 - Retired the `*Testable` subclass test pattern in favor of direct unit testing, and introduced reusable Claude testing guides alongside a regenerated `AlgoliaConnector` unit suite ([#1929](https://github.com/algolia/algoliasearch-magento-2/pull/1929)).
+- Added a standardized unit-test generation workflow covering blocks, controllers, helpers, models, observers, plugins, services, and view models, and removed the remaining `@dataProvider` annotations in favor of PHPUnit attributes ([#1940](https://github.com/algolia/algoliasearch-magento-2/pull/1940)).
 - Applied the updated `magento2-tools` PHPCS-Fixer linting baseline across the module for a consistent contribution standard, retaining PHP 8.2 backward compatibility ([#1923](https://github.com/algolia/algoliasearch-magento-2/pull/1923)).
 - Refactored `ConfigHelper` and many block, controller, observer, and service classes to align with the new linting baseline and tighten type declarations.
 - Hoisted CLI command unit tests to the `AbstractStoreCommand` scope ([#1942](https://github.com/algolia/algoliasearch-magento-2/pull/1942)).
 - Added an architecture context document and adopted the open `AGENTS.md` standard for contributor and agent guidance ([#1921](https://github.com/algolia/algoliasearch-magento-2/pull/1921)).
-- Updated unit and integration tests.
+- Updated unit and integration tests ([#1932](https://github.com/algolia/algoliasearch-magento-2/pull/1932), [#1980](https://github.com/algolia/algoliasearch-magento-2/pull/1980)).
 
 ### Bug fixes
+- Injected the missing `CollectionProcessorInterface` into `Model\QueueArchiveRepository`, fixing a latent runtime fatal in `getList()` ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
+- Fixed `Uncaught Exception: Serialization of 'Closure' is not allowed` on the Indexing Queue and Queue Archive job view pages, caused by storing the fully hydrated model in the backend session. (thanks @angelvilaplana, [#1939](https://github.com/algolia/algoliasearch-magento-2/pull/1939), [#1978](https://github.com/algolia/algoliasearch-magento-2/pull/1978))
+- Fixed a getter typo in the Queue Archive view template that left the Processed At field blank on the Queue Archive view page ([#1978](https://github.com/algolia/algoliasearch-magento-2/pull/1978)).
+- Stripped `semanticSearch` from the settings merged onto a temporary index. An empty `semanticSearch` object returned by `getSettings` round-trips through PHP as an empty array and re-encodes as a JSON array, which the API rejects ([#1972](https://github.com/algolia/algoliasearch-magento-2/pull/1972)).
+- Fixed incorrect escaping of object IDs passed to the Recommend widgets, and fixed the standalone Looking Similar widget failing to render on the cart page ([#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
 - Added a missing CDATA tag in `system.xml`.
+
+### Breaking Changes
+- Raised the minimum requirements to PHP 8.3 and Magento 2.4.8. Supported targets are now Magento `~2.4.8||~2.4.9` on PHP `~8.3||~8.4||~8.5`; PHP 8.2 and Magento 2.4.7 are no longer supported ([#1959](https://github.com/algolia/algoliasearch-magento-2/pull/1959)).
+- Several constructor signatures changed. Any class extending these must update its `parent::__construct()` call:
+  - `Service\Product\RecordBuilder` now requires `Magento\Catalog\Model\ResourceModel\Product` and `Magento\Catalog\Model\Product\Gallery\ReadHandler` (12 to 14 arguments).
+  - `Helper\Entity\Product\PriceManager\ProductWithoutChildren` now requires `Magento\Catalog\Api\ProductRepositoryInterface` in place of `Magento\Catalog\Model\ProductFactory`.
+  - The LandingPage and Query admin controllers and edit blocks, and `Controller\Router`, gained resource-model constructor dependencies.
+  - `Controller\Adminhtml\Queue\AbstractAction` and `Controller\Adminhtml\QueueArchive\AbstractAction` no longer accept `Magento\Framework\Session\SessionManagerInterface`.
+  - `Block\Adminhtml\Job\View` now requires `Model\JobFactory` and `Model\ResourceModel\Job` in place of the session manager.
+  - `Block\Adminhtml\QueueArchive\View` now requires `Api\QueueArchiveRepositoryInterface` in place of the session manager.
+  - `Cron\ProcessQueue` now requires `Helper\Configuration\QueueHelper` in place of `Helper\ConfigHelper`.
+- `composer.json` now declares conflicts with the companion modules it can no longer work with: `algolia/algoliasearch-inventory-magento-2:<1.5.0` and `algolia/algoliasearch-adapter-magento-2:<0.10.0` ([#1976](https://github.com/algolia/algoliasearch-magento-2/pull/1976), [#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
+- The MSI compatibility module `algolia/algoliasearch-inventory-magento-2` extends `Service\Product\RecordBuilder`, so it requires the coordinated 1.5.0 release to stay compatible with 3.19.0. Install `algolia/algoliasearch-inventory-magento-2:^1.5.0` alongside this version ([#1976](https://github.com/algolia/algoliasearch-magento-2/pull/1976)).
+- `Helper\Entity\ProductHelper::addStockFilter()` now declares `ProductCollection $products` and `int $storeId`. A subclass overriding this protected method with a narrower or incompatible signature will fatal on class load; untyped or wider overrides remain valid ([#1976](https://github.com/algolia/algoliasearch-magento-2/pull/1976)).
+- The Recommend product template (`view/frontend/web/js/template/recommend/products.js`) now passes a single destructured options object to its methods instead of positional arguments, aligning it with the autocomplete product template. Any RequireJS mixin overriding these methods must be updated ([#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
 
 ## 3.18.1
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Algolia Search & Discovery extension for Magento 2
 ==================================================
 
-![Latest version](https://img.shields.io/badge/latest-3.18.1-green)
-![Magento 2](https://img.shields.io/badge/Magento-2.4.7+-orange)
+![Latest version](https://img.shields.io/badge/latest-3.19.0-green)
+![Magento 2](https://img.shields.io/badge/Magento-2.4.8+-orange)
 
 ![PHP](https://img.shields.io/badge/PHP-8.3%2C8.4%2C8.5-blue)
 
@@ -78,7 +78,7 @@ The easiest way to install the extension is to use [Composer](https://getcompose
 
 If you would like to stay on a minor version, please upgrade your composer to only accept minor versions. The following example will keep you on the minor version and will update patches automatically.
 
-`"algolia/algoliasearch-magento-2": "~3.18.0"`
+`"algolia/algoliasearch-magento-2": "~3.19.0"`
 
 ### Customisation
 
@@ -167,7 +167,7 @@ Enables Algolia indexing compatibility with Magento's Multi-Source Inventory (MS
 composer require algolia/algoliasearch-inventory-magento-2
 ```
 
-Requires base extension `>=3.17.3`
+Requires base extension `>=3.17.3`. With base extension `>=3.19.0`, MSI module `^1.5.0` is required (earlier MSI versions are blocked by a Composer conflict declaration).
 
 #### Search adapter module
 
@@ -179,7 +179,7 @@ Registers Algolia as a native Magento search engine backend, enabling server-sid
 composer require algolia/algoliasearch-adapter-magento-2
 ```
 
-Requires PHP 8.2+, Magento 2.4+, and base extension `^3.18`.
+Requires PHP 8.2+, Magento 2.4+, and base extension `^3.18`. With base extension `>=3.19.0`, adapter module `>=0.10.0` is required (earlier adapter versions are blocked by a Composer conflict declaration).
 
 #### Ingestion module
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.19.0-beta.1",
+  "version": "3.19.0",
   "require": {
     "php": "~8.3|~8.4|~8.5",
     "magento/framework": "~103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.19.0-beta.1">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.19.0">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>


### PR DESCRIPTION
## MAGE-1656 — Prepare release 3.19.0

### Summary

Version bump and release preparation for **3.19.0** (previous release: 3.18.1).

- Updates `composer.json` version to `3.19.0`
- Updates `module.xml` setup_version to `3.19.0`
- Updates README.md compatibility/SLA matrix and companion-module floors
- Consolidates the CHANGELOG entry for `3.19.0` (the `3.19.0-beta.1` section is folded in)

This release ships in lockstep with the [Algolia Ingestion module](https://github.com/algolia/algoliasearch-ingestion-magento-2) 0.2.0.

### Changelog

#### Security
- Raised the `guzzlehttp/guzzle` floor to `^7.15.2` and dropped the EOL `^6.3.3` branch, remediating three CVEs: dot-only cookie domains matching all hosts, silent HTTPS-proxy downgrade to cleartext, and [CVE-2026-69246](https://github.com/advisories/GHSA-v5mv-p594-2x33) ([#1964](https://github.com/algolia/algoliasearch-magento-2/pull/1964), [#1981](https://github.com/algolia/algoliasearch-magento-2/pull/1981), [#1984](https://github.com/algolia/algoliasearch-magento-2/pull/1984)).

#### Features
- Added support for the new Algolia Ingestion module ([algolia/algoliasearch-ingestion-magento-2](https://github.com/algolia/algoliasearch-ingestion-magento-2)), which routes product indexing through the Algolia Ingestion API to unlock pre-indexing JavaScript transformations, low-latency Collections, and per-operation observability. This release ships in lockstep with Ingestion module 0.2.0 ([#1919](https://github.com/algolia/algoliasearch-magento-2/pull/1919), [#1967](https://github.com/algolia/algoliasearch-magento-2/pull/1967)).
- Introduced a per-store `SendStrategy` resolver on `AlgoliaConnector`, enabling alternative indexing backends to be selected at the store scope while direct indexing remains the default ([#1924](https://github.com/algolia/algoliasearch-magento-2/pull/1924), [#1923](https://github.com/algolia/algoliasearch-magento-2/pull/1923)).
- Added `SearchClientProvider` and `AbstractClientProvider`, extracting Algolia client construction behind `ClientProviderInterface` / `SearchClientProviderInterface` so satellite modules can supply their own clients ([#1926](https://github.com/algolia/algoliasearch-magento-2/pull/1926), [#1928](https://github.com/algolia/algoliasearch-magento-2/pull/1928)).

#### Updates
- Unified temporary index management across entities so the move-to-production step is consistent for products, categories, pages, suggestions, and additional sections; page indexing now supports delta updates ([#1960](https://github.com/algolia/algoliasearch-magento-2/pull/1960)).
- Added `IndexSettingsPreserver` to retain ingestion-owned index settings across a full reindex, and reorganized the `Service/Index*` class family into `Service/Index/` and `Service/Index/Settings/` (no behavior change) ([#1961](https://github.com/algolia/algoliasearch-magento-2/pull/1961), [#1956](https://github.com/algolia/algoliasearch-magento-2/pull/1956)).
- Updated the Algolia PHP API Client to version 4.40.0 ([#1922](https://github.com/algolia/algoliasearch-magento-2/pull/1922)).
- Centralized the default store scope constant and added a reflection utility in preparation for the Ingestion task service ([#1927](https://github.com/algolia/algoliasearch-magento-2/pull/1927)).
- Added an `AlgoliaLogger` virtual type for PSR-3 substitution and a helper for resolving the original (production) name of a temporary index ([#1932](https://github.com/algolia/algoliasearch-magento-2/pull/1932)).
- Completed a PHPStan (`magento2-analyse`) static-analysis cleanup so analyzer reports zero file errors ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- `AlgoliaLogger` now extends `Magento\Framework\Logger\Monolog` instead of `Monolog\Logger` directly, resolving the "extends @final class" violation introduced by Monolog 3.x, with no behavior change ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- Replaced deprecated `getResource()` / `_getResource()` usage in the LandingPage and Query merchandising admin controllers and blocks by injecting the resource models directly ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- `Controller\Router` now resolves the landing page identifier through `ResourceModel\LandingPage` directly; the `Model\LandingPage::checkIdentifier()` passthrough was removed ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- Replaced the deprecated product reload in the bundle and downloadable price managers with `ProductRepositoryInterface::getById()` ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- Replaced the deprecated `media_gallery` attribute reload in `Service\Product\RecordBuilder` with the catalog gallery `ReadHandler`, and resolved product and category attributes through injected resource models ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- Removed the unused `Model\Job::saveError()` method. The one remaining `Model\Job::save()` deprecation is temporarily suppressed via a scoped, documented `phpstan.neon` entry pending a dedicated JobProcessor refactor ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- `Logger\Handler\AlgoliaLoggerHandler` now accepts the log level and file name as constructor arguments, allowing developers to tune `var/log/algolia.log` verbosity via `di.xml` (defaults to `INFO`, previously hard-coded to `DEBUG`) ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- Upgraded the bundled `algoliasearch` JavaScript client from v4.24.0 to the v5.56.0 "lite" build ahead of the v4 August 2026 deprecation ([#1970](https://github.com/algolia/algoliasearch-magento-2/pull/1970)).
- Bumped InstantSearch.js to 4.106.0 and Autocomplete.js to 1.19.9 for optimal v5 peer compatibility ([#1970](https://github.com/algolia/algoliasearch-magento-2/pull/1970)).
- Migrated the frontend Recommend surfaces (Frequently Bought Together, Related Products, Trending Items, Looking Similar) from the standalone `@algolia/recommend` and `@algolia/recommend-js` v4 bundles to the InstantSearch.js recommend widgets running on the v5 lite client. Widgets are lazy-loaded via `IntersectionObserver` so their weight stays off the PDP and cart critical path ([#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
- The Recommend product template (`view/frontend/web/js/template/recommend/products.js`) received a new `getNoResultHtml({html})` method so integrators can customize it via the same mixin mechanism ([#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
- `Cron\ProcessQueue` now resolves the queue-active and built-in-cron conditions through `Helper\Configuration\QueueHelper` instead of the deprecated `ConfigHelper` equivalents. The evaluated configuration paths are unchanged ([#1977](https://github.com/algolia/algoliasearch-magento-2/pull/1977)).
- Retired the `*Testable` subclass test pattern in favor of direct unit testing, and introduced reusable Claude testing guides alongside a regenerated `AlgoliaConnector` unit suite ([#1929](https://github.com/algolia/algoliasearch-magento-2/pull/1929)).
- Added a standardized unit-test generation workflow covering blocks, controllers, helpers, models, observers, plugins, services, and view models, and removed the remaining `@dataProvider` annotations in favor of PHPUnit attributes ([#1940](https://github.com/algolia/algoliasearch-magento-2/pull/1940)).
- Applied the updated `magento2-tools` PHPCS-Fixer linting baseline across the module for a consistent contribution standard, retaining PHP 8.2 backward compatibility ([#1923](https://github.com/algolia/algoliasearch-magento-2/pull/1923)).
- Refactored `ConfigHelper` and many block, controller, observer, and service classes to align with the new linting baseline and tighten type declarations.
- Hoisted CLI command unit tests to the `AbstractStoreCommand` scope ([#1942](https://github.com/algolia/algoliasearch-magento-2/pull/1942)).
- Added an architecture context document and adopted the open `AGENTS.md` standard for contributor and agent guidance ([#1921](https://github.com/algolia/algoliasearch-magento-2/pull/1921)).
- Updated unit and integration tests ([#1932](https://github.com/algolia/algoliasearch-magento-2/pull/1932), [#1980](https://github.com/algolia/algoliasearch-magento-2/pull/1980)).

#### Bug fixes
- Injected the missing `CollectionProcessorInterface` into `Model\QueueArchiveRepository`, fixing a latent runtime fatal in `getList()` ([#1973](https://github.com/algolia/algoliasearch-magento-2/pull/1973)).
- Fixed `Uncaught Exception: Serialization of 'Closure' is not allowed` on the Indexing Queue and Queue Archive job view pages, caused by storing the fully hydrated model in the backend session. (thanks @angelvilaplana, [#1939](https://github.com/algolia/algoliasearch-magento-2/pull/1939), [#1978](https://github.com/algolia/algoliasearch-magento-2/pull/1978))
- Fixed a getter typo in the Queue Archive view template that left the Processed At field blank on the Queue Archive view page ([#1978](https://github.com/algolia/algoliasearch-magento-2/pull/1978)).
- Stripped `semanticSearch` from the settings merged onto a temporary index. An empty `semanticSearch` object returned by `getSettings` round-trips through PHP as an empty array and re-encodes as a JSON array, which the API rejects ([#1972](https://github.com/algolia/algoliasearch-magento-2/pull/1972)).
- Fixed incorrect escaping of object IDs passed to the Recommend widgets, and fixed the standalone Looking Similar widget failing to render on the cart page ([#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
- Added a missing CDATA tag in `system.xml`.

#### Breaking Changes
- Raised the minimum requirements to PHP 8.3 and Magento 2.4.8. Supported targets are now Magento `~2.4.8||~2.4.9` on PHP `~8.3||~8.4||~8.5`; PHP 8.2 and Magento 2.4.7 are no longer supported ([#1959](https://github.com/algolia/algoliasearch-magento-2/pull/1959)).
- Several constructor signatures changed. Any class extending these must update its `parent::__construct()` call:
  - `Service\Product\RecordBuilder` now requires `Magento\Catalog\Model\ResourceModel\Product` and `Magento\Catalog\Model\Product\Gallery\ReadHandler` (12 to 14 arguments).
  - `Helper\Entity\Product\PriceManager\ProductWithoutChildren` now requires `Magento\Catalog\Api\ProductRepositoryInterface` in place of `Magento\Catalog\Model\ProductFactory`.
  - The LandingPage and Query admin controllers and edit blocks, and `Controller\Router`, gained resource-model constructor dependencies.
  - `Controller\Adminhtml\Queue\AbstractAction` and `Controller\Adminhtml\QueueArchive\AbstractAction` no longer accept `Magento\Framework\Session\SessionManagerInterface`.
  - `Block\Adminhtml\Job\View` now requires `Model\JobFactory` and `Model\ResourceModel\Job` in place of the session manager.
  - `Block\Adminhtml\QueueArchive\View` now requires `Api\QueueArchiveRepositoryInterface` in place of the session manager.
  - `Cron\ProcessQueue` now requires `Helper\Configuration\QueueHelper` in place of `Helper\ConfigHelper`.
- `composer.json` now declares conflicts with the companion modules it can no longer work with: `algolia/algoliasearch-inventory-magento-2:<1.5.0` and `algolia/algoliasearch-adapter-magento-2:<0.10.0` ([#1976](https://github.com/algolia/algoliasearch-magento-2/pull/1976), [#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).
- The MSI compatibility module `algolia/algoliasearch-inventory-magento-2` extends `Service\Product\RecordBuilder`, so it requires the coordinated 1.5.0 release to stay compatible with 3.19.0. Install `algolia/algoliasearch-inventory-magento-2:^1.5.0` alongside this version ([#1976](https://github.com/algolia/algoliasearch-magento-2/pull/1976)).
- `Helper\Entity\ProductHelper::addStockFilter()` now declares `ProductCollection $products` and `int $storeId`. A subclass overriding this protected method with a narrower or incompatible signature will fatal on class load; untyped or wider overrides remain valid ([#1976](https://github.com/algolia/algoliasearch-magento-2/pull/1976)).
- The Recommend product template (`view/frontend/web/js/template/recommend/products.js`) now passes a single destructured options object to its methods instead of positional arguments, aligning it with the autocomplete product template. Any RequireJS mixin overriding these methods must be updated ([#1975](https://github.com/algolia/algoliasearch-magento-2/pull/1975)).

### Files Changed

Version bump files (from `release.yaml` `bump_files`):

- `composer.json` (version): `3.19.0-beta.1` to `3.19.0`
- `etc/module.xml` (setup_version): `3.19.0-beta.1` to `3.19.0`

Release documentation:

- `CHANGELOG.md`
- `README.md`

### README Updates

- Version badge `3.18.1` to `3.19.0`; Magento badge `2.4.7+` to `2.4.8+` (3.19.0 narrows Magento to `~2.4.8||~2.4.9` on PHP `~8.3|~8.4|~8.5`).
- "Stay on a minor version" pinning example `~3.18.0` to `~3.19.0`.
- MSI compatibility module section now states that base extension `>=3.19.0` requires MSI module `^1.5.0`.
- Search adapter module section now states that base extension `>=3.19.0` requires adapter module `>=0.10.0`.
- Compatibility / EOL / SLA matrix required **no row edits**. The `~3.19.0` row and the `~3.17.0` EOL date were pre-staged on `release/3.19.0-dev` under MAGE-1580. With 3.19.0 GA the supported window becomes 3.19.x and 3.18.x, so 3.17.x drops out of support.

### Checklist

- [x] Version numbers are correct in all bump files
- [x] CHANGELOG entry is accurate and complete
- [x] README compatibility matrix reflects current support policy
- [x] No unintended changes included
- [x] Confirm the `~3.17.0` End of Life date (`9/1/2026`) is still intended now that 3.19.0 is GA

### Jira

MAGE-1656

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
