### PR TITLE
MAGE-1669: Updated `IndexSettingsHandler::setSettings()` (3.18.2)

### DIFF
--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -323,7 +323,6 @@ class ProductHelper extends AbstractEntityHelper
         if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
             $this->logger->log('Index name: ' . $indexOptions->getIndexName());
             $this->logger->log('Settings: ' . json_encode($indexSettings));
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         if ($saveToTmpIndicesToo) {

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -137,7 +137,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -162,7 +161,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -187,7 +185,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -219,7 +216,6 @@ class IndicesConfigurator
 
             if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
                 $this->logSettingsPush($indexOptions, $settings);
-                $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
             }
         }
 
@@ -275,7 +271,6 @@ class IndicesConfigurator
 
                     if ($this->indexSettingsHandler->setSettings($indexOptions, $extraSettings)) {
                         $this->logSettingsPush($indexOptions, $extraSettings);
-                        $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
                     }
 
                     if ($section === 'products' && $saveToTmpIndicesToo) {

--- a/Service/IndexSettingsComparator.php
+++ b/Service/IndexSettingsComparator.php
@@ -13,12 +13,20 @@ class IndexSettingsComparator
     ) {}
 
     /**
+     * @param array|null $algoliaSettings pre-fetched remote settings; when null they are fetched from the connector
+     *
      * @throws NoSuchEntityException
      * @throws AlgoliaException
      */
-    public function matches(IndexOptionsInterface $indexOptions, array $indexSettings): bool
-    {
-        $algoliaSettings = $this->connector->getSettings($indexOptions);
+    public function matches(
+        IndexOptionsInterface $indexOptions,
+        array $indexSettings,
+        ?array $algoliaSettings = null
+    ): bool {
+        if ($algoliaSettings === null) {
+            $algoliaSettings = $this->connector->getSettings($indexOptions);
+        }
+
         [$algoliaSettings, $indexSettings] = $this->reconcileKeys($algoliaSettings, $indexSettings);
 
         return $this->getSettingsHash($indexSettings) === $this->getSettingsHash($algoliaSettings);

--- a/Service/IndexSettingsHandler.php
+++ b/Service/IndexSettingsHandler.php
@@ -35,7 +35,7 @@ class IndexSettingsHandler
      */
     public function setSettings(IndexOptionsInterface $indexOptions, array $indexSettings): bool
     {
-        // Fetch the remote settings once and thread them through both the preserver and the comparator.
+        // Fetch the remote settings once and thread them through the comparator.
         $remoteSettings = $this->connector->getSettings($indexOptions);
 
         // Early return if Algolia settings are already the same

--- a/Service/IndexSettingsHandler.php
+++ b/Service/IndexSettingsHandler.php
@@ -35,8 +35,11 @@ class IndexSettingsHandler
      */
     public function setSettings(IndexOptionsInterface $indexOptions, array $indexSettings): bool
     {
+        // Fetch the remote settings once and thread them through both the preserver and the comparator.
+        $remoteSettings = $this->connector->getSettings($indexOptions);
+
         // Early return if Algolia settings are already the same
-        if ($this->indexSettingsComparator->matches($indexOptions, $indexSettings)) {
+        if ($this->indexSettingsComparator->matches($indexOptions, $indexSettings, $remoteSettings)) {
             if ($this->config->isLoggingEnabled($indexOptions->getStoreId())) {
                 $this->logger->info(
                     sprintf("Skipped setSettings (no diff with existing) for store ID: %d (index name: %s)",
@@ -54,6 +57,8 @@ class IndexSettingsHandler
                 $indexSettings,
                 false
             );
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
+
             return true;
         }
 
@@ -62,22 +67,23 @@ class IndexSettingsHandler
         [$forward, $noForward] = $this->splitSettings($indexSettings);
 
         // FORWARDED: $settings without excluded attributes
-        if ($forward) {
+        if ($forward && !$this->indexSettingsComparator->matches($indexOptions, $forward, $remoteSettings)) {
             $this->connector->setSettings(
                 $indexOptions,
                 $forward,
                 true
             );
-            $this->connector->waitLastTask($indexOptions->getStoreId());
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
         }
 
         // NOT FORWARDED: array containing excluded attributes only
-        if ($noForward) {
+        if ($noForward && !$this->indexSettingsComparator->matches($indexOptions, $noForward, $remoteSettings)) {
             $this->connector->setSettings(
                 $indexOptions,
                 $noForward,
                 false
             );
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
         }
 
         return true;

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -117,11 +117,11 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
-    public function testWaitsForLastTaskWhenSettingsChanged(): void
+    public function testDoesNotCollectTaskIdWhenSettingsChanged(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
+        $this->algoliaConnector->expects($this->never())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
 
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }

--- a/Test/Unit/Service/IndexSettingsComparatorTest.php
+++ b/Test/Unit/Service/IndexSettingsComparatorTest.php
@@ -359,4 +359,21 @@ class IndexSettingsComparatorTest extends TestCase
 
         $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $local));
     }
+
+    public function testUsesProvidedRemoteSettingsWhenPassed(): void
+    {
+        // When remote settings are supplied, the connector must not be queried.
+        $this->connector->expects($this->never())->method('getSettings');
+
+        $this->assertTrue(
+            $this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings, $this->testSettings)
+        );
+
+        $changedRemote = $this->testSettings;
+        $changedRemote['maxValuesPerFacet'] = 10;
+
+        $this->assertFalse(
+            $this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings, $changedRemote)
+        );
+    }
 }

--- a/Test/Unit/Service/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/IndexSettingsHandlerTest.php
@@ -22,12 +22,6 @@ class IndexSettingsHandlerTest extends TestCase
 
     private ?IndexSettingsHandler $handler = null;
 
-    /**
-     * State machine to track pending operations per store ID
-     * Format: [storeId => ['totalCalls' => int, 'waitCalled' => bool, 'batchesCompleted' => int]]
-     */
-    private array $operationState = [];
-
     protected function setUp(): void
     {
         $this->connector = $this->createMock(AlgoliaConnector::class);
@@ -37,9 +31,6 @@ class IndexSettingsHandlerTest extends TestCase
         $this->logger = $this->createMock(AlgoliaLogger::class);
         $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
 
-        // Configure the mock to use our state machine
-        $this->setupStateMachineMock();
-
         $this->handler = new IndexSettingsHandlerTestable(
             $this->connector,
             $this->config,
@@ -48,51 +39,8 @@ class IndexSettingsHandlerTest extends TestCase
         );
     }
 
-    private function setupStateMachineMock(): void
-    {
-        $this->connector->method('setSettings')
-            ->willReturnCallback(function($indexOptions, $settings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') {
-                $storeId = $indexOptions->getStoreId();
-
-                // Initialize state if not exists
-                if (!isset($this->operationState[$storeId])) {
-                    $this->operationState[$storeId] = [
-                        'setSettingsCalled' => false,
-                        'waitCalled' => false
-                    ];
-                }
-
-                // Check that setSettings is not stacked for this $storeId
-                if ($this->operationState[$storeId]['setSettingsCalled'] &&
-                    !$this->operationState[$storeId]['waitCalled']) {
-                    throw new \RuntimeException(
-                        // phpcs:ignore
-                        "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
-                    );
-                }
-
-                // Update state
-                $this->operationState[$storeId]['setSettingsCalled'] = true;
-                $this->operationState[$storeId]['waitCalled'] = false;
-            });
-
-        $this->connector->method('waitLastTask')
-            ->willReturnCallback(function($storeId = null) {
-                if ($storeId !== null && isset($this->operationState[$storeId])) {
-                    $this->operationState[$storeId]['waitCalled'] = true;
-                }
-            });
-    }
-
-    private function resetOperationState(): void
-    {
-        $this->operationState = [];
-    }
-
     public function testSetSettingsWithForwardingEnabledAndMixedSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
@@ -125,13 +73,20 @@ class IndexSettingsHandlerTest extends TestCase
                 }
             });
 
