### PR TITLE
MAGE-1669: Updated `IndexSettingsHandler::setSettings()`

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -295,7 +295,6 @@ class ProductHelper extends AbstractEntityHelper
         if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
             $this->logger->log('Index name: ' . $indexOptions->getIndexName());
             $this->logger->log('Settings: ' . json_encode($indexSettings));
-//            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         if ($saveToTmpIndicesToo) {

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -295,7 +295,7 @@ class ProductHelper extends AbstractEntityHelper
         if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
             $this->logger->log('Index name: ' . $indexOptions->getIndexName());
             $this->logger->log('Settings: ' . json_encode($indexSettings));
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
+//            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         if ($saveToTmpIndicesToo) {

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -137,7 +137,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -162,7 +161,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -187,7 +185,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -219,7 +216,6 @@ class IndicesConfigurator
 
             if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
                 $this->logSettingsPush($indexOptions, $settings);
-                $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
             }
         }
 
@@ -275,7 +271,6 @@ class IndicesConfigurator
 
                     if ($this->indexSettingsHandler->setSettings($indexOptions, $extraSettings)) {
                         $this->logSettingsPush($indexOptions, $extraSettings);
-                        $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
                     }
 
                     if ($section === 'products' && $saveToTmpIndicesToo) {

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -63,6 +63,7 @@ class IndexSettingsHandler
                 $indexSettings,
                 false
             );
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
 
             return true;
         }
@@ -73,21 +74,27 @@ class IndexSettingsHandler
 
         // FORWARDED: $settings without excluded attributes
         if ($forward) {
-            $this->connector->setSettings(
-                $indexOptions,
-                $forward,
-                true
-            );
-            $this->connector->waitLastTask($indexOptions->getStoreId());
+            if (! $this->indexSettingsComparator->matches($indexOptions, $forward, $remoteSettings)) {
+                $this->connector->setSettings(
+                    $indexOptions,
+                    $forward,
+                    true
+                );
+                $this->connector->collectTaskIdToWaitFor($indexOptions);
+//                $this->connector->waitLastTask($indexOptions->getStoreId());
+            }
         }
 
         // NOT FORWARDED: array containing excluded attributes only
         if ($noForward) {
-            $this->connector->setSettings(
-                $indexOptions,
-                $noForward,
-                false
-            );
+            if (! $this->indexSettingsComparator->matches($indexOptions, $noForward, $remoteSettings)) {
+                $this->connector->setSettings(
+                    $indexOptions,
+                    $noForward,
+                    false
+                );
+                $this->connector->collectTaskIdToWaitFor($indexOptions);
+            }
         }
 
         return true;

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -81,7 +81,6 @@ class IndexSettingsHandler
                     true
                 );
                 $this->connector->collectTaskIdToWaitFor($indexOptions);
-//                $this->connector->waitLastTask($indexOptions->getStoreId());
             }
         }
 

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -73,27 +73,23 @@ class IndexSettingsHandler
         [$forward, $noForward] = $this->splitSettings($indexSettings);
 
         // FORWARDED: $settings without excluded attributes
