### PR TITLE
MAGE-1670: Update IndexSettingsComparator class with reconcileKeys logic (3.18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed suggestions indexing issue where the index could be completely emptied during the process - thank you @its-leoeff511
 - Prevented semanticSearch echo back to Algolia when extra settings are enabled 
 - Upgraded guzzlehttp/guzzle to ^7.15.2 to remediate [CVE-2026-69246](https://github.com/advisories/GHSA-v5mv-p594-2x33)
+- Updated `IndexSettingsComparator` to include a protected method `reconcileKeys` to ensure empty attributes such as `customRanking` or `unretrievableAttributes` are handled properly.
 
 ## 3.18.1
 

--- a/Service/IndexSettingsComparator.php
+++ b/Service/IndexSettingsComparator.php
@@ -19,9 +19,33 @@ class IndexSettingsComparator
     public function matches(IndexOptionsInterface $indexOptions, array $indexSettings): bool
     {
         $algoliaSettings = $this->connector->getSettings($indexOptions);
-        $algoliaSettings = array_intersect_key($algoliaSettings, $indexSettings);
+        [$algoliaSettings, $indexSettings] = $this->reconcileKeys($algoliaSettings, $indexSettings);
 
         return $this->getSettingsHash($indexSettings) === $this->getSettingsHash($algoliaSettings);
+    }
+
+    protected function reconcileKeys(array $remote, array $local): array
+    {
+        // Existing behaviour: settings Algolia manages but the extension does not
+        // are not differences.
+        $remote = array_intersect_key($remote, $local);
+
+        // Algolia does not round-trip empty list settings. `customRanking` is
+        // omitted from getSettings whenever it is empty, and
+        // `unretrievableAttributes` is omitted until it has been set at least
+        // once. For these keys "absent remotely" and "empty locally" describe the
+        // same index state, so they must compare equal.
+        foreach ($local as $key => $value) {
+            if ($value === []) {
+                if (!array_key_exists($key, $remote)) {
+                    unset($local[$key]);
+                } else if ($remote[$key] === null)  {
+                    $local[$key] = null;
+                }
+            }
+        }
+
+        return [$remote, $local];
     }
 
     /**

--- a/Test/Unit/Service/IndexSettingsComparatorTest.php
+++ b/Test/Unit/Service/IndexSettingsComparatorTest.php
@@ -209,4 +209,154 @@ class IndexSettingsComparatorTest extends TestCase
         // Must be different
         $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, [INF]));
     }
+
+    // ── reconcileKeys() ──
+
+    /**
+     * @dataProvider reconcileKeysProvider
+     */
+    public function testReconcileKeys(array $remote, array $local, array $expectedRemote, array $expectedLocal): void
+    {
+        [$reconciledRemote, $reconciledLocal] = $this->invokeMethod(
+            $this->indexSettingsComparator,
+            'reconcileKeys',
+            [$remote, $local]
+        );
+
+        $this->assertSame($expectedRemote, $reconciledRemote);
+        $this->assertSame($expectedLocal, $reconciledLocal);
+    }
+
+    public static function reconcileKeysProvider(): array
+    {
+        return [
+            'remote-only keys are dropped' => [
+                'remote' => ['searchableAttributes' => ['name'], 'algoliaManagedSetting' => 'foo'],
+                'local' => ['searchableAttributes' => ['name']],
+                'expectedRemote' => ['searchableAttributes' => ['name']],
+                'expectedLocal' => ['searchableAttributes' => ['name']],
+            ],
+            'empty local customRanking absent remotely is dropped from local' => [
+                'remote' => ['searchableAttributes' => ['name']],
+                'local' => ['searchableAttributes' => ['name'], 'customRanking' => []],
+                'expectedRemote' => ['searchableAttributes' => ['name']],
+                'expectedLocal' => ['searchableAttributes' => ['name']],
+            ],
+            'empty local unretrievableAttributes absent remotely is dropped from local' => [
+                'remote' => ['searchableAttributes' => ['name']],
+                'local' => ['searchableAttributes' => ['name'], 'unretrievableAttributes' => []],
+                'expectedRemote' => ['searchableAttributes' => ['name']],
+                'expectedLocal' => ['searchableAttributes' => ['name']],
+            ],
+            'empty local customRanking with null remote value is coerced to null' => [
+                'remote' => ['customRanking' => null],
+                'local' => ['customRanking' => []],
+                'expectedRemote' => ['customRanking' => null],
+                'expectedLocal' => ['customRanking' => null],
+            ],
+            'empty local unretrievableAttributes with null remote value is coerced to null' => [
+                'remote' => ['unretrievableAttributes' => null],
+                'local' => ['unretrievableAttributes' => []],
+                'expectedRemote' => ['unretrievableAttributes' => null],
+                'expectedLocal' => ['unretrievableAttributes' => null],
+            ],
+            'empty local value with non-null empty remote value is left untouched' => [
+                'remote' => ['customRanking' => []],
+                'local' => ['customRanking' => []],
+                'expectedRemote' => ['customRanking' => []],
+                'expectedLocal' => ['customRanking' => []],
+            ],
+            'empty local value with real remote value is left untouched (surfaces as a diff)' => [
+                'remote' => ['customRanking' => ['desc(price)']],
+                'local' => ['customRanking' => []],
+                'expectedRemote' => ['customRanking' => ['desc(price)']],
+                'expectedLocal' => ['customRanking' => []],
+            ],
+            'non-empty local value absent remotely is left untouched (surfaces as a diff)' => [
+                'remote' => [],
+                'local' => ['customRanking' => ['desc(price)']],
+                'expectedRemote' => [],
+                'expectedLocal' => ['customRanking' => ['desc(price)']],
+            ],
+        ];
+    }
+
+    // ── customRanking / unretrievableAttributes round-trip omission ──
+
+    public function testMatchesWhenCustomRankingEmptyLocallyAndAbsentFromRemote(): void
+    {
+        $local = ['searchableAttributes' => ['name'], 'customRanking' => []];
+        // Algolia omits customRanking entirely from getSettings() whenever it's empty.
+        $remote = ['searchableAttributes' => ['name']];
+
+        $this->connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $local));
+    }
+
+    public function testMatchesWhenUnretrievableAttributesEmptyLocallyAndAbsentFromRemote(): void
+    {
+        $local = ['searchableAttributes' => ['name'], 'unretrievableAttributes' => []];
+        // Algolia omits unretrievableAttributes until it has been set at least once.
+        $remote = ['searchableAttributes' => ['name']];
+
+        $this->connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $local));
+    }
+
+    public function testMatchesWhenCustomRankingEmptyLocallyAndNullRemotely(): void
+    {
+        $local = ['customRanking' => []];
+        $remote = ['customRanking' => null];
+
+        $this->connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $local));
+    }
+
+    public function testMatchesWhenUnretrievableAttributesEmptyLocallyAndNullRemotely(): void
+    {
+        $local = ['unretrievableAttributes' => []];
+        $remote = ['unretrievableAttributes' => null];
+
+        $this->connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $local));
+    }
+
+    public function testMatchesWhenCustomRankingAndUnretrievableAttributesBothEmptyAndAbsentRemotely(): void
+    {
+        $local = [
+            'searchableAttributes' => ['name'],
+            'customRanking' => [],
+            'unretrievableAttributes' => [],
+        ];
+        $remote = ['searchableAttributes' => ['name']];
+
+        $this->connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $local));
+    }
+
+    public function testDoesNotMatchWhenCustomRankingNonEmptyLocallyButAbsentFromRemote(): void
+    {
+        $local = ['customRanking' => ['desc(price)']];
+        // Not an omitted-because-empty case: the extension proposes a real ranking Algolia doesn't have.
+        $remote = [];
+
+        $this->connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $local));
+    }
+
+    public function testDoesNotMatchWhenUnretrievableAttributesDifferAndBothNonEmpty(): void
+    {
+        $local = ['unretrievableAttributes' => ['in_stock']];
+        $remote = ['unretrievableAttributes' => ['ordered_qty']];
+
+        $this->connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $local));
+    }
 }


### PR DESCRIPTION
This PR backports changes from https://github.com/algolia/algoliasearch-magento-2/pull/1989 for 3.18.2