+
+        // IndexSettingsComparator::matches() is called 3 times:
+        // - once for the full payload
+        // - once for $forward
+        // - once for $noforward
+        $this->indexSettingsComparator->expects($this->exactly(3))->method('matches');
+        // Only two taskIDs are collected ($forward and $noforward
+        $this->connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyExcludedSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'ranking' => ['asc(name)'],
@@ -151,13 +106,18 @@ class IndexSettingsHandlerTest extends TestCase
                 false
             );
 
+        // IndexSettingsComparator::matches() is called 2 times:
+        // - once for the full payload
+        // - once for $noforward
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        // Only one taskID is collected ($noforward)
+        $this->connector->expects($this->once())->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyForwardableSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'attributesToHighlight' => ['title'],
@@ -177,13 +137,18 @@ class IndexSettingsHandlerTest extends TestCase
                 true
             );
 
+        // IndexSettingsComparator::matches() is called 2 times:
+        // - once for the full payloadExpand comment
+        // - once for $forward
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        // Only one taskID is collected ($forward)
+        $this->connector->expects($this->exactly(1))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingDisabled(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
@@ -202,13 +167,16 @@ class IndexSettingsHandlerTest extends TestCase
                 false
             );
 
+        // IndexSettingsComparator::matches() is called once (since we don't split)
+        $this->indexSettingsComparator->expects($this->once())->method('matches');
+        // Only one taskID is collected (full payload with early return)
+        $this->connector->expects($this->once())->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testForwardSettingsWithEmptyInput(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [];
 
@@ -218,6 +186,10 @@ class IndexSettingsHandlerTest extends TestCase
 
         // Connector should not be called
         $this->connector->expects($this->never())->method('setSettings');
+
+        // IndexSettingsComparator::matches() is called once (empty array will always match and early return)
+        $this->indexSettingsComparator->expects($this->once())->method('matches');
+        $this->connector->expects($this->never())->method('collectTaskIdToWaitFor');
 
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
@@ -240,70 +212,8 @@ class IndexSettingsHandlerTest extends TestCase
         ], $noForward);
     }
 