-        if ($forward) {
-            if (! $this->indexSettingsComparator->matches($indexOptions, $forward, $remoteSettings)) {
-                $this->connector->setSettings(
-                    $indexOptions,
-                    $forward,
-                    true
-                );
-                $this->connector->collectTaskIdToWaitFor($indexOptions);
-            }
+        if ($forward && !$this->indexSettingsComparator->matches($indexOptions, $forward, $remoteSettings)) {
+            $this->connector->setSettings(
+                $indexOptions,
+                $forward,
+                true
+            );
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
         }
 
         // NOT FORWARDED: array containing excluded attributes only
-        if ($noForward) {
-            if (! $this->indexSettingsComparator->matches($indexOptions, $noForward, $remoteSettings)) {
-                $this->connector->setSettings(
-                    $indexOptions,
-                    $noForward,
-                    false
-                );
-                $this->connector->collectTaskIdToWaitFor($indexOptions);
-            }
+        if ($noForward && !$this->indexSettingsComparator->matches($indexOptions, $noForward, $remoteSettings)) {
+            $this->connector->setSettings(
+                $indexOptions,
+                $noForward,
+                false
+            );
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
         }
 
         return true;

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -123,7 +123,7 @@ class ProductHelperTest extends TestCase
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
+        $this->algoliaConnector->expects($this->never())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
 
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -119,7 +119,7 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
-    public function testWaitsForLastTaskWhenSettingsChanged(): void
+    public function testWDoesNotCollectTaskIdWhenSettingsChanged(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -119,15 +119,6 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
-    public function testWaitsForLastTaskWhenSettingsChanged(): void
-    {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
-
-        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
-
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
-    }
-
     public function testDoesNotPushSettingsToTmpIndexWhenFlagIsFalse(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -119,7 +119,7 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
-    public function testWDoesNotCollectTaskIdWhenSettingsChanged(): void
+    public function testDoesNotCollectTaskIdWhenSettingsChanged(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -119,6 +119,15 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
+    public function testWaitsForLastTaskWhenSettingsChanged(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+
+        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+    }
+
     public function testDoesNotPushSettingsToTmpIndexWhenFlagIsFalse(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Service\Index\Settings;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
-use Algolia\AlgoliaSearch\Controller\View\Index;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
@@ -123,7 +122,7 @@ class IndexSettingsHandlerTest extends TestCase
                 false
             );
 
-        // IndexSettingsComparator::matches() is called 3 times:
+        // IndexSettingsComparator::matches() is called 2 times:
         // - once for the full payload
         // - once for $noforward
         $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
@@ -154,7 +153,7 @@ class IndexSettingsHandlerTest extends TestCase
                 true
             );
 
-        // IndexSettingsComparator::matches() is called 3 times:
+        // IndexSettingsComparator::matches() is called 2 times:
         // - once for the full payload
         // - once for $forward
         $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -11,6 +11,7 @@ use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsHandler;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsPreserver;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[AllowMockObjectsWithoutExpectations]
 class IndexSettingsHandlerTest extends TestCase
@@ -25,12 +26,6 @@ class IndexSettingsHandlerTest extends TestCase
     protected ?IndexOptionsInterface $indexOptions = null;
 
     private ?IndexSettingsHandler $handler = null;
-
-    /**
-     * State machine to track pending operations per store ID
-     * Format: [storeId => ['totalCalls' => int, 'waitCalled' => bool, 'batchesCompleted' => int]]
-     */
-    private array $operationState = [];
 
     protected function setUp(): void
     {
@@ -392,5 +387,99 @@ class IndexSettingsHandlerTest extends TestCase
         $this->indexOptions->method('getStoreId')->willReturn(1);
 
         $this->assertFalse($handler->setSettings($this->indexOptions, $proposed));
+    }
+
+    #[DataProvider('settingsProvider')]
+    public function testBothForwardAndNoForwardChanged(
+        array $proposed,
+        array $remote,
+        bool $forwardToReplicas,
+        int $expectedNumberOfTasksCollected
+    ) : void
+    {
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->method('getSettings')->willReturn($remote);
+
+        $preserver = $this->createMock(IndexSettingsPreserver::class);
+        $preserver->method('preserve')->willReturn($proposed);
+
+        $comparator = new IndexSettingsComparator($connector);
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn($forwardToReplicas);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $connector->expects($this->exactly($expectedNumberOfTasksCollected))->method('setSettings');
+        $connector->expects($this->exactly($expectedNumberOfTasksCollected))->method('collectTaskIdToWaitFor');
+
+        $handler->setSettings($this->indexOptions, $proposed);
+    }
+
+    public static function settingsProvider(): array
+    {
+        return [
+            [ // Both forward and noforward have changes => 2 collected tasks expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 2
+            ],
+            [ // Only forward has changes  => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+            [ // Only noforward has changes => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+            [ // forward and noforward are identical => 0 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 0
+            ],
+            [ // Both forward and noforward have changes but forward to replicas is set to false => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => false,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+        ];
     }
 }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -390,7 +390,7 @@ class IndexSettingsHandlerTest extends TestCase
     }
 
     #[DataProvider('settingsProvider')]
-    public function testBothForwardAndNoForwardChanged(
+    public function testForwardAndNoForwardSettingsChanges(
         array $proposed,
         array $remote,
         bool $forwardToReplicas,

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Service\Index\Settings;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Controller\View\Index;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
@@ -44,9 +45,6 @@ class IndexSettingsHandlerTest extends TestCase
         $this->logger = $this->createMock(AlgoliaLogger::class);
         $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
 
-        // Configure the mock to use our state machine
-        $this->setupStateMachineMock();
-
         $this->handler = new IndexSettingsHandler(
             $this->connector,
             $this->config,
@@ -56,51 +54,8 @@ class IndexSettingsHandlerTest extends TestCase
         );
     }
 
-    private function setupStateMachineMock(): void
-    {
-        $this->connector->method('setSettings')
-            ->willReturnCallback(function($indexOptions, $settings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') {
-                $storeId = $indexOptions->getStoreId();
-
-                // Initialize state if not exists
-                if (!isset($this->operationState[$storeId])) {
-                    $this->operationState[$storeId] = [
-                        'setSettingsCalled' => false,
-                        'waitCalled' => false,
-                    ];
-                }
-
-//                // Check that setSettings is not stacked for this $storeId
-//                if ($this->operationState[$storeId]['setSettingsCalled'] &&
-//                    !$this->operationState[$storeId]['waitCalled']) {
-//                    throw new \RuntimeException(
-//                        // phpcs:ignore
-//                        "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
-//                    );
-//                }
-
-                // Update state
-                $this->operationState[$storeId]['setSettingsCalled'] = true;
-                $this->operationState[$storeId]['waitCalled'] = false;
-            });
-
-        $this->connector->method('waitLastTask')
-            ->willReturnCallback(function($storeId = null) {
-                if ($storeId !== null && isset($this->operationState[$storeId])) {
-                    $this->operationState[$storeId]['waitCalled'] = true;
-                }
-            });
-    }
-
-    private function resetOperationState(): void
-    {
-        $this->operationState = [];
-    }
-
     public function testSetSettingsWithForwardingEnabledAndMixedSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
@@ -136,13 +91,19 @@ class IndexSettingsHandlerTest extends TestCase
             }
             );
 
+        // IndexSettingsComparator::matches() is called 3 times:
+        // - once for the full payload
+        // - once for $forward
+        // - once for $noforward
+        $this->indexSettingsComparator->expects($this->exactly(3))->method('matches');
+        // Only two taskIDs are collected ($forward and $noforward
+        $this->connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyExcludedSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'ranking' => ['asc(name)'],
@@ -162,13 +123,18 @@ class IndexSettingsHandlerTest extends TestCase
                 false
             );
 
+        // IndexSettingsComparator::matches() is called 3 times:
+        // - once for the full payload
+        // - once for $noforward
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        // Only one taskID is collected ($noforward)
+        $this->connector->expects($this->once())->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyForwardableSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'attributesToHighlight' => ['title'],
@@ -188,13 +154,18 @@ class IndexSettingsHandlerTest extends TestCase
                 true
             );
 
+        // IndexSettingsComparator::matches() is called 3 times:
+        // - once for the full payload
+        // - once for $forward
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        // Only one taskID is collected ($forward)
+        $this->connector->expects($this->exactly(1))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingDisabled(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
@@ -213,13 +184,16 @@ class IndexSettingsHandlerTest extends TestCase
                 false
             );
 
+        // IndexSettingsComparator::matches() is called once (since we don't split)
+        $this->indexSettingsComparator->expects($this->once())->method('matches');
+        // Only one taskID is collected (full payload with early return)
+        $this->connector->expects($this->once())->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testForwardSettingsWithEmptyInput(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [];
 
@@ -229,6 +203,10 @@ class IndexSettingsHandlerTest extends TestCase
 
         // Connector should not be called
         $this->connector->expects($this->never())->method('setSettings');
+
+        // IndexSettingsComparator::matches() is called once (empty array will always match and early return)
+        $this->indexSettingsComparator->expects($this->once())->method('matches');
+        $this->connector->expects($this->never())->method('collectTaskIdToWaitFor');
 
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
@@ -251,70 +229,8 @@ class IndexSettingsHandlerTest extends TestCase
         ], $noForward);
     }
 
-//    /**
-//     * Ensure the state machine is working as expected by disabling replica forwarding
-//     * and explicitly invoking subsequent setSettings operations
-//     */
-//    public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
-//    {
-//        $this->resetOperationState();
-//
-//        $storeId = 1;
-//        $settings = ['attributesToRetrieve' => ['name']];
-//
-//        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-//
-//        // Disable forwarding for explicit test
-//        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-//            ->willReturn(false);
-//
-//        // First call should succeed
-//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-//
-//        // Second call without wait should throw exception
-//        $this->expectException(\RuntimeException::class);
-//        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-//
-//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-//    }
-
-    /**
-     * Explicitly test the state machine succeeds by disabling replica forwarding
-     * and explicitly invoking the wait operation
-     * */
-    public function testSubsequentSetSettingsAfterWaitSucceeds(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = ['attributesToRetrieve' => ['name']];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        // Disable forwarding for explicit test
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
-
-        $this->connector->expects($this->exactly(2))
-            ->method('setSettings');
-
-        $this->connector->expects($this->once())
-            ->method('waitLastTask')
-            ->with($storeId);
-
-        // First call should succeed
-        $this->handler->setSettings($this->indexOptions, $settings);
-
-        // Wait for the task
-        $this->connector->waitLastTask($storeId);
-
-        // Second call after wait should succeed
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
-
     public function testDifferentStoreIdsDontInterfere(): void
     {
-        $this->resetOperationState();
-
         $storeId1 = 1;
         $storeId2 = 2;
         $settings = ['attributesToRetrieve' => ['name']];
@@ -332,48 +248,18 @@ class IndexSettingsHandlerTest extends TestCase
         $this->connector->expects($this->exactly(2))
             ->method('setSettings');
 
+        // IndexSettingsComparator::matches() is called 2 times:
+        // - once for the full payload of the 2 stores
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+
+        $this->connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($indexOptions1, $settings));
         $this->assertTrue($this->handler->setSettings($indexOptions2, $settings));
     }
 