-    /**
-     * Ensure the state machine is working as expected by disabling replica forwarding
-     * and explicitly invoking subsequent setSettings operations
-     */
-    public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = ['attributesToRetrieve' => ['name']];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-
-        // Disable forwarding for explicit test
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
-
-        // First call should succeed
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-
-        // Second call without wait should throw exception
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
-
-    /**
-     * Explicitly test the state machine succeeds by disabling replica forwarding
-     * and explicitly invoking the wait operation
-     * */
-    public function testSubsequentSetSettingsAfterWaitSucceeds(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = ['attributesToRetrieve' => ['name']];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        // Disable forwarding for explicit test
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
-
-        $this->connector->expects($this->exactly(2))
-            ->method('setSettings');
-
-        $this->connector->expects($this->once())
-            ->method('waitLastTask')
-            ->with($storeId);
-
-        // First call should succeed
-        $this->handler->setSettings($this->indexOptions, $settings);
-
-        // Wait for the task
-        $this->connector->waitLastTask($storeId);
-
-        // Second call after wait should succeed
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
-
     public function testDifferentStoreIdsDontInterfere(): void
     {
-        $this->resetOperationState();
-
         $storeId1 = 1;
         $storeId2 = 2;
         $settings = ['attributesToRetrieve' => ['name']];
@@ -321,48 +231,17 @@ class IndexSettingsHandlerTest extends TestCase
         $this->connector->expects($this->exactly(2))
             ->method('setSettings');
 
+        // IndexSettingsComparator::matches() is called 2 times:
+        // - once for the full payload of the 2 stores
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        $this->connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($indexOptions1, $settings));
         $this->assertTrue($this->handler->setSettings($indexOptions2, $settings));
     }
 
-    /**
-     *  Replica forwarding should abstract the wait operation internally
-     *  However require caller to invoke wait for subsequent ops
-     *  This is *by design* to minimize unnecessary IO blocking
-     *  This test ensures this logic stays in place
-     */
-    public function testForwardingEnabledMultipleCallsRequireWait(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = [
-            'customRanking' => ['desc(price)'],
-            'attributesToRetrieve' => ['name']
-        ];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
-
-        // 2 internal calls + 1 explicit call
-        $this->connector->expects($this->exactly(3))
-            ->method('setSettings');
-
-        // First call makes two internal setSettings calls
-        $this->handler->setSettings($this->indexOptions, $settings);
-
-        // Second call to handler should fail because no wait was called
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
-
     public function testSkippedSetSettings(): void
     {
-        $this->resetOperationState();
-
         $indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
         $indexSettingsComparator->method('matches')->willReturn(true);
 
@@ -381,6 +260,146 @@ class IndexSettingsHandlerTest extends TestCase
 
         $this->indexOptions->method('getStoreId')->willReturn($storeId);
 
+        // IndexSettingsComparator::matches() is called once (match = early return)
+        $indexSettingsComparator->expects($this->once())->method('matches');
+
+        $this->connector->expects($this->never())->method('collectTaskIdToWaitFor');
+
         $this->assertFalse($this->handler->setSettings($this->indexOptions, $settings));
     }
+
+    public function testGetSettingsCalledExactlyOncePerSetSettings(): void
+    {
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())
+            ->method('getSettings')
+            ->willReturn(['attributesForFaceting' => ['categories']]);
+
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->method('matches')->willReturn(false);
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $this->assertTrue($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
+    }
+
+    public function testComparatorReceivesPreFetchedRemote(): void
+    {
+        $remote = ['attributesForFaceting' => ['categories', '_collections']];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->once())
+            ->method('matches')
+            ->with($this->indexOptions, $this->anything(), $remote)
+            ->willReturn(true);
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('isLoggingEnabled')->willReturn(false);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $this->assertFalse($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
+    }
+
+    /**
+     * @dataProvider settingsProvider
+     */
+    public function testForwardAndNoForwardSettingsChanges(
+        array $proposed,
+        array $remote,
+        bool $forwardToReplicas,
+        int $expectedNumberOfTasksCollected
+    ) : void
+    {
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->method('getSettings')->willReturn($remote);
+
+        $comparator = new IndexSettingsComparator($connector);
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn($forwardToReplicas);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $this->logger);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $connector->expects($this->exactly($expectedNumberOfTasksCollected))->method('setSettings');
+        $connector->expects($this->exactly($expectedNumberOfTasksCollected))->method('collectTaskIdToWaitFor');
+
+        $handler->setSettings($this->indexOptions, $proposed);
+    }
+
+    public static function settingsProvider(): array
+    {
+        return [
+            [ // Both forward and noforward have changes => 2 collected tasks expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 2
+            ],
+            [ // Only forward has changes  => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+            [ // Only noforward has changes => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+            [ // forward and noforward are identical => 0 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 0
+            ],
+            [ // Both forward and noforward have changes but forward to replicas is set to false => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => false,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+        ];
+    }
+
 }


### PR DESCRIPTION
This PR contains changes from
- https://github.com/algolia/algoliasearch-magento-2/pull/1990
- https://github.com/algolia/algoliasearch-magento-2/pull/1961 (minus the introduction of the Index Settings Preserver which only belongs to 3.19.x)