-//    /**
-//     *  Replica forwarding should abstract the wait operation internally
-//     *  However require caller to invoke wait for subsequent ops
-//     *  This is *by design* to minimize unnecessary IO blocking
-//     *  This test ensures this logic stays in place
-//     */
-//    public function testForwardingEnabledMultipleCallsRequireWait(): void
-//    {
-//        $this->resetOperationState();
-//
-//        $storeId = 1;
-//        $settings = [
-//            'customRanking' => ['desc(price)'],
-//            'attributesToRetrieve' => ['name'],
-//        ];
-//
-//        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-//        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-//            ->willReturn(true);
-//
-//        // 2 internal calls + 1 explicit call
-//        $this->connector->expects($this->exactly(3))
-//            ->method('setSettings');
-//
-//        // First call makes two internal setSettings calls
-//        $this->handler->setSettings($this->indexOptions, $settings);
-//
-//        // Second call to handler should fail because no wait was called
-//        $this->expectException(\RuntimeException::class);
-//        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-//
-//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-//    }
-
     public function testSkippedSetSettings(): void
     {
-        $this->resetOperationState();
-
         $indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
         $indexSettingsComparator->method('matches')->willReturn(true);
 
@@ -392,6 +278,11 @@ class IndexSettingsHandlerTest extends TestCase
         ];
 
         $this->indexOptions->method('getStoreId')->willReturn($storeId);
+
+        // IndexSettingsComparator::matches() is called once (match = early return)
+        $indexSettingsComparator->expects($this->once())->method('matches');
+
+        $this->connector->expects($this->never())->method('collectTaskIdToWaitFor');
 
         $this->assertFalse($this->handler->setSettings($this->indexOptions, $settings));
     }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -70,14 +70,14 @@ class IndexSettingsHandlerTest extends TestCase
                     ];
                 }
 
-                // Check that setSettings is not stacked for this $storeId
-                if ($this->operationState[$storeId]['setSettingsCalled'] &&
-                    !$this->operationState[$storeId]['waitCalled']) {
-                    throw new \RuntimeException(
-                        // phpcs:ignore
-                        "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
-                    );
-                }
+//                // Check that setSettings is not stacked for this $storeId
+//                if ($this->operationState[$storeId]['setSettingsCalled'] &&
+//                    !$this->operationState[$storeId]['waitCalled']) {
+//                    throw new \RuntimeException(
+//                        // phpcs:ignore
+//                        "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
+//                    );
+//                }
 
                 // Update state
                 $this->operationState[$storeId]['setSettingsCalled'] = true;
@@ -251,32 +251,32 @@ class IndexSettingsHandlerTest extends TestCase
         ], $noForward);
     }
 
-    /**
-     * Ensure the state machine is working as expected by disabling replica forwarding
-     * and explicitly invoking subsequent setSettings operations
-     */
-    public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = ['attributesToRetrieve' => ['name']];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-
-        // Disable forwarding for explicit test
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
-
-        // First call should succeed
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-
-        // Second call without wait should throw exception
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
+//    /**
+//     * Ensure the state machine is working as expected by disabling replica forwarding
+//     * and explicitly invoking subsequent setSettings operations
+//     */
+//    public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
+//    {
+//        $this->resetOperationState();
+//
+//        $storeId = 1;
+//        $settings = ['attributesToRetrieve' => ['name']];
+//
+//        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+//
+//        // Disable forwarding for explicit test
+//        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+//            ->willReturn(false);
+//
+//        // First call should succeed
+//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+//
+//        // Second call without wait should throw exception
+//        $this->expectException(\RuntimeException::class);
+//        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
+//
+//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+//    }
 
     /**
      * Explicitly test the state machine succeeds by disabling replica forwarding
@@ -336,39 +336,39 @@ class IndexSettingsHandlerTest extends TestCase
         $this->assertTrue($this->handler->setSettings($indexOptions2, $settings));
     }
 
-    /**
-     *  Replica forwarding should abstract the wait operation internally
-     *  However require caller to invoke wait for subsequent ops
-     *  This is *by design* to minimize unnecessary IO blocking
-     *  This test ensures this logic stays in place
-     */
-    public function testForwardingEnabledMultipleCallsRequireWait(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = [
-            'customRanking' => ['desc(price)'],
-            'attributesToRetrieve' => ['name'],
-        ];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
-
-        // 2 internal calls + 1 explicit call
-        $this->connector->expects($this->exactly(3))
-            ->method('setSettings');
-
-        // First call makes two internal setSettings calls
-        $this->handler->setSettings($this->indexOptions, $settings);
-
-        // Second call to handler should fail because no wait was called
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
+//    /**
+//     *  Replica forwarding should abstract the wait operation internally
+//     *  However require caller to invoke wait for subsequent ops
+//     *  This is *by design* to minimize unnecessary IO blocking
+//     *  This test ensures this logic stays in place
+//     */
+//    public function testForwardingEnabledMultipleCallsRequireWait(): void
+//    {
+//        $this->resetOperationState();
+//
+//        $storeId = 1;
+//        $settings = [
+//            'customRanking' => ['desc(price)'],
+//            'attributesToRetrieve' => ['name'],
+//        ];
+//
+//        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+//        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+//            ->willReturn(true);
+//
+//        // 2 internal calls + 1 explicit call
+//        $this->connector->expects($this->exactly(3))
+//            ->method('setSettings');
+//
+//        // First call makes two internal setSettings calls
+//        $this->handler->setSettings($this->indexOptions, $settings);
+//
+//        // Second call to handler should fail because no wait was called
+//        $this->expectException(\RuntimeException::class);
+//        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
+//
+//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+//    }
 
     public function testSkippedSetSettings(): void
     {


### PR DESCRIPTION
This PR contains:
- Updated `IndexSettingsHandler::setSettings()`: 
  - We now use multiple `IndexSettingsComparator::matches()` for settings both forwarded and non-forwarded to replicas to ensure no no-op operations are sent to the dashboard. (`getSettings()` is still called once though)
  - Removed `waitLastTask` occurrences in favor of `collectTaskIdToWaitFor` ones to ensure waiting at the end of the process.
- As a result, the `collectTaskIdToWaitFor` occurrences of the `ProductHelper::setSettings() `and `IndexConfigurator` methods are removed (task collection is now completely managed by the `IndexSettingsHandler` itself)
- Updated `IndexSettingsHandler` unit tests.   
  - Removed state machine logic which was there to ensure that the removed `waitForLastTask()` logic was properly working 
  - Updated all tests to ensure proper number of `matches` and `collectTaskIdToWaitFor` triggered for each case.