### PR TITLE
3.19.1-dev => 3.19.1

### DIFF
--- a/.claude/reference/testing/core.md
+++ b/.claude/reference/testing/core.md
@@ -41,6 +41,7 @@
     - Use createMock() with expects() only when the call itself is the behavior under test (indirect output: dispatch, persist, log, an outbound API call). The interaction is the contract you are proving.
     - Default a dependency to a stub. Promote it to a mock only when you are asserting the interaction.
 - Prefer usage of `$this->callback('is_callable')` over `$this->callable()`
+- `expects` must be derived from the specification for the test, never from the test's own wiring.
 
 **DO Mock:**
 - Every object that needs to be passed in the constructor of the tested class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGE LOG
 
+## 3.19.1-dev
+
+### Bug fixes
+- Updated `IndexSettingsComparator` to include a protected method `reconcileKeys` to ensure empty attributes such as `customRanking` or `unretrievableAttributes` are handled properly.
+
 ## 3.19.0
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGE LOG
 
-## 3.19.1-dev
+## 3.19.1
+
+### Updates
+- Updated `IndexSettingsHandler::setSettings`:
+    - It now fetches the remote settings once, runs preservation, then threads that same payload into the comparator.
+    - It now use multiple `IndexSettingsComparator::matches()` for settings both forwarded and non-forwarded to replicas to ensure no no-op operations are sent to the dashboard.
+    - Removed `waitLastTask` occurrences in favor of `collectTaskIdToWaitFor` ones to ensure waiting at the end of the process.
+    - Updated unit tests.
 
 ### Bug fixes
 - Updated `IndexSettingsComparator` to include a protected method `reconcileKeys` to ensure empty attributes such as `customRanking` or `unretrievableAttributes` are handled properly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
     - It now fetches the remote settings once, runs preservation, then threads that same payload into the comparator.
     - It now use multiple `IndexSettingsComparator::matches()` for settings both forwarded and non-forwarded to replicas to ensure no no-op operations are sent to the dashboard.
     - Removed `waitLastTask` occurrences in favor of `collectTaskIdToWaitFor` ones to ensure waiting at the end of the process.
-    - Updated unit tests.
+    - Updated unit tests related to those classes.
+- Updated all unit and integration tests to be compatible with PHPUnit 12.
 
 ### Bug fixes
 - Updated `IndexSettingsComparator` to include a protected method `reconcileKeys` to ensure empty attributes such as `customRanking` or `unretrievableAttributes` are handled properly.

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -295,7 +295,6 @@ class ProductHelper extends AbstractEntityHelper
         if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
             $this->logger->log('Index name: ' . $indexOptions->getIndexName());
             $this->logger->log('Settings: ' . json_encode($indexSettings));
-//            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         if ($saveToTmpIndicesToo) {

--- a/Helper/Entity/ProductHelper.php
+++ b/Helper/Entity/ProductHelper.php
@@ -295,7 +295,7 @@ class ProductHelper extends AbstractEntityHelper
         if ($this->indexSettingsHandler->setSettings($indexOptions, $indexSettings)) {
             $this->logger->log('Index name: ' . $indexOptions->getIndexName());
             $this->logger->log('Settings: ' . json_encode($indexSettings));
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
+//            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         if ($saveToTmpIndicesToo) {

--- a/Model/IndicesConfigurator.php
+++ b/Model/IndicesConfigurator.php
@@ -137,7 +137,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -162,7 +161,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -187,7 +185,6 @@ class IndicesConfigurator
 
         if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
             $this->logSettingsPush($indexOptions, $settings);
-            $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
         }
 
         $this->logger->stop($logEventName, true);
@@ -219,7 +216,6 @@ class IndicesConfigurator
 
             if ($this->indexSettingsHandler->setSettings($indexOptions, $settings)) {
                 $this->logSettingsPush($indexOptions, $settings);
-                $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
             }
         }
 
@@ -275,7 +271,6 @@ class IndicesConfigurator
 
                     if ($this->indexSettingsHandler->setSettings($indexOptions, $extraSettings)) {
                         $this->logSettingsPush($indexOptions, $extraSettings);
-                        $this->algoliaConnector->collectTaskIdToWaitFor($indexOptions);
                     }
 
                     if ($section === 'products' && $saveToTmpIndicesToo) {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Algolia Search & Discovery extension for Magento 2
 ==================================================
 
-![Latest version](https://img.shields.io/badge/latest-3.19.0-green)
+![Latest version](https://img.shields.io/badge/latest-3.19.1-green)
 ![Magento 2](https://img.shields.io/badge/Magento-2.4.8+-orange)
 
 ![PHP](https://img.shields.io/badge/PHP-8.3%2C8.4%2C8.5-blue)

--- a/Service/Index/Settings/IndexSettingsComparator.php
+++ b/Service/Index/Settings/IndexSettingsComparator.php
@@ -28,9 +28,33 @@ class IndexSettingsComparator
             $algoliaSettings = $this->connector->getSettings($indexOptions);
         }
 
-        $algoliaSettings = array_intersect_key($algoliaSettings, $indexSettings);
+        [$algoliaSettings, $indexSettings] = $this->reconcileKeys($algoliaSettings, $indexSettings);
 
         return $this->getSettingsHash($indexSettings) === $this->getSettingsHash($algoliaSettings);
+    }
+
+    private function reconcileKeys(array $remote, array $local): array
+    {
+        // Existing behaviour: settings Algolia manages but the extension does not
+        // are not differences.
+        $remote = array_intersect_key($remote, $local);
+
+        // Algolia does not round-trip empty list settings. `customRanking` is
+        // omitted from getSettings whenever it is empty, and
+        // `unretrievableAttributes` is omitted until it has been set at least
+        // once. For these keys "absent remotely" and "empty locally" describe the
+        // same index state, so they must compare equal.
+        foreach ($local as $key => $value) {
+            if ($value === []) {
+                if (!array_key_exists($key, $remote)) {
+                    unset($local[$key]);
+                } else if ($remote[$key] === null)  {
+                    $local[$key] = null;
+                }
+            }
+        }
+
+        return [$remote, $local];
     }
 
     /**

--- a/Service/Index/Settings/IndexSettingsComparator.php
+++ b/Service/Index/Settings/IndexSettingsComparator.php
@@ -33,7 +33,7 @@ class IndexSettingsComparator
         return $this->getSettingsHash($indexSettings) === $this->getSettingsHash($algoliaSettings);
     }
 
-    private function reconcileKeys(array $remote, array $local): array
+    protected function reconcileKeys(array $remote, array $local): array
     {
         // Existing behaviour: settings Algolia manages but the extension does not
         // are not differences.

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -63,6 +63,7 @@ class IndexSettingsHandler
                 $indexSettings,
                 false
             );
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
 
             return true;
         }
@@ -73,21 +74,27 @@ class IndexSettingsHandler
 
         // FORWARDED: $settings without excluded attributes
         if ($forward) {
-            $this->connector->setSettings(
-                $indexOptions,
-                $forward,
-                true
-            );
-            $this->connector->waitLastTask($indexOptions->getStoreId());
+            if (! $this->indexSettingsComparator->matches($indexOptions, $forward, $remoteSettings)) {
+                $this->connector->setSettings(
+                    $indexOptions,
+                    $forward,
+                    true
+                );
+                $this->connector->collectTaskIdToWaitFor($indexOptions);
+//                $this->connector->waitLastTask($indexOptions->getStoreId());
+            }
         }
 
         // NOT FORWARDED: array containing excluded attributes only
         if ($noForward) {
-            $this->connector->setSettings(
-                $indexOptions,
-                $noForward,
-                false
-            );
+            if (! $this->indexSettingsComparator->matches($indexOptions, $noForward, $remoteSettings)) {
+                $this->connector->setSettings(
+                    $indexOptions,
+                    $noForward,
+                    false
+                );
+                $this->connector->collectTaskIdToWaitFor($indexOptions);
+            }
         }
 
         return true;

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -81,7 +81,6 @@ class IndexSettingsHandler
                     true
                 );
                 $this->connector->collectTaskIdToWaitFor($indexOptions);
-//                $this->connector->waitLastTask($indexOptions->getStoreId());
             }
         }
 

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -37,6 +37,15 @@ class IndexSettingsHandler
     {
         // Fetch the remote settings once and thread them through both the preserver and the comparator.
         $remoteSettings = $this->connector->getSettings($indexOptions);
+        if ($this->config->isLoggingEnabled($indexOptions->getStoreId())) {
+            $this->logger->info(
+                sprintf("Remote settings for store ID: %d (index name: %s) : %s",
+                    $indexOptions->getStoreId(),
+                    $indexOptions->getIndexName(),
+                    json_encode($remoteSettings)
+                )
+            );
+        }
 
         // Merge back any remotely managed entries (e.g. ingestion-owned attributesForFaceting) so they
         // survive this write. This must run before the comparison so no-op detection sees the final payload.

--- a/Service/Index/Settings/IndexSettingsHandler.php
+++ b/Service/Index/Settings/IndexSettingsHandler.php
@@ -73,27 +73,23 @@ class IndexSettingsHandler
         [$forward, $noForward] = $this->splitSettings($indexSettings);
 
         // FORWARDED: $settings without excluded attributes
-        if ($forward) {
-            if (! $this->indexSettingsComparator->matches($indexOptions, $forward, $remoteSettings)) {
-                $this->connector->setSettings(
-                    $indexOptions,
-                    $forward,
-                    true
-                );
-                $this->connector->collectTaskIdToWaitFor($indexOptions);
-            }
+        if ($forward && !$this->indexSettingsComparator->matches($indexOptions, $forward, $remoteSettings)) {
+            $this->connector->setSettings(
+                $indexOptions,
+                $forward,
+                true
+            );
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
         }
 
         // NOT FORWARDED: array containing excluded attributes only
-        if ($noForward) {
-            if (! $this->indexSettingsComparator->matches($indexOptions, $noForward, $remoteSettings)) {
-                $this->connector->setSettings(
-                    $indexOptions,
-                    $noForward,
-                    false
-                );
-                $this->connector->collectTaskIdToWaitFor($indexOptions);
-            }
+        if ($noForward && !$this->indexSettingsComparator->matches($indexOptions, $noForward, $remoteSettings)) {
+            $this->connector->setSettings(
+                $indexOptions,
+                $noForward,
+                false
+            );
+            $this->connector->collectTaskIdToWaitFor($indexOptions);
         }
 
         return true;

--- a/Test/Integration/Indexing/IndexingTestCase.php
+++ b/Test/Integration/Indexing/IndexingTestCase.php
@@ -65,8 +65,8 @@ abstract class IndexingTestCase extends TestCase
             $command,
             'execute',
             [
-                $this->createMock(InputInterface::class),
-                $this->createMock(OutputInterface::class),
+                $this->createStub(InputInterface::class),
+                $this->createStub(OutputInterface::class),
             ]
         );
         $this->algoliaConnector->waitLastTask();

--- a/Test/Integration/Indexing/Product/MultiStoreReplicaTest.php
+++ b/Test/Integration/Indexing/Product/MultiStoreReplicaTest.php
@@ -136,8 +136,8 @@ class MultiStoreReplicaTest extends MultiStoreTestCase
             $rebuildCmd,
             'execute',
             [
-                $this->createMock(InputInterface::class),
-                $this->createMock(OutputInterface::class),
+                $this->createStub(InputInterface::class),
+                $this->createStub(OutputInterface::class),
             ]
         );
         $this->algoliaConnector->waitLastTask($defaultStore->getId());

--- a/Test/Integration/Indexing/Product/PricingTest.php
+++ b/Test/Integration/Indexing/Product/PricingTest.php
@@ -7,6 +7,7 @@ use Algolia\AlgoliaSearch\Exceptions\ExceededRetriesException;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @magentoDbIsolation disabled
@@ -120,9 +121,7 @@ class PricingTest extends ProductsIndexingTestCase
         $this->assertAlgoliaPrice($productId);
     }
 
-    /**
-     * @dataProvider productProvider
-     */
+    #[DataProvider('productProvider')]
     public function testMagentoProductData(int $productId, float $expectedPrice): void
     {
         /**

--- a/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
+++ b/Test/Integration/Indexing/Product/ReplicaIndexingTest.php
@@ -168,8 +168,8 @@ class ReplicaIndexingTest extends TestCase
             $rebuildCmd,
             'execute',
             [
-                $this->createMock(\Symfony\Component\Console\Input\InputInterface::class),
-                $this->createMock(\Symfony\Component\Console\Output\OutputInterface::class),
+                $this->createStub(\Symfony\Component\Console\Input\InputInterface::class),
+                $this->createStub(\Symfony\Component\Console\Output\OutputInterface::class),
             ]
         );
         $this->algoliaConnector->waitLastTask();

--- a/Test/TestCase.php
+++ b/Test/TestCase.php
@@ -81,7 +81,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function mockProperty(object $object, string $propertyName, string $propertyClass): void
     {
-        $mock = $this->createMock($propertyClass);
+        $mock = $this->createStub($propertyClass);
         $this->setPrivateProperty($object, $propertyName, $mock);
     }
 }

--- a/Test/Unit/Block/Adminhtml/Category/MerchandisingTest.php
+++ b/Test/Unit/Block/Adminhtml/Category/MerchandisingTest.php
@@ -120,11 +120,11 @@ class MerchandisingTest extends TestCase
     {
         $store = $this->createStub(StoreInterface::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(2);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('store')->willReturn(2);
 
-        $storeManager = $this->createStub(StoreManagerInterface::class);
-        $storeManager->method('getStore')->willReturn($store);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->with(2)->willReturn($store);
 
         $block = $this->createObjectToTest(storeManager: $storeManager, request: $request);
 
@@ -135,8 +135,8 @@ class MerchandisingTest extends TestCase
     {
         $defaultStore = $this->createStub(StoreInterface::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(null);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('store')->willReturn(null);
 
         $storeManager = $this->createStub(StoreManagerInterface::class);
         $storeManager->method('getDefaultStoreView')->willReturn($defaultStore);

--- a/Test/Unit/Block/Adminhtml/Category/MerchandisingTest.php
+++ b/Test/Unit/Block/Adminhtml/Category/MerchandisingTest.php
@@ -11,85 +11,138 @@ use Magento\Catalog\Model\Category;
 use Magento\Framework\App\RequestInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class MerchandisingTest extends TestCase
 {
-    protected null|(Merchandising&MockObject) $block = null;
-    protected null|(CurrentCategory&MockObject) $currentCategory = null;
-    protected null|(Category&MockObject) $category = null;
-    protected null|(StoreManagerInterface&MockObject) $storeManager = null;
-    protected null|(RequestInterface&MockObject) $request = null;
+    /**
+     * Merchandising::__construct() calls Context::getStoreManager() and then
+     * parent::__construct() (Magento\Backend\Block\Template), which reaches into the
+     * ObjectManager — unavailable in a unit test. The constructor must stay disabled; a partial
+     * mock overriding getRequest() (also ObjectManager-backed via the real request resolution)
+     * is the only way to exercise this block, with the remaining collaborators injected directly
+     * via reflection.
+     */
+    protected function createObjectToTest(
+        ?CurrentCategory $currentCategory = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?RequestInterface $request = null,
+    ): Merchandising {
+        $block = $this->createPartialMock(Merchandising::class, ['getRequest']);
+        // getRequest() is overridden purely to dodge the ObjectManager call above. Only
+        // getCurrentStore() actually calls it (isRootCategory()/canDisplayProducts() never do), so
+        // the real call count is genuinely tied to whether the test supplies a $request —
+        // expects($this->any()) does NOT satisfy PHPUnit's "no expectations set" check (verified:
+        // it still reports a notice), so this has to be a real, accurate count.
+        $block->expects($request !== null ? $this->once() : $this->never())
+            ->method('getRequest')
+            ->willReturn($request ?? $this->createStub(RequestInterface::class));
 
-    protected function setUp(): void
-    {
-        $this->currentCategory = $this->createMock(CurrentCategory::class);
-        $this->category = $this->createMock(Category::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->request = $this->createMock(RequestInterface::class);
+        $this->setPrivateProperty(
+            $block,
+            'currentCategory',
+            $currentCategory ?? $this->createStub(CurrentCategory::class)
+        );
+        $this->setPrivateProperty(
+            $block,
+            'storeManager',
+            $storeManager ?? $this->createStub(StoreManagerInterface::class)
+        );
 
-        $this->block = $this->getMockBuilder(Merchandising::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getRequest'])
-            ->getMock();
-
-        $this->block->method('getRequest')->willReturn($this->request);
-        $this->setPrivateProperty($this->block, 'currentCategory', $this->currentCategory);
-        $this->setPrivateProperty($this->block, 'storeManager', $this->storeManager);
+        return $block;
     }
 
     public function testIsRootCategoryReturnsFalseWhenPathIsEmpty(): void
     {
-        $this->category->method('getPath')->willReturn('');
-        $this->currentCategory->method('get')->willReturn($this->category);
-        $this->assertFalse($this->block->isRootCategory());
+        $category = $this->createStub(Category::class);
+        $category->method('getPath')->willReturn('');
+
+        $currentCategory = $this->createStub(CurrentCategory::class);
+        $currentCategory->method('get')->willReturn($category);
+
+        $block = $this->createObjectToTest(currentCategory: $currentCategory);
+
+        $this->assertFalse($block->isRootCategory());
     }
 
     public function testIsRootCategoryReturnsTrueWhenPathHasTwoParts(): void
     {
-        $this->category->method('getPath')->willReturn('1/2');
-        $this->currentCategory->method('get')->willReturn($this->category);
-        $this->assertTrue($this->block->isRootCategory());
+        $category = $this->createStub(Category::class);
+        $category->method('getPath')->willReturn('1/2');
+
+        $currentCategory = $this->createStub(CurrentCategory::class);
+        $currentCategory->method('get')->willReturn($category);
+
+        $block = $this->createObjectToTest(currentCategory: $currentCategory);
+
+        $this->assertTrue($block->isRootCategory());
     }
 
     public function testIsRootCategoryReturnsFalseWhenPathHasMoreThanTwoParts(): void
     {
-        $this->category->method('getPath')->willReturn('1/2/3');
-        $this->currentCategory->method('get')->willReturn($this->category);
-        $this->assertFalse($this->block->isRootCategory());
+        $category = $this->createStub(Category::class);
+        $category->method('getPath')->willReturn('1/2/3');
+
+        $currentCategory = $this->createStub(CurrentCategory::class);
+        $currentCategory->method('get')->willReturn($category);
+
+        $block = $this->createObjectToTest(currentCategory: $currentCategory);
+
+        $this->assertFalse($block->isRootCategory());
     }
 
     public function testCanDisplayProductsReturnsFalseWhenDisplayModeIsPage(): void
     {
-        $this->currentCategory->method('get')->willReturn($this->category);
-        $this->category->method('getDisplayMode')->willReturn(Category::DM_PAGE);
-        $this->assertFalse($this->block->canDisplayProducts());
+        $category = $this->createStub(Category::class);
+        $category->method('getDisplayMode')->willReturn(Category::DM_PAGE);
+
+        $currentCategory = $this->createStub(CurrentCategory::class);
+        $currentCategory->method('get')->willReturn($category);
+
+        $block = $this->createObjectToTest(currentCategory: $currentCategory);
+
+        $this->assertFalse($block->canDisplayProducts());
     }
 
     public function testCanDisplayProductsReturnsTrueWhenDisplayModeIsNotPage(): void
     {
-        $this->currentCategory->method('get')->willReturn($this->category);
-        $this->category->method('getDisplayMode')->willReturn('PRODUCT');
-        $this->assertTrue($this->block->canDisplayProducts());
+        $category = $this->createStub(Category::class);
+        $category->method('getDisplayMode')->willReturn('PRODUCT');
+
+        $currentCategory = $this->createStub(CurrentCategory::class);
+        $currentCategory->method('get')->willReturn($category);
+
+        $block = $this->createObjectToTest(currentCategory: $currentCategory);
+
+        $this->assertTrue($block->canDisplayProducts());
     }
 
     public function testGetCurrentStoreReturnsStoreForRequestedStoreId(): void
     {
-        $store = $this->createMock(StoreInterface::class);
-        $this->request->method('getParam')->with('store')->willReturn(2);
-        $this->storeManager->method('getStore')->with(2)->willReturn($store);
+        $store = $this->createStub(StoreInterface::class);
 
-        $this->assertSame($store, $this->block->getCurrentStore());
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(2);
+
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $block = $this->createObjectToTest(storeManager: $storeManager, request: $request);
+
+        $this->assertSame($store, $block->getCurrentStore());
     }
 
     public function testGetCurrentStoreReturnsDefaultStoreWhenNoStoreParam(): void
     {
-        $defaultStore = $this->createMock(StoreInterface::class);
-        $this->request->method('getParam')->with('store')->willReturn(null);
-        $this->storeManager->method('getDefaultStoreView')->willReturn($defaultStore);
+        $defaultStore = $this->createStub(StoreInterface::class);
 
-        $this->assertSame($defaultStore, $this->block->getCurrentStore());
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(null);
+
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getDefaultStoreView')->willReturn($defaultStore);
+
+        $block = $this->createObjectToTest(storeManager: $storeManager, request: $request);
+
+        $this->assertSame($defaultStore, $block->getCurrentStore());
     }
 }

--- a/Test/Unit/Block/Adminhtml/Category/MerchandisingTest.php
+++ b/Test/Unit/Block/Adminhtml/Category/MerchandisingTest.php
@@ -14,28 +14,18 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class MerchandisingTest extends TestCase
 {
-    /**
-     * Merchandising::__construct() calls Context::getStoreManager() and then
-     * parent::__construct() (Magento\Backend\Block\Template), which reaches into the
-     * ObjectManager — unavailable in a unit test. The constructor must stay disabled; a partial
-     * mock overriding getRequest() (also ObjectManager-backed via the real request resolution)
-     * is the only way to exercise this block, with the remaining collaborators injected directly
-     * via reflection.
-     */
     protected function createObjectToTest(
         ?CurrentCategory $currentCategory = null,
         ?StoreManagerInterface $storeManager = null,
         ?RequestInterface $request = null,
     ): Merchandising {
-        $block = $this->createPartialMock(Merchandising::class, ['getRequest']);
-        // getRequest() is overridden purely to dodge the ObjectManager call above. Only
-        // getCurrentStore() actually calls it (isRootCategory()/canDisplayProducts() never do), so
-        // the real call count is genuinely tied to whether the test supplies a $request —
-        // expects($this->any()) does NOT satisfy PHPUnit's "no expectations set" check (verified:
-        // it still reports a notice), so this has to be a real, accurate count.
-        $block->expects($request !== null ? $this->once() : $this->never())
-            ->method('getRequest')
-            ->willReturn($request ?? $this->createStub(RequestInterface::class));
+        $block = (new \ReflectionClass(Merchandising::class))->newInstanceWithoutConstructor();
+
+        $this->setPrivateProperty(
+            $block,
+            '_request',
+            $request ?? $this->createStub(RequestInterface::class)
+        );
 
         $this->setPrivateProperty(
             $block,

--- a/Test/Unit/Block/Adminhtml/Job/ViewTest.php
+++ b/Test/Unit/Block/Adminhtml/Job/ViewTest.php
@@ -33,8 +33,8 @@ class ViewTest extends TestCase
     {
         $job = $this->createStub(Job::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(42);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('id')->willReturn(42);
 
         $jobFactory = $this->createStub(JobFactory::class);
         $jobFactory->method('create')->willReturn($job);
@@ -51,8 +51,8 @@ class ViewTest extends TestCase
     {
         $job = $this->createStub(Job::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn('42');
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('id')->willReturn('42');
 
         $jobFactory = $this->createStub(JobFactory::class);
         $jobFactory->method('create')->willReturn($job);
@@ -69,8 +69,8 @@ class ViewTest extends TestCase
     {
         $job = $this->createStub(Job::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(42);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('id')->willReturn(42);
 
         $jobFactory = $this->createMock(JobFactory::class);
         $jobFactory->expects($this->once())->method('create')->willReturn($job);

--- a/Test/Unit/Block/Adminhtml/Job/ViewTest.php
+++ b/Test/Unit/Block/Adminhtml/Job/ViewTest.php
@@ -10,62 +10,78 @@ use Algolia\AlgoliaSearch\Model\JobFactory;
 use Algolia\AlgoliaSearch\Model\ResourceModel\Job as JobResource;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\App\RequestInterface;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
-use PHPUnit\Framework\MockObject\MockObject;
+use Magento\Framework\View\Element\Template\Context;
 
-#[AllowMockObjectsWithoutExpectations]
 class ViewTest extends TestCase
 {
-    protected null|(View&MockObject) $block = null;
-    protected null|(JobFactory&MockObject) $jobFactory = null;
-    protected null|(JobResource&MockObject) $jobResource = null;
-    protected null|(RequestInterface&MockObject) $request = null;
+    protected function createObjectToTest(
+        ?JobFactory $jobFactory = null,
+        ?JobResource $jobResource = null,
+        ?RequestInterface $request = null,
+    ): View {
+        $context = $this->createStub(Context::class);
+        $context->method('getRequest')->willReturn($request ?? $this->createStub(RequestInterface::class));
 
-    protected function setUp(): void
-    {
-        $this->jobFactory = $this->createMock(JobFactory::class);
-        $this->jobResource = $this->createMock(JobResource::class);
-        $this->request = $this->createMock(RequestInterface::class);
-
-        $this->block = $this->getMockBuilder(View::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getRequest'])
-            ->getMock();
-
-        $this->block->method('getRequest')->willReturn($this->request);
-        $this->setPrivateProperty($this->block, 'jobFactory', $this->jobFactory);
-        $this->setPrivateProperty($this->block, 'jobResource', $this->jobResource);
+        return new View(
+            $context,
+            $jobFactory ?? $this->createStub(JobFactory::class),
+            $jobResource ?? $this->createStub(JobResource::class),
+        );
     }
 
     public function testGetCurrentJobLoadsJobUsingRequestId(): void
     {
-        $job = $this->createMock(Job::class);
-        $this->request->method('getParam')->with('id')->willReturn(42);
-        $this->jobFactory->method('create')->willReturn($job);
-        $this->jobResource->expects($this->once())->method('load')->with($job, 42);
+        $job = $this->createStub(Job::class);
 
-        $this->assertSame($job, $this->block->getCurrentJob());
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(42);
+
+        $jobFactory = $this->createStub(JobFactory::class);
+        $jobFactory->method('create')->willReturn($job);
+
+        $jobResource = $this->createMock(JobResource::class);
+        $jobResource->expects($this->once())->method('load')->with($job, 42);
+
+        $block = $this->createObjectToTest(jobFactory: $jobFactory, jobResource: $jobResource, request: $request);
+
+        $this->assertSame($job, $block->getCurrentJob());
     }
 
     public function testGetCurrentJobCastsStringIdToInt(): void
     {
-        $job = $this->createMock(Job::class);
-        $this->request->method('getParam')->with('id')->willReturn('42');
-        $this->jobFactory->method('create')->willReturn($job);
-        $this->jobResource->expects($this->once())->method('load')->with($job, 42);
+        $job = $this->createStub(Job::class);
 
-        $this->block->getCurrentJob();
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn('42');
+
+        $jobFactory = $this->createStub(JobFactory::class);
+        $jobFactory->method('create')->willReturn($job);
+
+        $jobResource = $this->createMock(JobResource::class);
+        $jobResource->expects($this->once())->method('load')->with($job, 42);
+
+        $block = $this->createObjectToTest(jobFactory: $jobFactory, jobResource: $jobResource, request: $request);
+
+        $block->getCurrentJob();
     }
 
     public function testGetCurrentJobMemoizesResult(): void
     {
-        $job = $this->createMock(Job::class);
-        $this->request->method('getParam')->with('id')->willReturn(42);
-        $this->jobFactory->expects($this->once())->method('create')->willReturn($job);
-        $this->jobResource->expects($this->once())->method('load')->with($job, 42);
+        $job = $this->createStub(Job::class);
 
-        $first = $this->block->getCurrentJob();
-        $second = $this->block->getCurrentJob();
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(42);
+
+        $jobFactory = $this->createMock(JobFactory::class);
+        $jobFactory->expects($this->once())->method('create')->willReturn($job);
+
+        $jobResource = $this->createMock(JobResource::class);
+        $jobResource->expects($this->once())->method('load')->with($job, 42);
+
+        $block = $this->createObjectToTest(jobFactory: $jobFactory, jobResource: $jobResource, request: $request);
+
+        $first = $block->getCurrentJob();
+        $second = $block->getCurrentJob();
 
         $this->assertSame($first, $second);
     }

--- a/Test/Unit/Block/Adminhtml/Query/MerchandisingTest.php
+++ b/Test/Unit/Block/Adminhtml/Query/MerchandisingTest.php
@@ -34,11 +34,11 @@ class MerchandisingTest extends TestCase
     {
         $store = $this->createStub(StoreInterface::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(3);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('store')->willReturn(3);
 
-        $storeManager = $this->createStub(StoreManagerInterface::class);
-        $storeManager->method('getStore')->willReturn($store);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->with(3)->willReturn($store);
 
         $block = $this->createObjectToTest(storeManager: $storeManager, request: $request);
 
@@ -49,8 +49,8 @@ class MerchandisingTest extends TestCase
     {
         $defaultStore = $this->createStub(StoreInterface::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(null);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('store')->willReturn(null);
 
         $storeManager = $this->createStub(StoreManagerInterface::class);
         $storeManager->method('getDefaultStoreView')->willReturn($defaultStore);

--- a/Test/Unit/Block/Adminhtml/Query/MerchandisingTest.php
+++ b/Test/Unit/Block/Adminhtml/Query/MerchandisingTest.php
@@ -9,45 +9,54 @@ use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\App\RequestInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class MerchandisingTest extends TestCase
 {
-    protected null|(Merchandising&MockObject) $block = null;
-    protected null|(StoreManagerInterface&MockObject) $storeManager = null;
-    protected null|(RequestInterface&MockObject) $request = null;
+    protected function createObjectToTest(
+        ?StoreManagerInterface $storeManager = null,
+        ?RequestInterface $request = null,
+    ): Merchandising {
+        $block = $this->createPartialMock(Merchandising::class, ['getRequest']);
+        $block->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($request ?? $this->createStub(RequestInterface::class));
 
-    protected function setUp(): void
-    {
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->request = $this->createMock(RequestInterface::class);
+        $this->setPrivateProperty(
+            $block,
+            'storeManager',
+            $storeManager ?? $this->createStub(StoreManagerInterface::class)
+        );
 
-        $this->block = $this->getMockBuilder(Merchandising::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getRequest'])
-            ->getMock();
-
-        $this->block->method('getRequest')->willReturn($this->request);
-        $this->setPrivateProperty($this->block, 'storeManager', $this->storeManager);
+        return $block;
     }
 
     public function testGetCurrentStoreReturnsStoreForRequestedStoreId(): void
     {
-        $store = $this->createMock(StoreInterface::class);
-        $this->request->method('getParam')->with('store')->willReturn(3);
-        $this->storeManager->method('getStore')->with(3)->willReturn($store);
+        $store = $this->createStub(StoreInterface::class);
 
-        $this->assertSame($store, $this->block->getCurrentStore());
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(3);
+
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $block = $this->createObjectToTest(storeManager: $storeManager, request: $request);
+
+        $this->assertSame($store, $block->getCurrentStore());
     }
 
     public function testGetCurrentStoreReturnsDefaultStoreWhenNoStoreParam(): void
     {
-        $defaultStore = $this->createMock(StoreInterface::class);
-        $this->request->method('getParam')->with('store')->willReturn(null);
-        $this->storeManager->method('getDefaultStoreView')->willReturn($defaultStore);
+        $defaultStore = $this->createStub(StoreInterface::class);
 
-        $this->assertSame($defaultStore, $this->block->getCurrentStore());
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(null);
+
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getDefaultStoreView')->willReturn($defaultStore);
+
+        $block = $this->createObjectToTest(storeManager: $storeManager, request: $request);
+
+        $this->assertSame($defaultStore, $block->getCurrentStore());
     }
 }

--- a/Test/Unit/Block/Adminhtml/Queue/StatusTest.php
+++ b/Test/Unit/Block/Adminhtml/Queue/StatusTest.php
@@ -5,47 +5,56 @@ declare(strict_types=1);
 namespace Algolia\AlgoliaSearch\Test\Unit\Block\Adminhtml\Queue;
 
 use Algolia\AlgoliaSearch\Block\Adminhtml\Queue\Status;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Model\Queue;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\Indexer\StateInterface;
 use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\Template\Context;
 use Magento\Indexer\Model\Indexer;
-use PHPUnit\Framework\MockObject\MockObject;
+use Magento\Indexer\Model\IndexerFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class StatusTest extends TestCase
 {
-    protected null|(Status&MockObject) $block = null;
-    protected null|(Indexer&MockObject) $queueRunnerIndexer = null;
-    protected null|(Queue&MockObject) $queue = null;
-    protected null|(DateTime&MockObject) $dateTime = null;
+    protected function createObjectToTest(
+        ?Indexer $queueRunnerIndexer = null,
+        ?Queue $queue = null,
+        ?DateTime $dateTime = null,
+    ): Status {
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isQueueActive')->willReturn(true);
 
-    protected function setUp(): void
-    {
-        $this->queueRunnerIndexer = $this->createMock(Indexer::class);
-        $this->queue = $this->createMock(Queue::class);
-        $this->dateTime = $this->createMock(DateTime::class);
+        $indexerFactory = $this->createStub(IndexerFactory::class);
+        $indexerFactory->method('create')->willReturn(
+            $queueRunnerIndexer ?? $this->createStub(Indexer::class)
+        );
 
-        $this->block = $this->getMockBuilder(Status::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getUrl'])
-            ->getMock();
+        $urlBuilder = $this->createStub(UrlInterface::class);
+        $urlBuilder->method('getUrl')->willReturn('http://example.com/reset');
 
-        $this->block->method('getUrl')->willReturn('http://example.com/reset');
+        $context = $this->createStub(Context::class);
+        $context->method('getUrlBuilder')->willReturn($urlBuilder);
 
-        $this->setPrivateProperty($this->block, 'queueRunnerIndexer', $this->queueRunnerIndexer);
-        $this->setPrivateProperty($this->block, 'queue', $this->queue);
-        $this->setPrivateProperty($this->block, 'dateTime', $this->dateTime);
+        return new Status(
+            $context,
+            $indexerFactory,
+            $dateTime ?? $this->createStub(DateTime::class),
+            $configHelper,
+            $queue ?? $this->createStub(Queue::class),
+        );
     }
 
     #[DataProvider('queueRunnerStatusDataProvider')]
     public function testGetQueueRunnerStatusReturnsExpectedLabel(string $status, string $expected): void
     {
-        $this->queueRunnerIndexer->method('getStatus')->willReturn($status);
+        $queueRunnerIndexer = $this->createStub(Indexer::class);
+        $queueRunnerIndexer->method('getStatus')->willReturn($status);
 
-        $this->assertSame($expected, $this->block->getQueueRunnerStatus());
+        $block = $this->createObjectToTest(queueRunnerIndexer: $queueRunnerIndexer);
+
+        $this->assertSame($expected, $block->getQueueRunnerStatus());
     }
 
     public static function queueRunnerStatusDataProvider(): array
@@ -60,23 +69,35 @@ class StatusTest extends TestCase
 
     public function testGetNoticesReturnsEmptyArrayWhenNoConditionsMet(): void
     {
-        $this->queueRunnerIndexer->method('getStatus')->willReturn(StateInterface::STATUS_VALID);
-        $this->dateTime->method('gmtTimestamp')
-            ->willReturnCallback(fn($arg) => $arg === 'now' ? 100 : 0);
-        $this->queue->method('getAverageProcessingTime')->willReturn(null);
+        $queueRunnerIndexer = $this->createStub(Indexer::class);
+        $queueRunnerIndexer->method('getStatus')->willReturn(StateInterface::STATUS_VALID);
 
-        $this->assertSame([], $this->block->getNotices());
+        $dateTime = $this->createStub(DateTime::class);
+        $dateTime->method('gmtTimestamp')->willReturnCallback(fn($arg) => $arg === 'now' ? 100 : 0);
+
+        $queue = $this->createStub(Queue::class);
+        $queue->method('getAverageProcessingTime')->willReturn(null);
+
+        $block = $this->createObjectToTest(queueRunnerIndexer: $queueRunnerIndexer, queue: $queue, dateTime: $dateTime);
+
+        $this->assertSame([], $block->getNotices());
     }
 
     public function testGetNoticesIncludesResetLinkWhenQueueIsStuck(): void
     {
         // Status != VALID and delta > CRON_QUEUE_FREQUENCY (330) but < QUEUE_NOT_PROCESSED_LIMIT (3600)
-        $this->queueRunnerIndexer->method('getStatus')->willReturn(StateInterface::STATUS_INVALID);
-        $this->dateTime->method('gmtTimestamp')
-            ->willReturnCallback(fn($arg) => $arg === 'now' ? 500 : 0);
-        $this->queue->method('getAverageProcessingTime')->willReturn(null);
+        $queueRunnerIndexer = $this->createStub(Indexer::class);
+        $queueRunnerIndexer->method('getStatus')->willReturn(StateInterface::STATUS_INVALID);
 
-        $notices = $this->block->getNotices();
+        $dateTime = $this->createStub(DateTime::class);
+        $dateTime->method('gmtTimestamp')->willReturnCallback(fn($arg) => $arg === 'now' ? 500 : 0);
+
+        $queue = $this->createStub(Queue::class);
+        $queue->method('getAverageProcessingTime')->willReturn(null);
+
+        $block = $this->createObjectToTest(queueRunnerIndexer: $queueRunnerIndexer, queue: $queue, dateTime: $dateTime);
+
+        $notices = $block->getNotices();
 
         $this->assertCount(1, $notices);
         $this->assertStringContainsString('Reset queue', $notices[0]);
@@ -85,12 +106,18 @@ class StatusTest extends TestCase
     public function testGetNoticesIncludesNotProcessedWarningWhenQueueIsStale(): void
     {
         // VALID status so not stuck, but delta > QUEUE_NOT_PROCESSED_LIMIT (3600)
-        $this->queueRunnerIndexer->method('getStatus')->willReturn(StateInterface::STATUS_VALID);
-        $this->dateTime->method('gmtTimestamp')
-            ->willReturnCallback(fn($arg) => $arg === 'now' ? 5000 : 0);
-        $this->queue->method('getAverageProcessingTime')->willReturn(null);
+        $queueRunnerIndexer = $this->createStub(Indexer::class);
+        $queueRunnerIndexer->method('getStatus')->willReturn(StateInterface::STATUS_VALID);
 
-        $notices = $this->block->getNotices();
+        $dateTime = $this->createStub(DateTime::class);
+        $dateTime->method('gmtTimestamp')->willReturnCallback(fn($arg) => $arg === 'now' ? 5000 : 0);
+
+        $queue = $this->createStub(Queue::class);
+        $queue->method('getAverageProcessingTime')->willReturn(null);
+
+        $block = $this->createObjectToTest(queueRunnerIndexer: $queueRunnerIndexer, queue: $queue, dateTime: $dateTime);
+
+        $notices = $block->getNotices();
 
         $this->assertCount(2, $notices);
         $this->assertStringContainsString('Queue has not been processed', (string) $notices[0]);
@@ -99,12 +126,18 @@ class StatusTest extends TestCase
     public function testGetNoticesIncludesPerformanceSuggestionWhenQueueIsFast(): void
     {
         // delta < CRON_QUEUE_FREQUENCY so not stuck, avg < QUEUE_FAST_LIMIT (220)
-        $this->queueRunnerIndexer->method('getStatus')->willReturn(StateInterface::STATUS_VALID);
-        $this->dateTime->method('gmtTimestamp')
-            ->willReturnCallback(fn($arg) => $arg === 'now' ? 100 : 0);
-        $this->queue->method('getAverageProcessingTime')->willReturn(100.0);
+        $queueRunnerIndexer = $this->createStub(Indexer::class);
+        $queueRunnerIndexer->method('getStatus')->willReturn(StateInterface::STATUS_VALID);
 
-        $notices = $this->block->getNotices();
+        $dateTime = $this->createStub(DateTime::class);
+        $dateTime->method('gmtTimestamp')->willReturnCallback(fn($arg) => $arg === 'now' ? 100 : 0);
+
+        $queue = $this->createStub(Queue::class);
+        $queue->method('getAverageProcessingTime')->willReturn(100.0);
+
+        $block = $this->createObjectToTest(queueRunnerIndexer: $queueRunnerIndexer, queue: $queue, dateTime: $dateTime);
+
+        $notices = $block->getNotices();
 
         $this->assertCount(2, $notices);
         $this->assertStringContainsString('average processing time', (string) $notices[0]);

--- a/Test/Unit/Block/Adminhtml/QueueArchive/ViewTest.php
+++ b/Test/Unit/Block/Adminhtml/QueueArchive/ViewTest.php
@@ -10,59 +10,68 @@ use Algolia\AlgoliaSearch\Block\Adminhtml\QueueArchive\View;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
-use PHPUnit\Framework\MockObject\MockObject;
+use Magento\Framework\View\Element\Template\Context;
 
-#[AllowMockObjectsWithoutExpectations]
 class ViewTest extends TestCase
 {
-    protected null|(View&MockObject) $block = null;
-    protected null|(QueueArchiveRepositoryInterface&MockObject) $queueArchiveRepository = null;
-    protected null|(RequestInterface&MockObject) $request = null;
+    protected function createObjectToTest(
+        ?QueueArchiveRepositoryInterface $queueArchiveRepository = null,
+        ?RequestInterface $request = null,
+    ): View {
+        $context = $this->createStub(Context::class);
+        $context->method('getRequest')->willReturn($request ?? $this->createStub(RequestInterface::class));
 
-    protected function setUp(): void
-    {
-        $this->queueArchiveRepository = $this->createMock(QueueArchiveRepositoryInterface::class);
-        $this->request = $this->createMock(RequestInterface::class);
-
-        $this->block = $this->getMockBuilder(View::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getRequest'])
-            ->getMock();
-
-        $this->block->method('getRequest')->willReturn($this->request);
-        $this->setPrivateProperty($this->block, 'queueArchiveRepository', $this->queueArchiveRepository);
+        return new View(
+            $context,
+            $queueArchiveRepository ?? $this->createStub(QueueArchiveRepositoryInterface::class),
+        );
     }
 
     public function testGetCurrentJobLoadsArchiveUsingRequestId(): void
     {
-        $archive = $this->createMock(QueueArchiveInterface::class);
-        $this->request->method('getParam')->with('id')->willReturn(42);
-        $this->queueArchiveRepository->method('getById')->with(42)->willReturn($archive);
+        $archive = $this->createStub(QueueArchiveInterface::class);
 
-        $this->assertSame($archive, $this->block->getCurrentJob());
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(42);
+
+        $queueArchiveRepository = $this->createStub(QueueArchiveRepositoryInterface::class);
+        $queueArchiveRepository->method('getById')->willReturn($archive);
+
+        $block = $this->createObjectToTest(queueArchiveRepository: $queueArchiveRepository, request: $request);
+
+        $this->assertSame($archive, $block->getCurrentJob());
     }
 
     public function testGetCurrentJobMemoizesResult(): void
     {
-        $archive = $this->createMock(QueueArchiveInterface::class);
-        $this->request->method('getParam')->with('id')->willReturn(42);
-        $this->queueArchiveRepository->expects($this->once())->method('getById')->with(42)->willReturn($archive);
+        $archive = $this->createStub(QueueArchiveInterface::class);
 
-        $first = $this->block->getCurrentJob();
-        $second = $this->block->getCurrentJob();
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(42);
+
+        $queueArchiveRepository = $this->createMock(QueueArchiveRepositoryInterface::class);
+        $queueArchiveRepository->expects($this->once())->method('getById')->with(42)->willReturn($archive);
+
+        $block = $this->createObjectToTest(queueArchiveRepository: $queueArchiveRepository, request: $request);
+
+        $first = $block->getCurrentJob();
+        $second = $block->getCurrentJob();
 
         $this->assertSame($first, $second);
     }
 
     public function testGetCurrentJobPropagatesNoSuchEntityException(): void
     {
-        $this->request->method('getParam')->with('id')->willReturn(42);
-        $this->queueArchiveRepository->method('getById')->with(42)
-            ->willThrowException(new NoSuchEntityException());
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(42);
+
+        $queueArchiveRepository = $this->createStub(QueueArchiveRepositoryInterface::class);
+        $queueArchiveRepository->method('getById')->willThrowException(new NoSuchEntityException());
+
+        $block = $this->createObjectToTest(queueArchiveRepository: $queueArchiveRepository, request: $request);
 
         $this->expectException(NoSuchEntityException::class);
 
-        $this->block->getCurrentJob();
+        $block->getCurrentJob();
     }
 }

--- a/Test/Unit/Block/Adminhtml/QueueArchive/ViewTest.php
+++ b/Test/Unit/Block/Adminhtml/QueueArchive/ViewTest.php
@@ -31,11 +31,11 @@ class ViewTest extends TestCase
     {
         $archive = $this->createStub(QueueArchiveInterface::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(42);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('id')->willReturn(42);
 
-        $queueArchiveRepository = $this->createStub(QueueArchiveRepositoryInterface::class);
-        $queueArchiveRepository->method('getById')->willReturn($archive);
+        $queueArchiveRepository = $this->createMock(QueueArchiveRepositoryInterface::class);
+        $queueArchiveRepository->method('getById')->with(42)->willReturn($archive);
 
         $block = $this->createObjectToTest(queueArchiveRepository: $queueArchiveRepository, request: $request);
 
@@ -46,8 +46,8 @@ class ViewTest extends TestCase
     {
         $archive = $this->createStub(QueueArchiveInterface::class);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(42);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('id')->willReturn(42);
 
         $queueArchiveRepository = $this->createMock(QueueArchiveRepositoryInterface::class);
         $queueArchiveRepository->expects($this->once())->method('getById')->with(42)->willReturn($archive);
@@ -62,11 +62,11 @@ class ViewTest extends TestCase
 
     public function testGetCurrentJobPropagatesNoSuchEntityException(): void
     {
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(42);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('id')->willReturn(42);
 
-        $queueArchiveRepository = $this->createStub(QueueArchiveRepositoryInterface::class);
-        $queueArchiveRepository->method('getById')->willThrowException(new NoSuchEntityException());
+        $queueArchiveRepository = $this->createMock(QueueArchiveRepositoryInterface::class);
+        $queueArchiveRepository->method('getById')->with(42)->willThrowException(new NoSuchEntityException());
 
         $block = $this->createObjectToTest(queueArchiveRepository: $queueArchiveRepository, request: $request);
 

--- a/Test/Unit/Block/Adminhtml/Reindex/AbstractReindexAllButtonTest.php
+++ b/Test/Unit/Block/Adminhtml/Reindex/AbstractReindexAllButtonTest.php
@@ -17,8 +17,8 @@ class AbstractReindexAllButtonTest extends TestCase
         string $redirectPath,
         ?ConfigHelper $configHelper = null,
     ): AbstractReindexAllButton {
-        $urlBuilder = $this->createStub(UrlInterface::class);
-        $urlBuilder->method('getUrl')->willReturn('http://example.com/reindex');
+        $urlBuilder = $this->createMock(UrlInterface::class);
+        $urlBuilder->method('getUrl')->with('algolia_algoliasearch/indexingmanager/reindex')->willReturn('http://example.com/reindex');
 
         $context = $this->createStub(Context::class);
         $context->method('getUrlBuilder')->willReturn($urlBuilder);

--- a/Test/Unit/Block/Adminhtml/Reindex/AbstractReindexAllButtonTest.php
+++ b/Test/Unit/Block/Adminhtml/Reindex/AbstractReindexAllButtonTest.php
@@ -9,32 +9,26 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Backend\Block\Widget\Context;
 use Magento\Framework\UrlInterface;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class AbstractReindexAllButtonTest extends TestCase
 {
-    protected null|(ConfigHelper&MockObject) $configHelper = null;
-    protected null|(Context&MockObject) $context = null;
-    protected null|(UrlInterface&MockObject) $urlBuilder = null;
+    protected function createObjectToTest(
+        string $entity,
+        string $redirectPath,
+        ?ConfigHelper $configHelper = null,
+    ): AbstractReindexAllButton {
+        $urlBuilder = $this->createStub(UrlInterface::class);
+        $urlBuilder->method('getUrl')->willReturn('http://example.com/reindex');
 
-    protected function setUp(): void
-    {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->context = $this->createMock(Context::class);
-        $this->urlBuilder = $this->createMock(UrlInterface::class);
+        $context = $this->createStub(Context::class);
+        $context->method('getUrlBuilder')->willReturn($urlBuilder);
 
-        $this->urlBuilder->method('getUrl')
-            ->with('algolia_algoliasearch/indexingmanager/reindex')
-            ->willReturn('http://example.com/reindex');
-
-        $this->context->method('getUrlBuilder')->willReturn($this->urlBuilder);
-    }
-
-    private function makeButton(string $entity, string $redirectPath): AbstractReindexAllButton
-    {
-        return new class($this->context, $this->configHelper, $entity, $redirectPath) extends AbstractReindexAllButton {
+        return new class(
+            $context,
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $entity,
+            $redirectPath,
+        ) extends AbstractReindexAllButton {
             public function __construct(
                 Context $context,
                 ConfigHelper $configHelper,
@@ -50,8 +44,10 @@ class AbstractReindexAllButtonTest extends TestCase
 
     public function testGetButtonDataReturnsBasicStructureForNonProductEntity(): void
     {
-        $this->configHelper->method('isQueueActive')->willReturn(false);
-        $button = $this->makeButton('categories', 'algolia/indexingmanager/categories');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isQueueActive')->willReturn(false);
+
+        $button = $this->createObjectToTest('categories', 'algolia/indexingmanager/categories', $configHelper);
 
         $data = $button->getButtonData();
 
@@ -63,8 +59,10 @@ class AbstractReindexAllButtonTest extends TestCase
 
     public function testGetButtonDataAddsWarningWhenQueueInactiveAndEntityIsProducts(): void
     {
-        $this->configHelper->method('isQueueActive')->willReturn(false);
-        $button = $this->makeButton('products', 'algolia/indexingmanager/products');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isQueueActive')->willReturn(false);
+
+        $button = $this->createObjectToTest('products', 'algolia/indexingmanager/products', $configHelper);
 
         $data = $button->getButtonData();
 
@@ -74,8 +72,10 @@ class AbstractReindexAllButtonTest extends TestCase
 
     public function testGetButtonDataDoesNotAddWarningWhenQueueActiveAndEntityIsProducts(): void
     {
-        $this->configHelper->method('isQueueActive')->willReturn(true);
-        $button = $this->makeButton('products', 'algolia/indexingmanager/products');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isQueueActive')->willReturn(true);
+
+        $button = $this->createObjectToTest('products', 'algolia/indexingmanager/products', $configHelper);
 
         $data = $button->getButtonData();
 

--- a/Test/Unit/Block/Adminhtml/System/Config/Form/Field/CheckboxesTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Form/Field/CheckboxesTest.php
@@ -6,26 +6,24 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Block\Adminhtml\System\Config\Form\Fie
 
 use Algolia\AlgoliaSearch\Block\Adminhtml\System\Config\Form\Field\Checkboxes;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
-use PHPUnit\Framework\MockObject\MockObject;
 
-#[AllowMockObjectsWithoutExpectations]
 class CheckboxesTest extends TestCase
 {
-    protected null|(Checkboxes&MockObject) $field = null;
-
-    protected function setUp(): void
+    /**
+     * Checkboxes extends Magento\Backend\Block\Template, whose constructor reaches into the
+     * ObjectManager — unavailable in a unit test. getCheckboxHtml() touches no collaborator, so
+     * rather than mocking the class (which would need a fake expectation just to dodge the
+     * constructor), a constructor-less reflection instance is used instead.
+     */
+    protected function createObjectToTest(): Checkboxes
     {
-        $this->field = $this->getMockBuilder(Checkboxes::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
+        return (new \ReflectionClass(Checkboxes::class))->newInstanceWithoutConstructor();
     }
 
     public function testGetCheckboxHtmlRendersCheckedInputWithDescription(): void
     {
         $html = $this->invokeMethod(
-            $this->field,
+            $this->createObjectToTest(),
             'getCheckboxHtml',
             ['my_id', 'my_name', 'my_value', true, 'My Label', 'My description']
         );
@@ -40,7 +38,7 @@ class CheckboxesTest extends TestCase
     public function testGetCheckboxHtmlRendersUncheckedInputWithoutDescription(): void
     {
         $html = $this->invokeMethod(
-            $this->field,
+            $this->createObjectToTest(),
             'getCheckboxHtml',
             ['my_id', 'my_name', 'my_value', false, 'My Label', null]
         );
@@ -53,7 +51,7 @@ class CheckboxesTest extends TestCase
     public function testGetCheckboxHtmlUsesNameAsLabelFallback(): void
     {
         $html = $this->invokeMethod(
-            $this->field,
+            $this->createObjectToTest(),
             'getCheckboxHtml',
             ['my_id', 'fallback_name', 'val', false, null, null]
         );

--- a/Test/Unit/Block/Cart/RecommendTest.php
+++ b/Test/Unit/Block/Cart/RecommendTest.php
@@ -8,82 +8,70 @@ use Algolia\AlgoliaSearch\Block\Cart\Recommend;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Checkout\Model\Session;
+use Magento\Framework\DataObject;
+use Magento\Framework\View\Element\Template\Context;
 use Magento\Quote\Model\Quote;
-use Magento\Quote\Model\Quote\Item;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class RecommendTest extends TestCase
 {
-    protected null|(Recommend&MockObject) $block = null;
-    protected null|(Session&MockObject) $checkoutSession = null;
-    protected null|(ConfigHelper&MockObject) $configHelper = null;
-    protected null|(Quote&MockObject) $quote = null;
+    protected function createObjectToTest(
+        ?Session $checkoutSession = null,
+        ?ConfigHelper $configHelper = null,
+    ): Recommend {
+        $context = $this->createStub(Context::class);
 
-    protected function setUp(): void
-    {
-        $this->checkoutSession = $this->createMock(Session::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->quote = $this->createMock(Quote::class);
-
-        $this->block = $this->getMockBuilder(Recommend::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
-
-        $this->setPrivateProperty($this->block, 'checkoutSession', $this->checkoutSession);
-        $this->setPrivateProperty($this->block, 'configHelper', $this->configHelper);
-
-        $this->checkoutSession->method('getQuote')->willReturn($this->quote);
+        return new Recommend(
+            $context,
+            $checkoutSession ?? $this->createStub(Session::class),
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+        );
     }
 
     public function testGetAllCartItemsReturnsEmptyArrayWhenCartIsEmpty(): void
     {
-        $this->quote->method('getAllVisibleItems')->willReturn([]);
-        $this->assertSame([], $this->block->getAllCartItems());
+        $quote = $this->createStub(Quote::class);
+        $quote->method('getAllVisibleItems')->willReturn([]);
+
+        $checkoutSession = $this->createStub(Session::class);
+        $checkoutSession->method('getQuote')->willReturn($quote);
+
+        $block = $this->createObjectToTest(checkoutSession: $checkoutSession);
+
+        $this->assertSame([], $block->getAllCartItems());
     }
 
     public function testGetAllCartItemsReturnsProductIdsFromCart(): void
     {
-        $item1 = $this->getMockBuilder(Item::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__call'])
-            ->getMock();
-        $item1->method('__call')
-            ->willReturnCallback(fn($name, $args) => $name === 'getProductId' ? 10 : null);
+        // Quote\Item::getProductId() is a magic getter (via DataObject::__call), so a plain
+        // DataObject stands in for it here instead of mocking an undeclared method.
+        $item1 = new DataObject(['product_id' => 10]);
+        $item2 = new DataObject(['product_id' => 20]);
 
-        $item2 = $this->getMockBuilder(Item::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__call'])
-            ->getMock();
-        $item2->method('__call')
-            ->willReturnCallback(fn($name, $args) => $name === 'getProductId' ? 20 : null);
+        $quote = $this->createStub(Quote::class);
+        $quote->method('getAllVisibleItems')->willReturn([$item1, $item2]);
 
-        $this->quote->method('getAllVisibleItems')->willReturn([$item1, $item2]);
+        $checkoutSession = $this->createStub(Session::class);
+        $checkoutSession->method('getQuote')->willReturn($quote);
 
-        $this->assertSame([10, 20], $this->block->getAllCartItems());
+        $block = $this->createObjectToTest(checkoutSession: $checkoutSession);
+
+        $this->assertSame([10, 20], $block->getAllCartItems());
     }
 
     public function testGetAllCartItemsDeduplicatesProductIds(): void
     {
-        $item1 = $this->getMockBuilder(Item::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__call'])
-            ->getMock();
-        $item1->method('__call')
-            ->willReturnCallback(fn($name, $args) => $name === 'getProductId' ? 10 : null);
+        $item1 = new DataObject(['product_id' => 10]);
+        $item2 = new DataObject(['product_id' => 10]);
 
-        $item2 = $this->getMockBuilder(Item::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__call'])
-            ->getMock();
-        $item2->method('__call')
-            ->willReturnCallback(fn($name, $args) => $name === 'getProductId' ? 10 : null);
+        $quote = $this->createStub(Quote::class);
+        $quote->method('getAllVisibleItems')->willReturn([$item1, $item2]);
 
-        $this->quote->method('getAllVisibleItems')->willReturn([$item1, $item2]);
+        $checkoutSession = $this->createStub(Session::class);
+        $checkoutSession->method('getQuote')->willReturn($quote);
 
-        $result = $this->block->getAllCartItems();
+        $block = $this->createObjectToTest(checkoutSession: $checkoutSession);
+
+        $result = $block->getAllCartItems();
         $this->assertCount(1, $result);
         $this->assertContains(10, $result);
     }

--- a/Test/Unit/Block/Checkout/ConversionTest.php
+++ b/Test/Unit/Block/Checkout/ConversionTest.php
@@ -9,74 +9,92 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\InsightsHelper;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Checkout\Model\Session;
+use Magento\Framework\View\Element\Template\Context;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Item;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class ConversionTest extends TestCase
 {
-    protected null|(Conversion&MockObject) $block = null;
-    protected null|(Session&MockObject) $checkoutSession = null;
-    protected null|(ConfigHelper&MockObject) $configHelper = null;
-    protected null|(Order&MockObject) $order = null;
+    protected function createObjectToTest(
+        ?Session $checkoutSession = null,
+        ?ConfigHelper $configHelper = null,
+    ): Conversion {
+        $context = $this->createStub(Context::class);
 
-    protected function setUp(): void
-    {
-        $this->checkoutSession = $this->createMock(Session::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->order = $this->createMock(Order::class);
-
-        $this->block = $this->getMockBuilder(Conversion::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
-
-        $this->setPrivateProperty($this->block, 'checkoutSession', $this->checkoutSession);
-        $this->setPrivateProperty($this->block, 'configHelper', $this->configHelper);
-        $this->checkoutSession->method('getLastRealOrder')->willReturn($this->order);
+        return new Conversion(
+            $context,
+            $checkoutSession ?? $this->createStub(Session::class),
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+        );
     }
 
     public function testGetOrderItemsConversionJsonExcludesItemsWithoutQueryParam(): void
     {
-        $item = $this->createMock(Item::class);
-        $item->method('hasData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn(false);
+        $item = $this->createStub(Item::class);
+        $item->method('hasData')->willReturn(false);
 
-        $this->order->method('getAllVisibleItems')->willReturn([$item]);
+        $order = $this->createStub(Order::class);
+        $order->method('getAllVisibleItems')->willReturn([$item]);
 
-        $this->assertSame('[]', $this->block->getOrderItemsConversionJson());
+        $checkoutSession = $this->createStub(Session::class);
+        $checkoutSession->method('getLastRealOrder')->willReturn($order);
+
+        $block = $this->createObjectToTest(checkoutSession: $checkoutSession);
+
+        $this->assertSame('[]', $block->getOrderItemsConversionJson());
     }
 
     public function testGetOrderItemsConversionJsonIncludesItemsWithQueryParam(): void
     {
         $queryData = json_encode(['queryID' => 'abc123', 'position' => 1]);
 
-        $item = $this->createMock(Item::class);
-        $item->method('hasData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn(true);
-        $item->method('getData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn($queryData);
+        $item = $this->createStub(Item::class);
+        $item->method('hasData')->willReturn(true);
+        $item->method('getData')->willReturn($queryData);
         $item->method('getProductId')->willReturn(42);
 
-        $this->order->method('getAllVisibleItems')->willReturn([$item]);
+        $order = $this->createStub(Order::class);
+        $order->method('getAllVisibleItems')->willReturn([$item]);
 
-        $result = json_decode($this->block->getOrderItemsConversionJson());
+        $checkoutSession = $this->createStub(Session::class);
+        $checkoutSession->method('getLastRealOrder')->willReturn($order);
+
+        $block = $this->createObjectToTest(checkoutSession: $checkoutSession);
+
+        $result = json_decode($block->getOrderItemsConversionJson());
         $this->assertEquals('abc123', $result->{'42'}->queryID);
     }
 
     public function testToHtmlReturnsEmptyStringWhenConversionAnalyticsDisabled(): void
     {
-        $this->order->method('getStoreId')->willReturn(1);
-        $this->configHelper->method('isClickConversionAnalyticsEnabled')->with(1)->willReturn(false);
+        $order = $this->createStub(Order::class);
+        $order->method('getStoreId')->willReturn(1);
 
-        $this->assertSame('', $this->block->toHtml());
+        $checkoutSession = $this->createStub(Session::class);
+        $checkoutSession->method('getLastRealOrder')->willReturn($order);
+
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(false);
+
+        $block = $this->createObjectToTest(checkoutSession: $checkoutSession, configHelper: $configHelper);
+
+        $this->assertSame('', $block->toHtml());
     }
 
     public function testToHtmlReturnsEmptyStringWhenConversionModeIsNotPurchase(): void
     {
-        $this->order->method('getStoreId')->willReturn(1);
-        $this->configHelper->method('isClickConversionAnalyticsEnabled')->with(1)->willReturn(true);
-        $this->configHelper->method('getConversionAnalyticsMode')->with(1)->willReturn('click');
+        $order = $this->createStub(Order::class);
+        $order->method('getStoreId')->willReturn(1);
 
-        $this->assertSame('', $this->block->toHtml());
+        $checkoutSession = $this->createStub(Session::class);
+        $checkoutSession->method('getLastRealOrder')->willReturn($order);
+
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(true);
+        $configHelper->method('getConversionAnalyticsMode')->willReturn('click');
+
+        $block = $this->createObjectToTest(checkoutSession: $checkoutSession, configHelper: $configHelper);
+
+        $this->assertSame('', $block->toHtml());
     }
 }

--- a/Test/Unit/Block/Checkout/ConversionTest.php
+++ b/Test/Unit/Block/Checkout/ConversionTest.php
@@ -30,8 +30,8 @@ class ConversionTest extends TestCase
 
     public function testGetOrderItemsConversionJsonExcludesItemsWithoutQueryParam(): void
     {
-        $item = $this->createStub(Item::class);
-        $item->method('hasData')->willReturn(false);
+        $item = $this->createMock(Item::class);
+        $item->method('hasData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn(false);
 
         $order = $this->createStub(Order::class);
         $order->method('getAllVisibleItems')->willReturn([$item]);
@@ -48,9 +48,9 @@ class ConversionTest extends TestCase
     {
         $queryData = json_encode(['queryID' => 'abc123', 'position' => 1]);
 
-        $item = $this->createStub(Item::class);
-        $item->method('hasData')->willReturn(true);
-        $item->method('getData')->willReturn($queryData);
+        $item = $this->createMock(Item::class);
+        $item->method('hasData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn(true);
+        $item->method('getData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn($queryData);
         $item->method('getProductId')->willReturn(42);
 
         $order = $this->createStub(Order::class);
@@ -73,8 +73,8 @@ class ConversionTest extends TestCase
         $checkoutSession = $this->createStub(Session::class);
         $checkoutSession->method('getLastRealOrder')->willReturn($order);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(false);
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('isClickConversionAnalyticsEnabled')->with(1)->willReturn(false);
 
         $block = $this->createObjectToTest(checkoutSession: $checkoutSession, configHelper: $configHelper);
 
@@ -89,9 +89,9 @@ class ConversionTest extends TestCase
         $checkoutSession = $this->createStub(Session::class);
         $checkoutSession->method('getLastRealOrder')->willReturn($order);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(true);
-        $configHelper->method('getConversionAnalyticsMode')->willReturn('click');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('isClickConversionAnalyticsEnabled')->with(1)->willReturn(true);
+        $configHelper->method('getConversionAnalyticsMode')->with(1)->willReturn('click');
 
         $block = $this->createObjectToTest(checkoutSession: $checkoutSession, configHelper: $configHelper);
 

--- a/Test/Unit/Block/ConfigurationTest.php
+++ b/Test/Unit/Block/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Algolia\AlgoliaSearch\Test\Unit\Block;
 
 use Algolia\AlgoliaSearch\Block\Configuration as ConfigurationBlock;
@@ -31,114 +33,94 @@ use Magento\Framework\View\Element\Template\Context;
 use Magento\Search\Helper\Data as CatalogSearchHelper;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class ConfigurationTest extends TestCase
 {
-    protected ?ConfigurationBlock $configurationBlock;
+    protected function createObjectToTest(
+        ?ConfigHelper $config = null,
+        ?AutocompleteHelper $autocompleteConfig = null,
+        ?InstantSearchHelper $instantSearchConfig = null,
+        ?PersonalizationHelper $personalizationHelper = null,
+        ?CatalogSearchHelper $catalogSearchHelper = null,
+        ?ProductHelper $productHelper = null,
+        ?Currency $currency = null,
+        ?Format $format = null,
+        ?CurrentProduct $currentProduct = null,
+        ?AlgoliaConnector $algoliaConnector = null,
+        ?UrlHelper $urlHelper = null,
+        ?FormKey $formKey = null,
+        ?HttpContext $httpContext = null,
+        ?CoreHelper $coreHelper = null,
+        ?CategoryHelper $categoryHelper = null,
+        ?SuggestionHelper $suggestionHelper = null,
+        ?LandingPageHelper $landingPageHelper = null,
+        ?CheckoutSession $checkoutSession = null,
+        ?DateTime $date = null,
+        ?CurrentCategory $currentCategory = null,
+        ?SortingTransformer $sortingTransformer = null,
+        ?PriceKeyResolver $priceKeyResolver = null,
+        ?CategoryPathProvider $categoryPathProvider = null,
+        ?Http $request = null,
+    ): ConfigurationBlock {
+        $context = $this->createStub(Context::class);
+        $context->method('getRequest')->willReturn($request ?? $this->createStub(Http::class));
 
-    protected ?ConfigHelper $config;
-    protected ?AutocompleteHelper $autocompleteConfig;
-    protected ?InstantSearchHelper $instantSearchConfig;
-    protected ?PersonalizationHelper $personalizationHelper;
-    protected ?CatalogSearchHelper $catalogSearchHelper;
-    protected ?ProductHelper $productHelper;
-    protected ?Currency $currency;
-    protected ?Format $format;
-    protected ?CurrentProduct $currentProduct;
-    protected ?AlgoliaConnector $algoliaConnector;
-    protected ?UrlHelper $urlHelper;
-    protected ?FormKey $formKey;
-    protected ?HttpContext $httpContext;
-    protected ?CoreHelper $coreHelper;
-    protected ?CategoryHelper $categoryHelper;
-    protected ?SuggestionHelper $suggestionHelper;
-    protected ?LandingPageHelper $landingPageHelper;
-    protected ?CheckoutSession $checkoutSession;
-    protected ?DateTime $date;
-    protected ?CurrentCategory $currentCategory;
-    protected ?SortingTransformer $sortingTransformer;
-    protected ?PriceKeyResolver $priceKeyResolver;
-    protected ?CategoryPathProvider $categoryPathProvider;
-    protected ?Context $context;
-    protected ?Http $request;
-
-    protected function setUp(): void
-    {
-        $this->config = $this->createMock(ConfigHelper::class);
-        $this->autocompleteConfig = $this->createMock(AutocompleteHelper::class);
-        $this->instantSearchConfig = $this->createMock(InstantSearchHelper::class);
-        $this->personalizationHelper = $this->createMock(PersonalizationHelper::class);
-        $this->catalogSearchHelper = $this->createMock(CatalogSearchHelper::class);
-        $this->productHelper = $this->createMock(ProductHelper::class);
-        $this->currency = $this->createMock(Currency::class);
-        $this->format = $this->createMock(Format::class);
-        $this->currentProduct = $this->createMock(CurrentProduct::class);
-        $this->algoliaConnector = $this->createMock(AlgoliaConnector::class);
-        $this->urlHelper = $this->createMock(UrlHelper::class);
-        $this->formKey = $this->createMock(FormKey::class);
-        $this->httpContext = $this->createMock(HttpContext::class);
-        $this->coreHelper = $this->createMock(CoreHelper::class);
-        $this->categoryHelper = $this->createMock(CategoryHelper::class);
-        $this->suggestionHelper = $this->createMock(SuggestionHelper::class);
-        $this->landingPageHelper = $this->createMock(LandingPageHelper::class);
-        $this->checkoutSession = $this->createMock(CheckoutSession::class);
-        $this->date = $this->createMock(DateTime::class);
-        $this->currentCategory = $this->createMock(CurrentCategory::class);
-        $this->sortingTransformer = $this->createMock(SortingTransformer::class);
-        $this->priceKeyResolver = $this->createMock(PriceKeyResolver::class);
-        $this->categoryPathProvider = $this->createMock(CategoryPathProvider::class);
-        $this->context = $this->createMock(Context::class);
-        $this->request = $this->createMock(Http::class);
-        $this->context->method('getRequest')->willReturn($this->request);
-
-        $this->configurationBlock = new ConfigurationBlock(
-            $this->config,
-            $this->autocompleteConfig,
-            $this->instantSearchConfig,
-            $this->personalizationHelper,
-            $this->catalogSearchHelper,
-            $this->productHelper,
-            $this->currency,
-            $this->format,
-            $this->currentProduct,
-            $this->algoliaConnector,
-            $this->urlHelper,
-            $this->formKey,
-            $this->httpContext,
-            $this->coreHelper,
-            $this->categoryHelper,
-            $this->suggestionHelper,
-            $this->landingPageHelper,
-            $this->checkoutSession,
-            $this->date,
-            $this->currentCategory,
-            $this->sortingTransformer,
-            $this->priceKeyResolver,
-            $this->categoryPathProvider,
-            $this->context,
+        return new ConfigurationBlock(
+            $config ?? $this->createStub(ConfigHelper::class),
+            $autocompleteConfig ?? $this->createStub(AutocompleteHelper::class),
+            $instantSearchConfig ?? $this->createStub(InstantSearchHelper::class),
+            $personalizationHelper ?? $this->createStub(PersonalizationHelper::class),
+            $catalogSearchHelper ?? $this->createStub(CatalogSearchHelper::class),
+            $productHelper ?? $this->createStub(ProductHelper::class),
+            $currency ?? $this->createStub(Currency::class),
+            $format ?? $this->createStub(Format::class),
+            $currentProduct ?? $this->createStub(CurrentProduct::class),
+            $algoliaConnector ?? $this->createStub(AlgoliaConnector::class),
+            $urlHelper ?? $this->createStub(UrlHelper::class),
+            $formKey ?? $this->createStub(FormKey::class),
+            $httpContext ?? $this->createStub(HttpContext::class),
+            $coreHelper ?? $this->createStub(CoreHelper::class),
+            $categoryHelper ?? $this->createStub(CategoryHelper::class),
+            $suggestionHelper ?? $this->createStub(SuggestionHelper::class),
+            $landingPageHelper ?? $this->createStub(LandingPageHelper::class),
+            $checkoutSession ?? $this->createStub(CheckoutSession::class),
+            $date ?? $this->createStub(DateTime::class),
+            $currentCategory ?? $this->createStub(CurrentCategory::class),
+            $sortingTransformer ?? $this->createStub(SortingTransformer::class),
+            $priceKeyResolver ?? $this->createStub(PriceKeyResolver::class),
+            $categoryPathProvider ?? $this->createStub(CategoryPathProvider::class),
+            $context,
         );
     }
 
     #[DataProvider('searchPageDataProvider')]
     public function testIsSearchPage($action, $categoryId, $categoryDisplayMode, $expectedResult): void
     {
-        $this->instantSearchConfig->method('isEnabled')->willReturn(true);
-        $this->request->method('getFullActionName')->willReturn($action);
+        $instantSearchConfig = $this->createStub(InstantSearchHelper::class);
+        $instantSearchConfig->method('isEnabled')->willReturn(true);
+        $instantSearchConfig->method('shouldReplaceCategories')->willReturn(true);
+
+        $request = $this->createStub(Http::class);
+        $request->method('getFullActionName')->willReturn($action);
 
         $controller = explode('_', $action);
         $controller = $controller[1];
+        $request->method('getControllerName')->willReturn($controller);
 
-        $this->request->method('getControllerName')->willReturn($controller);
-        $this->instantSearchConfig->method('shouldReplaceCategories')->willReturn(true);
-
-        $category = $this->createMock(Category::class);
+        $category = $this->createStub(Category::class);
         $category->method('getId')->willReturn($categoryId);
         $category->method('getDisplayMode')->willReturn($categoryDisplayMode);
-        $this->currentCategory->method('get')->willReturn($category);
 
-        $this->assertEquals($expectedResult, $this->configurationBlock->isSearchPage());
+        $currentCategory = $this->createStub(CurrentCategory::class);
+        $currentCategory->method('get')->willReturn($category);
+
+        $configurationBlock = $this->createObjectToTest(
+            instantSearchConfig: $instantSearchConfig,
+            currentCategory: $currentCategory,
+            request: $request,
+        );
+
+        $this->assertEquals($expectedResult, $configurationBlock->isSearchPage());
     }
 
     public function testAreCategoriesInFacetsReturnsTrueWhenCategoriesAttributePresent(): void
@@ -148,7 +130,9 @@ class ConfigurationTest extends TestCase
             ['attribute' => 'categories'],
         ];
 
-        $this->assertTrue($this->invokeMethod($this->configurationBlock, 'areCategoriesInFacets', [$facets]));
+        $configurationBlock = $this->createObjectToTest();
+
+        $this->assertTrue($this->invokeMethod($configurationBlock, 'areCategoriesInFacets', [$facets]));
     }
 
     public function testAreCategoriesInFacetsReturnsFalseWhenCategoriesAttributeAbsent(): void
@@ -158,37 +142,50 @@ class ConfigurationTest extends TestCase
             ['attribute' => 'size'],
         ];
 
-        $this->assertFalse($this->invokeMethod($this->configurationBlock, 'areCategoriesInFacets', [$facets]));
+        $configurationBlock = $this->createObjectToTest();
+
+        $this->assertFalse($this->invokeMethod($configurationBlock, 'areCategoriesInFacets', [$facets]));
     }
 
     public function testAreCategoriesInFacetsReturnsFalseWhenFacetsIsEmpty(): void
     {
-        $this->assertFalse($this->invokeMethod($this->configurationBlock, 'areCategoriesInFacets', [[]]));
+        $configurationBlock = $this->createObjectToTest();
+
+        $this->assertFalse($this->invokeMethod($configurationBlock, 'areCategoriesInFacets', [[]]));
     }
 
     public function testGetUrlTrackedParametersIncludesPageWhenInfiniteScrollDisabled(): void
     {
-        $this->instantSearchConfig->method('isInfiniteScrollEnabled')->willReturn(false);
+        $instantSearchConfig = $this->createStub(InstantSearchHelper::class);
+        $instantSearchConfig->method('isInfiniteScrollEnabled')->willReturn(false);
 
-        $params = $this->invokeMethod($this->configurationBlock, 'getUrlTrackedParameters');
+        $configurationBlock = $this->createObjectToTest(instantSearchConfig: $instantSearchConfig);
+
+        $params = $this->invokeMethod($configurationBlock, 'getUrlTrackedParameters');
 
         $this->assertContains('page', $params);
     }
 
     public function testGetUrlTrackedParametersExcludesPageWhenInfiniteScrollEnabled(): void
     {
-        $this->instantSearchConfig->method('isInfiniteScrollEnabled')->willReturn(true);
+        $instantSearchConfig = $this->createStub(InstantSearchHelper::class);
+        $instantSearchConfig->method('isInfiniteScrollEnabled')->willReturn(true);
 
-        $params = $this->invokeMethod($this->configurationBlock, 'getUrlTrackedParameters');
+        $configurationBlock = $this->createObjectToTest(instantSearchConfig: $instantSearchConfig);
+
+        $params = $this->invokeMethod($configurationBlock, 'getUrlTrackedParameters');
 
         $this->assertNotContains('page', $params);
     }
 
     public function testGetUrlTrackedParametersAlwaysIncludesBaseParams(): void
     {
-        $this->instantSearchConfig->method('isInfiniteScrollEnabled')->willReturn(true);
+        $instantSearchConfig = $this->createStub(InstantSearchHelper::class);
+        $instantSearchConfig->method('isInfiniteScrollEnabled')->willReturn(true);
 
-        $params = $this->invokeMethod($this->configurationBlock, 'getUrlTrackedParameters');
+        $configurationBlock = $this->createObjectToTest(instantSearchConfig: $instantSearchConfig);
+
+        $params = $this->invokeMethod($configurationBlock, 'getUrlTrackedParameters');
 
         $this->assertContains('query', $params);
         $this->assertContains('attribute:*', $params);

--- a/Test/Unit/Block/Instant/WrapperTest.php
+++ b/Test/Unit/Block/Instant/WrapperTest.php
@@ -7,36 +7,37 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Block\Instant;
 use Algolia\AlgoliaSearch\Block\Instant\Wrapper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Magento\Framework\View\Element\Template\Context;
 
-#[AllowMockObjectsWithoutExpectations]
 class WrapperTest extends TestCase
 {
-    protected null|(Wrapper&MockObject) $block = null;
-    protected null|(ConfigHelper&MockObject) $config = null;
-
-    protected function setUp(): void
+    protected function createObjectToTest(?ConfigHelper $config = null): Wrapper
     {
-        $this->config = $this->createMock(ConfigHelper::class);
+        $context = $this->createStub(Context::class);
 
-        $this->block = $this->getMockBuilder(Wrapper::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
-
-        $this->setPrivateProperty($this->block, 'config', $this->config);
+        return new Wrapper(
+            $context,
+            $config ?? $this->createStub(ConfigHelper::class),
+        );
     }
 
     public function testHasFacetsReturnsTrueWhenFacetsExist(): void
     {
-        $this->config->method('getFacets')->willReturn([['attribute' => 'color'], ['attribute' => 'size']]);
-        $this->assertTrue($this->block->hasFacets());
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('getFacets')->willReturn([['attribute' => 'color'], ['attribute' => 'size']]);
+
+        $block = $this->createObjectToTest($config);
+
+        $this->assertTrue($block->hasFacets());
     }
 
     public function testHasFacetsReturnsFalseWhenFacetsArrayIsEmpty(): void
     {
-        $this->config->method('getFacets')->willReturn([]);
-        $this->assertFalse($this->block->hasFacets());
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('getFacets')->willReturn([]);
+
+        $block = $this->createObjectToTest($config);
+
+        $this->assertFalse($block->hasFacets());
     }
 }

--- a/Test/Unit/Block/LandingPageTest.php
+++ b/Test/Unit/Block/LandingPageTest.php
@@ -6,58 +6,78 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Block;
 
 use Algolia\AlgoliaSearch\Block\LandingPage;
 use Algolia\AlgoliaSearch\Model\LandingPage as LandingPageModel;
+use Algolia\AlgoliaSearch\Model\LandingPageFactory;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Magento\Catalog\Model\Layer;
+use Magento\Catalog\Model\Layer\Resolver as LayerResolver;
+use Magento\CatalogSearch\Helper\Data;
+use Magento\Cms\Model\Template\FilterProvider;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Search\Model\QueryFactory;
 
-#[AllowMockObjectsWithoutExpectations]
 class LandingPageTest extends TestCase
 {
-    protected null|(LandingPage&MockObject) $block = null;
-    protected null|(LandingPageModel&MockObject) $landingPage = null;
+    protected function createObjectToTest(
+        ?LandingPageModel $landingPage = null,
+        ?FilterProvider $filterProvider = null,
+        ?LandingPageFactory $landingPageFactory = null,
+    ): LandingPage {
+        $context = $this->createStub(Context::class);
 
-    protected function setUp(): void
-    {
-        $this->landingPage = $this->createMock(LandingPageModel::class);
+        $layerResolver = $this->createStub(LayerResolver::class);
+        $layerResolver->method('get')->willReturn($this->createStub(Layer::class));
 
-        $this->block = $this->getMockBuilder(LandingPage::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
-
-        $this->setPrivateProperty($this->block, 'landingPage', $this->landingPage);
+        return new LandingPage(
+            $context,
+            $layerResolver,
+            $this->createStub(Data::class),
+            $this->createStub(QueryFactory::class),
+            $filterProvider ?? $this->createStub(FilterProvider::class),
+            $landingPage ?? $this->createStub(LandingPageModel::class),
+            $landingPageFactory ?? $this->createStub(LandingPageFactory::class),
+        );
     }
 
     public function testGetPageReturnsCachedLandingPageWhenNoPageId(): void
     {
-        // No page_id data set, so getPageId() returns null → falls back to $this->landingPage
-        $result = $this->block->getPage();
+        // No page_id data set, so the real getPageId() magic getter returns null → falls back
+        // to the injected landingPage.
+        $landingPage = $this->createStub(LandingPageModel::class);
+        $block = $this->createObjectToTest($landingPage);
 
-        $this->assertSame($this->landingPage, $result);
+        $this->assertSame($landingPage, $block->getPage());
     }
 
     public function testGetPageReturnsSameCachedInstanceOnSecondCall(): void
     {
-        $first = $this->block->getPage();
-        $second = $this->block->getPage();
+        $block = $this->createObjectToTest();
+
+        $first = $block->getPage();
+        $second = $block->getPage();
 
         $this->assertSame($first, $second);
     }
 
     public function testGetLandingCustomJsReturnsEmptyStringWhenNoCustomJs(): void
     {
-        $this->landingPage->method('getCustomJs')->willReturn('');
+        $landingPage = $this->createStub(LandingPageModel::class);
+        $landingPage->method('getCustomJs')->willReturn('');
 
-        $result = $this->invokeMethod($this->block, 'getLandingCustomJs');
+        $block = $this->createObjectToTest($landingPage);
+
+        $result = $this->invokeMethod($block, 'getLandingCustomJs');
 
         $this->assertSame('', $result);
     }
 
     public function testGetLandingCustomJsWrapsJsInScriptTag(): void
     {
-        $this->landingPage->method('getCustomJs')->willReturn('console.log("hello");');
+        $landingPage = $this->createStub(LandingPageModel::class);
+        $landingPage->method('getCustomJs')->willReturn('console.log("hello");');
 
-        $result = $this->invokeMethod($this->block, 'getLandingCustomJs');
+        $block = $this->createObjectToTest($landingPage);
+
+        $result = $this->invokeMethod($block, 'getLandingCustomJs');
 
         $this->assertStringContainsString('<script type="text/javascript">', $result);
         $this->assertStringContainsString('console.log("hello");', $result);
@@ -65,18 +85,24 @@ class LandingPageTest extends TestCase
 
     public function testGetLandingCustomCssReturnsEmptyStringWhenNoCustomCss(): void
     {
-        $this->landingPage->method('getCustomCss')->willReturn('');
+        $landingPage = $this->createStub(LandingPageModel::class);
+        $landingPage->method('getCustomCss')->willReturn('');
 
-        $result = $this->invokeMethod($this->block, 'getLandingCustomCss');
+        $block = $this->createObjectToTest($landingPage);
+
+        $result = $this->invokeMethod($block, 'getLandingCustomCss');
 
         $this->assertSame('', $result);
     }
 
     public function testGetLandingCustomCssWrapsContentInStyleTag(): void
     {
-        $this->landingPage->method('getCustomCss')->willReturn('body { color: red; }');
+        $landingPage = $this->createStub(LandingPageModel::class);
+        $landingPage->method('getCustomCss')->willReturn('body { color: red; }');
 
-        $result = $this->invokeMethod($this->block, 'getLandingCustomCss');
+        $block = $this->createObjectToTest($landingPage);
+
+        $result = $this->invokeMethod($block, 'getLandingCustomCss');
 
         $this->assertStringContainsString('<style type="text/css">', $result);
         $this->assertStringContainsString('body { color: red; }', $result);

--- a/Test/Unit/Block/Navigation/Renderer/SliderRendererTest.php
+++ b/Test/Unit/Block/Navigation/Renderer/SliderRendererTest.php
@@ -7,36 +7,43 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Block\Navigation\Renderer;
 use Algolia\AlgoliaSearch\Block\Navigation\Renderer\SliderRenderer;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Catalog\Model\Layer\Filter\FilterInterface;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Magento\Framework\Json\EncoderInterface;
+use Magento\Framework\Locale\FormatInterface;
+use Magento\Framework\View\Element\Template\Context;
 
-#[AllowMockObjectsWithoutExpectations]
 class SliderRendererTest extends TestCase
 {
-    protected null|(SliderRenderer&MockObject) $block = null;
+    protected function createObjectToTest(
+        ?EncoderInterface $jsonEncoder = null,
+        ?FormatInterface $localeFormat = null,
+    ): SliderRenderer {
+        $context = $this->createStub(Context::class);
 
-    protected function setUp(): void
-    {
-        $this->block = $this->getMockBuilder(SliderRenderer::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
+        return new SliderRenderer(
+            $context,
+            $jsonEncoder ?? $this->createStub(EncoderInterface::class),
+            $localeFormat ?? $this->createStub(FormatInterface::class),
+        );
     }
 
     public function testGetDataRoleConcatenatesRoleWithFilterRequestVar(): void
     {
-        $filter = $this->createMock(FilterInterface::class);
+        $filter = $this->createStub(FilterInterface::class);
         $filter->method('getRequestVar')->willReturn('price');
-        $this->setPrivateProperty($this->block, 'filter', $filter);
 
-        $this->assertSame('range-slider-price', $this->block->getDataRole());
+        $block = $this->createObjectToTest();
+        $this->setPrivateProperty($block, 'filter', $filter);
+
+        $this->assertSame('range-slider-price', $block->getDataRole());
     }
 
     public function testGetFilterReturnsStoredFilter(): void
     {
-        $filter = $this->createMock(FilterInterface::class);
-        $this->setPrivateProperty($this->block, 'filter', $filter);
+        $filter = $this->createStub(FilterInterface::class);
 
-        $this->assertSame($filter, $this->block->getFilter());
+        $block = $this->createObjectToTest();
+        $this->setPrivateProperty($block, 'filter', $filter);
+
+        $this->assertSame($filter, $block->getFilter());
     }
 }

--- a/Test/Unit/Block/RecommendProductViewTest.php
+++ b/Test/Unit/Block/RecommendProductViewTest.php
@@ -9,54 +9,58 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Registry\CurrentProduct;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Catalog\Model\Product;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Magento\Framework\View\Element\Template\Context;
 
-#[AllowMockObjectsWithoutExpectations]
 class RecommendProductViewTest extends TestCase
 {
-    protected null|(RecommendProductView&MockObject) $block = null;
-    protected null|(CurrentProduct&MockObject) $currentProduct = null;
-    protected null|(ConfigHelper&MockObject) $configHelper = null;
+    protected function createObjectToTest(
+        ?CurrentProduct $currentProduct = null,
+        ?ConfigHelper $configHelper = null,
+    ): RecommendProductView {
+        $context = $this->createStub(Context::class);
 
-    protected function setUp(): void
-    {
-        $this->currentProduct = $this->createMock(CurrentProduct::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-
-        $this->block = $this->getMockBuilder(RecommendProductView::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
-
-        $this->setPrivateProperty($this->block, 'currentProduct', $this->currentProduct);
-        $this->setPrivateProperty($this->block, 'configHelper', $this->configHelper);
+        return new RecommendProductView(
+            $context,
+            $currentProduct ?? $this->createStub(CurrentProduct::class),
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+        );
     }
 
     public function testGetProductReturnsProductFromRegistry(): void
     {
-        $product = $this->createMock(Product::class);
-        $this->currentProduct->method('get')->willReturn($product);
+        $product = $this->createStub(Product::class);
 
-        $this->assertSame($product, $this->block->getProduct());
+        $currentProduct = $this->createStub(CurrentProduct::class);
+        $currentProduct->method('get')->willReturn($product);
+
+        $block = $this->createObjectToTest(currentProduct: $currentProduct);
+
+        $this->assertSame($product, $block->getProduct());
     }
 
     public function testGetProductCachesRegistryLookup(): void
     {
-        $product = $this->createMock(Product::class);
-        $this->currentProduct->expects($this->once())->method('get')->willReturn($product);
+        $product = $this->createStub(Product::class);
 
-        $this->block->getProduct();
-        $this->block->getProduct();
+        $currentProduct = $this->createMock(CurrentProduct::class);
+        $currentProduct->expects($this->once())->method('get')->willReturn($product);
+
+        $block = $this->createObjectToTest(currentProduct: $currentProduct);
+
+        $block->getProduct();
+        $block->getProduct();
     }
 
     public function testGetAlgoliaRecommendConfigurationReturnsExpectedKeys(): void
     {
-        $this->configHelper->method('isRecommendFrequentlyBroughtTogetherEnabled')->willReturn(true);
-        $this->configHelper->method('isRecommendRelatedProductsEnabled')->willReturn(false);
-        $this->configHelper->method('isTrendItemsEnabledInPDP')->willReturn(true);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isRecommendFrequentlyBroughtTogetherEnabled')->willReturn(true);
+        $configHelper->method('isRecommendRelatedProductsEnabled')->willReturn(false);
+        $configHelper->method('isTrendItemsEnabledInPDP')->willReturn(true);
 
-        $config = $this->block->getAlgoliaRecommendConfiguration();
+        $block = $this->createObjectToTest(configHelper: $configHelper);
+
+        $config = $block->getAlgoliaRecommendConfiguration();
 
         $this->assertTrue($config['enabledFBT']);
         $this->assertFalse($config['enabledRelated']);

--- a/Test/Unit/Block/Widget/LookingSimilarTest.php
+++ b/Test/Unit/Block/Widget/LookingSimilarTest.php
@@ -7,34 +7,32 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Block\Widget;
 use Algolia\AlgoliaSearch\Block\Widget\LookingSimilar;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
+use Magento\Framework\Math\Random;
+use Magento\Framework\View\Element\Template\Context;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class LookingSimilarTest extends TestCase
 {
-    protected null|(LookingSimilar&MockObject) $block = null;
-    protected null|(ConfigHelper&MockObject) $configHelper = null;
+    protected function createObjectToTest(
+        ?ConfigHelper $configHelper = null,
+        ?Random $mathRandom = null,
+    ): LookingSimilar {
+        $context = $this->createStub(Context::class);
 
-    protected function setUp(): void
-    {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-
-        $this->block = $this->getMockBuilder(LookingSimilar::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
-
-        $this->setPrivateProperty($this->block, 'configHelper', $this->configHelper);
+        return new LookingSimilar(
+            $context,
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $mathRandom ?? $this->createStub(Random::class),
+        );
     }
 
     #[DataProvider('productIdsDataProvider')]
     public function testGetProductIdsReturnsJsonEncodedArray(string $input, string $expected): void
     {
-        $this->block->setData('productIds', $input);
+        $block = $this->createObjectToTest();
+        $block->setData('productIds', $input);
 
-        $this->assertSame($expected, $this->block->getProductIds());
+        $this->assertSame($expected, $block->getProductIds());
     }
 
     public static function productIdsDataProvider(): array

--- a/Test/Unit/Console/Command/AbstractStoreCommandTest.php
+++ b/Test/Unit/Console/Command/AbstractStoreCommandTest.php
@@ -8,55 +8,18 @@ use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Output\BufferedOutput;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class AbstractStoreCommandTest extends TestCase
 {
-    private null|(State&MockObject) $state = null;
-    private null|(StoreNameFetcher&MockObject) $storeNameFetcher = null;
-
-    protected function setUp(): void
-    {
-        $this->state            = $this->createMock(State::class);
-        $this->storeNameFetcher = $this->createMock(StoreNameFetcher::class);
-    }
-
-    public function testStoreIdArgumentDefinition(): void
-    {
-        $args = $this->makeStubCommand()->getDefinition()->getArguments();
-
-        $this->assertArrayHasKey('store_id', $args);
-        $this->assertTrue($args['store_id']->isArray());
-        $this->assertFalse($args['store_id']->isRequired());
-    }
-
-    /**
-     * @throws \ReflectionException
-     */
-    public function testSetAreaCodeSwallowsLocalizedException(): void
-    {
-        $this->state->expects($this->once())
-            ->method('setAreaCode')
-            ->with(Area::AREA_CRONTAB)
-            ->willThrowException(new LocalizedException(__('already set')));
-
-        $cmd    = $this->makeStubCommand();
-        $output = new BufferedOutput();
-        $this->setPrivateProperty($cmd, 'output', $output);
-
-        $this->invokeMethod($cmd, 'setAreaCode');
-
-        $written = $output->fetch();
-        $this->assertStringContainsString('Unable to set area code', $written);
-        $this->assertStringContainsString('already set', $written);
-    }
-
-    private function makeStubCommand(): AbstractStoreCommand
-    {
-        return new class($this->state, $this->storeNameFetcher) extends AbstractStoreCommand {
+    protected function createObjectToTest(
+        ?State $state = null,
+        ?StoreNameFetcher $storeNameFetcher = null,
+    ): AbstractStoreCommand {
+        return new class(
+            $state ?? $this->createStub(State::class),
+            $storeNameFetcher ?? $this->createStub(StoreNameFetcher::class),
+        ) extends AbstractStoreCommand {
             protected function getCommandName(): string
             {
                 return 'stub';
@@ -77,5 +40,36 @@ class AbstractStoreCommandTest extends TestCase
                 return [];
             }
         };
+    }
+
+    public function testStoreIdArgumentDefinition(): void
+    {
+        $args = $this->createObjectToTest()->getDefinition()->getArguments();
+
+        $this->assertArrayHasKey('store_id', $args);
+        $this->assertTrue($args['store_id']->isArray());
+        $this->assertFalse($args['store_id']->isRequired());
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testSetAreaCodeSwallowsLocalizedException(): void
+    {
+        $state = $this->createMock(State::class);
+        $state->expects($this->once())
+            ->method('setAreaCode')
+            ->with(Area::AREA_CRONTAB)
+            ->willThrowException(new LocalizedException(__('already set')));
+
+        $cmd = $this->createObjectToTest(state: $state);
+        $output = new BufferedOutput();
+        $this->setPrivateProperty($cmd, 'output', $output);
+
+        $this->invokeMethod($cmd, 'setAreaCode');
+
+        $written = $output->fetch();
+        $this->assertStringContainsString('Unable to set area code', $written);
+        $this->assertStringContainsString('already set', $written);
     }
 }

--- a/Test/Unit/Console/Command/Queue/ClearQueueCommandTest.php
+++ b/Test/Unit/Console/Command/Queue/ClearQueueCommandTest.php
@@ -165,8 +165,8 @@ class ClearQueueCommandTest extends TestCase
 
     public function testClearQueueForStoreSuccess(): void
     {
-        $storeNameFetcher = $this->createStub(StoreNameFetcher::class);
-        $storeNameFetcher->method('getStoreName')->willReturn('Default Store');
+        $storeNameFetcher = $this->createMock(StoreNameFetcher::class);
+        $storeNameFetcher->method('getStoreName')->with(1)->willReturn('Default Store');
 
         $cmd = $this->createPartialObjectToTest(['clearQueueTableForStore'], storeNameFetcher: $storeNameFetcher);
         $output = new BufferedOutput();
@@ -183,8 +183,8 @@ class ClearQueueCommandTest extends TestCase
 
     public function testClearQueueForStoreErrorPrinted(): void
     {
-        $storeNameFetcher = $this->createStub(StoreNameFetcher::class);
-        $storeNameFetcher->method('getStoreName')->willReturn('Default Store');
+        $storeNameFetcher = $this->createMock(StoreNameFetcher::class);
+        $storeNameFetcher->method('getStoreName')->with(1)->willReturn('Default Store');
 
         $cmd = $this->createPartialObjectToTest(['clearQueueTableForStore'], storeNameFetcher: $storeNameFetcher);
         $output = new BufferedOutput();

--- a/Test/Unit/Console/Command/Queue/ClearQueueCommandTest.php
+++ b/Test/Unit/Console/Command/Queue/ClearQueueCommandTest.php
@@ -10,59 +10,73 @@ use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Select;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class ClearQueueCommandTest extends TestCase
 {
-    private null|(State&MockObject) $state = null;
-    private null|(StoreNameFetcher&MockObject) $storeNameFetcher = null;
-    private null|(StoreManagerInterface&MockObject) $storeManager = null;
-    private null|(JobResourceModel&MockObject) $jobResourceModel = null;
-
-    protected function setUp(): void
-    {
-        /* Load mock constructor arguments for the Command partial */
-        $this->state            = $this->createMock(State::class);
-        $this->storeNameFetcher = $this->createMock(StoreNameFetcher::class);
-        $this->storeManager     = $this->createMock(StoreManagerInterface::class);
-        $this->jobResourceModel = $this->createMock(JobResourceModel::class);
+    protected function createObjectToTest(
+        ?State $state = null,
+        ?StoreNameFetcher $storeNameFetcher = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?JobResourceModel $jobResourceModel = null,
+    ): ClearQueueCommand {
+        return new ClearQueueCommand(
+            $state ?? $this->createStub(State::class),
+            $storeNameFetcher ?? $this->createStub(StoreNameFetcher::class),
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $jobResourceModel ?? $this->createStub(JobResourceModel::class),
+        );
     }
 
     /**
-     * Test that the command returns success when the user cancels the operation
-     *
-     * @throws \ReflectionException
+     * A partial mock is needed to isolate the method under test from the sibling methods it
+     * calls on the same class (e.g. execute() calling clearQueue()).
      */
+    protected function createPartialObjectToTest(
+        array $methodsToMock,
+        ?State $state = null,
+        ?StoreNameFetcher $storeNameFetcher = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?JobResourceModel $jobResourceModel = null,
+    ): ClearQueueCommand&MockObject {
+        return $this->getMockBuilder(ClearQueueCommand::class)
+            ->setConstructorArgs([
+                $state ?? $this->createStub(State::class),
+                $storeNameFetcher ?? $this->createStub(StoreNameFetcher::class),
+                $storeManager ?? $this->createStub(StoreManagerInterface::class),
+                $jobResourceModel ?? $this->createStub(JobResourceModel::class),
+                null,
+            ])
+            ->onlyMethods($methodsToMock)
+            ->getMock();
+    }
+
     public function testExecuteReturnsSuccessWhenUserCancels(): void
     {
-        $cmd = $this->makePartial(['setAreaCode', 'confirmOperation', 'getStoreIds', 'decorateOperationAnnouncementMessage', 'clearQueue']);
+        $cmd = $this->createPartialObjectToTest(
+            ['setAreaCode', 'confirmOperation', 'getStoreIds', 'decorateOperationAnnouncementMessage', 'clearQueue']
+        );
 
         $cmd->expects($this->once())->method('setAreaCode');
         $cmd->expects($this->once())->method('confirmOperation')->willReturn(false);
         $cmd->expects($this->never())->method('getStoreIds');
         $cmd->expects($this->never())->method('clearQueue');
 
-        $input  = new ArrayInput([]);
-        $output = $this->bufOut();
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
 
-        $code = $this->invokeExecute($cmd, $input, $output);
+        $code = $this->invokeMethod($cmd, 'execute', [$input, $output]);
         $this->assertSame(Cli::RETURN_SUCCESS, $code);
     }
 
-    /**
-     * Test that the command clears the indexing queue for the provided store IDs
-     *
-     * @throws \ReflectionException
-     */
     public function testExecuteClearsProvidedStoreIds(): void
     {
-        $cmd = $this->makePartial(['setAreaCode', 'confirmOperation', 'getStoreIds', 'decorateOperationAnnouncementMessage', 'clearQueue']);
+        $cmd = $this->createPartialObjectToTest(
+            ['setAreaCode', 'confirmOperation', 'getStoreIds', 'decorateOperationAnnouncementMessage', 'clearQueue']
+        );
 
         $cmd->method('setAreaCode');
         $cmd->method('confirmOperation')->willReturn(true);
@@ -71,27 +85,22 @@ class ClearQueueCommandTest extends TestCase
         $msg = 'Clearing indexing queue for stores 1, 2';
         $cmd->method('decorateOperationAnnouncementMessage')->willReturn($msg);
 
-        $cmd->expects($this->once())
-            ->method('clearQueue')
-            ->with([1,2]);
+        $cmd->expects($this->once())->method('clearQueue')->with([1, 2]);
 
-        $input  = new ArrayInput([]);
-        $output = $this->bufOut();
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
 
-        $code = $this->invokeExecute($cmd, $input, $output);
+        $code = $this->invokeMethod($cmd, 'execute', [$input, $output]);
         $this->assertSame(Cli::RETURN_SUCCESS, $code);
 
         $this->assertStringContainsString($msg, $output->fetch());
     }
 
-    /**
-     * Test that the command returns failure when the clear operation fails
-     *
-     * @throws \ReflectionException
-     */
     public function testExecuteReturnsFailureOnClearException(): void
     {
-        $cmd = $this->makePartial(['setAreaCode', 'confirmOperation', 'getStoreIds', 'decorateOperationAnnouncementMessage', 'clearQueue']);
+        $cmd = $this->createPartialObjectToTest(
+            ['setAreaCode', 'confirmOperation', 'getStoreIds', 'decorateOperationAnnouncementMessage', 'clearQueue']
+        );
 
         $cmd->method('setAreaCode');
         $cmd->method('confirmOperation')->willReturn(true);
@@ -99,30 +108,25 @@ class ClearQueueCommandTest extends TestCase
         $cmd->method('decorateOperationAnnouncementMessage')->willReturn('Clearing indexing queue for all stores');
 
         $errMsg = 'Error encountered while attempting to clear queue.';
-        $cmd->method('clearQueue')->willThrowException(new \Exception($errMsg));
+        $cmd->expects($this->once())->method('clearQueue')->willThrowException(new \Exception($errMsg));
 
-        $input  = new ArrayInput([]);
-        $output = $this->bufOut();
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
 
-        $code = $this->invokeExecute($cmd, $input, $output);
+        $code = $this->invokeMethod($cmd, 'execute', [$input, $output]);
         $this->assertSame(Cli::RETURN_FAILURE, $code);
         $this->assertStringContainsString($errMsg, $output->fetch());
     }
 
-    /**
-     * Test that the command calls the clearQueueForStore method for each store ID
-     *
-     * @throws \ReflectionException
-     */
     public function testClearQueueCallsPerStore(): void
     {
-        $cmd = $this->makePartial(['clearQueueForStore', 'clearQueueForAllStores']);
+        $cmd = $this->createPartialObjectToTest(['clearQueueForStore', 'clearQueueForAllStores']);
 
         $expectedStoreIds = [1, 2];
         $callIndex = 0;
         $cmd->expects($this->exactly(2))
             ->method('clearQueueForStore')
-            ->willReturnCallback(function($storeId) use (&$callIndex, $expectedStoreIds) {
+            ->willReturnCallback(function ($storeId) use (&$callIndex, $expectedStoreIds) {
                 $this->assertSame(
                     $expectedStoreIds[$callIndex],
                     $storeId,
@@ -136,14 +140,9 @@ class ClearQueueCommandTest extends TestCase
         $this->invokeMethod($cmd, 'clearQueue', [[1, 2]]);
     }
 
-    /**
-     * Test that the command calls the clearQueueForAllStores method when no store IDs are provided
-     *
-     * @throws \ReflectionException
-     */
     public function testClearQueueEmptyCallsAllStores(): void
     {
-        $cmd = $this->makePartial(['clearQueueForStore', 'clearQueueForAllStores']);
+        $cmd = $this->createPartialObjectToTest(['clearQueueForStore', 'clearQueueForAllStores']);
 
         $cmd->expects($this->never())->method('clearQueueForStore');
         $cmd->expects($this->once())->method('clearQueueForAllStores');
@@ -151,36 +150,28 @@ class ClearQueueCommandTest extends TestCase
         $this->invokeMethod($cmd, 'clearQueue');
     }
 
-    /**
-     * Test that the command truncates the main table when no store IDs are provided
-     *
-     * @throws \ReflectionException
-     */
     public function testClearQueueForAllStoresTruncatesMainTable(): void
     {
         $adapter = $this->createMock(AdapterInterface::class);
-
-        $this->jobResourceModel->method('getConnection')->willReturn($adapter);
-        $this->jobResourceModel->method('getMainTable')->willReturn('algoliasearch_queue');
-
         $adapter->expects($this->once())->method('truncateTable')->with('algoliasearch_queue');
 
-        $cmd = $this->makePartial();
+        $jobResourceModel = $this->createStub(JobResourceModel::class);
+        $jobResourceModel->method('getConnection')->willReturn($adapter);
+        $jobResourceModel->method('getMainTable')->willReturn('algoliasearch_queue');
+
+        $cmd = $this->createObjectToTest(jobResourceModel: $jobResourceModel);
         $this->invokeMethod($cmd, 'clearQueue');
     }
 
-    /**
-     * @throws \ReflectionException
-     */
     public function testClearQueueForStoreSuccess(): void
     {
-        $cmd = $this->makePartial(['clearQueueTableForStore']);
-        $output = $this->bufOut();
+        $storeNameFetcher = $this->createStub(StoreNameFetcher::class);
+        $storeNameFetcher->method('getStoreName')->willReturn('Default Store');
 
-        // Inject output (protected on the parent); easiest is via reflection:
+        $cmd = $this->createPartialObjectToTest(['clearQueueTableForStore'], storeNameFetcher: $storeNameFetcher);
+        $output = new BufferedOutput();
         $this->setPrivateProperty($cmd, 'output', $output);
 
-        $this->storeNameFetcher->method('getStoreName')->with(1)->willReturn('Default Store');
         $cmd->expects($this->once())->method('clearQueueTableForStore')->with(1);
 
         $this->invokeMethod($cmd, 'clearQueueForStore', [1]);
@@ -190,47 +181,39 @@ class ClearQueueCommandTest extends TestCase
         $this->assertStringContainsString('Indexing queue cleared for Default Store', $text);
     }
 
-    /**
-     * @throws \ReflectionException
-     * @throws NoSuchEntityException
-     */
     public function testClearQueueForStoreErrorPrinted(): void
     {
-        $cmd = $this->makePartial(['clearQueueTableForStore']);
-        $output = $this->bufOut();
+        $storeNameFetcher = $this->createStub(StoreNameFetcher::class);
+        $storeNameFetcher->method('getStoreName')->willReturn('Default Store');
+
+        $cmd = $this->createPartialObjectToTest(['clearQueueTableForStore'], storeNameFetcher: $storeNameFetcher);
+        $output = new BufferedOutput();
         $this->setPrivateProperty($cmd, 'output', $output);
 
-        $this->storeNameFetcher->method('getStoreName')->with(1)->willReturn('Default Store');
         $errorMsg = 'DB operation failed';
-        $cmd->method('clearQueueTableForStore')->willThrowException(new \Exception($errorMsg));
+        $cmd->expects($this->once())->method('clearQueueTableForStore')->willThrowException(new \Exception($errorMsg));
 
         $this->invokeMethod($cmd, 'clearQueueForStore', [1]);
 
         $this->assertStringContainsString("Failed to clear indexing queue for Default Store: $errorMsg", $output->fetch());
     }
 
-    /**
-     * @throws \ReflectionException
-     */
     public function testClearQueueForStoreJsonPathDeletesJobs(): void
     {
-        $adapter = $this->getMockSearchAdapter();
-        $output  = $this->bufOut();
+        $adapter = $this->createMockSearchAdapter();
+        $output = new BufferedOutput();
 
-        $cmd = $this->makePartial();
+        $jobResourceModel = $this->createStub(JobResourceModel::class);
+        $jobResourceModel->method('getConnection')->willReturn($adapter);
+        $jobResourceModel->method('getMainTable')->willReturn('algoliasearch_queue');
 
+        $cmd = $this->createObjectToTest(jobResourceModel: $jobResourceModel);
         $this->setPrivateProperty($cmd, 'output', $output);
 
-        $this->jobResourceModel->method('getConnection')->willReturn($adapter);
-        $this->jobResourceModel->method('getMainTable')->willReturn('algoliasearch_queue');
-
-        $adapter->expects($this->once())
-            ->method('fetchCol')
-            ->willReturn([10, 11]);
-
+        $adapter->expects($this->once())->method('fetchCol')->willReturn([10, 11]);
         $adapter->expects($this->once())
             ->method('delete')
-            ->with('algoliasearch_queue', ['job_id IN (?)' => [10,11]])
+            ->with('algoliasearch_queue', ['job_id IN (?)' => [10, 11]])
             ->willReturn(2);
 
         $this->invokeMethod($cmd, 'clearQueueForStore', [5]);
@@ -238,43 +221,36 @@ class ClearQueueCommandTest extends TestCase
         $this->assertStringContainsString('Deleted 2 jobs for store ID 5', $output->fetch());
     }
 
-    /**
-     * @throws NoSuchEntityException
-     * @throws \ReflectionException
-     */
     public function testClearQueueForStoreJsonPathNoJobs(): void
     {
-        $adapter = $this->getMockSearchAdapter();
-        $output  = $this->bufOut();
-
-        $cmd = $this->makePartial();
-
-        $this->setPrivateProperty($cmd, 'output', $output);
-
-        $this->jobResourceModel->method('getConnection')->willReturn($adapter);
-        $this->jobResourceModel->method('getMainTable')->willReturn('algoliasearch_queue');
-
+        $adapter = $this->createStubSearchAdapter();
         $adapter->method('fetchCol')->willReturn([]);
+
+        $output = new BufferedOutput();
+
+        $jobResourceModel = $this->createStub(JobResourceModel::class);
+        $jobResourceModel->method('getConnection')->willReturn($adapter);
+        $jobResourceModel->method('getMainTable')->willReturn('algoliasearch_queue');
+
+        $cmd = $this->createObjectToTest(jobResourceModel: $jobResourceModel);
+        $this->setPrivateProperty($cmd, 'output', $output);
 
         $this->invokeMethod($cmd, 'clearQueueForStore', [5]);
 
         $this->assertStringContainsString('No jobs found for store ID 5', $output->fetch());
     }
 
-    /**
-     * @throws NoSuchEntityException
-     * @throws \ReflectionException
-     */
     public function testClearQueueForStoreFallsBackWhenJsonThrows(): void
     {
-        $cmd = $this->makePartial(['clearQueueTableForStoreFallback']);
-        $output = $this->bufOut();
-        $this->setPrivateProperty($cmd, 'output', $output);
-
-        $adapter = $this->getMockSearchAdapter();
-        $this->jobResourceModel->method('getConnection')->willReturn($adapter);
-
+        $adapter = $this->createStub(AdapterInterface::class);
         $adapter->method('select')->willThrowException(new \Exception('No JSON support'));
+
+        $jobResourceModel = $this->createStub(JobResourceModel::class);
+        $jobResourceModel->method('getConnection')->willReturn($adapter);
+
+        $cmd = $this->createPartialObjectToTest(['clearQueueTableForStoreFallback'], jobResourceModel: $jobResourceModel);
+        $output = new BufferedOutput();
+        $this->setPrivateProperty($cmd, 'output', $output);
 
         $cmd->expects($this->once())->method('clearQueueTableForStoreFallback')->with(5);
 
@@ -283,19 +259,17 @@ class ClearQueueCommandTest extends TestCase
         $this->assertStringContainsString('JSON filtering not supported', $output->fetch());
     }
 
-    /**
-     * @throws \ReflectionException
-     */
     public function testClearQueueForStoreFallbackDeletesMatching(): void
     {
-        $cmd = $this->makePartial();
-        $output = $this->bufOut();
+        $adapter = $this->createMockSearchAdapter();
+        $output = new BufferedOutput();
+
+        $jobResourceModel = $this->createStub(JobResourceModel::class);
+        $jobResourceModel->method('getConnection')->willReturn($adapter);
+        $jobResourceModel->method('getMainTable')->willReturn('algoliasearch_queue');
+
+        $cmd = $this->createObjectToTest(jobResourceModel: $jobResourceModel);
         $this->setPrivateProperty($cmd, 'output', $output);
-
-        $adapter = $this->getMockSearchAdapter();
-
-        $this->jobResourceModel->method('getConnection')->willReturn($adapter);
-        $this->jobResourceModel->method('getMainTable')->willReturn('algoliasearch_queue');
 
         $adapter->method('fetchAll')->willReturn([
             ['job_id' => 1, 'data' => '{"storeId":5,"foo":1}'],
@@ -305,7 +279,7 @@ class ClearQueueCommandTest extends TestCase
 
         $adapter->expects($this->once())
             ->method('delete')
-            ->with('algoliasearch_queue', ['job_id IN (?)' => [1,3]])
+            ->with('algoliasearch_queue', ['job_id IN (?)' => [1, 3]])
             ->willReturn(2);
 
         $this->invokeMethod($cmd, 'clearQueueTableForStoreFallback', [5]);
@@ -313,21 +287,20 @@ class ClearQueueCommandTest extends TestCase
         $this->assertStringContainsString('Deleted 2 jobs for store ID 5 (fallback method)', $output->fetch());
     }
 
-    /**
-     * @throws \ReflectionException
-     */
     public function testClearQueueForStoreFallbackNoMatch(): void
     {
-        $cmd = $this->makePartial();
-        $output = $this->bufOut();
-        $this->setPrivateProperty($cmd, 'output', $output);
-
-        $adapter = $this->getMockSearchAdapter();
-        $this->jobResourceModel->method('getConnection')->willReturn($adapter);
-
+        $adapter = $this->createStubSearchAdapter();
         $adapter->method('fetchAll')->willReturn([
             ['job_id' => 1, 'data' => '{"storeId":8}'],
         ]);
+
+        $output = new BufferedOutput();
+
+        $jobResourceModel = $this->createStub(JobResourceModel::class);
+        $jobResourceModel->method('getConnection')->willReturn($adapter);
+
+        $cmd = $this->createObjectToTest(jobResourceModel: $jobResourceModel);
+        $this->setPrivateProperty($cmd, 'output', $output);
 
         $this->invokeMethod($cmd, 'clearQueueTableForStoreFallback', [5]);
 
@@ -336,11 +309,13 @@ class ClearQueueCommandTest extends TestCase
 
     public function testClearQueueForStoreFallbackThrowsWrapped(): void
     {
-        $cmd = $this->makePartial();
-        $adapter = $this->getMockSearchAdapter();
-        $this->jobResourceModel->method('getConnection')->willReturn($adapter);
-
+        $adapter = $this->createStubSearchAdapter();
         $adapter->method('fetchAll')->willThrowException(new \Exception('db fail'));
+
+        $jobResourceModel = $this->createStub(JobResourceModel::class);
+        $jobResourceModel->method('getConnection')->willReturn($adapter);
+
+        $cmd = $this->createObjectToTest(jobResourceModel: $jobResourceModel);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Failed to clear queue for store 5: db fail');
@@ -350,60 +325,34 @@ class ClearQueueCommandTest extends TestCase
 
     public function testMetadataStrings(): void
     {
-        $cmd = $this->makePartial();
+        $cmd = $this->createObjectToTest();
         $this->assertSame('clear', $this->invokeMethod($cmd, 'getCommandName'));
         $this->assertStringContainsString('queue:', $this->invokeMethod($cmd, 'getCommandPrefix'));
         $this->assertStringContainsString('Clear the indexing queue', $this->invokeMethod($cmd, 'getCommandDescription'));
         $this->assertStringContainsString('algolia:queue:clear', $this->invokeMethod($cmd, 'getStoreArgumentDescription'));
     }
 
-    /**
-     * Create a partial mock of the ClearQueueCommand
-     *
-     * @param array $methodsToMock List of methods to mock
-     */
-    private function makePartial(array $methodsToMock = []): ClearQueueCommand&MockObject
+    private function createStubSearchAdapter(): AdapterInterface
     {
-        /** @var ClearQueueCommand&MockObject $cmd */
-        $cmd = $this->getMockBuilder(ClearQueueCommand::class)
-            ->setConstructorArgs([
-                $this->state,
-                $this->storeNameFetcher,
-                $this->storeManager,
-                $this->jobResourceModel,
-                null,
-            ])
-            ->onlyMethods($methodsToMock)
-            ->getMock();
-
-        return $cmd;
-    }
-
-    private function getMockSearchAdapter(): AdapterInterface&MockObject
-    {
-        $adapter = $this->createMock(AdapterInterface::class);
-        $select  = $this->createMock(Select::class);
-
-        // Build chainable select
-        $adapter->method('select')->willReturn($select);
+        $select = $this->createStub(Select::class);
         $select->method('from')->willReturnSelf();
         $select->method('where')->willReturnSelf();
+
+        $adapter = $this->createStub(AdapterInterface::class);
+        $adapter->method('select')->willReturn($select);
 
         return $adapter;
     }
 
-    private function bufOut(): BufferedOutput
+    private function createMockSearchAdapter(): AdapterInterface&MockObject
     {
-        // Verbosity NORMAL is fine; change if you want debug output
-        return new BufferedOutput();
-    }
+        $select = $this->createStub(Select::class);
+        $select->method('from')->willReturnSelf();
+        $select->method('where')->willReturnSelf();
 
-    /**
-     * @throws \ReflectionException
-     */
-    private function invokeExecute(ClearQueueCommand $cmd, $input, $output): int
-    {
-        return $this->invokeMethod($cmd, 'execute', [$input, $output]);
-    }
+        $adapter = $this->createMock(AdapterInterface::class);
+        $adapter->method('select')->willReturn($select);
 
+        return $adapter;
+    }
 }

--- a/Test/Unit/Controller/Adminhtml/IndexingManager/ReindexTest.php
+++ b/Test/Unit/Controller/Adminhtml/IndexingManager/ReindexTest.php
@@ -16,175 +16,178 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[AllowMockObjectsWithoutExpectations]
 class ReindexTest extends TestCase
 {
-    protected ?Reindex $reindexController = null;
+    protected function createObjectToTest(
+        ?RequestInterface $request = null,
+        ?ManagerInterface $messageManager = null,
+        ?ResultFactory $resultFactory = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?StoreNameFetcher $storeNameFetcher = null,
+        ?IndexNameFetcher $indexNameFetcher = null,
+        ?ConfigHelper $configHelper = null,
+        ?ProductBatchQueueProcessor $productBatchQueueProcessor = null,
+        ?CategoryBatchQueueProcessor $categoryBatchQueueProcessor = null,
+        ?PageBatchQueueProcessor $pageBatchQueueProcessor = null,
+    ): Reindex {
+        if ($resultFactory === null) {
+            $resultInstance = $this->createStub(Redirect::class);
+            $resultInstance->method('setPath')->willReturnSelf();
 
-    protected ?Context $context = null;
-    protected ?RequestInterface $request = null;
-    protected ?ManagerInterface $messageManager = null;
-    protected ?ResultFactory $resultFactory = null;
+            $resultFactory = $this->createStub(ResultFactory::class);
+            $resultFactory->method('create')->willReturn($resultInstance);
+        }
 
-    protected ?StoreManagerInterface $storeManager = null;
-    protected ?StoreNameFetcher $storeNameFetcher = null;
-    protected ?IndexNameFetcher $indexNameFetcher = null;
-    protected ?ConfigHelper $configHelper = null;
-    protected ?ProductBatchQueueProcessor $productBatchQueueProcessor = null;
-    protected ?CategoryBatchQueueProcessor $categoryBatchQueueProcessor = null;
-    protected ?PageBatchQueueProcessor $pageBatchQueueProcessor = null;
+        $context = $this->createStub(Context::class);
+        $context->method('getRequest')->willReturn($request ?? $this->createStub(RequestInterface::class));
+        $context->method('getMessageManager')->willReturn($messageManager ?? $this->createStub(ManagerInterface::class));
+        $context->method('getResultFactory')->willReturn($resultFactory);
 
-    protected ?array $stores = ['1' => 'foo', '2' => 'bar'];
-
-    protected function setUp(): void
-    {
-        $this->request = $this->createMock(RequestInterface::class);
-        $this->messageManager = $this->createMock(ManagerInterface::class);
-        $this->resultFactory = $this->createMock(ResultFactory::class);
-        $resultInstance = $this->createMock(Redirect::class);
-        $resultInstance->method('setPath')->willReturn('');
-        $this->resultFactory->method('create')
-            ->with(ResultFactory::TYPE_REDIRECT)
-            ->willReturn($resultInstance);
-
-        $this->context = $this->createMock(Context::class);
-        $this->context->method('getRequest')->willReturn($this->request);
-        $this->context->method('getMessageManager')->willReturn($this->messageManager);
-        $this->context->method('getResultFactory')->willReturn($this->resultFactory);
-
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->storeManager->method('getStores')->willReturn($this->stores);
-
-        $this->storeNameFetcher = $this->createMock(StoreNameFetcher::class);
-        $this->indexNameFetcher = $this->createMock(IndexNameFetcher::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
-        $this->categoryBatchQueueProcessor = $this->createMock(CategoryBatchQueueProcessor::class);
-        $this->pageBatchQueueProcessor = $this->createMock(PageBatchQueueProcessor::class);
-
-        $this->reindexController = new Reindex(
-            $this->context,
-            $this->storeManager,
-            $this->storeNameFetcher,
-            $this->indexNameFetcher,
-            $this->configHelper,
-            $this->productBatchQueueProcessor,
-            $this->categoryBatchQueueProcessor,
-            $this->pageBatchQueueProcessor
+        return new Reindex(
+            $context,
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $storeNameFetcher ?? $this->createStub(StoreNameFetcher::class),
+            $indexNameFetcher ?? $this->createStub(IndexNameFetcher::class),
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $productBatchQueueProcessor ?? $this->createStub(ProductBatchQueueProcessor::class),
+            $categoryBatchQueueProcessor ?? $this->createStub(CategoryBatchQueueProcessor::class),
+            $pageBatchQueueProcessor ?? $this->createStub(PageBatchQueueProcessor::class),
         );
     }
 
     public function testExecuteFullIndexingAllEntitiesAllStores()
     {
-        $this->request
-            ->expects($this->once())
-            ->method('getParams')
-            ->willReturn([
-                'store_id' => null,
-                'entity' => 'all',
-            ]);
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->once())->method('getParams')->willReturn([
+            'store_id' => null,
+            'entity' => 'all',
+        ]);
 
-        $this->productBatchQueueProcessor
-            ->expects($this->exactly(2))
-            ->method('processBatch');
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn(['1' => 'foo', '2' => 'bar']);
 
-        $this->categoryBatchQueueProcessor
-            ->expects($this->exactly(2))
-            ->method('processBatch');
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->exactly(2))->method('processBatch');
 
-        $this->pageBatchQueueProcessor
-            ->expects($this->exactly(2))
-            ->method('processBatch');
+        $categoryBatchQueueProcessor = $this->createMock(CategoryBatchQueueProcessor::class);
+        $categoryBatchQueueProcessor->expects($this->exactly(2))->method('processBatch');
 
-        $this->reindexController->execute();
+        $pageBatchQueueProcessor = $this->createMock(PageBatchQueueProcessor::class);
+        $pageBatchQueueProcessor->expects($this->exactly(2))->method('processBatch');
+
+        $controller = $this->createObjectToTest(
+            request: $request,
+            storeManager: $storeManager,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+            categoryBatchQueueProcessor: $categoryBatchQueueProcessor,
+            pageBatchQueueProcessor: $pageBatchQueueProcessor,
+        );
+
+        $controller->execute();
     }
 
     public function testExecuteFullIndexingPagesAllStores()
     {
-        $this->request
-            ->expects($this->once())
-            ->method('getParams')
-            ->willReturn([
-                'store_id' => null,
-                'entity' => 'pages',
-            ]);
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->once())->method('getParams')->willReturn([
+            'store_id' => null,
+            'entity' => 'pages',
+        ]);
 
-        $this->productBatchQueueProcessor
-            ->expects($this->never())
-            ->method('processBatch');
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn(['1' => 'foo', '2' => 'bar']);
 
-        $this->categoryBatchQueueProcessor
-            ->expects($this->never())
-            ->method('processBatch');
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->never())->method('processBatch');
 
-        $this->pageBatchQueueProcessor
-            ->expects($this->exactly(2))
-            ->method('processBatch');
+        $categoryBatchQueueProcessor = $this->createMock(CategoryBatchQueueProcessor::class);
+        $categoryBatchQueueProcessor->expects($this->never())->method('processBatch');
 
-        $this->reindexController->execute();
+        $pageBatchQueueProcessor = $this->createMock(PageBatchQueueProcessor::class);
+        $pageBatchQueueProcessor->expects($this->exactly(2))->method('processBatch');
+
+        $controller = $this->createObjectToTest(
+            request: $request,
+            storeManager: $storeManager,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+            categoryBatchQueueProcessor: $categoryBatchQueueProcessor,
+            pageBatchQueueProcessor: $pageBatchQueueProcessor,
+        );
+
+        $controller->execute();
     }
 
     public function testExecuteFullIndexingProductsOneStore()
     {
-        $this->request
-            ->expects($this->once())
-            ->method('getParams')
-            ->willReturn([
-                'store_id' => '1',
-                'entity' => 'products',
-            ]);
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->once())->method('getParams')->willReturn([
+            'store_id' => '1',
+            'entity' => 'products',
+        ]);
 
-        $this->productBatchQueueProcessor
-            ->expects($this->once())
-            ->method('processBatch');
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->once())->method('processBatch');
 
-        $this->categoryBatchQueueProcessor
-            ->expects($this->never())
-            ->method('processBatch');
+        $categoryBatchQueueProcessor = $this->createMock(CategoryBatchQueueProcessor::class);
+        $categoryBatchQueueProcessor->expects($this->never())->method('processBatch');
 
-        $this->pageBatchQueueProcessor
-            ->expects($this->never())
-            ->method('processBatch');
+        $pageBatchQueueProcessor = $this->createMock(PageBatchQueueProcessor::class);
+        $pageBatchQueueProcessor->expects($this->never())->method('processBatch');
 
-        $this->reindexController->execute();
+        $controller = $this->createObjectToTest(
+            request: $request,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+            categoryBatchQueueProcessor: $categoryBatchQueueProcessor,
+            pageBatchQueueProcessor: $pageBatchQueueProcessor,
+        );
+
+        $controller->execute();
     }
 
     public function testExecuteProductsMassAction()
     {
         $selectedProducts = [2, 3, 4];
 
-        $this->request
-            ->expects($this->once())
-            ->method('getParams')
-            ->willReturn([
-                'store_id' => null,
-                'namespace' => 'product_listing',
-                'selected' => $selectedProducts,
-            ]);
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->once())->method('getParams')->willReturn([
+            'store_id' => null,
+            'namespace' => 'product_listing',
+            'selected' => $selectedProducts,
+        ]);
 
-        $this->productBatchQueueProcessor
-            ->expects($this->exactly(2))
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn(['1' => 'foo', '2' => 'bar']);
+
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->exactly(2))
             ->method('processBatch')
             ->with(1 || 2, $selectedProducts);
 
-        $this->categoryBatchQueueProcessor
-            ->expects($this->never())
-            ->method('processBatch');
+        $categoryBatchQueueProcessor = $this->createMock(CategoryBatchQueueProcessor::class);
+        $categoryBatchQueueProcessor->expects($this->never())->method('processBatch');
 
-        $this->pageBatchQueueProcessor
-            ->expects($this->never())
-            ->method('processBatch');
+        $pageBatchQueueProcessor = $this->createMock(PageBatchQueueProcessor::class);
+        $pageBatchQueueProcessor->expects($this->never())->method('processBatch');
 
-        $this->reindexController->execute();
+        $controller = $this->createObjectToTest(
+            request: $request,
+            storeManager: $storeManager,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+            categoryBatchQueueProcessor: $categoryBatchQueueProcessor,
+            pageBatchQueueProcessor: $pageBatchQueueProcessor,
+        );
+
+        $controller->execute();
     }
 
     #[DataProvider('entityParamsProvider')]
     public function testEntityToIndex($params, $result)
     {
-        $this->assertEquals($result, $this->invokeMethod($this->reindexController, 'defineEntitiesToIndex', [$params]));
+        $controller = $this->createObjectToTest();
+
+        $this->assertEquals($result, $this->invokeMethod($controller, 'defineEntitiesToIndex', [$params]));
     }
 
     public static function entityParamsProvider(): array
@@ -216,7 +219,9 @@ class ReindexTest extends TestCase
     #[DataProvider('redirectParamsProvider')]
     public function testRedirectPath($params, $result)
     {
-        $this->assertEquals($result, $this->invokeMethod($this->reindexController, 'defineRedirectPath', [$params]));
+        $controller = $this->createObjectToTest();
+
+        $this->assertEquals($result, $this->invokeMethod($controller, 'defineRedirectPath', [$params]));
     }
 
     public static function redirectParamsProvider(): array

--- a/Test/Unit/Controller/Adminhtml/IndexingManager/ReindexTest.php
+++ b/Test/Unit/Controller/Adminhtml/IndexingManager/ReindexTest.php
@@ -36,8 +36,8 @@ class ReindexTest extends TestCase
             $resultInstance = $this->createStub(Redirect::class);
             $resultInstance->method('setPath')->willReturnSelf();
 
-            $resultFactory = $this->createStub(ResultFactory::class);
-            $resultFactory->method('create')->willReturn($resultInstance);
+            $resultFactory = $this->createMock(ResultFactory::class);
+            $resultFactory->method('create')->with(ResultFactory::TYPE_REDIRECT)->willReturn($resultInstance);
         }
 
         $context = $this->createStub(Context::class);

--- a/Test/Unit/Helper/ConfigHelperTest.php
+++ b/Test/Unit/Helper/ConfigHelperTest.php
@@ -95,11 +95,11 @@ class ConfigHelperTest extends TestCase
     ): void {
         $storeId = 1;
 
-        $autocompleteHelper = $this->createStub(AutocompleteHelper::class);
-        $autocompleteHelper->method('isEnabled')->willReturn($isAutocompleteEnabled);
+        $autocompleteHelper = $this->createMock(AutocompleteHelper::class);
+        $autocompleteHelper->method('isEnabled')->with($storeId)->willReturn($isAutocompleteEnabled);
 
-        $instantSearchHelper = $this->createStub(InstantSearchHelper::class);
-        $instantSearchHelper->method('isEnabled')->willReturn($isInstantSearchEnabled);
+        $instantSearchHelper = $this->createMock(InstantSearchHelper::class);
+        $instantSearchHelper->method('isEnabled')->with($storeId)->willReturn($isInstantSearchEnabled);
 
         $configHelper = $this->createObjectToTest(
             autocompleteHelper: $autocompleteHelper,

--- a/Test/Unit/Helper/ConfigHelperTest.php
+++ b/Test/Unit/Helper/ConfigHelperTest.php
@@ -22,82 +22,69 @@ use Magento\Framework\Module\ResourceInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Weee\Helper\Data as WeeeHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class ConfigHelperTest extends TestCase
 {
-    protected ?ConfigHelper $configHelper;
-    protected ?ScopeConfigInterface $configInterface;
-    protected ?WriterInterface $configWriter;
-    protected ?StoreManagerInterface $storeManager;
-    protected ?Currency $currency;
-    protected ?DirCurrency $dirCurrency;
-    protected ?DirectoryList $directoryList;
-    protected ?ResourceInterface $moduleResource;
-    protected ?ProductMetadataInterface $productMetadata;
-    protected ?ManagerInterface $eventManager;
-    protected ?Serializer $serializer;
-    protected ?GroupCollection $groupCollection;
-    protected ?GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository;
-    protected ?CookieHelper $cookieHelper;
-    protected ?AutocompleteHelper $autocompleteHelper;
-    protected ?InstantSearchHelper $instantSearchHelper;
-    protected ?QueueHelper $queueHelper;
-
-    protected ?WeeeHelper $weeeHelper;
-
-    protected function setUp(): void
-    {
-        $this->configInterface = $this->createMock(ScopeConfigInterface::class);
-        $this->configWriter = $this->createMock(WriterInterface::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->currency = $this->createMock(Currency::class);
-        $this->dirCurrency = $this->createMock(DirCurrency::class);
-        $this->directoryList = $this->createMock(DirectoryList::class);
-        $this->moduleResource = $this->createMock(ResourceInterface::class);
-        $this->productMetadata = $this->createMock(ProductMetadataInterface::class);
-        $this->eventManager = $this->createMock(ManagerInterface::class);
-        $this->serializer = $this->createMock(Serializer::class);
-        $this->groupCollection = $this->createMock(GroupCollection::class);
-        $this->groupExcludedWebsiteRepository = $this->createMock(GroupExcludedWebsiteRepositoryInterface::class);
-        $this->cookieHelper = $this->createMock(CookieHelper::class);
-        $this->autocompleteHelper = $this->createMock(AutocompleteHelper::class);
-        $this->instantSearchHelper = $this->createMock(InstantSearchHelper::class);
-        $this->queueHelper = $this->createMock(QueueHelper::class);
-        $this->weeeHelper = $this->createMock(WeeeHelper::class);
-
-        $this->configHelper = new ConfigHelper(
-            $this->configInterface,
-            $this->configWriter,
-            $this->storeManager,
-            $this->currency,
-            $this->dirCurrency,
-            $this->directoryList,
-            $this->moduleResource,
-            $this->productMetadata,
-            $this->eventManager,
-            $this->serializer,
-            $this->groupCollection,
-            $this->groupExcludedWebsiteRepository,
-            $this->cookieHelper,
-            $this->autocompleteHelper,
-            $this->instantSearchHelper,
-            $this->queueHelper,
-            $this->weeeHelper
+    protected function createObjectToTest(
+        ?ScopeConfigInterface $configInterface = null,
+        ?WriterInterface $configWriter = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?Currency $currency = null,
+        ?DirCurrency $dirCurrency = null,
+        ?DirectoryList $directoryList = null,
+        ?ResourceInterface $moduleResource = null,
+        ?ProductMetadataInterface $productMetadata = null,
+        ?ManagerInterface $eventManager = null,
+        ?Serializer $serializer = null,
+        ?GroupCollection $groupCollection = null,
+        ?GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository = null,
+        ?CookieHelper $cookieHelper = null,
+        ?AutocompleteHelper $autocompleteHelper = null,
+        ?InstantSearchHelper $instantSearchHelper = null,
+        ?QueueHelper $queueHelper = null,
+        ?WeeeHelper $weeeHelper = null,
+    ): ConfigHelper {
+        return new ConfigHelper(
+            $configInterface ?? $this->createStub(ScopeConfigInterface::class),
+            $configWriter ?? $this->createStub(WriterInterface::class),
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $currency ?? $this->createStub(Currency::class),
+            $dirCurrency ?? $this->createStub(DirCurrency::class),
+            $directoryList ?? $this->createStub(DirectoryList::class),
+            $moduleResource ?? $this->createStub(ResourceInterface::class),
+            $productMetadata ?? $this->createStub(ProductMetadataInterface::class),
+            $eventManager ?? $this->createStub(ManagerInterface::class),
+            $serializer ?? $this->createStub(Serializer::class),
+            $groupCollection ?? $this->createStub(GroupCollection::class),
+            $groupExcludedWebsiteRepository ?? $this->createStub(GroupExcludedWebsiteRepositoryInterface::class),
+            $cookieHelper ?? $this->createStub(CookieHelper::class),
+            $autocompleteHelper ?? $this->createStub(AutocompleteHelper::class),
+            $instantSearchHelper ?? $this->createStub(InstantSearchHelper::class),
+            $queueHelper ?? $this->createStub(QueueHelper::class),
+            $weeeHelper ?? $this->createStub(WeeeHelper::class),
         );
     }
 
     public function testGetIndexPrefix()
     {
         $testPrefix = 'foo_bar_';
-        $this->configInterface->method('getValue')->willReturn($testPrefix);
-        $this->assertEquals($testPrefix, $this->configHelper->getIndexPrefix());
+
+        $configInterface = $this->createStub(ScopeConfigInterface::class);
+        $configInterface->method('getValue')->willReturn($testPrefix);
+
+        $configHelper = $this->createObjectToTest(configInterface: $configInterface);
+
+        $this->assertEquals($testPrefix, $configHelper->getIndexPrefix());
     }
 
-    public function testGetIndexPrefixWhenNull() {
-        $this->configInterface->method('getValue')->willReturn(null);
-        $this->assertEquals('', $this->configHelper->getIndexPrefix());
+    public function testGetIndexPrefixWhenNull()
+    {
+        $configInterface = $this->createStub(ScopeConfigInterface::class);
+        $configInterface->method('getValue')->willReturn(null);
+
+        $configHelper = $this->createObjectToTest(configInterface: $configInterface);
+
+        $this->assertEquals('', $configHelper->getIndexPrefix());
     }
 
     #[DataProvider('isEnabledFrontEndProvider')]
@@ -108,10 +95,18 @@ class ConfigHelperTest extends TestCase
     ): void {
         $storeId = 1;
 
-        $this->autocompleteHelper->method('isEnabled')->with($storeId)->willReturn($isAutocompleteEnabled);
-        $this->instantSearchHelper->method('isEnabled')->with($storeId)->willReturn($isInstantSearchEnabled);
+        $autocompleteHelper = $this->createStub(AutocompleteHelper::class);
+        $autocompleteHelper->method('isEnabled')->willReturn($isAutocompleteEnabled);
 
-        $this->assertSame($expectedResult, $this->configHelper->isEnabledFrontEnd($storeId));
+        $instantSearchHelper = $this->createStub(InstantSearchHelper::class);
+        $instantSearchHelper->method('isEnabled')->willReturn($isInstantSearchEnabled);
+
+        $configHelper = $this->createObjectToTest(
+            autocompleteHelper: $autocompleteHelper,
+            instantSearchHelper: $instantSearchHelper,
+        );
+
+        $this->assertSame($expectedResult, $configHelper->isEnabledFrontEnd($storeId));
     }
 
     public static function isEnabledFrontEndProvider(): array

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -110,7 +110,7 @@ class ProductHelperTest extends TestCase
         $indexOptions = $this->createIndexOptions('prod_index');
 
         $algoliaConnector = $this->createMock(AlgoliaConnector::class);
-        $algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($indexOptions);
+        $algoliaConnector->expects($this->never())->method('collectTaskIdToWaitFor')->with($indexOptions);
 
         $productHelper = $this->createObjectToTest(
             indexSettingsHandler: $indexSettingsHandler,

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -123,7 +123,7 @@ class ProductHelperTest extends TestCase
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
+        $this->algoliaConnector->expects($this->never())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
 
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -119,7 +119,7 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
-    public function testWaitsForLastTaskWhenSettingsChanged(): void
+    public function testWDoesNotCollectTaskIdWhenSettingsChanged(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -119,15 +119,6 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
-    public function testWaitsForLastTaskWhenSettingsChanged(): void
-    {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
-
-        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
-
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
-    }
-
     public function testDoesNotPushSettingsToTmpIndexWhenFlagIsFalse(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -6,7 +6,6 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Helper\Entity;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
-use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
@@ -26,157 +25,184 @@ use Magento\Eav\Model\Config;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class ProductHelperTest extends TestCase
 {
     private array $defaultSettings = ['searchableAttributes' => [], 'customRanking' => []];
     private int $storeId = 1;
 
-    private null|(Config&MockObject) $eavConfig = null;
-    private null|(ConfigHelper&MockObject) $configHelper = null;
-    private null|(AlgoliaConnector&MockObject) $algoliaConnector = null;
-    private null|(IndexOptionsBuilder&MockObject) $indexOptionsBuilder = null;
-    private null|(DiagnosticsLogger&MockObject) $logger = null;
-    private null|(StoreManagerInterface&MockObject) $storeManager = null;
-    private null|(ManagerInterface&MockObject) $eventManager = null;
-    private null|(Visibility&MockObject) $visibility = null;
-    private null|(Stock&MockObject) $stockHelper = null;
-    private null|(Type&MockObject) $productType = null;
-    private null|(CollectionFactory&MockObject) $productCollectionFactory = null;
-    private null|(IndexNameFetcher&MockObject) $indexNameFetcher = null;
-    private null|(ReplicaManagerInterface&MockObject) $replicaManager = null;
-    private null|(ProductInterfaceFactory&MockObject) $productFactory = null;
-    private null|(ProductRecordBuilder&MockObject) $productRecordBuilder = null;
-    private null|(FacetBuilder&MockObject) $facetBuilder = null;
-    private null|(IndexSettingsHandler&MockObject) $indexSettingsHandler = null;
-    private null|(ProductHelper&MockObject) $productHelper = null;
-    private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
-    private null|(IndexOptionsInterface&MockObject) $indexTmpOptions = null;
-
-    protected function setUp(): void
-    {
-        $this->eavConfig = $this->createMock(Config::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->algoliaConnector = $this->createMock(AlgoliaConnector::class);
-        $this->indexOptionsBuilder = $this->createMock(IndexOptionsBuilder::class);
-        $this->logger = $this->createMock(DiagnosticsLogger::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->eventManager = $this->createMock(ManagerInterface::class);
-        $this->visibility = $this->createMock(Visibility::class);
-        $this->stockHelper = $this->createMock(Stock::class);
-        $this->productType = $this->createMock(Type::class);
-        $this->productCollectionFactory = $this->createMock(CollectionFactory::class);
-        $this->indexNameFetcher = $this->createMock(IndexNameFetcher::class);
-        $this->replicaManager = $this->createMock(ReplicaManagerInterface::class);
-        $this->productFactory = $this->createMock(ProductInterfaceFactory::class);
-        $this->productRecordBuilder = $this->createMock(ProductRecordBuilder::class);
-        $this->facetBuilder = $this->createMock(FacetBuilder::class);
-        $this->indexSettingsHandler = $this->createMock(IndexSettingsHandler::class);
-
-        // Partial mock: stub getIndexSettings and the protected setFacetsQueryRules
-        // so setSettings() tests remain isolated from their implementations
-        $this->productHelper = $this->getMockBuilder(ProductHelper::class)
+    /**
+     * ProductHelper is partially mocked to isolate setSettings() from getIndexSettings() and
+     * setFacetsQueryRules(), whose own real implementations pull in unrelated collaborators.
+     * getIndexSettings() is unconditionally called exactly once by setSettings(), so asserting
+     * that real invariant here also satisfies PHPUnit's "no expectations" check for this mock.
+     */
+    protected function createObjectToTest(
+        ?ConfigHelper $configHelper = null,
+        ?AlgoliaConnector $algoliaConnector = null,
+        ?DiagnosticsLogger $logger = null,
+        ?IndexSettingsHandler $indexSettingsHandler = null,
+        ?ReplicaManagerInterface $replicaManager = null,
+        ?FacetBuilder $facetBuilder = null,
+    ): ProductHelper&MockObject {
+        $productHelper = $this->getMockBuilder(ProductHelper::class)
             ->setConstructorArgs([
-                $this->eavConfig,
-                $this->configHelper,
-                $this->algoliaConnector,
-                $this->indexOptionsBuilder,
-                $this->logger,
-                $this->storeManager,
-                $this->eventManager,
-                $this->visibility,
-                $this->stockHelper,
-                $this->productType,
-                $this->productCollectionFactory,
-                $this->indexNameFetcher,
-                $this->replicaManager,
-                $this->productFactory,
-                $this->productRecordBuilder,
-                $this->facetBuilder,
-                $this->indexSettingsHandler,
+                $this->createStub(Config::class),
+                $configHelper ?? $this->createStub(ConfigHelper::class),
+                $algoliaConnector ?? $this->createStub(AlgoliaConnector::class),
+                $this->createStub(IndexOptionsBuilder::class),
+                $logger ?? $this->createStub(DiagnosticsLogger::class),
+                $this->createStub(StoreManagerInterface::class),
+                $this->createStub(ManagerInterface::class),
+                $this->createStub(Visibility::class),
+                $this->createStub(Stock::class),
+                $this->createStub(Type::class),
+                $this->createStub(CollectionFactory::class),
+                $this->createStub(IndexNameFetcher::class),
+                $replicaManager ?? $this->createStub(ReplicaManagerInterface::class),
+                $this->createStub(ProductInterfaceFactory::class),
+                $this->createStub(ProductRecordBuilder::class),
+                $facetBuilder ?? $this->createStub(FacetBuilder::class),
+                $indexSettingsHandler ?? $this->createStub(IndexSettingsHandler::class),
             ])
             ->onlyMethods(['getIndexSettings', 'setFacetsQueryRules'])
             ->getMock();
 
-        $this->productHelper->method('getIndexSettings')->willReturn($this->defaultSettings);
+        $productHelper->expects($this->once())->method('getIndexSettings')->willReturn($this->defaultSettings);
 
-        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
-        $this->indexOptions->method('getIndexName')->willReturn('prod_index');
+        return $productHelper;
+    }
 
-        $this->indexTmpOptions = $this->createMock(IndexOptionsInterface::class);
-        $this->indexTmpOptions->method('getIndexName')->willReturn('prod_index_tmp');
+    private function createIndexOptions(string $indexName): IndexOptionsInterface
+    {
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
+        $indexOptions->method('getIndexName')->willReturn($indexName);
+
+        return $indexOptions;
     }
 
     public function testSkipsAlgoliaConnectorUpdateWhenSettingsUnchanged(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(false);
 
-        $this->algoliaConnector->expects($this->never())->method('waitLastTask');
-        $this->algoliaConnector->expects($this->never())->method('setSettings');
+        $algoliaConnector = $this->createMock(AlgoliaConnector::class);
+        $algoliaConnector->expects($this->never())->method('waitLastTask');
+        $algoliaConnector->expects($this->never())->method('setSettings');
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+        $productHelper = $this->createObjectToTest(
+            indexSettingsHandler: $indexSettingsHandler,
+            algoliaConnector: $algoliaConnector,
+        );
+
+        $productHelper->setSettings(
+            $this->createIndexOptions('prod_index'),
+            $this->createIndexOptions('prod_index_tmp'),
+            $this->storeId
+        );
     }
 
     public function testWaitsForLastTaskWhenSettingsChanged(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
+        $indexOptions = $this->createIndexOptions('prod_index');
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+        $algoliaConnector = $this->createMock(AlgoliaConnector::class);
+        $algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($indexOptions);
+
+        $productHelper = $this->createObjectToTest(
+            indexSettingsHandler: $indexSettingsHandler,
+            algoliaConnector: $algoliaConnector,
+        );
+
+        $productHelper->setSettings($indexOptions, $this->createIndexOptions('prod_index_tmp'), $this->storeId);
     }
 
     public function testDoesNotPushSettingsToTmpIndexWhenFlagIsFalse(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->never())->method('setSettings');
+        $algoliaConnector = $this->createMock(AlgoliaConnector::class);
+        $algoliaConnector->expects($this->never())->method('setSettings');
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, false);
+        $productHelper = $this->createObjectToTest(
+            indexSettingsHandler: $indexSettingsHandler,
+            algoliaConnector: $algoliaConnector,
+        );
+
+        $productHelper->setSettings(
+            $this->createIndexOptions('prod_index'),
+            $this->createIndexOptions('prod_index_tmp'),
+            $this->storeId,
+            false
+        );
     }
 
     public function testPushesSettingsToTmpIndexWithMergeParametersWhenFlagIsTrue(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->once())
+        $indexOptions = $this->createIndexOptions('prod_index');
+        $indexTmpOptions = $this->createIndexOptions('prod_index_tmp');
+
+        $algoliaConnector = $this->createMock(AlgoliaConnector::class);
+        $algoliaConnector->expects($this->once())
             ->method('copyIndexConfig')
-            ->with(
-                $this->indexOptions,
-                $this->indexTmpOptions
-            );
+            ->with($indexOptions, $indexTmpOptions);
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
+        $productHelper = $this->createObjectToTest(
+            indexSettingsHandler: $indexSettingsHandler,
+            algoliaConnector: $algoliaConnector,
+        );
+
+        $productHelper->setSettings($indexOptions, $indexTmpOptions, $this->storeId, true);
     }
 
     public function testNoPushSettingsToTmpIndexWithMergeParametersWhenFlagIsFalse(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(true);
 
-        $this->algoliaConnector->expects($this->never())
-            ->method('copyIndexConfig');
+        $algoliaConnector = $this->createMock(AlgoliaConnector::class);
+        $algoliaConnector->expects($this->never())->method('copyIndexConfig');
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, false);
+        $productHelper = $this->createObjectToTest(
+            indexSettingsHandler: $indexSettingsHandler,
+            algoliaConnector: $algoliaConnector,
+        );
+
+        $productHelper->setSettings(
+            $this->createIndexOptions('prod_index'),
+            $this->createIndexOptions('prod_index_tmp'),
+            $this->storeId,
+            false
+        );
     }
 
     public function testAlwaysCallsSetFacetsQueryRulesForMainIndexEvenWhenSettingsUnchanged(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(false);
 
-        $this->productHelper->expects($this->atLeastOnce())
-            ->method('setFacetsQueryRules')
-            ->with($this->indexOptions);
+        $indexOptions = $this->createIndexOptions('prod_index');
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+        $productHelper = $this->createObjectToTest(indexSettingsHandler: $indexSettingsHandler);
+        $productHelper->expects($this->atLeastOnce())->method('setFacetsQueryRules')->with($indexOptions);
+
+        $productHelper->setSettings($indexOptions, $this->createIndexOptions('prod_index_tmp'), $this->storeId);
     }
 
     public function testCallsSetFacetsQueryRulesForTmpIndexWhenSaveToTmpIsTrue(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(false);
 
-        $this->productHelper->expects($this->exactly(2))
+        $productHelper = $this->createObjectToTest(indexSettingsHandler: $indexSettingsHandler);
+        $productHelper->expects($this->exactly(2))
             ->method('setFacetsQueryRules')
             ->willReturnCallback(function (IndexOptionsInterface $opts) {
                 static $calls = [];
@@ -184,28 +210,46 @@ class ProductHelperTest extends TestCase
                 return null;
             });
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, true);
+        $productHelper->setSettings(
+            $this->createIndexOptions('prod_index'),
+            $this->createIndexOptions('prod_index_tmp'),
+            $this->storeId,
+            true
+        );
     }
 
     public function testDoesNotCallSetFacetsQueryRulesForTmpIndexWhenFlagIsFalse(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(false);
 
-        $this->productHelper->expects($this->once())
-            ->method('setFacetsQueryRules')
-            ->with($this->indexOptions);
+        $indexOptions = $this->createIndexOptions('prod_index');
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId, false);
+        $productHelper = $this->createObjectToTest(indexSettingsHandler: $indexSettingsHandler);
+        $productHelper->expects($this->once())->method('setFacetsQueryRules')->with($indexOptions);
+
+        $productHelper->setSettings($indexOptions, $this->createIndexOptions('prod_index_tmp'), $this->storeId, false);
     }
 
     public function testAlwaysSyncsReplicasToAlgoliaWithIndexSettings(): void
     {
-        $this->indexSettingsHandler->method('setSettings')->willReturn(false);
+        $indexSettingsHandler = $this->createStub(IndexSettingsHandler::class);
+        $indexSettingsHandler->method('setSettings')->willReturn(false);
 
-        $this->replicaManager->expects($this->once())
+        $replicaManager = $this->createMock(ReplicaManagerInterface::class);
+        $replicaManager->expects($this->once())
             ->method('syncReplicasToAlgolia')
             ->with($this->storeId, $this->defaultSettings);
 
-        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+        $productHelper = $this->createObjectToTest(
+            indexSettingsHandler: $indexSettingsHandler,
+            replicaManager: $replicaManager,
+        );
+
+        $productHelper->setSettings(
+            $this->createIndexOptions('prod_index'),
+            $this->createIndexOptions('prod_index_tmp'),
+            $this->storeId
+        );
     }
 }

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -119,7 +119,7 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
-    public function testWDoesNotCollectTaskIdWhenSettingsChanged(): void
+    public function testDoesNotCollectTaskIdWhenSettingsChanged(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);
 

--- a/Test/Unit/Helper/Entity/ProductHelperTest.php
+++ b/Test/Unit/Helper/Entity/ProductHelperTest.php
@@ -119,6 +119,15 @@ class ProductHelperTest extends TestCase
         $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
     }
 
+    public function testWaitsForLastTaskWhenSettingsChanged(): void
+    {
+        $this->indexSettingsHandler->method('setSettings')->willReturn(true);
+
+        $this->algoliaConnector->expects($this->atLeastOnce())->method('collectTaskIdToWaitFor')->with($this->indexOptions);
+
+        $this->productHelper->setSettings($this->indexOptions, $this->indexTmpOptions, $this->storeId);
+    }
+
     public function testDoesNotPushSettingsToTmpIndexWhenFlagIsFalse(): void
     {
         $this->indexSettingsHandler->method('setSettings')->willReturn(true);

--- a/Test/Unit/Helper/InstantSearchHelperTest.php
+++ b/Test/Unit/Helper/InstantSearchHelperTest.php
@@ -10,60 +10,52 @@ use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Store\Model\ScopeInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class InstantSearchHelperTest extends TestCase
 {
     public const MAGENTO_GRID_PRODUCTS_NB = 9;
     public const MAGENTO_LIST_PRODUCTS_NB = 15;
 
-    protected ?InstantSearchHelper $instantSearchHelper;
-
-    protected ?ScopeConfigInterface $configInterface;
-    protected ?WriterInterface $configWriter;
-    protected ?Serializer $serializer;
-
-    protected function setUp(): void
-    {
-        $this->configInterface = $this->createMock(ScopeConfigInterface::class);
-        $this->configWriter = $this->createMock(WriterInterface::class);
-        $this->serializer = $this->createMock(Serializer::class);
-
-        $this->instantSearchHelper = new InstantSearchHelper(
-            $this->configInterface,
-            $this->configWriter,
-            $this->serializer
+    protected function createObjectToTest(
+        ?ScopeConfigInterface $configInterface = null,
+        ?WriterInterface $configWriter = null,
+        ?Serializer $serializer = null,
+    ): InstantSearchHelper {
+        return new InstantSearchHelper(
+            $configInterface ?? $this->createStub(ScopeConfigInterface::class),
+            $configWriter ?? $this->createStub(WriterInterface::class),
+            $serializer ?? $this->createStub(Serializer::class),
         );
     }
 
     #[DataProvider('conficProvider')]
     public function testGetNumberOfProductResults($paginationMode, $customNbOfProducts, $expectedResult): void
     {
-        $this->configInterface
-            ->method('getValue')
-            ->willReturnMap(
-                [
-                    [InstantSearchHelper::PAGINATION_MODE, ScopeInterface::SCOPE_STORE, null, $paginationMode],
-                    [InstantSearchHelper::MAGENTO_GRID_PER_PAGE, ScopeInterface::SCOPE_STORE, null, self::MAGENTO_GRID_PRODUCTS_NB],
-                    [InstantSearchHelper::MAGENTO_LIST_PER_PAGE, ScopeInterface::SCOPE_STORE, null, self::MAGENTO_LIST_PRODUCTS_NB],
-                    [InstantSearchHelper::NUMBER_OF_PRODUCT_RESULTS, ScopeInterface::SCOPE_STORE, null, $customNbOfProducts],
-                ]
-            );
+        $configInterface = $this->createStub(ScopeConfigInterface::class);
+        $configInterface->method('getValue')->willReturnMap(
+            [
+                [InstantSearchHelper::PAGINATION_MODE, ScopeInterface::SCOPE_STORE, null, $paginationMode],
+                [InstantSearchHelper::MAGENTO_GRID_PER_PAGE, ScopeInterface::SCOPE_STORE, null, self::MAGENTO_GRID_PRODUCTS_NB],
+                [InstantSearchHelper::MAGENTO_LIST_PER_PAGE, ScopeInterface::SCOPE_STORE, null, self::MAGENTO_LIST_PRODUCTS_NB],
+                [InstantSearchHelper::NUMBER_OF_PRODUCT_RESULTS, ScopeInterface::SCOPE_STORE, null, $customNbOfProducts],
+            ]
+        );
+
+        $instantSearchHelper = $this->createObjectToTest(configInterface: $configInterface);
 
         // Sanity checks
-        $this->assertEquals($paginationMode, $this->instantSearchHelper->getPaginationMode());
+        $this->assertEquals($paginationMode, $instantSearchHelper->getPaginationMode());
         $this->assertEquals(
             self::MAGENTO_GRID_PRODUCTS_NB,
-            $this->instantSearchHelper->getMagentoGridProductsPerPage(ScopeInterface::SCOPE_STORE)
+            $instantSearchHelper->getMagentoGridProductsPerPage(ScopeInterface::SCOPE_STORE)
         );
         $this->assertEquals(
             self::MAGENTO_LIST_PRODUCTS_NB,
-            $this->instantSearchHelper->getMagentoListProductsPerPage(ScopeInterface::SCOPE_STORE)
+            $instantSearchHelper->getMagentoListProductsPerPage(ScopeInterface::SCOPE_STORE)
         );
 
         // Assert returned number of products according to the config
-        $this->assertEquals($expectedResult, $this->instantSearchHelper->getNumberOfProductResults());
+        $this->assertEquals($expectedResult, $instantSearchHelper->getNumberOfProductResults());
     }
 
     public static function conficProvider(): array

--- a/Test/Unit/Logger/DiagnosticLoggerTest.php
+++ b/Test/Unit/Logger/DiagnosticLoggerTest.php
@@ -7,36 +7,33 @@ use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Logger\TimedLogger;
 use Algolia\AlgoliaSearch\Service\StoreNameFetcher;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class DiagnosticLoggerTest extends TestCase
 {
-    protected ?ConfigHelper $configHelper;
-    protected ?TimedLogger $timedLogger;
-    protected ?StoreNameFetcher $storeNameFetcher;
-    protected ?DiagnosticsLogger $diagnosticsLogger;
+    protected function createObjectToTest(
+        ?ConfigHelper $configHelper = null,
+        ?TimedLogger $timedLogger = null,
+        ?StoreNameFetcher $storeNameFetcher = null,
+    ): DiagnosticsLogger {
+        $configHelper ??= $this->createStub(ConfigHelper::class);
+        $configHelper->method('isLoggingEnabled')->willReturn(true);
 
-    protected function setUp(): void
-    {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->configHelper->method('isLoggingEnabled')->willReturn(true);
-
-        $this->timedLogger = $this->createMock(TimedLogger::class);
-        $this->storeNameFetcher = $this->createMock(StoreNameFetcher::class);
-        $this->diagnosticsLogger = new DiagnosticsLogger(
-            $this->configHelper,
-            $this->timedLogger,
-            $this->storeNameFetcher
+        return new DiagnosticsLogger(
+            $configHelper,
+            $timedLogger ?? $this->createStub(TimedLogger::class),
+            $storeNameFetcher ?? $this->createStub(StoreNameFetcher::class),
         );
     }
 
-    public function testLog(): void {
+    public function testLog(): void
+    {
         $msg = 'Adding a log message';
-        $this->timedLogger->expects($this->once())
-            ->method('log')
-            ->with($msg, \Monolog\Logger::INFO);
-        $this->diagnosticsLogger->log($msg);
-    }
 
+        $timedLogger = $this->createMock(TimedLogger::class);
+        $timedLogger->expects($this->once())->method('log')->with($msg, \Monolog\Logger::INFO);
+
+        $diagnosticsLogger = $this->createObjectToTest(timedLogger: $timedLogger);
+
+        $diagnosticsLogger->log($msg);
+    }
 }

--- a/Test/Unit/Logger/Handler/AlgoliaLoggerHandlerTest.php
+++ b/Test/Unit/Logger/Handler/AlgoliaLoggerHandlerTest.php
@@ -4,20 +4,18 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Logger\Handler;
 
 use Algolia\AlgoliaSearch\Logger\Handler\AlgoliaLoggerHandler;
 use Magento\Framework\Filesystem\DriverInterface;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class AlgoliaLoggerHandlerTest extends AbstractHandlerTestCase
 {
-    protected function setUp(): void
+    protected function createObjectToTest(?DriverInterface $driver = null): AlgoliaLoggerHandler
     {
-        $this->handler = new AlgoliaLoggerHandler(
-            $this->createMock(DriverInterface::class)
-        );
+        return new AlgoliaLoggerHandler($driver ?? $this->createStub(DriverInterface::class));
     }
 
     public function testAlgoliaHandlerLogsEverything(): void
     {
+        $handler = $this->createObjectToTest();
+
         $debugRecord = $this->makeLogRecord(
             \Monolog\Logger::DEBUG,
             'Should log'
@@ -33,8 +31,8 @@ class AlgoliaLoggerHandlerTest extends AbstractHandlerTestCase
             'Should log'
         );
 
-        $this->assertFalse($this->handler->isHandling($debugRecord), 'DEBUG should not be handled unless overridden by DI');
-        $this->assertTrue($this->handler->isHandling($infoRecord), 'INFO should be handled');
-        $this->assertTrue($this->handler->isHandling($errorRecord), 'ERROR should be handled');
+        $this->assertFalse($handler->isHandling($debugRecord), 'DEBUG should not be handled unless overridden by DI');
+        $this->assertTrue($handler->isHandling($infoRecord), 'INFO should be handled');
+        $this->assertTrue($handler->isHandling($errorRecord), 'ERROR should be handled');
     }
 }

--- a/Test/Unit/Logger/Handler/SystemLoggerHandlerTest.php
+++ b/Test/Unit/Logger/Handler/SystemLoggerHandlerTest.php
@@ -5,24 +5,23 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Logger\Handler;
 use Algolia\AlgoliaSearch\Logger\Handler\SystemLoggerHandler;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Logger\Handler\Exception as ExceptionHandler;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class SystemLoggerHandlerTest extends AbstractHandlerTestCase
 {
-    /**
-     * @throws \Exception
-     */
-    protected function setUp(): void
-    {
-        $this->handler = new SystemLoggerHandler(
-            $this->createMock(DriverInterface::class),
-            $this->createMock(ExceptionHandler::class),
+    protected function createObjectToTest(
+        ?DriverInterface $driver = null,
+        ?ExceptionHandler $exceptionHandler = null,
+    ): SystemLoggerHandler {
+        return new SystemLoggerHandler(
+            $driver ?? $this->createStub(DriverInterface::class),
+            $exceptionHandler ?? $this->createStub(ExceptionHandler::class),
         );
     }
 
     public function testSystemHandlerFiltersBelowError(): void
     {
+        $handler = $this->createObjectToTest();
+
         $infoRecord = $this->makeLogRecord(
             \Monolog\Logger::INFO,
             'Should not log'
@@ -33,7 +32,7 @@ class SystemLoggerHandlerTest extends AbstractHandlerTestCase
             'Should log'
         );
 
-        $this->assertFalse($this->handler->isHandling($infoRecord), 'INFO should be ignored');
-        $this->assertTrue($this->handler->isHandling($errorRecord), 'ERROR should be handled');
+        $this->assertFalse($handler->isHandling($infoRecord), 'INFO should be ignored');
+        $this->assertTrue($handler->isHandling($errorRecord), 'ERROR should be handled');
     }
 }

--- a/Test/Unit/Model/Backend/QueueCronTest.php
+++ b/Test/Unit/Model/Backend/QueueCronTest.php
@@ -11,33 +11,30 @@ use Magento\Framework\Model\Context;
 use Magento\Framework\Registry;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class QueueCronTest extends TestCase
 {
-    protected ?QueueCron $queueCronModel;
-
-    protected function setUp(): void
+    protected function createObjectToTest(): QueueCron
     {
-        $context = $this->createMock(Context::class);
-        $eventDispatcher = $this->createMock(ManagerInterface::class);
-        $context->method('getEventDispatcher')->willReturn($eventDispatcher);
+        $context = $this->createStub(Context::class);
+        $context->method('getEventDispatcher')->willReturn($this->createStub(ManagerInterface::class));
 
-        $registry = $this->createMock(Registry::class);
-        $config = $this->createMock(ScopeConfigInterface::class);
-        $cacheTypeList = $this->createMock(TypeListInterface::class);
-
-        $this->queueCronModel = new QueueCron($context, $registry, $config, $cacheTypeList);
+        return new QueueCron(
+            $context,
+            $this->createStub(Registry::class),
+            $this->createStub(ScopeConfigInterface::class),
+            $this->createStub(TypeListInterface::class),
+        );
     }
 
     #[DataProvider('valuesProvider')]
     public function testInput($value, $isValid, $canReplay = true): void
     {
-        $this->queueCronModel->setValue($value);
+        $queueCronModel = $this->createObjectToTest();
+        $queueCronModel->setValue($value);
 
         try {
-            $result = $this->queueCronModel->beforeSave();
+            $result = $queueCronModel->beforeSave();
             $this->assertIsObject($result);
         } catch (InvalidCronException $exception) {
             $this->assertEquals(

--- a/Test/Unit/Model/Indexer/CategoryObserverTest.php
+++ b/Test/Unit/Model/Indexer/CategoryObserverTest.php
@@ -61,8 +61,8 @@ class CategoryObserverTest extends TestCase
 
     private function createProductCollectionStub(array $productIds): ProductCollection
     {
-        $collection = $this->createStub(ProductCollection::class);
-        $collection->method('getColumnValues')->willReturn($productIds);
+        $collection = $this->createMock(ProductCollection::class);
+        $collection->method('getColumnValues')->with('entity_id')->willReturn($productIds);
 
         return $collection;
     }
@@ -312,7 +312,7 @@ class CategoryObserverTest extends TestCase
         $productIndexer->method('getView')->willReturn($view);
 
         $connection = $this->createMock(AdapterInterface::class);
-        $connection->method('isTableExists')->willReturn(true);
+        $connection->method('isTableExists')->with($changelogTableName)->willReturn(true);
         $connection->expects($this->once())
             ->method('insertMultiple')
             ->with($changelogTableName, [
@@ -320,8 +320,8 @@ class CategoryObserverTest extends TestCase
                 ['entity_id' => 20],
             ]);
 
-        $resource = $this->createStub(ResourceConnection::class);
-        $resource->method('getTableName')->willReturn($changelogTableName);
+        $resource = $this->createMock(ResourceConnection::class);
+        $resource->method('getTableName')->with('algolia_products_cl')->willReturn($changelogTableName);
         $resource->method('getConnection')->willReturn($connection);
 
         $observer = $this->createObjectToTest(

--- a/Test/Unit/Model/Indexer/CategoryObserverTest.php
+++ b/Test/Unit/Model/Indexer/CategoryObserverTest.php
@@ -18,55 +18,81 @@ use Magento\Framework\Mview\ViewInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class CategoryObserverTest extends TestCase
 {
-    protected null|(IndexerInterface&MockObject) $categoryIndexer = null;
-    protected null|(IndexerInterface&MockObject) $productIndexer = null;
-    protected null|(IndexerRegistry&MockObject) $indexerRegistry = null;
-    protected null|(StoreManagerInterface&MockObject) $storeManager = null;
-    protected null|(ResourceConnection&MockObject) $resource = null;
-    protected null|(ProductBatchQueueProcessor&MockObject) $productBatchQueueProcessor = null;
-    protected null|(AlgoliaCredentialsManager&MockObject) $algoliaCredentialsManager = null;
-    protected ?CategoryObserver $observer = null;
-    protected null|(CategoryResourceModel&MockObject) $categoryResource = null;
-    protected null|(CategoryResourceModel&MockObject) $result = null;
-    protected null|(CategoryModel&MockObject) $category = null;
+    protected function createObjectToTest(
+        ?IndexerInterface $categoryIndexer = null,
+        ?IndexerInterface $productIndexer = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?ResourceConnection $resource = null,
+        ?ProductBatchQueueProcessor $productBatchQueueProcessor = null,
+        ?AlgoliaCredentialsManager $algoliaCredentialsManager = null,
+    ): CategoryObserver {
+        $categoryIndexer ??= $this->createStub(IndexerInterface::class);
+        $productIndexer ??= $this->createStub(IndexerInterface::class);
 
-    protected function setUp(): void
-    {
-        $this->categoryIndexer = $this->createMock(IndexerInterface::class);
-        $this->productIndexer = $this->createMock(IndexerInterface::class);
-        $this->indexerRegistry = $this->createMock(IndexerRegistry::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->resource = $this->createMock(ResourceConnection::class);
-        $this->productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
-        $this->algoliaCredentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $indexerRegistry = $this->createStub(IndexerRegistry::class);
+        $indexerRegistry->method('get')->willReturnMap([
+            ['algolia_categories', $categoryIndexer],
+            ['algolia_products', $productIndexer],
+        ]);
 
-        $this->indexerRegistry->method('get')
-            ->willReturnMap([
-                ['algolia_categories', $this->categoryIndexer],
-                ['algolia_products', $this->productIndexer],
-            ]);
-
-        $this->observer = new CategoryObserver(
-            $this->indexerRegistry,
-            $this->storeManager,
-            $this->resource,
-            $this->productBatchQueueProcessor,
-            $this->algoliaCredentialsManager
+        return new CategoryObserver(
+            $indexerRegistry,
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $resource ?? $this->createStub(ResourceConnection::class),
+            $productBatchQueueProcessor ?? $this->createStub(ProductBatchQueueProcessor::class),
+            $algoliaCredentialsManager ?? $this->createStub(AlgoliaCredentialsManager::class),
         );
+    }
 
-        $this->categoryResource = $this->createMock(CategoryResourceModel::class);
-        $this->result = $this->createMock(CategoryResourceModel::class);
-        // getChangedProductIds() is a @method docblock annotation (magic method), not a real PHP method.
-        // __call is included in onlyMethods so magic method calls can be configured in PHPUnit 12.
-        $this->category = $this->getMockBuilder(CategoryModel::class)
+    /**
+     * getChangedProductIds() is a @method docblock annotation (magic method), not a real PHP
+     * method — __call must be included in onlyMethods so it can be configured in PHPUnit 12.
+     */
+    private function createCategoryMock(): CategoryModel&MockObject
+    {
+        return $this->getMockBuilder(CategoryModel::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getId', 'getOrigData', 'getData', 'getProductCollection', 'getProductsPosition', '__call'])
             ->getMock();
+    }
+
+    private function createProductCollectionStub(array $productIds): ProductCollection
+    {
+        $collection = $this->createStub(ProductCollection::class);
+        $collection->method('getColumnValues')->willReturn($productIds);
+
+        return $collection;
+    }
+
+    private function createStoreStub(int $storeId): StoreInterface
+    {
+        $store = $this->createStub(StoreInterface::class);
+        $store->method('getId')->willReturn($storeId);
+
+        return $store;
+    }
+
+    /**
+     * Captures the commit callback registered via addCommitCallback and immediately invokes it.
+     */
+    private function captureAndInvokeCommitCallback(CategoryObserver $observer, string $method, CategoryModel $category): void
+    {
+        $capturedCallback = null;
+        $categoryResource = $this->createStub(CategoryResourceModel::class);
+        $categoryResource->method('addCommitCallback')
+            ->willReturnCallback(function (callable $callback) use (&$capturedCallback) {
+                $capturedCallback = $callback;
+            });
+
+        $result = $this->createStub(CategoryResourceModel::class);
+
+        $observer->$method($categoryResource, $result, $category);
+
+        $this->assertNotNull($capturedCallback, 'No commit callback was registered by ' . $method);
+        $capturedCallback();
     }
 
     // -------------------------------------------------------------------------
@@ -75,104 +101,169 @@ class CategoryObserverTest extends TestCase
 
     public function testAfterSaveReturnsEarlyWhenCredentialsInvalid(): void
     {
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(false);
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(false);
 
-        $this->categoryResource->expects($this->never())->method('addCommitCallback');
+        $categoryResource = $this->createMock(CategoryResourceModel::class);
+        $categoryResource->expects($this->never())->method('addCommitCallback');
 
-        $returnValue = $this->observer->afterSave($this->categoryResource, $this->result, $this->category);
+        $result = $this->createStub(CategoryResourceModel::class);
 
-        $this->assertSame($this->result, $returnValue);
+        // The credentials check short-circuits before the callback ever touches the category.
+        $category = $this->createCategoryMock();
+        $category->expects($this->never())->method('getId');
+
+        $observer = $this->createObjectToTest(algoliaCredentialsManager: $algoliaCredentialsManager);
+
+        $returnValue = $observer->afterSave($categoryResource, $result, $category);
+
+        $this->assertSame($result, $returnValue);
     }
 
     public function testAfterSaveReturnsResultWhenCredentialsValid(): void
     {
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->categoryResource->method('addCommitCallback');
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
 
-        $returnValue = $this->observer->afterSave($this->categoryResource, $this->result, $this->category);
+        $categoryResource = $this->createStub(CategoryResourceModel::class);
+        $categoryResource->method('addCommitCallback');
 
-        $this->assertSame($this->result, $returnValue);
+        $result = $this->createStub(CategoryResourceModel::class);
+
+        // The callback is registered but never invoked in this test, so the category is untouched.
+        $category = $this->createCategoryMock();
+        $category->expects($this->never())->method('getId');
+
+        $observer = $this->createObjectToTest(algoliaCredentialsManager: $algoliaCredentialsManager);
+
+        $returnValue = $observer->afterSave($categoryResource, $result, $category);
+
+        $this->assertSame($result, $returnValue);
     }
 
     public function testAfterSaveCallbackReindexesCategoryRowWhenNotScheduled(): void
     {
         $categoryId = 42;
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->category->method('getId')->willReturn($categoryId);
-        $this->category->method('__call')
+
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $category = $this->createCategoryMock();
+        // Not scheduled → reindexRow(category->getId()) is called exactly once.
+        $category->expects($this->once())->method('getId')->willReturn($categoryId);
+        $category->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getChangedProductIds' ? null : null);
-        $this->category->method('getOrigData')->willReturn('same');
-        $this->category->method('getData')->willReturn('same');
-        $this->category->method('getProductCollection')->willReturn($this->createMockProductCollection([]));
-        $this->categoryIndexer->method('isScheduled')->willReturn(false);
+        $category->method('getOrigData')->willReturn('same');
+        $category->method('getData')->willReturn('same');
+        $category->method('getProductCollection')->willReturn($this->createProductCollectionStub([]));
 
-        $this->categoryIndexer->expects($this->once())->method('reindexRow')->with($categoryId);
+        $categoryIndexer = $this->createMock(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(false);
+        $categoryIndexer->expects($this->once())->method('reindexRow')->with($categoryId);
 
-        $this->captureAndInvokeCommitCallback('afterSave', $this->category);
+        $observer = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            categoryIndexer: $categoryIndexer,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterSave', $category);
     }
 
     public function testAfterSaveCallbackSkipsProductReindexWhenNoAttributeChangesAndNoChangedProducts(): void
     {
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->category->method('getId')->willReturn(1);
-        $this->category->method('__call')
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $category = $this->createCategoryMock();
+        $category->expects($this->once())->method('getId')->willReturn(1);
+        $category->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getChangedProductIds' ? [] : null);
         // origData === getData for all watched keys → no collectionIds
-        $this->category->method('getOrigData')->willReturn('same');
-        $this->category->method('getData')->willReturn('same');
-        $this->category->method('getProductCollection')->willReturn($this->createMockProductCollection([]));
-        $this->categoryIndexer->method('isScheduled')->willReturn(false);
+        $category->method('getOrigData')->willReturn('same');
+        $category->method('getData')->willReturn('same');
+        $category->method('getProductCollection')->willReturn($this->createProductCollectionStub([]));
 
-        $this->productBatchQueueProcessor->expects($this->never())->method('processBatch');
+        $categoryIndexer = $this->createStub(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(false);
 
-        $this->captureAndInvokeCommitCallback('afterSave', $this->category);
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->never())->method('processBatch');
+
+        $observer = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            categoryIndexer: $categoryIndexer,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterSave', $category);
     }
 
     public function testAfterSaveCallbackReindexesProductsWhenNameChanges(): void
     {
         $productIds = [10, 20, 30];
-        $store = $this->createMockStore(1);
-        $this->storeManager->method('getStores')->willReturn([1 => $store]);
+        $store = $this->createStoreStub(1);
 
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->category->method('getId')->willReturn(1);
-        $this->category->method('__call')
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn([1 => $store]);
+
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $category = $this->createCategoryMock();
+        $category->expects($this->once())->method('getId')->willReturn(1);
+        $category->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getChangedProductIds' ? [] : null);
-        $this->category->method('getProductCollection')->willReturn($this->createMockProductCollection($productIds));
-        $this->categoryIndexer->method('isScheduled')->willReturn(false);
-
-        $this->category->method('getOrigData')->willReturnCallback(
+        $category->method('getProductCollection')->willReturn($this->createProductCollectionStub($productIds));
+        $category->method('getOrigData')->willReturnCallback(
             fn($key) => $key === 'name' ? 'Old Name' : null
         );
-        $this->category->method('getData')->willReturnCallback(
+        $category->method('getData')->willReturnCallback(
             fn($key) => $key === 'name' ? 'New Name' : null
         );
 
-        $this->productBatchQueueProcessor->expects($this->once())
+        $categoryIndexer = $this->createStub(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(false);
+
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->once())
             ->method('processBatch')
             ->with(1, $productIds);
 
-        $this->captureAndInvokeCommitCallback('afterSave', $this->category);
+        $observer = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            categoryIndexer: $categoryIndexer,
+            storeManager: $storeManager,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterSave', $category);
     }
 
     public function testAfterSaveCallbackMergesAndDeduplicatesChangedAndCollectionProductIds(): void
     {
         $changedProductIds = [5, 6];
         $collectionIds = [6, 7, 8]; // 6 appears in both
-        $store = $this->createMockStore(1);
-        $this->storeManager->method('getStores')->willReturn([1 => $store]);
+        $store = $this->createStoreStub(1);
 
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->category->method('getId')->willReturn(1);
-        $this->category->method('__call')
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn([1 => $store]);
+
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $category = $this->createCategoryMock();
+        $category->expects($this->once())->method('getId')->willReturn(1);
+        $category->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getChangedProductIds' ? $changedProductIds : null);
-        $this->category->method('getProductCollection')->willReturn($this->createMockProductCollection($collectionIds));
-        $this->categoryIndexer->method('isScheduled')->willReturn(false);
+        $category->method('getProductCollection')->willReturn($this->createProductCollectionStub($collectionIds));
+        $category->method('getOrigData')->willReturnCallback(fn($k) => $k === 'name' ? 'Old' : null);
+        $category->method('getData')->willReturnCallback(fn($k) => $k === 'name' ? 'New' : null);
 
-        $this->category->method('getOrigData')->willReturnCallback(fn($k) => $k === 'name' ? 'Old' : null);
-        $this->category->method('getData')->willReturnCallback(fn($k) => $k === 'name' ? 'New' : null);
+        $categoryIndexer = $this->createStub(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(false);
 
-        $this->productBatchQueueProcessor->expects($this->once())
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->once())
             ->method('processBatch')
             ->with(1, $this->callback(function (array $ids) {
                 sort($ids);
@@ -180,7 +271,14 @@ class CategoryObserverTest extends TestCase
                 return true;
             }));
 
-        $this->captureAndInvokeCommitCallback('afterSave', $this->category);
+        $observer = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            categoryIndexer: $categoryIndexer,
+            storeManager: $storeManager,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterSave', $category);
     }
 
     public function testAfterSaveCallbackUpdatesChangelogWhenScheduledAndHasCollectionIdsButNoChangedProducts(): void
@@ -188,30 +286,33 @@ class CategoryObserverTest extends TestCase
         $collectionIds = [10, 20];
         $changelogTableName = 'algolia_products_cl';
 
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->category->method('getId')->willReturn(1);
-        $this->category->method('__call')
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $category = $this->createCategoryMock();
+        // Scheduled branch never reaches category->getId().
+        $category->expects($this->never())->method('getId');
+        $category->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getChangedProductIds' ? [] : null);
-        $this->category->method('getProductCollection')->willReturn($this->createMockProductCollection($collectionIds));
-        $this->categoryIndexer->method('isScheduled')->willReturn(true);
-
+        $category->method('getProductCollection')->willReturn($this->createProductCollectionStub($collectionIds));
         // Attribute change to populate collectionIds
-        $this->category->method('getOrigData')->willReturnCallback(fn($k) => $k === 'name' ? 'Old' : null);
-        $this->category->method('getData')->willReturnCallback(fn($k) => $k === 'name' ? 'New' : null);
+        $category->method('getOrigData')->willReturnCallback(fn($k) => $k === 'name' ? 'Old' : null);
+        $category->method('getData')->willReturnCallback(fn($k) => $k === 'name' ? 'New' : null);
 
-        $this->productIndexer->method('isScheduled')->willReturn(true);
+        $categoryIndexer = $this->createStub(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(true);
 
-        $changelog = $this->createMock(ChangelogInterface::class);
+        $changelog = $this->createStub(ChangelogInterface::class);
         $changelog->method('getName')->willReturn('algolia_products_cl');
-        $view = $this->createMock(ViewInterface::class);
+        $view = $this->createStub(ViewInterface::class);
         $view->method('getChangelog')->willReturn($changelog);
-        $this->productIndexer->method('getView')->willReturn($view);
+
+        $productIndexer = $this->createStub(IndexerInterface::class);
+        $productIndexer->method('isScheduled')->willReturn(true);
+        $productIndexer->method('getView')->willReturn($view);
 
         $connection = $this->createMock(AdapterInterface::class);
-        $this->resource->method('getTableName')->with('algolia_products_cl')->willReturn($changelogTableName);
-        $this->resource->method('getConnection')->willReturn($connection);
-        $connection->method('isTableExists')->with($changelogTableName)->willReturn(true);
-
+        $connection->method('isTableExists')->willReturn(true);
         $connection->expects($this->once())
             ->method('insertMultiple')
             ->with($changelogTableName, [
@@ -219,79 +320,129 @@ class CategoryObserverTest extends TestCase
                 ['entity_id' => 20],
             ]);
 
-        $this->captureAndInvokeCommitCallback('afterSave', $this->category);
+        $resource = $this->createStub(ResourceConnection::class);
+        $resource->method('getTableName')->willReturn($changelogTableName);
+        $resource->method('getConnection')->willReturn($connection);
+
+        $observer = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            categoryIndexer: $categoryIndexer,
+            productIndexer: $productIndexer,
+            resource: $resource,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterSave', $category);
     }
 
     public function testAfterSaveCallbackCallsReindexListWhenScheduledAndProductIndexerNotScheduled(): void
     {
         $collectionIds = [10, 20];
 
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->category->method('getId')->willReturn(1);
-        $this->category->method('__call')
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $category = $this->createCategoryMock();
+        $category->expects($this->never())->method('getId');
+        $category->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getChangedProductIds' ? [] : null);
-        $this->category->method('getProductCollection')->willReturn($this->createMockProductCollection($collectionIds));
-        $this->categoryIndexer->method('isScheduled')->willReturn(true);
-
+        $category->method('getProductCollection')->willReturn($this->createProductCollectionStub($collectionIds));
         // Attribute change to populate collectionIds
-        $this->category->method('getOrigData')->willReturnCallback(fn($k) => $k === 'name' ? 'Old' : null);
-        $this->category->method('getData')->willReturnCallback(fn($k) => $k === 'name' ? 'New' : null);
+        $category->method('getOrigData')->willReturnCallback(fn($k) => $k === 'name' ? 'Old' : null);
+        $category->method('getData')->willReturnCallback(fn($k) => $k === 'name' ? 'New' : null);
 
-        $this->productIndexer->method('isScheduled')->willReturn(false);
-        $this->productIndexer->expects($this->once())->method('reindexList')->with($collectionIds);
+        $categoryIndexer = $this->createStub(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(true);
 
-        $this->captureAndInvokeCommitCallback('afterSave', $this->category);
+        $productIndexer = $this->createMock(IndexerInterface::class);
+        $productIndexer->method('isScheduled')->willReturn(false);
+        $productIndexer->expects($this->once())->method('reindexList')->with($collectionIds);
+
+        $observer = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            categoryIndexer: $categoryIndexer,
+            productIndexer: $productIndexer,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterSave', $category);
     }
 
     public function testAfterSaveCallbackSkipsInsertWhenChangelogTableDoesNotExist(): void
     {
         $collectionIds = [10, 20];
 
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->category->method('getId')->willReturn(1);
-        $this->category->method('__call')
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $category = $this->createCategoryMock();
+        $category->expects($this->never())->method('getId');
+        $category->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getChangedProductIds' ? [] : null);
-        $this->category->method('getProductCollection')->willReturn($this->createMockProductCollection($collectionIds));
-        $this->categoryIndexer->method('isScheduled')->willReturn(true);
+        $category->method('getProductCollection')->willReturn($this->createProductCollectionStub($collectionIds));
+        $category->method('getOrigData')->willReturnCallback(fn($k) => $k === 'name' ? 'Old' : null);
+        $category->method('getData')->willReturnCallback(fn($k) => $k === 'name' ? 'New' : null);
 
-        $this->category->method('getOrigData')->willReturnCallback(fn($k) => $k === 'name' ? 'Old' : null);
-        $this->category->method('getData')->willReturnCallback(fn($k) => $k === 'name' ? 'New' : null);
+        $categoryIndexer = $this->createStub(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(true);
 
-        $this->productIndexer->method('isScheduled')->willReturn(true);
-
-        $changelog = $this->createMock(ChangelogInterface::class);
+        $changelog = $this->createStub(ChangelogInterface::class);
         $changelog->method('getName')->willReturn('algolia_products_cl');
-        $view = $this->createMock(ViewInterface::class);
+        $view = $this->createStub(ViewInterface::class);
         $view->method('getChangelog')->willReturn($changelog);
-        $this->productIndexer->method('getView')->willReturn($view);
+
+        $productIndexer = $this->createStub(IndexerInterface::class);
+        $productIndexer->method('isScheduled')->willReturn(true);
+        $productIndexer->method('getView')->willReturn($view);
 
         $connection = $this->createMock(AdapterInterface::class);
-        $this->resource->method('getTableName')->willReturn('algolia_products_cl');
-        $this->resource->method('getConnection')->willReturn($connection);
         $connection->method('isTableExists')->willReturn(false);
-
         $connection->expects($this->never())->method('insertMultiple');
 
-        $this->captureAndInvokeCommitCallback('afterSave', $this->category);
+        $resource = $this->createStub(ResourceConnection::class);
+        $resource->method('getTableName')->willReturn('algolia_products_cl');
+        $resource->method('getConnection')->willReturn($connection);
+
+        $observer = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            categoryIndexer: $categoryIndexer,
+            productIndexer: $productIndexer,
+            resource: $resource,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterSave', $category);
     }
 
     public function testAfterSaveCallbackSkipsUpdateCategoryProductsWhenScheduledAndChangedProductsExist(): void
     {
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->category->method('getId')->willReturn(1);
-        $this->category->method('__call')
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $category = $this->createCategoryMock();
+        $category->expects($this->never())->method('getId');
+        $category->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getChangedProductIds' ? [10, 20] : null);
         // No attribute changes, so collectionIds stays empty
-        $this->category->method('getOrigData')->willReturn('same');
-        $this->category->method('getData')->willReturn('same');
-        $this->category->method('getProductCollection')->willReturn($this->createMockProductCollection([]));
-        $this->categoryIndexer->method('isScheduled')->willReturn(true);
+        $category->method('getOrigData')->willReturn('same');
+        $category->method('getData')->willReturn('same');
+        $category->method('getProductCollection')->willReturn($this->createProductCollectionStub([]));
+
+        $categoryIndexer = $this->createStub(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(true);
 
         // updateCategoryProducts should not be triggered (changedProductIds count > 0)
-        $this->productIndexer->expects($this->never())->method('reindexList');
-        $this->resource->expects($this->never())->method('getConnection');
+        $productIndexer = $this->createMock(IndexerInterface::class);
+        $productIndexer->expects($this->never())->method('reindexList');
 
-        $this->captureAndInvokeCommitCallback('afterSave', $this->category);
+        $resource = $this->createMock(ResourceConnection::class);
+        $resource->expects($this->never())->method('getConnection');
+
+        $observer = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            categoryIndexer: $categoryIndexer,
+            productIndexer: $productIndexer,
+            resource: $resource,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterSave', $category);
     }
 
     // -------------------------------------------------------------------------
@@ -300,41 +451,71 @@ class CategoryObserverTest extends TestCase
 
     public function testAfterDeleteReturnsResult(): void
     {
-        $this->categoryResource->method('addCommitCallback');
+        $categoryResource = $this->createStub(CategoryResourceModel::class);
+        $categoryResource->method('addCommitCallback');
 
-        $returnValue = $this->observer->afterDelete($this->categoryResource, $this->result, $this->category);
+        $result = $this->createStub(CategoryResourceModel::class);
 
-        $this->assertSame($this->result, $returnValue);
+        $category = $this->createCategoryMock();
+        $category->expects($this->never())->method('getId');
+
+        $observer = $this->createObjectToTest();
+
+        $returnValue = $observer->afterDelete($categoryResource, $result, $category);
+
+        $this->assertSame($result, $returnValue);
     }
 
     public function testAfterDeleteCallbackReindexesCategoryAndProductsWhenNotScheduled(): void
     {
         $categoryId = 15;
         $productPositions = [10 => 0, 20 => 1, 30 => 2];
-        $store = $this->createMockStore(1);
-        $this->storeManager->method('getStores')->willReturn([1 => $store]);
+        $store = $this->createStoreStub(1);
 
-        $this->category->method('getId')->willReturn($categoryId);
-        $this->category->method('getProductsPosition')->willReturn($productPositions);
-        $this->categoryIndexer->method('isScheduled')->willReturn(false);
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn([1 => $store]);
 
-        $this->categoryIndexer->expects($this->once())->method('reindexRow')->with($categoryId);
-        $this->productBatchQueueProcessor->expects($this->once())
+        $category = $this->createCategoryMock();
+        $category->expects($this->once())->method('getId')->willReturn($categoryId);
+        $category->method('getProductsPosition')->willReturn($productPositions);
+
+        $categoryIndexer = $this->createMock(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(false);
+        $categoryIndexer->expects($this->once())->method('reindexRow')->with($categoryId);
+
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->once())
             ->method('processBatch')
             ->with(1, array_keys($productPositions));
 
-        $this->captureAndInvokeCommitCallback('afterDelete', $this->category);
+        $observer = $this->createObjectToTest(
+            categoryIndexer: $categoryIndexer,
+            storeManager: $storeManager,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterDelete', $category);
     }
 
     public function testAfterDeleteCallbackSkipsReindexWhenScheduled(): void
     {
-        $this->category->method('getId')->willReturn(1);
-        $this->categoryIndexer->method('isScheduled')->willReturn(true);
+        // Scheduled → the whole reindex branch is skipped, so category->getId() is never reached.
+        $category = $this->createCategoryMock();
+        $category->expects($this->never())->method('getId');
 
-        $this->categoryIndexer->expects($this->never())->method('reindexRow');
-        $this->productBatchQueueProcessor->expects($this->never())->method('processBatch');
+        $categoryIndexer = $this->createMock(IndexerInterface::class);
+        $categoryIndexer->method('isScheduled')->willReturn(true);
+        $categoryIndexer->expects($this->never())->method('reindexRow');
 
-        $this->captureAndInvokeCommitCallback('afterDelete', $this->category);
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->never())->method('processBatch');
+
+        $observer = $this->createObjectToTest(
+            categoryIndexer: $categoryIndexer,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+        );
+
+        $this->captureAndInvokeCommitCallback($observer, 'afterDelete', $category);
     }
 
     // -------------------------------------------------------------------------
@@ -343,61 +524,42 @@ class CategoryObserverTest extends TestCase
 
     public function testReindexAffectedProductsSkipsWhenEmpty(): void
     {
-        $this->storeManager->expects($this->never())->method('getStores');
-        $this->productBatchQueueProcessor->expects($this->never())->method('processBatch');
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->expects($this->never())->method('getStores');
 
-        $this->invokeMethod($this->observer, 'reindexAffectedProducts', [[]]);
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->never())->method('processBatch');
+
+        $observer = $this->createObjectToTest(
+            storeManager: $storeManager,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+        );
+
+        $this->invokeMethod($observer, 'reindexAffectedProducts', [[]]);
     }
 
     public function testReindexAffectedProductsCallsProcessBatchForEachStore(): void
     {
         $productIds = [1, 2, 3];
-        $store1 = $this->createMockStore(1);
-        $store2 = $this->createMockStore(2);
-        $this->storeManager->method('getStores')->willReturn([1 => $store1, 2 => $store2]);
+        $store1 = $this->createStoreStub(1);
+        $store2 = $this->createStoreStub(2);
 
-        $this->productBatchQueueProcessor->expects($this->exactly(2))
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn([1 => $store1, 2 => $store2]);
+
+        $productBatchQueueProcessor = $this->createMock(ProductBatchQueueProcessor::class);
+        $productBatchQueueProcessor->expects($this->exactly(2))
             ->method('processBatch')
             ->willReturnCallback(function (int $storeId, array $ids) use ($productIds) {
                 $this->assertContains($storeId, [1, 2]);
                 $this->assertEquals($productIds, $ids);
             });
 
-        $this->invokeMethod($this->observer, 'reindexAffectedProducts', [$productIds]);
-    }
+        $observer = $this->createObjectToTest(
+            storeManager: $storeManager,
+            productBatchQueueProcessor: $productBatchQueueProcessor,
+        );
 
-    // -------------------------------------------------------------------------
-    // Helpers
-    // -------------------------------------------------------------------------
-
-    private function createMockProductCollection(array $productIds): ProductCollection
-    {
-        $collection = $this->createMock(ProductCollection::class);
-        $collection->method('getColumnValues')->with('entity_id')->willReturn($productIds);
-        return $collection;
-    }
-
-    private function createMockStore(int $storeId): StoreInterface
-    {
-        $store = $this->createMock(StoreInterface::class);
-        $store->method('getId')->willReturn($storeId);
-        return $store;
-    }
-
-    /**
-     * Captures the commit callback registered via addCommitCallback and immediately invokes it.
-     */
-    private function captureAndInvokeCommitCallback(string $method, CategoryModel $category): void
-    {
-        $capturedCallback = null;
-        $this->categoryResource->method('addCommitCallback')
-            ->willReturnCallback(function (callable $callback) use (&$capturedCallback) {
-                $capturedCallback = $callback;
-            });
-
-        $this->observer->$method($this->categoryResource, $this->result, $category);
-
-        $this->assertNotNull($capturedCallback, 'No commit callback was registered by ' . $method);
-        $capturedCallback();
+        $this->invokeMethod($observer, 'reindexAffectedProducts', [$productIds]);
     }
 }

--- a/Test/Unit/Model/IndicesConfiguratorTest.php
+++ b/Test/Unit/Model/IndicesConfiguratorTest.php
@@ -24,73 +24,42 @@ use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder as ProductIndexOpt
 use Algolia\AlgoliaSearch\Service\Suggestion\IndexOptionsBuilder as SuggestionIndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class IndicesConfiguratorTest extends TestCase
 {
     private int $storeId = 1;
 
-    private null|(Data&MockObject) $baseHelper = null;
-    private null|(IndexOptionsBuilder&MockObject) $indexOptionsBuilder = null;
-    private null|(CategoryIndexOptionsBuilder&MockObject) $categoryIndexOptionsBuilder = null;
-    private null|(PageIndexOptionsBuilder&MockObject) $pageIndexOptionsBuilder = null;
-    private null|(ProductIndexOptionsBuilder&MockObject) $productIndexOptionsBuilder = null;
-    private null|(SuggestionIndexOptionsBuilder&MockObject) $suggestionIndexOptionsBuilder = null;
-    private null|(AlgoliaConnector&MockObject) $algoliaConnector = null;
-    private null|(ConfigHelper&MockObject) $configHelper = null;
-    private null|(AutocompleteHelper&MockObject) $autocompleteHelper = null;
-    private null|(ProductHelper&MockObject) $productHelper = null;
-    private null|(CategoryHelper&MockObject) $categoryHelper = null;
-    private null|(PageHelper&MockObject) $pageHelper = null;
-    private null|(SuggestionHelper&MockObject) $suggestionHelper = null;
-    private null|(AdditionalSectionHelper&MockObject) $additionalSectionHelper = null;
-    private null|(AlgoliaCredentialsManager&MockObject) $algoliaCredentialsManager = null;
-    private null|(IndexSettingsHandler&MockObject) $indexSettingsHandler = null;
-    private null|(DiagnosticsLogger&MockObject) $logger = null;
-    private null|(IndicesConfigurator&MockObject) $configurator = null;
+    /**
+     * Partial mock: stub the protected routing methods so saveConfigurationToAlgolia can be
+     * tested in isolation without pulling in each entity's full dependency chain.
+     */
+    protected function createObjectToTest(
+        ?AlgoliaCredentialsManager $algoliaCredentialsManager = null,
+        ?Data $baseHelper = null,
+        ?DiagnosticsLogger $logger = null,
+    ): IndicesConfigurator&MockObject {
+        $logger ??= $this->createStub(DiagnosticsLogger::class);
+        $logger->method('getStoreName')->willReturn('Default Store');
 
-    protected function setUp(): void
-    {
-        $this->baseHelper = $this->createMock(Data::class);
-        $this->indexOptionsBuilder = $this->createMock(IndexOptionsBuilder::class);
-        $this->categoryIndexOptionsBuilder = $this->createMock(CategoryIndexOptionsBuilder::class);
-        $this->pageIndexOptionsBuilder = $this->createMock(PageIndexOptionsBuilder::class);
-        $this->productIndexOptionsBuilder = $this->createMock(ProductIndexOptionsBuilder::class);
-        $this->suggestionIndexOptionsBuilder = $this->createMock(SuggestionIndexOptionsBuilder::class);
-        $this->algoliaConnector = $this->createMock(AlgoliaConnector::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->autocompleteHelper = $this->createMock(AutocompleteHelper::class);
-        $this->productHelper = $this->createMock(ProductHelper::class);
-        $this->categoryHelper = $this->createMock(CategoryHelper::class);
-        $this->pageHelper = $this->createMock(PageHelper::class);
-        $this->suggestionHelper = $this->createMock(SuggestionHelper::class);
-        $this->additionalSectionHelper = $this->createMock(AdditionalSectionHelper::class);
-        $this->algoliaCredentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
-        $this->indexSettingsHandler = $this->createMock(IndexSettingsHandler::class);
-        $this->logger = $this->createMock(DiagnosticsLogger::class);
-
-        // Partial mock: stub protected routing methods so saveConfigurationToAlgolia
-        // can be tested in isolation without pulling in each entity's full dependency chain
-        $this->configurator = $this->getMockBuilder(IndicesConfigurator::class)
+        return $this->getMockBuilder(IndicesConfigurator::class)
             ->setConstructorArgs([
-                $this->baseHelper,
-                $this->indexOptionsBuilder,
-                $this->categoryIndexOptionsBuilder,
-                $this->pageIndexOptionsBuilder,
-                $this->productIndexOptionsBuilder,
-                $this->suggestionIndexOptionsBuilder,
-                $this->algoliaConnector,
-                $this->configHelper,
-                $this->autocompleteHelper,
-                $this->productHelper,
-                $this->categoryHelper,
-                $this->pageHelper,
-                $this->suggestionHelper,
-                $this->additionalSectionHelper,
-                $this->algoliaCredentialsManager,
-                $this->indexSettingsHandler,
-                $this->logger,
+                $baseHelper ?? $this->createStub(Data::class),
+                $this->createStub(IndexOptionsBuilder::class),
+                $this->createStub(CategoryIndexOptionsBuilder::class),
+                $this->createStub(PageIndexOptionsBuilder::class),
+                $this->createStub(ProductIndexOptionsBuilder::class),
+                $this->createStub(SuggestionIndexOptionsBuilder::class),
+                $this->createStub(AlgoliaConnector::class),
+                $this->createStub(ConfigHelper::class),
+                $this->createStub(AutocompleteHelper::class),
+                $this->createStub(ProductHelper::class),
+                $this->createStub(CategoryHelper::class),
+                $this->createStub(PageHelper::class),
+                $this->createStub(SuggestionHelper::class),
+                $this->createStub(AdditionalSectionHelper::class),
+                $algoliaCredentialsManager ?? $this->createStub(AlgoliaCredentialsManager::class),
+                $this->createStub(IndexSettingsHandler::class),
+                $logger,
             ])
             ->onlyMethods(
                 [
@@ -103,118 +72,139 @@ class IndicesConfiguratorTest extends TestCase
                 ]
             )
             ->getMock();
-
-        $this->logger->method('getStoreName')->willReturn('Default Store');
     }
 
-    private function allowPassingGuards(): void
+    private function createPassingGuards(): array
     {
-        $this->algoliaCredentialsManager->method('checkCredentials')->willReturn(true);
-        $this->baseHelper->method('isIndexingEnabled')->willReturn(true);
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentials')->willReturn(true);
+
+        $baseHelper = $this->createStub(Data::class);
+        $baseHelper->method('isIndexingEnabled')->willReturn(true);
+
+        return [$algoliaCredentialsManager, $baseHelper];
     }
 
     public function testReturnsEarlyWhenCredentialCheckFails(): void
     {
-        $this->algoliaCredentialsManager->method('checkCredentials')->willReturn(false);
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentials')->willReturn(false);
 
-        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
-        $this->configurator->expects($this->never())->method('setProductsSettings');
-        $this->configurator->expects($this->never())->method('setCategoriesSettings');
-        $this->configurator->expects($this->never())->method('setExtraSettings');
+        $configurator = $this->createObjectToTest(algoliaCredentialsManager: $algoliaCredentialsManager);
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId);
+        $configurator->expects($this->never())->method('setAllEntitiesSettings');
+        $configurator->expects($this->never())->method('setProductsSettings');
+        $configurator->expects($this->never())->method('setCategoriesSettings');
+        $configurator->expects($this->never())->method('setExtraSettings');
+
+        $configurator->saveConfigurationToAlgolia($this->storeId);
     }
 
     public function testReturnsEarlyWhenIndexingIsDisabled(): void
     {
-        $this->algoliaCredentialsManager->method('checkCredentials')->willReturn(true);
-        $this->baseHelper->method('isIndexingEnabled')->willReturn(false);
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentials')->willReturn(true);
 
-        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
-        $this->configurator->expects($this->never())->method('setProductsSettings');
-        $this->configurator->expects($this->never())->method('setCategoriesSettings');
-        $this->configurator->expects($this->never())->method('setExtraSettings');
+        $baseHelper = $this->createStub(Data::class);
+        $baseHelper->method('isIndexingEnabled')->willReturn(false);
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId);
+        $configurator = $this->createObjectToTest(
+            algoliaCredentialsManager: $algoliaCredentialsManager,
+            baseHelper: $baseHelper,
+        );
+
+        $configurator->expects($this->never())->method('setAllEntitiesSettings');
+        $configurator->expects($this->never())->method('setProductsSettings');
+        $configurator->expects($this->never())->method('setCategoriesSettings');
+        $configurator->expects($this->never())->method('setExtraSettings');
+
+        $configurator->saveConfigurationToAlgolia($this->storeId);
     }
 
     public function testCallsAllEntitiesSettingsWhenNoFilterProvided(): void
     {
-        $this->allowPassingGuards();
+        [$algoliaCredentialsManager, $baseHelper] = $this->createPassingGuards();
+        $configurator = $this->createObjectToTest($algoliaCredentialsManager, $baseHelper);
 
-        $this->configurator->expects($this->once())->method('setAllEntitiesSettings');
-        $this->configurator->expects($this->never())->method('setProductsSettings');
-        $this->configurator->expects($this->never())->method('setCategoriesSettings');
+        $configurator->expects($this->once())->method('setAllEntitiesSettings');
+        $configurator->expects($this->never())->method('setProductsSettings');
+        $configurator->expects($this->never())->method('setCategoriesSettings');
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId);
+        $configurator->saveConfigurationToAlgolia($this->storeId);
     }
 
     public function testForwardsUseTmpIndexToAllEntitiesSettings(): void
     {
-        $this->allowPassingGuards();
+        [$algoliaCredentialsManager, $baseHelper] = $this->createPassingGuards();
+        $configurator = $this->createObjectToTest($algoliaCredentialsManager, $baseHelper);
 
-        $this->configurator->expects($this->once())
+        $configurator->expects($this->once())
             ->method('setAllEntitiesSettings')
             ->with($this->storeId, true);
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId, true);
+        $configurator->saveConfigurationToAlgolia($this->storeId, true);
     }
 
     public function testCallsOnlyProductsSettingsWhenFilterContainsProducts(): void
     {
-        $this->allowPassingGuards();
+        [$algoliaCredentialsManager, $baseHelper] = $this->createPassingGuards();
+        $configurator = $this->createObjectToTest($algoliaCredentialsManager, $baseHelper);
 
-        $this->configurator->expects($this->once())->method('setProductsSettings');
-        $this->configurator->expects($this->never())->method('setCategoriesSettings');
-        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+        $configurator->expects($this->once())->method('setProductsSettings');
+        $configurator->expects($this->never())->method('setCategoriesSettings');
+        $configurator->expects($this->never())->method('setAllEntitiesSettings');
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId, false, ['products']);
+        $configurator->saveConfigurationToAlgolia($this->storeId, false, ['products']);
     }
 
     public function testForwardsUseTmpIndexToProductsSettings(): void
     {
-        $this->allowPassingGuards();
+        [$algoliaCredentialsManager, $baseHelper] = $this->createPassingGuards();
+        $configurator = $this->createObjectToTest($algoliaCredentialsManager, $baseHelper);
 
-        $this->configurator->expects($this->once())
+        $configurator->expects($this->once())
             ->method('setProductsSettings')
             ->with($this->storeId, true);
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId, true, ['products']);
+        $configurator->saveConfigurationToAlgolia($this->storeId, true, ['products']);
     }
 
     public function testCallsOnlyCategoriesSettingsWhenFilterContainsCategories(): void
     {
-        $this->allowPassingGuards();
+        [$algoliaCredentialsManager, $baseHelper] = $this->createPassingGuards();
+        $configurator = $this->createObjectToTest($algoliaCredentialsManager, $baseHelper);
 
-        $this->configurator->expects($this->once())->method('setCategoriesSettings');
-        $this->configurator->expects($this->never())->method('setProductsSettings');
-        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+        $configurator->expects($this->once())->method('setCategoriesSettings');
+        $configurator->expects($this->never())->method('setProductsSettings');
+        $configurator->expects($this->never())->method('setAllEntitiesSettings');
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId, false, ['categories']);
+        $configurator->saveConfigurationToAlgolia($this->storeId, false, ['categories']);
     }
 
     public function testCallsBothProductsAndCategoriesWhenBothInFilter(): void
     {
-        $this->allowPassingGuards();
+        [$algoliaCredentialsManager, $baseHelper] = $this->createPassingGuards();
+        $configurator = $this->createObjectToTest($algoliaCredentialsManager, $baseHelper);
 
-        $this->configurator->expects($this->once())->method('setProductsSettings');
-        $this->configurator->expects($this->once())->method('setCategoriesSettings');
-        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+        $configurator->expects($this->once())->method('setProductsSettings');
+        $configurator->expects($this->once())->method('setCategoriesSettings');
+        $configurator->expects($this->never())->method('setAllEntitiesSettings');
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId, false, ['products', 'categories']);
+        $configurator->saveConfigurationToAlgolia($this->storeId, false, ['products', 'categories']);
     }
 
     public function testSkipsUnrecognizedEntitiesInFilterBranch(): void
     {
-        $this->allowPassingGuards();
+        [$algoliaCredentialsManager, $baseHelper] = $this->createPassingGuards();
+        $configurator = $this->createObjectToTest($algoliaCredentialsManager, $baseHelper);
 
-        $this->configurator->expects($this->once())->method('setPagesSettings');
-        $this->configurator->expects($this->once())->method('setQuerySuggestionsSettings');
-        $this->configurator->expects($this->never())->method('setProductsSettings');
-        $this->configurator->expects($this->never())->method('setCategoriesSettings');
-        $this->configurator->expects($this->never())->method('setAllEntitiesSettings');
+        $configurator->expects($this->once())->method('setPagesSettings');
+        $configurator->expects($this->once())->method('setQuerySuggestionsSettings');
+        $configurator->expects($this->never())->method('setProductsSettings');
+        $configurator->expects($this->never())->method('setCategoriesSettings');
+        $configurator->expects($this->never())->method('setAllEntitiesSettings');
 
-        $this->configurator->saveConfigurationToAlgolia(
+        $configurator->saveConfigurationToAlgolia(
             $this->storeId,
             false,
             ['pages', 'suggestions', 'foo', 'bar']
@@ -223,14 +213,15 @@ class IndicesConfiguratorTest extends TestCase
 
     public function testForwardsAllParametersToSetExtraSettings(): void
     {
-        $this->allowPassingGuards();
+        [$algoliaCredentialsManager, $baseHelper] = $this->createPassingGuards();
+        $configurator = $this->createObjectToTest($algoliaCredentialsManager, $baseHelper);
 
         $filteredEntities = ['products', 'categories'];
 
-        $this->configurator->expects($this->once())
+        $configurator->expects($this->once())
             ->method('setExtraSettings')
             ->with($this->storeId, true, $filteredEntities);
 
-        $this->configurator->saveConfigurationToAlgolia($this->storeId, true, $filteredEntities);
+        $configurator->saveConfigurationToAlgolia($this->storeId, true, $filteredEntities);
     }
 }

--- a/Test/Unit/Model/JobTest.php
+++ b/Test/Unit/Model/JobTest.php
@@ -12,78 +12,68 @@ use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Model\Context;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Registry;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class JobTest extends TestCase
 {
-    private null|(Context&MockObject) $context = null;
-    private null|(Registry&MockObject) $registry = null;
-    private null|(ObjectManagerInterface&MockObject) $objectManager = null;
-    private null|(JobResourceModel&MockObject) $resourceModel = null;
+    protected function createObjectToTest(
+        ?ObjectManagerInterface $objectManager = null,
+        ?JobResourceModel $resourceModel = null,
+    ): Job {
+        $context = $this->createStub(Context::class);
+        $context->method('getEventDispatcher')->willReturn($this->createStub(ManagerInterface::class));
 
-    private ?Job $job = null;
-
-    protected function setUp(): void
-    {
-        $this->context = $this->createMock(Context::class);
-        $eventDispatcher = $this->createMock(ManagerInterface::class);
-        $this->context->method('getEventDispatcher')->willReturn($eventDispatcher);
-
-        $this->registry = $this->createMock(Registry::class);
-        $this->objectManager = $this->createMock(ObjectManagerInterface::class);
-        $this->resourceModel = $this->createMock(JobResourceModel::class);
-
-        $this->job = new Job(
-            $this->context,
-            $this->registry,
-            $this->objectManager,
-            $this->resourceModel
+        return new Job(
+            $context,
+            $this->createStub(Registry::class),
+            $objectManager ?? $this->createStub(ObjectManagerInterface::class),
+            $resourceModel ?? $this->createStub(JobResourceModel::class),
         );
     }
 
     #[DataProvider('authorizedHandlersProvider')]
     public function testExecuteSucceedsForAuthorizedHandler(string $class, string $method, array $methodArgs): void
     {
-        $this->job->setClass($class);
-        $this->job->setMethod($method);
-        $this->job->setData('decoded_data', $methodArgs);
-        $this->job->setData('retries', 0);
-
         $mockHandler = $this->getMockBuilder($class)
             ->disableOriginalConstructor()
             ->onlyMethods([$method])
             ->getMock();
 
-        $mockHandler->expects($this->once())
-            ->method($method);
+        $mockHandler->expects($this->once())->method($method);
 
-        $this->objectManager->expects($this->once())
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects($this->once())
             ->method('get')
             ->with($class)
             ->willReturn($mockHandler);
 
-        $this->resourceModel->method('save')->willReturnSelf();
+        $resourceModel = $this->createStub(JobResourceModel::class);
+        $resourceModel->method('save')->willReturnSelf();
 
-        $result = $this->job->execute();
+        $job = $this->createObjectToTest(objectManager: $objectManager, resourceModel: $resourceModel);
+        $job->setClass($class);
+        $job->setMethod($method);
+        $job->setData('decoded_data', $methodArgs);
+        $job->setData('retries', 0);
 
-        $this->assertSame($this->job, $result);
-        $this->assertEquals(1, $this->job->getData('retries'));
+        $result = $job->execute();
+
+        $this->assertSame($job, $result);
+        $this->assertEquals(1, $job->getData('retries'));
     }
 
     #[DataProvider('unauthorizedHandlersProvider')]
     public function testExecuteThrowsForUnauthorizedHandlers(string $class, string $method): void
     {
-        $this->job->setClass($class);
-        $this->job->setMethod($method);
-        $this->job->setData('decoded_data', []);
+        $job = $this->createObjectToTest();
+        $job->setClass($class);
+        $job->setMethod($method);
+        $job->setData('decoded_data', []);
 
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessage('Unauthorized job handler');
 
-        $this->job->execute();
+        $job->execute();
     }
 
     public static function authorizedHandlersProvider(): array
@@ -178,4 +168,3 @@ class JobTest extends TestCase
         ];
     }
 }
-

--- a/Test/Unit/Model/Observer/SaveSettingsTest.php
+++ b/Test/Unit/Model/Observer/SaveSettingsTest.php
@@ -13,93 +13,92 @@ use Magento\Framework\Event;
 use Magento\Framework\Event\Observer;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class SaveSettingsTest extends TestCase
 {
-    private null|(StoreManagerInterface&MockObject) $storeManager = null;
-    private null|(IndicesConfigurator&MockObject) $indicesConfigurator = null;
-    private null|(Data&MockObject) $helper = null;
-    private null|(ProductHelper&MockObject) $productHelper = null;
-    private ?SaveSettings $saveSettings = null;
-
-    protected function setUp(): void
-    {
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->indicesConfigurator = $this->createMock(IndicesConfigurator::class);
-        $this->helper = $this->createMock(Data::class);
-        $this->productHelper = $this->createMock(ProductHelper::class);
-
-        $this->saveSettings = new SaveSettings(
-            $this->storeManager,
-            $this->indicesConfigurator,
-            $this->helper,
-            $this->productHelper
+    protected function createObjectToTest(
+        ?StoreManagerInterface $storeManager = null,
+        ?IndicesConfigurator $indicesConfigurator = null,
+        ?Data $helper = null,
+    ): SaveSettings {
+        return new SaveSettings(
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $indicesConfigurator ?? $this->createStub(IndicesConfigurator::class),
+            $helper ?? $this->createStub(Data::class),
+            $this->createStub(ProductHelper::class),
         );
     }
 
     private function createObserver(string $eventName): Observer
     {
-        $event = $this->createMock(Event::class);
+        $event = $this->createStub(Event::class);
         $event->method('getName')->willReturn($eventName);
 
-        $observer = $this->createMock(Observer::class);
+        $observer = $this->createStub(Observer::class);
         $observer->method('getEvent')->willReturn($event);
 
         return $observer;
     }
 
-    private function withStores(array $storeIds, bool $indexingEnabled = true): void
+    private function createStoreManagerWithStores(array $storeIds): StoreManagerInterface
     {
         $stores = [];
         foreach ($storeIds as $id) {
-            $stores[$id] = $this->createMock(StoreInterface::class);
+            $stores[$id] = $this->createStub(StoreInterface::class);
         }
-        $this->storeManager->method('getStores')->willReturn($stores);
-        $this->helper->method('isIndexingEnabled')->willReturn($indexingEnabled);
+
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn($stores);
+
+        return $storeManager;
     }
 
     public function testCallsSaveConfigurationForEachEnabledStore(): void
     {
-        $this->storeManager->method('getStores')->willReturn([
-            1 => $this->createMock(StoreInterface::class),
-            2 => $this->createMock(StoreInterface::class),
-        ]);
-        $this->helper->method('isIndexingEnabled')->willReturn(true);
+        $storeManager = $this->createStoreManagerWithStores([1, 2]);
 
-        $this->indicesConfigurator->expects($this->exactly(2))
-            ->method('saveConfigurationToAlgolia');
+        $helper = $this->createStub(Data::class);
+        $helper->method('isIndexingEnabled')->willReturn(true);
 
-        $this->saveSettings->execute($this->createObserver('some_event'));
+        $indicesConfigurator = $this->createMock(IndicesConfigurator::class);
+        $indicesConfigurator->expects($this->exactly(2))->method('saveConfigurationToAlgolia');
+
+        $saveSettings = $this->createObjectToTest($storeManager, $indicesConfigurator, $helper);
+
+        $saveSettings->execute($this->createObserver('some_event'));
     }
 
     public function testSkipsStoreWhenIndexingIsDisabled(): void
     {
-        $this->storeManager->method('getStores')->willReturn([
-            1 => $this->createMock(StoreInterface::class),
-            2 => $this->createMock(StoreInterface::class),
-        ]);
-        $this->helper->method('isIndexingEnabled')
-            ->willReturnMap([[1, false], [2, true]]);
+        $storeManager = $this->createStoreManagerWithStores([1, 2]);
 
-        $this->indicesConfigurator->expects($this->once())
+        $helper = $this->createStub(Data::class);
+        $helper->method('isIndexingEnabled')->willReturnMap([[1, false], [2, true]]);
+
+        $indicesConfigurator = $this->createMock(IndicesConfigurator::class);
+        $indicesConfigurator->expects($this->once())
             ->method('saveConfigurationToAlgolia')
             ->with(2, false, $this->anything());
 
-        $this->saveSettings->execute($this->createObserver('some_event'));
+        $saveSettings = $this->createObjectToTest($storeManager, $indicesConfigurator, $helper);
+
+        $saveSettings->execute($this->createObserver('some_event'));
     }
 
     public function testNeverCallsSaveConfigurationWhenAllStoresHaveIndexingDisabled(): void
     {
-        $this->withStores([1, 2], false);
+        $storeManager = $this->createStoreManagerWithStores([1, 2]);
 
-        $this->indicesConfigurator->expects($this->never())
-            ->method('saveConfigurationToAlgolia');
+        $helper = $this->createStub(Data::class);
+        $helper->method('isIndexingEnabled')->willReturn(false);
 
-        $this->saveSettings->execute($this->createObserver('some_event'));
+        $indicesConfigurator = $this->createMock(IndicesConfigurator::class);
+        $indicesConfigurator->expects($this->never())->method('saveConfigurationToAlgolia');
+
+        $saveSettings = $this->createObjectToTest($storeManager, $indicesConfigurator, $helper);
+
+        $saveSettings->execute($this->createObserver('some_event'));
     }
 
     #[DataProvider('eventFilteredEntitiesProvider')]
@@ -107,13 +106,19 @@ class SaveSettingsTest extends TestCase
         string $eventName,
         array $expectedEntities
     ): void {
-        $this->withStores([1]);
+        $storeManager = $this->createStoreManagerWithStores([1]);
 
-        $this->indicesConfigurator->expects($this->once())
+        $helper = $this->createStub(Data::class);
+        $helper->method('isIndexingEnabled')->willReturn(true);
+
+        $indicesConfigurator = $this->createMock(IndicesConfigurator::class);
+        $indicesConfigurator->expects($this->once())
             ->method('saveConfigurationToAlgolia')
             ->with(1, false, $expectedEntities);
 
-        $this->saveSettings->execute($this->createObserver($eventName));
+        $saveSettings = $this->createObjectToTest($storeManager, $indicesConfigurator, $helper);
+
+        $saveSettings->execute($this->createObserver($eventName));
     }
 
     public static function eventFilteredEntitiesProvider(): array
@@ -144,12 +149,18 @@ class SaveSettingsTest extends TestCase
 
     public function testAlwaysPassesFalseForUseTmpIndex(): void
     {
-        $this->withStores([1]);
+        $storeManager = $this->createStoreManagerWithStores([1]);
 
-        $this->indicesConfigurator->expects($this->once())
+        $helper = $this->createStub(Data::class);
+        $helper->method('isIndexingEnabled')->willReturn(true);
+
+        $indicesConfigurator = $this->createMock(IndicesConfigurator::class);
+        $indicesConfigurator->expects($this->once())
             ->method('saveConfigurationToAlgolia')
             ->with(1, false, $this->anything());
 
-        $this->saveSettings->execute($this->createObserver('some_event'));
+        $saveSettings = $this->createObjectToTest($storeManager, $indicesConfigurator, $helper);
+
+        $saveSettings->execute($this->createObserver('some_event'));
     }
 }

--- a/Test/Unit/Model/QueueTest.php
+++ b/Test/Unit/Model/QueueTest.php
@@ -7,41 +7,53 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Model\Job;
 use Algolia\AlgoliaSearch\Model\Queue;
+use Algolia\AlgoliaSearch\Model\ResourceModel\Job\CollectionFactory as JobCollectionFactory;
 use Algolia\AlgoliaSearch\Service\Category\IndexBuilder as CategoryIndexBuilder;
 use Algolia\AlgoliaSearch\Service\Product\IndexBuilder as ProductIndexBuilder;
 use Algolia\AlgoliaSearch\Test\TestCase;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\ObjectManagerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
-#[AllowMockObjectsWithoutExpectations]
 class QueueTest extends TestCase
 {
-    private null|(ConfigHelper&MockObject) $configHelper = null;
-    private null|(DiagnosticsLogger&MockObject) $logger = null;
-    private null|(ObjectManagerInterface&MockObject) $objectManager = null;
-    private null|(AdapterInterface&MockObject) $dbAdapter = null;
-    private ?Queue $queue = null;
-
     /**
-     * @throws \ReflectionException
+     * Queue::__construct() resolves its db connection via $objectManager->create(...), an
+     * injected instance call (not a static ObjectManager access), so it's safe to construct for
+     * real once that instance is stubbed to hand back the desired $dbAdapter.
      */
-    protected function setUp(): void
-    {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->logger = $this->createMock(DiagnosticsLogger::class);
-        $this->objectManager = $this->createMock(ObjectManagerInterface::class);
-        $this->dbAdapter = $this->createMock(AdapterInterface::class);
+    protected function createObjectToTest(
+        ?ConfigHelper $configHelper = null,
+        ?DiagnosticsLogger $logger = null,
+        ?ObjectManagerInterface $objectManager = null,
+        ?AdapterInterface $dbAdapter = null,
+    ): Queue {
+        $dbAdapter ??= $this->createStub(AdapterInterface::class);
 
-        $this->queue = $this->createQueueMock();
+        $resourceConnection = $this->createStub(ResourceConnection::class);
+        $resourceConnection->method('getTableName')->willReturnArgument(0);
+        $resourceConnection->method('getConnection')->willReturn($dbAdapter);
+
+        $objectManager ??= $this->createStub(ObjectManagerInterface::class);
+        $objectManager->method('create')->willReturn($resourceConnection);
+
+        return new Queue(
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $logger ?? $this->createStub(DiagnosticsLogger::class),
+            $this->createStub(JobCollectionFactory::class),
+            $resourceConnection,
+            $objectManager,
+            $this->createStub(ConsoleOutput::class),
+        );
     }
 
     #[DataProvider('authorizedHandlersProvider')]
     public function testAddToQueueSucceedsForAuthorizedHandlerWhenQueueInactive(string $class, string $method, array $data): void
     {
-        $this->configHelper->method('isQueueActive')->willReturn(false);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isQueueActive')->willReturn(false);
 
         $mockHandler = $this->getMockBuilder($class)
             ->disableOriginalConstructor()
@@ -50,46 +62,60 @@ class QueueTest extends TestCase
 
         $mockHandler->expects($this->once())->method($method);
 
-        $this->objectManager->expects($this->once())
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects($this->once())
             ->method('get')
             ->with($class)
             ->willReturn($mockHandler);
 
-        $this->queue->addToQueue($class, $method, $data);
+        $queue = $this->createObjectToTest(configHelper: $configHelper, objectManager: $objectManager);
+
+        $queue->addToQueue($class, $method, $data);
     }
 
     #[DataProvider('authorizedHandlersProvider')]
     public function testAddToQueueSucceedsForAuthorizedHandlerWhenQueueActive(string $class, string $method, array $data): void
     {
-        $this->configHelper->method('isQueueActive')->willReturn(true);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isQueueActive')->willReturn(true);
 
-        $this->dbAdapter->expects($this->once())->method('insert');
+        $dbAdapter = $this->createMock(AdapterInterface::class);
+        $dbAdapter->expects($this->once())->method('insert');
 
-        $this->queue->addToQueue($class, $method, $data);
+        $queue = $this->createObjectToTest(configHelper: $configHelper, dbAdapter: $dbAdapter);
+
+        $queue->addToQueue($class, $method, $data);
     }
 
     #[DataProvider('unauthorizedHandlersProvider')]
     public function testAddToQueueThrowsForUnauthorizedHandlersWhenQueueInactive(string $class, string $method): void
     {
-        $this->configHelper->method('isQueueActive')->willReturn(false);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isQueueActive')->willReturn(false);
+
+        $queue = $this->createObjectToTest(configHelper: $configHelper);
 
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessage('Unauthorized job handler');
 
-        $this->queue->addToQueue($class, $method, []);
+        $queue->addToQueue($class, $method, []);
     }
 
     #[DataProvider('unauthorizedHandlersProvider')]
     public function testAddToQueueThrowsForUnauthorizedHandlersWhenQueueActive(string $class, string $method): void
     {
-        $this->configHelper->method('isQueueActive')->willReturn(true);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isQueueActive')->willReturn(true);
 
-        $this->dbAdapter->expects($this->never())->method('insert');
+        $dbAdapter = $this->createMock(AdapterInterface::class);
+        $dbAdapter->expects($this->never())->method('insert');
+
+        $queue = $this->createObjectToTest(configHelper: $configHelper, dbAdapter: $dbAdapter);
 
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessage('Unauthorized job handler');
 
-        $this->queue->addToQueue($class, $method, []);
+        $queue->addToQueue($class, $method, []);
     }
 
     /**
@@ -145,26 +171,4 @@ class QueueTest extends TestCase
             ],
         ];
     }
-
-    /**
-     * Create Queue using reflection to bypass the generated CollectionFactory dependency
-     *
-     * @throws \ReflectionException
-     */
-    private function createQueueMock(): Queue
-    {
-
-        $queue = $this->getMockBuilder(Queue::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([])
-            ->getMock();
-
-        $this->setPrivateProperty($queue, 'configHelper', $this->configHelper);
-        $this->setPrivateProperty($queue, 'logger', $this->logger);
-        $this->setPrivateProperty($queue, 'objectManager', $this->objectManager);
-        $this->setPrivateProperty($queue, 'db', $this->dbAdapter);
-
-        return $queue;
-    }
-
 }

--- a/Test/Unit/Observer/AddAlgoliaAssetsObserverTest.php
+++ b/Test/Unit/Observer/AddAlgoliaAssetsObserverTest.php
@@ -43,8 +43,8 @@ class AddAlgoliaAssetsObserverTest extends TestCase
     private function createObserverStub(): Observer
     {
         $layout = $this->createStub(Layout::class);
-        $observer = $this->createStub(Observer::class);
-        $observer->method('getData')->willReturn($layout);
+        $observer = $this->createMock(Observer::class);
+        $observer->method('getData')->with('layout')->willReturn($layout);
 
         return $observer;
     }
@@ -93,15 +93,15 @@ class AddAlgoliaAssetsObserverTest extends TestCase
         $storeManager = $this->createStub(StoreManagerInterface::class);
         $storeManager->method('getStore')->willReturn($this->createStoreStub($storeId));
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('isEnabledFrontEnd')->willReturn($isFrontendEnabled);
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('isEnabledFrontEnd')->with($storeId)->willReturn($isFrontendEnabled);
 
-        $credentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
-        $credentialsManager->method('checkCredentials')->willReturn($areCredentialsValid);
+        $credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $credentialsManager->method('checkCredentials')->with($storeId)->willReturn($areCredentialsValid);
 
         $layout = $this->createStub(Layout::class);
-        $observerArg = $this->createStub(Observer::class);
-        $observerArg->method('getData')->willReturn($layout);
+        $observerArg = $this->createMock(Observer::class);
+        $observerArg->method('getData')->with('layout')->willReturn($layout);
 
         $renderingManager = $this->createMock(RenderingManager::class);
         if ($expectRenderingManagerCalled) {

--- a/Test/Unit/Observer/AddAlgoliaAssetsObserverTest.php
+++ b/Test/Unit/Observer/AddAlgoliaAssetsObserverTest.php
@@ -13,63 +13,69 @@ use Magento\Framework\View\Layout;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class AddAlgoliaAssetsObserverTest extends TestCase
 {
-    protected ?AddAlgoliaAssetsObserver $observer;
-    protected ?ConfigHelper $configHelper;
-    protected ?RenderingManager $renderingManager;
-    protected ?StoreManagerInterface $storeManager;
-    protected ?Http $request;
-    protected ?AlgoliaCredentialsManager $credentialsManager;
-
-    protected function setUp(): void
-    {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->renderingManager = $this->createMock(RenderingManager::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->request = $this->createMock(Http::class);
-        $this->credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
-
-        $this->observer = new AddAlgoliaAssetsObserver(
-            $this->configHelper,
-            $this->renderingManager,
-            $this->storeManager,
-            $this->request,
-            $this->credentialsManager
+    protected function createObjectToTest(
+        ?ConfigHelper $configHelper = null,
+        ?RenderingManager $renderingManager = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?Http $request = null,
+        ?AlgoliaCredentialsManager $credentialsManager = null,
+    ): AddAlgoliaAssetsObserver {
+        return new AddAlgoliaAssetsObserver(
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $renderingManager ?? $this->createStub(RenderingManager::class),
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $request ?? $this->createStub(Http::class),
+            $credentialsManager ?? $this->createStub(AlgoliaCredentialsManager::class),
         );
     }
 
-    protected function createMockStore(int $storeId = 1): StoreInterface
+    private function createStoreStub(int $storeId = 1): StoreInterface
     {
-        $store = $this->createMock(StoreInterface::class);
+        $store = $this->createStub(StoreInterface::class);
         $store->method('getId')->willReturn($storeId);
 
         return $store;
     }
 
-    protected function createMockObserver(): Observer
+    private function createObserverStub(): Observer
     {
-        $layout = $this->createMock(Layout::class);
-        $observer = $this->createMock(Observer::class);
-        $observer->method('getData')->with('layout')->willReturn($layout);
+        $layout = $this->createStub(Layout::class);
+        $observer = $this->createStub(Observer::class);
+        $observer->method('getData')->willReturn($layout);
 
         return $observer;
     }
 
     public function testSwaggerActionReturnsEarly(): void
     {
-        $this->request->method('getFullActionName')->willReturn('swagger_index_index');
+        $request = $this->createStub(Http::class);
+        $request->method('getFullActionName')->willReturn('swagger_index_index');
 
-        $this->storeManager->expects($this->never())->method('getStore');
-        $this->configHelper->expects($this->never())->method('isEnabledFrontEnd');
-        $this->credentialsManager->expects($this->never())->method('checkCredentials');
-        $this->renderingManager->expects($this->never())->method('handleFrontendAssets');
-        $this->renderingManager->expects($this->never())->method('handleBackendRendering');
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->expects($this->never())->method('getStore');
 
-        $this->observer->execute($this->createMockObserver());
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->never())->method('isEnabledFrontEnd');
+
+        $credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $credentialsManager->expects($this->never())->method('checkCredentials');
+
+        $renderingManager = $this->createMock(RenderingManager::class);
+        $renderingManager->expects($this->never())->method('handleFrontendAssets');
+        $renderingManager->expects($this->never())->method('handleBackendRendering');
+
+        $observer = $this->createObjectToTest(
+            configHelper: $configHelper,
+            renderingManager: $renderingManager,
+            storeManager: $storeManager,
+            request: $request,
+            credentialsManager: $credentialsManager,
+        );
+
+        $observer->execute($this->createObserverStub());
     }
 
     #[DataProvider('executeConditionsProvider')]
@@ -81,28 +87,44 @@ class AddAlgoliaAssetsObserverTest extends TestCase
         $storeId = 1;
         $actionName = 'catalog_category_view';
 
-        $this->request->method('getFullActionName')->willReturn($actionName);
-        $this->storeManager->method('getStore')->willReturn($this->createMockStore($storeId));
-        $this->configHelper->method('isEnabledFrontEnd')->with($storeId)->willReturn($isFrontendEnabled);
-        $this->credentialsManager->method('checkCredentials')->with($storeId)->willReturn($areCredentialsValid);
+        $request = $this->createStub(Http::class);
+        $request->method('getFullActionName')->willReturn($actionName);
 
-        $layout = $this->createMock(Layout::class);
-        $observer = $this->createMock(Observer::class);
-        $observer->method('getData')->with('layout')->willReturn($layout);
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($this->createStoreStub($storeId));
 
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isEnabledFrontEnd')->willReturn($isFrontendEnabled);
+
+        $credentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $credentialsManager->method('checkCredentials')->willReturn($areCredentialsValid);
+
+        $layout = $this->createStub(Layout::class);
+        $observerArg = $this->createStub(Observer::class);
+        $observerArg->method('getData')->willReturn($layout);
+
+        $renderingManager = $this->createMock(RenderingManager::class);
         if ($expectRenderingManagerCalled) {
-            $this->renderingManager->expects($this->once())
+            $renderingManager->expects($this->once())
                 ->method('handleFrontendAssets')
                 ->with($layout, $storeId);
-            $this->renderingManager->expects($this->once())
+            $renderingManager->expects($this->once())
                 ->method('handleBackendRendering')
                 ->with($layout, $actionName, $storeId);
         } else {
-            $this->renderingManager->expects($this->never())->method('handleFrontendAssets');
-            $this->renderingManager->expects($this->never())->method('handleBackendRendering');
+            $renderingManager->expects($this->never())->method('handleFrontendAssets');
+            $renderingManager->expects($this->never())->method('handleBackendRendering');
         }
 
-        $this->observer->execute($observer);
+        $observer = $this->createObjectToTest(
+            configHelper: $configHelper,
+            renderingManager: $renderingManager,
+            storeManager: $storeManager,
+            request: $request,
+            credentialsManager: $credentialsManager,
+        );
+
+        $observer->execute($observerArg);
     }
 
     public static function executeConditionsProvider(): array
@@ -131,4 +153,3 @@ class AddAlgoliaAssetsObserverTest extends TestCase
         ];
     }
 }
-

--- a/Test/Unit/Plugin/AddToCartRedirectForInsightsTest.php
+++ b/Test/Unit/Plugin/AddToCartRedirectForInsightsTest.php
@@ -38,8 +38,8 @@ class AddToCartRedirectForInsightsTest extends TestCase
 
     public function testBeforeAddProductReturnsNullWhenInsightsDisabled(): void
     {
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(false);
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('isClickConversionAnalyticsEnabled')->with(1)->willReturn(false);
 
         $plugin = $this->createObjectToTest($configHelper);
 

--- a/Test/Unit/Plugin/AddToCartRedirectForInsightsTest.php
+++ b/Test/Unit/Plugin/AddToCartRedirectForInsightsTest.php
@@ -12,56 +12,40 @@ use Magento\Catalog\Model\Product;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\Checkout\Model\Cart;
 use Magento\Checkout\Model\Session;
-use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class AddToCartRedirectForInsightsTest extends TestCase
 {
-    protected null|(StoreManagerInterface&MockObject) $storeManager = null;
-    protected null|(ProductRepositoryInterface&MockObject) $productRepository = null;
-    protected null|(Session&MockObject) $checkoutSession = null;
-    protected null|(StockRegistryInterface&MockObject) $stockRegistry = null;
-    protected null|(ManagerInterface&MockObject) $eventManager = null;
-    protected null|(ConfigHelper&MockObject) $configHelper = null;
-    protected null|(Cart&MockObject) $cart = null;
-    protected ?AddToCartRedirectForInsights $plugin = null;
-
-    protected function setUp(): void
+    protected function createObjectToTest(?ConfigHelper $configHelper = null): AddToCartRedirectForInsights
     {
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
-        $this->checkoutSession = $this->createMock(Session::class);
-        $this->stockRegistry = $this->createMock(StockRegistryInterface::class);
-        $this->eventManager = $this->createMock(ManagerInterface::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->cart = $this->createMock(Cart::class);
-
-        $store = $this->createMock(StoreInterface::class);
+        $store = $this->createStub(StoreInterface::class);
         $store->method('getId')->willReturn(1);
-        $this->storeManager->method('getStore')->willReturn($store);
 
-        $this->plugin = new AddToCartRedirectForInsights(
-            $this->storeManager,
-            $this->productRepository,
-            $this->checkoutSession,
-            $this->stockRegistry,
-            $this->eventManager,
-            $this->configHelper
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        return new AddToCartRedirectForInsights(
+            $storeManager,
+            $this->createStub(ProductRepositoryInterface::class),
+            $this->createStub(Session::class),
+            $this->createStub(StockRegistryInterface::class),
+            $this->createStub(ManagerInterface::class),
+            $configHelper ?? $this->createStub(ConfigHelper::class),
         );
     }
 
     public function testBeforeAddProductReturnsNullWhenInsightsDisabled(): void
     {
-        $this->configHelper->method('isClickConversionAnalyticsEnabled')->with(1)->willReturn(false);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(false);
 
-        $result = $this->plugin->beforeAddProduct(
-            $this->cart,
-            $this->createMock(Product::class),
+        $plugin = $this->createObjectToTest($configHelper);
+
+        $result = $plugin->beforeAddProduct(
+            $this->createStub(Cart::class),
+            $this->createStub(Product::class),
             ['referer' => 'instantsearch', 'queryID' => 'abc', 'indexName' => 'idx']
         );
 
@@ -70,10 +54,13 @@ class AddToCartRedirectForInsightsTest extends TestCase
 
     public function testBeforeAddProductReturnsNullWhenRequestInfoMissingInsightsKeys(): void
     {
-        $this->configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(true);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(true);
 
-        $result = $this->plugin->beforeAddProduct(
-            $this->cart,
+        $plugin = $this->createObjectToTest($configHelper);
+
+        $result = $plugin->beforeAddProduct(
+            $this->createStub(Cart::class),
             1,
             ['referer' => 'instantsearch'] // missing queryID and indexName
         );
@@ -83,10 +70,13 @@ class AddToCartRedirectForInsightsTest extends TestCase
 
     public function testBeforeAddProductReturnsNullWhenRefererIsNotInstantSearch(): void
     {
-        $this->configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(true);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isClickConversionAnalyticsEnabled')->willReturn(true);
 
-        $result = $this->plugin->beforeAddProduct(
-            $this->cart,
+        $plugin = $this->createObjectToTest($configHelper);
+
+        $result = $plugin->beforeAddProduct(
+            $this->createStub(Cart::class),
             1,
             ['referer' => 'catalog', 'queryID' => 'abc123', 'indexName' => 'products']
         );

--- a/Test/Unit/Plugin/Cache/CacheCleanBulkAttributePluginTest.php
+++ b/Test/Unit/Plugin/Cache/CacheCleanBulkAttributePluginTest.php
@@ -11,21 +11,17 @@ use Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute\Save;
 use Magento\Catalog\Helper\Product\Edit\Action\Attribute;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\Redirect;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class CacheCleanBulkAttributePluginTest extends TestCase
 {
-    protected null|(Attribute&MockObject) $attributeHelper = null;
-    protected null|(CacheHelper&MockObject) $cacheHelper = null;
-    protected ?CacheCleanBulkAttributePlugin $plugin = null;
-
-    protected function setUp(): void
-    {
-        $this->attributeHelper = $this->createMock(Attribute::class);
-        $this->cacheHelper = $this->createMock(CacheHelper::class);
-        $this->plugin = new CacheCleanBulkAttributePlugin($this->attributeHelper, $this->cacheHelper);
+    protected function createObjectToTest(
+        ?Attribute $attributeHelper = null,
+        ?CacheHelper $cacheHelper = null,
+    ): CacheCleanBulkAttributePlugin {
+        return new CacheCleanBulkAttributePlugin(
+            $attributeHelper ?? $this->createStub(Attribute::class),
+            $cacheHelper ?? $this->createStub(CacheHelper::class),
+        );
     }
 
     public function testAfterExecuteCallsHandleBulkAttributeChangeWithArgsFromHelperAndRequest(): void
@@ -34,25 +30,30 @@ class CacheCleanBulkAttributePluginTest extends TestCase
         $attributes = ['status' => '1'];
         $storeId = 2;
 
-        $this->attributeHelper->method('getProductIds')->willReturn($productIds);
-        $this->attributeHelper->method('getSelectedStoreId')->willReturn($storeId);
+        $attributeHelper = $this->createStub(Attribute::class);
+        $attributeHelper->method('getProductIds')->willReturn($productIds);
+        $attributeHelper->method('getSelectedStoreId')->willReturn($storeId);
 
-        $request = $this->createMock(RequestInterface::class);
-        $request->method('getParam')->with('attributes', [])->willReturn($attributes);
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn($attributes);
 
+        // getRequest() is unconditionally called exactly once by afterExecute().
         $subject = $this->getMockBuilder(Save::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getRequest'])
             ->getMock();
-        $subject->method('getRequest')->willReturn($request);
+        $subject->expects($this->once())->method('getRequest')->willReturn($request);
 
-        $redirect = $this->createMock(Redirect::class);
+        $redirect = $this->createStub(Redirect::class);
 
-        $this->cacheHelper->expects($this->once())
+        $cacheHelper = $this->createMock(CacheHelper::class);
+        $cacheHelper->expects($this->once())
             ->method('handleBulkAttributeChange')
             ->with($productIds, $attributes, $storeId);
 
-        $result = $this->plugin->afterExecute($subject, $redirect);
+        $plugin = $this->createObjectToTest($attributeHelper, $cacheHelper);
+
+        $result = $plugin->afterExecute($subject, $redirect);
 
         $this->assertSame($redirect, $result);
     }

--- a/Test/Unit/Plugin/Cache/CacheCleanBulkAttributePluginTest.php
+++ b/Test/Unit/Plugin/Cache/CacheCleanBulkAttributePluginTest.php
@@ -34,8 +34,8 @@ class CacheCleanBulkAttributePluginTest extends TestCase
         $attributeHelper->method('getProductIds')->willReturn($productIds);
         $attributeHelper->method('getSelectedStoreId')->willReturn($storeId);
 
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn($attributes);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('attributes', [])->willReturn($attributes);
 
         // getRequest() is unconditionally called exactly once by afterExecute().
         $subject = $this->getMockBuilder(Save::class)

--- a/Test/Unit/Plugin/Cache/CacheCleanProductPluginTest.php
+++ b/Test/Unit/Plugin/Cache/CacheCleanProductPluginTest.php
@@ -13,37 +13,30 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class CacheCleanProductPluginTest extends TestCase
 {
-    protected null|(Cache&MockObject) $cache = null;
-    protected null|(ConfigHelper&MockObject) $configHelper = null;
-    protected null|(CacheHelper&MockObject) $cacheHelper = null;
-    protected null|(ProductResource&MockObject) $subject = null;
-    protected null|(ProductResource&MockObject) $result = null;
-    protected null|(CacheCleanProductPlugin&MockObject) $plugin = null;
-
-    protected function setUp(): void
-    {
-        $this->cache = $this->createMock(Cache::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->cacheHelper = $this->createMock(CacheHelper::class);
-        $this->subject = $this->createMock(ProductResource::class);
-        $this->result = $this->createMock(ProductResource::class);
-
-        // Partial mock to isolate afterSave from the complex isEligibleNewProduct logic
-        $this->plugin = $this->getMockBuilder(CacheCleanProductPlugin::class)
-            ->setConstructorArgs([$this->cache, $this->configHelper, $this->cacheHelper])
+    /**
+     * Partial mock to isolate afterSave from the complex isEligibleNewProduct logic.
+     */
+    protected function createObjectToTest(
+        ?Cache $cache = null,
+        ?ConfigHelper $configHelper = null,
+        ?CacheHelper $cacheHelper = null,
+    ): CacheCleanProductPlugin&MockObject {
+        return $this->getMockBuilder(CacheCleanProductPlugin::class)
+            ->setConstructorArgs([
+                $cache ?? $this->createStub(Cache::class),
+                $configHelper ?? $this->createStub(ConfigHelper::class),
+                $cacheHelper ?? $this->createStub(CacheHelper::class),
+            ])
             ->onlyMethods(['isEligibleNewProduct'])
             ->getMock();
-        $this->plugin->method('isEligibleNewProduct')->willReturn(false);
     }
 
-    private function makeProduct(string $sku, array $origData, array $newData): Product&MockObject
+    private function createProductStub(string $sku, array $origData, array $newData): Product
     {
-        $product = $this->createMock(Product::class);
+        $product = $this->createStub(Product::class);
         $product->method('getSku')->willReturn($sku);
         $product->method('getStoreId')->willReturn(1);
         $product->method('getOrigData')->willReturn($origData);
@@ -54,43 +47,69 @@ class CacheCleanProductPluginTest extends TestCase
 
     public function testAfterSaveClearsCacheWhenStatusChanges(): void
     {
-        $this->configHelper->method('includeNonVisibleProductsInIndex')->willReturn(true);
-        $this->configHelper->method('getShowOutOfStock')->willReturn(true);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('includeNonVisibleProductsInIndex')->willReturn(true);
+        $configHelper->method('getShowOutOfStock')->willReturn(true);
 
-        $product = $this->makeProduct(
+        $cache = $this->createMock(Cache::class);
+        $cache->expects($this->once())->method('clear')->with(1);
+
+        $plugin = $this->createObjectToTest($cache, $configHelper);
+        // isEligibleNewProduct() is the first term of the OR chain, so it's always evaluated
+        // exactly once when afterSave() has non-empty original data to compare against.
+        $plugin->expects($this->once())->method('isEligibleNewProduct')->willReturn(false);
+
+        $product = $this->createProductStub(
             'TEST-SKU',
             ['status' => Status::STATUS_DISABLED],
             ['status' => Status::STATUS_ENABLED]
         );
 
-        $this->cache->expects($this->once())->method('clear')->with(1);
+        $subject = $this->createStub(ProductResource::class);
+        $result = $this->createStub(ProductResource::class);
 
-        $this->plugin->beforeSave($this->subject, $product);
-        $result = $this->plugin->afterSave($this->subject, $this->result, $product);
+        $plugin->beforeSave($subject, $product);
+        $returnValue = $plugin->afterSave($subject, $result, $product);
 
-        $this->assertSame($this->result, $result);
+        $this->assertSame($result, $returnValue);
     }
 
     public function testAfterSaveDoesNotClearCacheWhenNothingChanges(): void
     {
-        $this->configHelper->method('includeNonVisibleProductsInIndex')->willReturn(true);
-        $this->configHelper->method('getShowOutOfStock')->willReturn(true);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('includeNonVisibleProductsInIndex')->willReturn(true);
+        $configHelper->method('getShowOutOfStock')->willReturn(true);
+
+        $cache = $this->createMock(Cache::class);
+        $cache->expects($this->never())->method('clear');
+
+        $plugin = $this->createObjectToTest($cache, $configHelper);
+        $plugin->expects($this->once())->method('isEligibleNewProduct')->willReturn(false);
 
         $data = ['status' => Status::STATUS_ENABLED];
-        $product = $this->makeProduct('TEST-SKU', $data, $data);
+        $product = $this->createProductStub('TEST-SKU', $data, $data);
 
-        $this->cache->expects($this->never())->method('clear');
+        $subject = $this->createStub(ProductResource::class);
+        $result = $this->createStub(ProductResource::class);
 
-        $this->plugin->beforeSave($this->subject, $product);
-        $this->plugin->afterSave($this->subject, $this->result, $product);
+        $plugin->beforeSave($subject, $product);
+        $plugin->afterSave($subject, $result, $product);
     }
 
     public function testAfterDeleteAlwaysClearsCache(): void
     {
-        $this->cache->expects($this->once())->method('clear')->with(null);
+        $cache = $this->createMock(Cache::class);
+        $cache->expects($this->once())->method('clear')->with(null);
 
-        $result = $this->plugin->afterDelete($this->subject, $this->result);
+        $plugin = $this->createObjectToTest($cache);
+        // afterDelete() never reaches afterSave()'s OR chain.
+        $plugin->expects($this->never())->method('isEligibleNewProduct');
 
-        $this->assertSame($this->result, $result);
+        $subject = $this->createStub(ProductResource::class);
+        $result = $this->createStub(ProductResource::class);
+
+        $returnValue = $plugin->afterDelete($subject, $result);
+
+        $this->assertSame($result, $returnValue);
     }
 }

--- a/Test/Unit/Plugin/CategoryUrlPluginTest.php
+++ b/Test/Unit/Plugin/CategoryUrlPluginTest.php
@@ -9,37 +9,32 @@ use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Catalog\Model\Category;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Url;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class CategoryUrlPluginTest extends TestCase
 {
-    protected null|(ObjectManagerInterface&MockObject) $objectManager = null;
-    protected ?CategoryUrlPlugin $plugin = null;
-
-    protected function setUp(): void
+    protected function createObjectToTest(?ObjectManagerInterface $objectManager = null): CategoryUrlPlugin
     {
-        $this->objectManager = $this->createMock(ObjectManagerInterface::class);
-        $this->plugin = new CategoryUrlPlugin($this->objectManager);
+        return new CategoryUrlPlugin($objectManager ?? $this->createStub(ObjectManagerInterface::class));
     }
 
     public function testCallsProceedWhenStoreIdIsZero(): void
     {
-        $category = $this->createMock(Category::class);
+        $category = $this->createStub(Category::class);
         $category->method('getStoreId')->willReturn(0);
 
         $expected = new \stdClass();
         $proceed = fn() => $expected;
 
-        $result = $this->plugin->aroundGetUrlInstance($category, $proceed);
+        $plugin = $this->createObjectToTest();
+
+        $result = $plugin->aroundGetUrlInstance($category, $proceed);
 
         $this->assertSame($expected, $result);
     }
 
     public function testCreatesUrlWithStoreIdWhenStoreIdIsNonZero(): void
     {
-        $category = $this->createMock(Category::class);
+        $category = $this->createStub(Category::class);
         $category->method('getStoreId')->willReturn(3);
 
         $urlInstance = $this->getMockBuilder(Url::class)
@@ -51,14 +46,17 @@ class CategoryUrlPluginTest extends TestCase
             ->with('setStoreId', [3])
             ->willReturnSelf();
 
-        $this->objectManager->expects($this->once())
+        $objectManager = $this->createMock(ObjectManagerInterface::class);
+        $objectManager->expects($this->once())
             ->method('create')
             ->with(Url::class)
             ->willReturn($urlInstance);
 
+        $plugin = $this->createObjectToTest($objectManager);
+
         $proceed = function () { $this->fail('proceed should not be called'); };
 
-        $result = $this->plugin->aroundGetUrlInstance($category, $proceed);
+        $result = $plugin->aroundGetUrlInstance($category, $proceed);
 
         $this->assertSame($urlInstance, $result);
     }

--- a/Test/Unit/Plugin/QuoteItemTest.php
+++ b/Test/Unit/Plugin/QuoteItemTest.php
@@ -24,17 +24,17 @@ class QuoteItemTest extends TestCase
         $product = $this->createStub(Product::class);
         $product->method('getStoreId')->willReturn(1);
 
-        $item = $this->createStub(AbstractItem::class);
+        $item = $this->createMock(AbstractItem::class);
         $item->method('getProduct')->willReturn($product);
-        $item->method('getData')->willReturn('encoded_query_data');
+        $item->method('getData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn('encoded_query_data');
 
         return $item;
     }
 
     public function testAfterConvertCopiesQueryParamWhenOrderTrackingEnabled(): void
     {
-        $insightsHelper = $this->createStub(InsightsHelper::class);
-        $insightsHelper->method('isOrderPlacedTracked')->willReturn(true);
+        $insightsHelper = $this->createMock(InsightsHelper::class);
+        $insightsHelper->method('isOrderPlacedTracked')->with(1)->willReturn(true);
 
         $orderItem = $this->getMockBuilder(OrderItem::class)
             ->disableOriginalConstructor()
@@ -55,8 +55,8 @@ class QuoteItemTest extends TestCase
 
     public function testAfterConvertDoesNotCopyQueryParamWhenOrderTrackingDisabled(): void
     {
-        $insightsHelper = $this->createStub(InsightsHelper::class);
-        $insightsHelper->method('isOrderPlacedTracked')->willReturn(false);
+        $insightsHelper = $this->createMock(InsightsHelper::class);
+        $insightsHelper->method('isOrderPlacedTracked')->with(1)->willReturn(false);
 
         $orderItem = $this->getMockBuilder(OrderItem::class)
             ->disableOriginalConstructor()

--- a/Test/Unit/Plugin/QuoteItemTest.php
+++ b/Test/Unit/Plugin/QuoteItemTest.php
@@ -11,62 +11,65 @@ use Magento\Catalog\Model\Product;
 use Magento\Quote\Model\Quote\Item\AbstractItem;
 use Magento\Quote\Model\Quote\Item\ToOrderItem;
 use Magento\Sales\Model\Order\Item as OrderItem;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class QuoteItemTest extends TestCase
 {
-    protected null|(InsightsHelper&MockObject) $insightsHelper = null;
-    protected null|(AbstractItem&MockObject) $item = null;
-    protected null|(OrderItem&MockObject) $orderItem = null;
-    protected null|(ToOrderItem&MockObject) $subject = null;
-    protected ?QuoteItem $plugin = null;
-
-    protected function setUp(): void
+    protected function createObjectToTest(?InsightsHelper $insightsHelper = null): QuoteItem
     {
-        $this->insightsHelper = $this->createMock(InsightsHelper::class);
+        return new QuoteItem($insightsHelper ?? $this->createStub(InsightsHelper::class));
+    }
 
-        $product = $this->createMock(Product::class);
+    private function createItemStub(): AbstractItem
+    {
+        $product = $this->createStub(Product::class);
         $product->method('getStoreId')->willReturn(1);
 
-        $this->item = $this->createMock(AbstractItem::class);
-        $this->item->method('getProduct')->willReturn($product);
-        $this->item->method('getData')
-            ->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)
-            ->willReturn('encoded_query_data');
+        $item = $this->createStub(AbstractItem::class);
+        $item->method('getProduct')->willReturn($product);
+        $item->method('getData')->willReturn('encoded_query_data');
 
-        $this->orderItem = $this->getMockBuilder(OrderItem::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['setData'])
-            ->getMock();
-
-        $this->subject = $this->createMock(ToOrderItem::class);
-
-        $this->plugin = new QuoteItem($this->insightsHelper);
+        return $item;
     }
 
     public function testAfterConvertCopiesQueryParamWhenOrderTrackingEnabled(): void
     {
-        $this->insightsHelper->method('isOrderPlacedTracked')->with(1)->willReturn(true);
+        $insightsHelper = $this->createStub(InsightsHelper::class);
+        $insightsHelper->method('isOrderPlacedTracked')->willReturn(true);
 
-        $this->orderItem->expects($this->once())
+        $orderItem = $this->getMockBuilder(OrderItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setData'])
+            ->getMock();
+        $orderItem->expects($this->once())
             ->method('setData')
             ->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM, 'encoded_query_data');
 
-        $result = $this->plugin->afterConvert($this->subject, $this->orderItem, $this->item);
+        $subject = $this->createStub(ToOrderItem::class);
 
-        $this->assertSame($this->orderItem, $result);
+        $plugin = $this->createObjectToTest($insightsHelper);
+
+        $result = $plugin->afterConvert($subject, $orderItem, $this->createItemStub());
+
+        $this->assertSame($orderItem, $result);
     }
 
     public function testAfterConvertDoesNotCopyQueryParamWhenOrderTrackingDisabled(): void
     {
-        $this->insightsHelper->method('isOrderPlacedTracked')->with(1)->willReturn(false);
+        $insightsHelper = $this->createStub(InsightsHelper::class);
+        $insightsHelper->method('isOrderPlacedTracked')->willReturn(false);
 
-        $this->orderItem->expects($this->never())->method('setData');
+        $orderItem = $this->getMockBuilder(OrderItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setData'])
+            ->getMock();
+        $orderItem->expects($this->never())->method('setData');
 
-        $result = $this->plugin->afterConvert($this->subject, $this->orderItem, $this->item);
+        $subject = $this->createStub(ToOrderItem::class);
 
-        $this->assertSame($this->orderItem, $result);
+        $plugin = $this->createObjectToTest($insightsHelper);
+
+        $result = $plugin->afterConvert($subject, $orderItem, $this->createItemStub());
+
+        $this->assertSame($orderItem, $result);
     }
 }

--- a/Test/Unit/Plugin/RemovePdpProductsBlockTest.php
+++ b/Test/Unit/Plugin/RemovePdpProductsBlockTest.php
@@ -8,70 +8,89 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Plugin\RemovePdpProductsBlock;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\View\Element\AbstractBlock;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class RemovePdpProductsBlockTest extends TestCase
 {
-    protected null|(ConfigHelper&MockObject) $configHelper = null;
-    protected null|(AbstractBlock&MockObject) $subject = null;
-    protected ?RemovePdpProductsBlock $plugin = null;
-
-    protected function setUp(): void
+    protected function createObjectToTest(?ConfigHelper $configHelper = null): RemovePdpProductsBlock
     {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->subject = $this->createMock(AbstractBlock::class);
-        $this->plugin = new RemovePdpProductsBlock($this->configHelper);
+        return new RemovePdpProductsBlock($configHelper ?? $this->createStub(ConfigHelper::class));
     }
 
     public function testReturnsEmptyStringForRelatedBlockWhenAllConditionsMet(): void
     {
-        $this->subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::RELATED_BLOCK_NAME);
-        $this->configHelper->method('isRecommendRelatedProductsEnabled')->willReturn(true);
-        $this->configHelper->method('isRemoveCoreRelatedProductsBlock')->willReturn(true);
+        $subject = $this->createStub(AbstractBlock::class);
+        $subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::RELATED_BLOCK_NAME);
 
-        $this->assertSame('', $this->plugin->afterToHtml($this->subject, '<div>related</div>'));
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isRecommendRelatedProductsEnabled')->willReturn(true);
+        $configHelper->method('isRemoveCoreRelatedProductsBlock')->willReturn(true);
+
+        $plugin = $this->createObjectToTest($configHelper);
+
+        $this->assertSame('', $plugin->afterToHtml($subject, '<div>related</div>'));
     }
 
     public function testReturnsOriginalResultForRelatedBlockWhenRelatedProductsNotEnabled(): void
     {
-        $this->subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::RELATED_BLOCK_NAME);
-        $this->configHelper->method('isRecommendRelatedProductsEnabled')->willReturn(false);
+        $subject = $this->createStub(AbstractBlock::class);
+        $subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::RELATED_BLOCK_NAME);
 
-        $this->assertSame('<div>related</div>', $this->plugin->afterToHtml($this->subject, '<div>related</div>'));
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isRecommendRelatedProductsEnabled')->willReturn(false);
+
+        $plugin = $this->createObjectToTest($configHelper);
+
+        $this->assertSame('<div>related</div>', $plugin->afterToHtml($subject, '<div>related</div>'));
     }
 
     public function testReturnsOriginalResultForRelatedBlockWhenCoreBlockRemovalNotEnabled(): void
     {
-        $this->subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::RELATED_BLOCK_NAME);
-        $this->configHelper->method('isRecommendRelatedProductsEnabled')->willReturn(true);
-        $this->configHelper->method('isRemoveCoreRelatedProductsBlock')->willReturn(false);
+        $subject = $this->createStub(AbstractBlock::class);
+        $subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::RELATED_BLOCK_NAME);
 
-        $this->assertSame('<div>related</div>', $this->plugin->afterToHtml($this->subject, '<div>related</div>'));
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isRecommendRelatedProductsEnabled')->willReturn(true);
+        $configHelper->method('isRemoveCoreRelatedProductsBlock')->willReturn(false);
+
+        $plugin = $this->createObjectToTest($configHelper);
+
+        $this->assertSame('<div>related</div>', $plugin->afterToHtml($subject, '<div>related</div>'));
     }
 
     public function testReturnsEmptyStringForUpsellBlockWhenAllConditionsMet(): void
     {
-        $this->subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::UPSELL_BLOCK_NAME);
-        $this->configHelper->method('isRecommendFrequentlyBroughtTogetherEnabled')->willReturn(true);
-        $this->configHelper->method('isRemoveUpsellProductsBlock')->willReturn(true);
+        $subject = $this->createStub(AbstractBlock::class);
+        $subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::UPSELL_BLOCK_NAME);
 
-        $this->assertSame('', $this->plugin->afterToHtml($this->subject, '<div>upsell</div>'));
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isRecommendFrequentlyBroughtTogetherEnabled')->willReturn(true);
+        $configHelper->method('isRemoveUpsellProductsBlock')->willReturn(true);
+
+        $plugin = $this->createObjectToTest($configHelper);
+
+        $this->assertSame('', $plugin->afterToHtml($subject, '<div>upsell</div>'));
     }
 
     public function testReturnsOriginalResultForUpsellBlockWhenFbtNotEnabled(): void
     {
-        $this->subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::UPSELL_BLOCK_NAME);
-        $this->configHelper->method('isRecommendFrequentlyBroughtTogetherEnabled')->willReturn(false);
+        $subject = $this->createStub(AbstractBlock::class);
+        $subject->method('getNameInLayout')->willReturn(RemovePdpProductsBlock::UPSELL_BLOCK_NAME);
 
-        $this->assertSame('<div>upsell</div>', $this->plugin->afterToHtml($this->subject, '<div>upsell</div>'));
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isRecommendFrequentlyBroughtTogetherEnabled')->willReturn(false);
+
+        $plugin = $this->createObjectToTest($configHelper);
+
+        $this->assertSame('<div>upsell</div>', $plugin->afterToHtml($subject, '<div>upsell</div>'));
     }
 
     public function testReturnsOriginalResultForUnknownBlock(): void
     {
-        $this->subject->method('getNameInLayout')->willReturn('some.other.block');
+        $subject = $this->createStub(AbstractBlock::class);
+        $subject->method('getNameInLayout')->willReturn('some.other.block');
 
-        $this->assertSame('<div>content</div>', $this->plugin->afterToHtml($this->subject, '<div>content</div>'));
+        $plugin = $this->createObjectToTest();
+
+        $this->assertSame('<div>content</div>', $plugin->afterToHtml($subject, '<div>content</div>'));
     }
 }

--- a/Test/Unit/Plugin/SearchHelperDataPluginTest.php
+++ b/Test/Unit/Plugin/SearchHelperDataPluginTest.php
@@ -7,37 +7,30 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Plugin;
 use Algolia\AlgoliaSearch\Plugin\SearchHelperDataPlugin;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Search\Helper\Data;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class SearchHelperDataPluginTest extends TestCase
 {
-    protected ?SearchHelperDataPlugin $plugin = null;
-
-    protected function setUp(): void
-    {
-        $this->plugin = new SearchHelperDataPlugin();
-    }
-
     public function testReturnsEmptyStringWhenResultIsEmptyPlaceholder(): void
     {
-        $subject = $this->createMock(Data::class);
+        $plugin = new SearchHelperDataPlugin();
+        $subject = $this->createStub(Data::class);
 
-        $this->assertSame('', $this->plugin->afterGetEscapedQueryText($subject, '__empty__'));
+        $this->assertSame('', $plugin->afterGetEscapedQueryText($subject, '__empty__'));
     }
 
     public function testReturnsOriginalResultForNormalQuery(): void
     {
-        $subject = $this->createMock(Data::class);
+        $plugin = new SearchHelperDataPlugin();
+        $subject = $this->createStub(Data::class);
 
-        $this->assertSame('running shoes', $this->plugin->afterGetEscapedQueryText($subject, 'running shoes'));
+        $this->assertSame('running shoes', $plugin->afterGetEscapedQueryText($subject, 'running shoes'));
     }
 
     public function testReturnsOriginalResultForEmptyString(): void
     {
-        $subject = $this->createMock(Data::class);
+        $plugin = new SearchHelperDataPlugin();
+        $subject = $this->createStub(Data::class);
 
-        $this->assertSame('', $this->plugin->afterGetEscapedQueryText($subject, ''));
+        $this->assertSame('', $plugin->afterGetEscapedQueryText($subject, ''));
     }
 }

--- a/Test/Unit/Plugin/SetAdminCurrentCategoryTest.php
+++ b/Test/Unit/Plugin/SetAdminCurrentCategoryTest.php
@@ -40,13 +40,13 @@ class SetAdminCurrentCategoryTest extends TestCase
 
     public function testAfterExecuteSetsCurrentCategoryAndReturnsResult(): void
     {
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(42);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('id')->willReturn(42);
 
         $category = $this->createStub(CategoryInterface::class);
 
-        $categoryRepository = $this->createStub(CategoryRepositoryInterface::class);
-        $categoryRepository->method('get')->willReturn($category);
+        $categoryRepository = $this->createMock(CategoryRepositoryInterface::class);
+        $categoryRepository->method('get')->with(42)->willReturn($category);
 
         $currentCategory = $this->createMock(CurrentCategory::class);
         $currentCategory->expects($this->once())->method('set')->with($category);
@@ -61,8 +61,8 @@ class SetAdminCurrentCategoryTest extends TestCase
 
     public function testAfterExecuteReturnsNullWhenCategoryNotFound(): void
     {
-        $request = $this->createStub(RequestInterface::class);
-        $request->method('getParam')->willReturn(999);
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')->with('id')->willReturn(999);
 
         $categoryRepository = $this->createStub(CategoryRepositoryInterface::class);
         $categoryRepository->method('get')->willThrowException(new NoSuchEntityException());

--- a/Test/Unit/Plugin/SetAdminCurrentCategoryTest.php
+++ b/Test/Unit/Plugin/SetAdminCurrentCategoryTest.php
@@ -13,58 +13,66 @@ use Magento\Catalog\Controller\Adminhtml\Category\Edit as EditController;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Result\Page;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class SetAdminCurrentCategoryTest extends TestCase
 {
-    protected null|(CurrentCategory&MockObject) $currentCategory = null;
-    protected null|(CategoryRepositoryInterface&MockObject) $categoryRepository = null;
-    protected null|(EditController&MockObject) $subject = null;
-    protected null|(RequestInterface&MockObject) $request = null;
-    protected ?SetAdminCurrentCategory $plugin = null;
+    protected function createObjectToTest(
+        ?CurrentCategory $currentCategory = null,
+        ?CategoryRepositoryInterface $categoryRepository = null,
+    ): SetAdminCurrentCategory {
+        return new SetAdminCurrentCategory(
+            $currentCategory ?? $this->createStub(CurrentCategory::class),
+            $categoryRepository ?? $this->createStub(CategoryRepositoryInterface::class),
+        );
+    }
 
-    protected function setUp(): void
+    private function createSubjectStub(RequestInterface $request): EditController&\PHPUnit\Framework\MockObject\MockObject
     {
-        $this->currentCategory = $this->createMock(CurrentCategory::class);
-        $this->categoryRepository = $this->createMock(CategoryRepositoryInterface::class);
-        $this->request = $this->createMock(RequestInterface::class);
-
-        $this->subject = $this->getMockBuilder(EditController::class)
+        $subject = $this->getMockBuilder(EditController::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getRequest'])
             ->getMock();
-        $this->subject->method('getRequest')->willReturn($this->request);
+        // getRequest() is unconditionally called exactly once by afterExecute().
+        $subject->expects($this->once())->method('getRequest')->willReturn($request);
 
-        $this->plugin = new SetAdminCurrentCategory($this->currentCategory, $this->categoryRepository);
+        return $subject;
     }
 
     public function testAfterExecuteSetsCurrentCategoryAndReturnsResult(): void
     {
-        $this->request->method('getParam')->with('id')->willReturn(42);
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(42);
 
-        $category = $this->createMock(CategoryInterface::class);
-        $this->categoryRepository->method('get')->with(42)->willReturn($category);
+        $category = $this->createStub(CategoryInterface::class);
 
-        $this->currentCategory->expects($this->once())->method('set')->with($category);
+        $categoryRepository = $this->createStub(CategoryRepositoryInterface::class);
+        $categoryRepository->method('get')->willReturn($category);
 
-        $page = $this->createMock(Page::class);
-        $result = $this->plugin->afterExecute($this->subject, $page);
+        $currentCategory = $this->createMock(CurrentCategory::class);
+        $currentCategory->expects($this->once())->method('set')->with($category);
+
+        $plugin = $this->createObjectToTest($currentCategory, $categoryRepository);
+
+        $page = $this->createStub(Page::class);
+        $result = $plugin->afterExecute($this->createSubjectStub($request), $page);
 
         $this->assertSame($page, $result);
     }
 
     public function testAfterExecuteReturnsNullWhenCategoryNotFound(): void
     {
-        $this->request->method('getParam')->with('id')->willReturn(999);
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')->willReturn(999);
 
-        $this->categoryRepository->method('get')
-            ->willThrowException(new NoSuchEntityException());
+        $categoryRepository = $this->createStub(CategoryRepositoryInterface::class);
+        $categoryRepository->method('get')->willThrowException(new NoSuchEntityException());
 
-        $this->currentCategory->expects($this->never())->method('set');
+        $currentCategory = $this->createMock(CurrentCategory::class);
+        $currentCategory->expects($this->never())->method('set');
 
-        $result = $this->plugin->afterExecute($this->subject, $this->createMock(Page::class));
+        $plugin = $this->createObjectToTest($currentCategory, $categoryRepository);
+
+        $result = $plugin->afterExecute($this->createSubjectStub($request), $this->createStub(Page::class));
 
         $this->assertNull($result);
     }

--- a/Test/Unit/Plugin/StockItemObserverTest.php
+++ b/Test/Unit/Plugin/StockItemObserverTest.php
@@ -16,8 +16,8 @@ class StockItemObserverTest extends TestCase
 {
     protected function createObjectToTest(?Indexer $indexer = null): StockItemObserver
     {
-        $indexerRegistry = $this->createStub(IndexerRegistry::class);
-        $indexerRegistry->method('get')->willReturn($indexer ?? $this->createStub(Indexer::class));
+        $indexerRegistry = $this->createMock(IndexerRegistry::class);
+        $indexerRegistry->method('get')->with('algolia_products')->willReturn($indexer ?? $this->createStub(Indexer::class));
 
         return new StockItemObserver($indexerRegistry);
     }

--- a/Test/Unit/Plugin/StockItemObserverTest.php
+++ b/Test/Unit/Plugin/StockItemObserverTest.php
@@ -11,45 +11,43 @@ use Magento\CatalogInventory\Model\ResourceModel\Stock\Item as StockItemResource
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Indexer\Model\Indexer;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class StockItemObserverTest extends TestCase
 {
-    protected null|(Indexer&MockObject) $indexer = null;
-    protected null|(IndexerRegistry&MockObject) $indexerRegistry = null;
-    protected null|(StockItemResource&MockObject) $stockItemResource = null;
-    protected ?StockItemObserver $plugin = null;
-
-    protected function setUp(): void
+    protected function createObjectToTest(?Indexer $indexer = null): StockItemObserver
     {
-        $this->indexer = $this->createMock(Indexer::class);
-        $this->indexerRegistry = $this->createMock(IndexerRegistry::class);
-        $this->indexerRegistry->method('get')->with('algolia_products')->willReturn($this->indexer);
-        $this->stockItemResource = $this->createMock(StockItemResource::class);
+        $indexerRegistry = $this->createStub(IndexerRegistry::class);
+        $indexerRegistry->method('get')->willReturn($indexer ?? $this->createStub(Indexer::class));
 
-        $this->plugin = new StockItemObserver($this->indexerRegistry);
+        return new StockItemObserver($indexerRegistry);
     }
 
     public function testBeforeSaveReindexesProductWhenIndexerNotScheduled(): void
     {
+        // getProductId() is a magic getter (via DataObject::__call), so __call is explicitly
+        // mocked to control it rather than mocking an undeclared method.
         $stockItem = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['__call'])
             ->getMock();
-        $stockItem->method('__call')
+        // getProductId() is called exactly once when the indexer isn't scheduled.
+        $stockItem->expects($this->once())
+            ->method('__call')
             ->willReturnCallback(fn($name, $args) => $name === 'getProductId' ? 42 : null);
 
-        $this->stockItemResource->expects($this->once())
+        $indexer = $this->createMock(Indexer::class);
+        $indexer->method('isScheduled')->willReturn(false);
+        $indexer->expects($this->once())->method('reindexRow')->with(42);
+
+        $stockItemResource = $this->createMock(StockItemResource::class);
+        $stockItemResource->expects($this->once())
             ->method('addCommitCallback')
             ->with($this->callback('is_callable'))
             ->willReturnCallback(fn(callable $cb) => $cb());
 
-        $this->indexer->method('isScheduled')->willReturn(false);
-        $this->indexer->expects($this->once())->method('reindexRow')->with(42);
+        $plugin = $this->createObjectToTest($indexer);
 
-        $this->plugin->beforeSave($this->stockItemResource, $stockItem);
+        $plugin->beforeSave($stockItemResource, $stockItem);
     }
 
     public function testBeforeSaveSkipsReindexWhenIndexerIsScheduled(): void
@@ -58,49 +56,63 @@ class StockItemObserverTest extends TestCase
             ->disableOriginalConstructor()
             ->onlyMethods(['__call'])
             ->getMock();
+        // Indexer is scheduled → getProductId() is never reached.
+        $stockItem->expects($this->never())->method('__call');
 
-        $this->stockItemResource->expects($this->once())
+        $indexer = $this->createMock(Indexer::class);
+        $indexer->method('isScheduled')->willReturn(true);
+        $indexer->expects($this->never())->method('reindexRow');
+
+        $stockItemResource = $this->createMock(StockItemResource::class);
+        $stockItemResource->expects($this->once())
             ->method('addCommitCallback')
             ->willReturnCallback(fn(callable $cb) => $cb());
 
-        $this->indexer->method('isScheduled')->willReturn(true);
-        $this->indexer->expects($this->never())->method('reindexRow');
+        $plugin = $this->createObjectToTest($indexer);
 
-        $this->plugin->beforeSave($this->stockItemResource, $stockItem);
+        $plugin->beforeSave($stockItemResource, $stockItem);
     }
 
     public function testAfterDeleteReindexesProductWhenIndexerNotScheduled(): void
     {
-        $stockItem = $this->createMock(StockItemInterface::class);
+        $stockItem = $this->createStub(StockItemInterface::class);
         $stockItem->method('getProductId')->willReturn(99);
 
-        $result = $this->createMock(StockItemResource::class);
+        $result = $this->createStub(StockItemResource::class);
 
-        $this->stockItemResource->expects($this->once())
+        $indexer = $this->createMock(Indexer::class);
+        $indexer->method('isScheduled')->willReturn(false);
+        $indexer->expects($this->once())->method('reindexRow')->with(99);
+
+        $stockItemResource = $this->createMock(StockItemResource::class);
+        $stockItemResource->expects($this->once())
             ->method('addCommitCallback')
             ->with($this->callback('is_callable'))
             ->willReturnCallback(fn(callable $cb) => $cb());
 
-        $this->indexer->method('isScheduled')->willReturn(false);
-        $this->indexer->expects($this->once())->method('reindexRow')->with(99);
+        $plugin = $this->createObjectToTest($indexer);
 
-        $returnedResult = $this->plugin->afterDelete($this->stockItemResource, $result, $stockItem);
+        $returnedResult = $plugin->afterDelete($stockItemResource, $result, $stockItem);
 
         $this->assertSame($result, $returnedResult);
     }
 
     public function testAfterDeleteSkipsReindexWhenIndexerIsScheduled(): void
     {
-        $stockItem = $this->createMock(StockItemInterface::class);
-        $result = $this->createMock(StockItemResource::class);
+        $stockItem = $this->createStub(StockItemInterface::class);
+        $result = $this->createStub(StockItemResource::class);
 
-        $this->stockItemResource->expects($this->once())
+        $indexer = $this->createMock(Indexer::class);
+        $indexer->method('isScheduled')->willReturn(true);
+        $indexer->expects($this->never())->method('reindexRow');
+
+        $stockItemResource = $this->createMock(StockItemResource::class);
+        $stockItemResource->expects($this->once())
             ->method('addCommitCallback')
             ->willReturnCallback(fn(callable $cb) => $cb());
 
-        $this->indexer->method('isScheduled')->willReturn(true);
-        $this->indexer->expects($this->never())->method('reindexRow');
+        $plugin = $this->createObjectToTest($indexer);
 
-        $this->plugin->afterDelete($this->stockItemResource, $result, $stockItem);
+        $plugin->afterDelete($stockItemResource, $result, $stockItem);
     }
 }

--- a/Test/Unit/Plugin/StockItemObserverTest.php
+++ b/Test/Unit/Plugin/StockItemObserverTest.php
@@ -24,16 +24,11 @@ class StockItemObserverTest extends TestCase
 
     public function testBeforeSaveReindexesProductWhenIndexerNotScheduled(): void
     {
-        // getProductId() is a magic getter (via DataObject::__call), so __call is explicitly
-        // mocked to control it rather than mocking an undeclared method.
-        $stockItem = $this->getMockBuilder(AbstractModel::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__call'])
-            ->getMock();
-        // getProductId() is called exactly once when the indexer isn't scheduled.
-        $stockItem->expects($this->once())
-            ->method('__call')
-            ->willReturnCallback(fn($name, $args) => $name === 'getProductId' ? 42 : null);
+        // getProductId() is a magic getter (via DataObject::__call), so __call is stubbed
+        // to control it rather than mocking an undeclared method. It's a feeder of canned
+        // data (indirect input), not behavior under test, so it stays a plain stub.
+        $stockItem = $this->createStub(AbstractModel::class);
+        $stockItem->method('__call')->willReturnCallback(fn($name, $args) => $name === 'getProductId' ? 42 : null);
 
         $indexer = $this->createMock(Indexer::class);
         $indexer->method('isScheduled')->willReturn(false);
@@ -52,12 +47,8 @@ class StockItemObserverTest extends TestCase
 
     public function testBeforeSaveSkipsReindexWhenIndexerIsScheduled(): void
     {
-        $stockItem = $this->getMockBuilder(AbstractModel::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__call'])
-            ->getMock();
-        // Indexer is scheduled → getProductId() is never reached.
-        $stockItem->expects($this->never())->method('__call');
+        // Indexer is scheduled → getProductId() is never reached, so __call needs no configuration.
+        $stockItem = $this->createStub(AbstractModel::class);
 
         $indexer = $this->createMock(Indexer::class);
         $indexer->method('isScheduled')->willReturn(true);

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -566,7 +566,7 @@ class AlgoliaConnectorTest extends TestCase
 
         $client = $this->createMock(SearchClient::class);
         // Merge source: the live production index.
-        $client->method('getSettings')->willReturn($onlineSettings);
+        $client->method('getSettings')->with('magento2_default_products')->willReturn($onlineSettings);
 
         $client->expects($this->once())
             ->method('setSettings')

--- a/Test/Unit/Service/AlgoliaConnectorTest.php
+++ b/Test/Unit/Service/AlgoliaConnectorTest.php
@@ -14,51 +14,47 @@ use Algolia\AlgoliaSearch\Service\Index\IndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Service\SendStrategyResolver;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\Message\ManagerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class AlgoliaConnectorTest extends TestCase
 {
-    private ?AlgoliaConnector $connector = null;
-    private null|(SendStrategyInterface&MockObject) $mockStrategy = null;
-    private null|(ConfigHelper&MockObject) $config = null;
-    private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
-    private null|(SearchClientProviderInterface&MockObject) $clientProvider = null;
-    private null|(SearchClient&MockObject) $client = null;
-
     private const STORE_ID = 1;
     private const INDEX_NAME = 'magento2_default_products';
     private const TASK_ID = 12345;
 
-    protected function setUp(): void
-    {
-        $this->mockStrategy = $this->createMock(SendStrategyInterface::class);
-        $mockResolver = $this->createMock(SendStrategyResolver::class);
-        $mockResolver->method('resolve')->willReturn($this->mockStrategy);
+    protected function createObjectToTest(
+        ?ConfigHelper $config = null,
+        ?SendStrategyInterface $strategy = null,
+        ?SearchClient $client = null,
+    ): AlgoliaConnector {
+        $config ??= $this->createStub(ConfigHelper::class);
+        $config->method('getNonCastableAttributes')->willReturn([]);
+        $config->method('getMaxRecordSizeLimit')->willReturn(10000);
 
-        $this->config = $this->createMock(ConfigHelper::class);
-        $this->config->method('getNonCastableAttributes')->willReturn([]);
-        $this->config->method('getMaxRecordSizeLimit')->willReturn(10000);
+        $resolver = $this->createStub(SendStrategyResolver::class);
+        $resolver->method('resolve')->willReturn($strategy ?? $this->createStub(SendStrategyInterface::class));
 
-        $this->client = $this->createMock(SearchClient::class);
-        $this->clientProvider = $this->createMock(SearchClientProviderInterface::class);
-        $this->clientProvider->method('getClient')->willReturn($this->client);
+        $clientProvider = $this->createStub(SearchClientProviderInterface::class);
+        $clientProvider->method('getClient')->willReturn($client ?? $this->createStub(SearchClient::class));
 
-        $this->connector = new AlgoliaConnector(
-            $this->config,
-            $this->createMock(ManagerInterface::class),
-            $this->createMock(ConsoleOutput::class),
-            $this->clientProvider,
-            $this->createMock(IndexNameFetcher::class),
-            $this->createMock(IndexOptionsBuilder::class),
-            $mockResolver
+        return new AlgoliaConnector(
+            $config,
+            $this->createStub(ManagerInterface::class),
+            $this->createStub(ConsoleOutput::class),
+            $clientProvider,
+            $this->createStub(IndexNameFetcher::class),
+            $this->createStub(IndexOptionsBuilder::class),
+            $resolver,
         );
+    }
 
-        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
-        $this->indexOptions->method('getStoreId')->willReturn(self::STORE_ID);
-        $this->indexOptions->method('getIndexName')->willReturn(self::INDEX_NAME);
+    private function createIndexOptionsStub(string $indexName = self::INDEX_NAME, int $storeId = self::STORE_ID): IndexOptionsInterface
+    {
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
+        $indexOptions->method('getStoreId')->willReturn($storeId);
+        $indexOptions->method('getIndexName')->willReturn($indexName);
+
+        return $indexOptions;
     }
 
     // ── saveObjects() ──
@@ -70,10 +66,12 @@ class AlgoliaConnectorTest extends TestCase
             ['objectID' => '2', 'name' => 'Product B'],
         ];
 
-        $this->mockStrategy->expects($this->once())
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $indexOptions = $this->createIndexOptionsStub();
+        $strategy->expects($this->once())
             ->method('send')
             ->with(
-                $this->indexOptions,
+                $indexOptions,
                 $this->callback(function ($requests) {
                     $this->assertCount(2, $requests);
                     $this->assertEquals('addObject', $requests[0]['action']);
@@ -86,7 +84,9 @@ class AlgoliaConnectorTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->saveObjects($this->indexOptions, $objects);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+
+        $connector->saveObjects($indexOptions, $objects);
     }
 
     public function testSaveObjectsWithPartialUpdateCallsBatchWithPartialUpdateAction(): void
@@ -95,10 +95,12 @@ class AlgoliaConnectorTest extends TestCase
             ['objectID' => '1', 'price' => '29.99'],
         ];
 
-        $this->mockStrategy->expects($this->once())
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $indexOptions = $this->createIndexOptionsStub();
+        $strategy->expects($this->once())
             ->method('send')
             ->with(
-                $this->indexOptions,
+                $indexOptions,
                 $this->callback(function ($requests) {
                     $this->assertEquals('partialUpdateObject', $requests[0]['action']);
 
@@ -107,19 +109,27 @@ class AlgoliaConnectorTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->saveObjects($this->indexOptions, $objects, true);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+
+        $connector->saveObjects($indexOptions, $objects, true);
     }
 
     public function testSaveObjectsTracksLastOperationInfo(): void
     {
         $objects = [['objectID' => '1', 'name' => 'Product A']];
 
-        $this->mockStrategy->method('send')
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        // saveObjects() sends exactly one batch for a single non-oversized object.
+        $strategy->expects($this->once())
+            ->method('send')
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->saveObjects($this->indexOptions, $objects);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+        $indexOptions = $this->createIndexOptionsStub();
 
-        $this->assertEquals(self::TASK_ID, $this->connector->getLastTaskId(self::STORE_ID));
+        $connector->saveObjects($indexOptions, $objects);
+
+        $this->assertEquals(self::TASK_ID, $connector->getLastTaskId(self::STORE_ID));
     }
 
     public function testSaveObjectsSetsAlgoliaLastUpdateTimestamp(): void
@@ -127,10 +137,12 @@ class AlgoliaConnectorTest extends TestCase
         $objects = [['objectID' => '1', 'name' => 'Product A']];
         $beforeTime = strtotime('now');
 
-        $this->mockStrategy->expects($this->once())
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $indexOptions = $this->createIndexOptionsStub();
+        $strategy->expects($this->once())
             ->method('send')
             ->with(
-                $this->indexOptions,
+                $indexOptions,
                 $this->callback(function ($requests) use ($beforeTime) {
                     $body = $requests[0]['body'];
                     $this->assertArrayHasKey('algoliaLastUpdateAtCET', $body);
@@ -141,17 +153,21 @@ class AlgoliaConnectorTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->saveObjects($this->indexOptions, $objects);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+
+        $connector->saveObjects($indexOptions, $objects);
     }
 
     public function testSaveObjectsCastsNumericValues(): void
     {
         $objects = [['objectID' => '1', 'price' => '29.99', 'qty' => '5']];
 
-        $this->mockStrategy->expects($this->once())
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $indexOptions = $this->createIndexOptionsStub();
+        $strategy->expects($this->once())
             ->method('send')
             ->with(
-                $this->indexOptions,
+                $indexOptions,
                 $this->callback(function ($requests) {
                     $body = $requests[0]['body'];
                     $this->assertSame(29.99, $body['price']);
@@ -162,23 +178,24 @@ class AlgoliaConnectorTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->saveObjects($this->indexOptions, $objects);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+
+        $connector->saveObjects($indexOptions, $objects);
     }
 
     public function testSaveObjectsSkipsOversizedRecords(): void
     {
-        // Set max size large enough for small records but too small for the bloated one
-        $this->setPrivateProperty($this->connector, 'maxRecordSize', 200);
-
         $objects = [
             ['objectID' => '1', 'name' => 'Small'],
             ['objectID' => '2', 'name' => str_repeat('x', 10000)],
         ];
 
-        $this->mockStrategy->expects($this->once())
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $indexOptions = $this->createIndexOptionsStub();
+        $strategy->expects($this->once())
             ->method('send')
             ->with(
-                $this->indexOptions,
+                $indexOptions,
                 $this->callback(function ($requests) {
                     $this->assertCount(1, $requests);
                     $this->assertEquals('1', $requests[0]['body']['objectID']);
@@ -188,7 +205,11 @@ class AlgoliaConnectorTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->saveObjects($this->indexOptions, $objects);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+        // Set max size large enough for small records but too small for the bloated one
+        $this->setPrivateProperty($connector, 'maxRecordSize', 200);
+
+        $connector->saveObjects($indexOptions, $objects);
     }
 
     // ── deleteObjects() ──
@@ -197,10 +218,12 @@ class AlgoliaConnectorTest extends TestCase
     {
         $ids = ['100', '200', '300'];
 
-        $this->mockStrategy->expects($this->once())
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $indexOptions = $this->createIndexOptionsStub();
+        $strategy->expects($this->once())
             ->method('send')
             ->with(
-                $this->indexOptions,
+                $indexOptions,
                 $this->callback(function ($requests) {
                     $this->assertCount(3, $requests);
                     foreach ($requests as $request) {
@@ -215,19 +238,27 @@ class AlgoliaConnectorTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->deleteObjects($ids, $this->indexOptions);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+
+        $connector->deleteObjects($ids, $indexOptions);
     }
 
     public function testDeleteObjectsTracksLastOperationInfo(): void
     {
         $ids = ['100'];
 
-        $this->mockStrategy->method('send')
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        // deleteObjects() sends exactly one batch for a single id.
+        $strategy->expects($this->once())
+            ->method('send')
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->deleteObjects($ids, $this->indexOptions);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+        $indexOptions = $this->createIndexOptionsStub();
 
-        $this->assertEquals(self::TASK_ID, $this->connector->getLastTaskId(self::STORE_ID));
+        $connector->deleteObjects($ids, $indexOptions);
+
+        $this->assertEquals(self::TASK_ID, $connector->getLastTaskId(self::STORE_ID));
     }
 
     // ── performBatchOperation() ──
@@ -238,12 +269,16 @@ class AlgoliaConnectorTest extends TestCase
             ['action' => 'addObject', 'body' => ['objectID' => '1', 'name' => 'Test']],
         ];
 
-        $this->mockStrategy->expects($this->once())
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $indexOptions = $this->createIndexOptionsStub();
+        $strategy->expects($this->once())
             ->method('send')
-            ->with($this->indexOptions, $requests)
+            ->with($indexOptions, $requests)
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->invokeMethod($this->connector, 'performBatchOperation', [$this->indexOptions, $requests]);
+        $connector = $this->createObjectToTest(strategy: $strategy);
+
+        $this->invokeMethod($connector, 'performBatchOperation', [$indexOptions, $requests]);
     }
 
     public function testPerformBatchOperationReturnsStrategyResponse(): void
@@ -253,10 +288,14 @@ class AlgoliaConnectorTest extends TestCase
             'objectIDs' => ['1', '2'],
         ];
 
-        $this->mockStrategy->method('send')->willReturn($expectedResponse);
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        // performBatchOperation() invoked directly, so send() is called exactly once.
+        $strategy->expects($this->once())->method('send')->willReturn($expectedResponse);
 
-        $result = $this->invokeMethod($this->connector, 'performBatchOperation', [
-            $this->indexOptions,
+        $connector = $this->createObjectToTest(strategy: $strategy);
+
+        $result = $this->invokeMethod($connector, 'performBatchOperation', [
+            $this->createIndexOptionsStub(),
             [['action' => 'addObject', 'body' => ['objectID' => '1']]],
         ]);
 
@@ -267,21 +306,30 @@ class AlgoliaConnectorTest extends TestCase
 
     public function testGetSettingsReturnsEmptyArrayWhenIndexDoesNotExist(): void
     {
-        $this->client->method('getSettings')
+        $client = $this->createMock(SearchClient::class);
+        // getSettings() is unconditionally called exactly once.
+        $client->expects($this->once())
+            ->method('getSettings')
             ->willThrowException(new \Exception('Not Found', 404));
 
-        $this->assertSame([], $this->connector->getSettings($this->indexOptions));
+        $connector = $this->createObjectToTest(client: $client);
+
+        $this->assertSame([], $connector->getSettings($this->createIndexOptionsStub()));
     }
 
     public function testGetSettingsRethrowsNon404Exceptions(): void
     {
-        $this->client->method('getSettings')
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
+            ->method('getSettings')
             ->willThrowException(new \Exception('Internal Server Error', 500));
+
+        $connector = $this->createObjectToTest(client: $client);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionCode(500);
 
-        $this->connector->getSettings($this->indexOptions);
+        $connector->getSettings($this->createIndexOptionsStub());
     }
 
     // ── setSettings() ──
@@ -290,35 +338,40 @@ class AlgoliaConnectorTest extends TestCase
     {
         $settings = ['searchableAttributes' => ['name', 'description']];
 
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('setSettings')
             ->with(self::INDEX_NAME, $settings, false)
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->setSettings($this->indexOptions, $settings);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->setSettings($this->createIndexOptionsStub(), $settings);
     }
 
     // ── deleteIndex() ──
 
     public function testDeleteIndexDelegatesToClient(): void
     {
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('deleteIndex')
             ->with(self::INDEX_NAME)
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->deleteIndex($this->indexOptions);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->deleteIndex($this->createIndexOptionsStub());
     }
 
     // ── moveIndex() ──
 
     public function testMoveIndexCallsOperationIndexWithMoveOperation(): void
     {
-        $toIndexOptions = $this->createMock(IndexOptionsInterface::class);
-        $toIndexOptions->method('getIndexName')->willReturn('magento2_default_products_tmp');
-        $toIndexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+        $toIndexOptions = $this->createIndexOptionsStub('magento2_default_products_tmp');
 
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('operationIndex')
             ->with(self::INDEX_NAME, [
                 'operation'   => 'move',
@@ -326,30 +379,34 @@ class AlgoliaConnectorTest extends TestCase
             ])
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->moveIndex($this->indexOptions, $toIndexOptions);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->moveIndex($this->createIndexOptionsStub(), $toIndexOptions);
     }
 
     // ── clearIndex() ──
 
     public function testClearIndexCallsClearObjectsOnClient(): void
     {
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('clearObjects')
             ->with(self::INDEX_NAME)
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->clearIndex($this->indexOptions);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->clearIndex($this->createIndexOptionsStub());
     }
 
     // ── copySynonyms() / copyQueryRules() ──
 
     public function testCopySynonymsUsesOperationIndexWithSynonymsScope(): void
     {
-        $toIndexOptions = $this->createMock(IndexOptionsInterface::class);
-        $toIndexOptions->method('getIndexName')->willReturn('magento2_default_products_replica');
-        $toIndexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+        $toIndexOptions = $this->createIndexOptionsStub('magento2_default_products_replica');
 
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('operationIndex')
             ->with(self::INDEX_NAME, [
                 'operation'   => 'copy',
@@ -358,16 +415,17 @@ class AlgoliaConnectorTest extends TestCase
             ])
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->copySynonyms($this->indexOptions, $toIndexOptions);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->copySynonyms($this->createIndexOptionsStub(), $toIndexOptions);
     }
 
     public function testCopyQueryRulesUsesOperationIndexWithRulesScope(): void
     {
-        $toIndexOptions = $this->createMock(IndexOptionsInterface::class);
-        $toIndexOptions->method('getIndexName')->willReturn('magento2_default_products_replica');
-        $toIndexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+        $toIndexOptions = $this->createIndexOptionsStub('magento2_default_products_replica');
 
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('operationIndex')
             ->with(self::INDEX_NAME, [
                 'operation'   => 'copy',
@@ -376,7 +434,9 @@ class AlgoliaConnectorTest extends TestCase
             ])
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->copyQueryRules($this->indexOptions, $toIndexOptions);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->copyQueryRules($this->createIndexOptionsStub(), $toIndexOptions);
     }
 
     // ── saveRule() / deleteRule() ──
@@ -385,38 +445,43 @@ class AlgoliaConnectorTest extends TestCase
     {
         $rule = [AlgoliaConnector::ALGOLIA_API_OBJECT_ID => 'rule-1', 'condition' => []];
 
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('saveRule')
             ->with(self::INDEX_NAME, 'rule-1', $rule, false)
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->saveRule($rule, $this->indexOptions);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->saveRule($rule, $this->createIndexOptionsStub());
     }
 
     public function testDeleteRuleDelegatesToClientWithCorrectArguments(): void
     {
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('deleteRule')
             ->with(self::INDEX_NAME, 'rule-1', false)
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->deleteRule($this->indexOptions, 'rule-1');
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->deleteRule($this->createIndexOptionsStub(), 'rule-1');
     }
 
     // ── query() ──
 
     public function testQueryBuildsCorrectRequestStructureForClient(): void
     {
-        $queryOptions = $this->createMock(IndexOptionsInterface::class);
-        $queryOptions->method('getIndexName')->willReturn(self::INDEX_NAME);
-        $queryOptions->method('getStoreId')->willReturn(self::STORE_ID);
+        $queryOptions = $this->createIndexOptionsStub();
 
-        $searchQuery = $this->createMock(SearchQueryInterface::class);
+        $searchQuery = $this->createStub(SearchQueryInterface::class);
         $searchQuery->method('getIndexOptions')->willReturn($queryOptions);
         $searchQuery->method('getQuery')->willReturn('blue shirt');
         $searchQuery->method('getParams')->willReturn(['hitsPerPage' => 10]);
 
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('search')
             ->with($this->callback(function (array $payload) {
                 $request = $payload['requests'][0];
@@ -427,14 +492,17 @@ class AlgoliaConnectorTest extends TestCase
             }))
             ->willReturn(['hits' => []]);
 
-        $this->connector->query($searchQuery);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->query($searchQuery);
     }
 
     // ── getObjects() ──
 
     public function testGetObjectsMapsObjectIdsToRequestFormatWithIndexName(): void
     {
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('getObjects')
             ->with($this->callback(function (array $payload) {
                 $this->assertCount(2, $payload['requests']);
@@ -445,7 +513,9 @@ class AlgoliaConnectorTest extends TestCase
             }))
             ->willReturn(['results' => []]);
 
-        $this->connector->getObjects($this->indexOptions, ['42', '99']);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->getObjects($this->createIndexOptionsStub(), ['42', '99']);
     }
 
     // ── setSettings() merge branch ──
@@ -455,8 +525,9 @@ class AlgoliaConnectorTest extends TestCase
         $onlineSettings = ['ranking' => ['typo', 'geo'], 'attributesToIndex' => ['old_name']];
         $localSettings  = ['searchableAttributes' => ['new_name']];
 
-        $this->client->method('getSettings')->willReturn($onlineSettings);
-        $this->client->expects($this->once())
+        $client = $this->createMock(SearchClient::class);
+        $client->method('getSettings')->willReturn($onlineSettings);
+        $client->expects($this->once())
             ->method('setSettings')
             ->with(
                 self::INDEX_NAME,
@@ -473,7 +544,9 @@ class AlgoliaConnectorTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->setSettings($this->indexOptions, $localSettings, false, true);
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->setSettings($this->createIndexOptionsStub(), $localSettings, false, true);
     }
 
     /**
@@ -491,12 +564,11 @@ class AlgoliaConnectorTest extends TestCase
         ];
         $localSettings = ['attributesToSnippet' => ['description:10']];
 
+        $client = $this->createMock(SearchClient::class);
         // Merge source: the live production index.
-        $this->client->method('getSettings')
-            ->with('magento2_default_products')
-            ->willReturn($onlineSettings);
+        $client->method('getSettings')->willReturn($onlineSettings);
 
-        $this->client->expects($this->once())
+        $client->expects($this->once())
             ->method('setSettings')
             ->with(
                 self::INDEX_NAME,
@@ -517,8 +589,10 @@ class AlgoliaConnectorTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->setSettings(
-            $this->indexOptions,
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->setSettings(
+            $this->createIndexOptionsStub(),
             $localSettings,
             false,
             true,
@@ -529,12 +603,12 @@ class AlgoliaConnectorTest extends TestCase
     /**
      * Pins the strip list directly so the regression cannot be reintroduced by
      * an edit to getSettingsToRemove() that drops the semanticSearch entry.
-     *
-     * @throws \ReflectionException
      */
     public function testGetSettingsToRemoveIncludesSemanticSearch(): void
     {
-        $removals = $this->invokeMethod($this->connector, 'getSettingsToRemove', [[]]);
+        $connector = $this->createObjectToTest();
+
+        $removals = $this->invokeMethod($connector, 'getSettingsToRemove', [[]]);
 
         $this->assertContains('semanticSearch', $removals);
     }
@@ -543,39 +617,53 @@ class AlgoliaConnectorTest extends TestCase
 
     public function testWaitLastTaskReturnsEarlyWhenNoOperationHasBeenPerformed(): void
     {
-        $this->client->expects($this->never())->method('waitForTask');
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->never())->method('waitForTask');
 
-        $this->connector->waitLastTask();
+        $connector = $this->createObjectToTest(client: $client);
+
+        $connector->waitLastTask();
     }
 
     public function testWaitLastTaskCallsClientWithStoreSpecificStateAfterOperation(): void
     {
         $objects = [['objectID' => '1', 'name' => 'A']];
-        $this->mockStrategy->method('send')
-            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
-        $this->connector->saveObjects($this->indexOptions, $objects);
 
-        $this->client->expects($this->once())
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        // saveObjects() sends exactly one batch for a single object.
+        $strategy->expects($this->once())
+            ->method('send')
+            ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
+
+        $client = $this->createMock(SearchClient::class);
+        $client->expects($this->once())
             ->method('waitForTask')
             ->with(self::INDEX_NAME, self::TASK_ID);
 
-        $this->connector->waitLastTask(self::STORE_ID);
+        $connector = $this->createObjectToTest(strategy: $strategy, client: $client);
+        $connector->saveObjects($this->createIndexOptionsStub(), $objects);
+
+        $connector->waitLastTask(self::STORE_ID);
     }
 
     // ── castProductObject() ──
 
     public function testCastProductObjectConvertsNumericStringToInteger(): void
     {
+        $connector = $this->createObjectToTest();
+
         $data = ['qty' => '5'];
-        $this->connector->castProductObject($data);
+        $connector->castProductObject($data);
 
         $this->assertSame(5, $data['qty']);
     }
 
     public function testCastProductObjectLeavesNonCastableAttributesUntouched(): void
     {
+        $connector = $this->createObjectToTest();
+
         $data = ['sku' => '12345', 'name' => '100 Faces'];
-        $this->connector->castProductObject($data);
+        $connector->castProductObject($data);
 
         $this->assertSame('12345', $data['sku']);
         $this->assertSame('100 Faces', $data['name']);
@@ -583,8 +671,10 @@ class AlgoliaConnectorTest extends TestCase
 
     public function testCastProductObjectSplitsPipeSeparatedStringsIntoTypedArray(): void
     {
+        $connector = $this->createObjectToTest();
+
         $data = ['color_ids' => '1|2|3'];
-        $this->connector->castProductObject($data);
+        $connector->castProductObject($data);
 
         $this->assertSame([1, 2, 3], $data['color_ids']);
     }
@@ -593,29 +683,40 @@ class AlgoliaConnectorTest extends TestCase
 
     public function testIsValidFloatReturnsFalseForValuesThatEvaluateToInfinity(): void
     {
-        $this->assertFalse($this->connector->isValidFloat('1.8e308'));
+        $connector = $this->createObjectToTest();
+
+        $this->assertFalse($connector->isValidFloat('1.8e308'));
     }
 
     public function testIsValidFloatReturnsTrueForRegularFloatingPointValues(): void
     {
-        $this->assertTrue($this->connector->isValidFloat('3.14'));
+        $connector = $this->createObjectToTest();
+
+        $this->assertTrue($connector->isValidFloat('3.14'));
     }
 
     // ── getLastTaskId() ──
 
     public function testGetLastTaskIdReturnsNullWhenNoOperationHasBeenPerformed(): void
     {
-        $this->assertNull($this->connector->getLastTaskId());
+        $connector = $this->createObjectToTest();
+
+        $this->assertNull($connector->getLastTaskId());
     }
 
     public function testGetLastTaskIdReturnsStoreSpecificTaskIdAfterOperation(): void
     {
         $objects = [['objectID' => '1', 'name' => 'A']];
-        $this->mockStrategy->method('send')
+
+        $strategy = $this->createMock(SendStrategyInterface::class);
+        $strategy->expects($this->once())
+            ->method('send')
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->connector->saveObjects($this->indexOptions, $objects);
+        $connector = $this->createObjectToTest(strategy: $strategy);
 
-        $this->assertSame(self::TASK_ID, $this->connector->getLastTaskId(self::STORE_ID));
+        $connector->saveObjects($this->createIndexOptionsStub(), $objects);
+
+        $this->assertSame(self::TASK_ID, $connector->getLastTaskId(self::STORE_ID));
     }
 }

--- a/Test/Unit/Service/Category/CategoryPathProviderTest.php
+++ b/Test/Unit/Service/Category/CategoryPathProviderTest.php
@@ -51,8 +51,8 @@ class CategoryPathProviderTest extends TestCase
         $storeId = 1;
         $category = $this->createCategoryStub([1, 2, 10, 25, 30]);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('getCategorySeparator')->willReturn(' /// ');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->with($storeId)->willReturn(' /// ');
 
         $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Electronics',
@@ -74,8 +74,8 @@ class CategoryPathProviderTest extends TestCase
         $storeId = 1;
         $category = $this->createCategoryStub([1, 2, 10, 25]);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('getCategorySeparator')->willReturn(' / ');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->with($storeId)->willReturn(' / ');
 
         $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Electronics',
@@ -111,8 +111,8 @@ class CategoryPathProviderTest extends TestCase
     {
         $category = $this->createCategoryStub([1, 2, 10, 20]);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('getCategorySeparator')->willReturn(' > ');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->with(null)->willReturn(' > ');
 
         $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Category A',
@@ -133,8 +133,8 @@ class CategoryPathProviderTest extends TestCase
         $storeId = 1;
         $category = $this->createCategoryStub([1, 2, 10, 20, 30]);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('getCategorySeparator')->willReturn('');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->with($storeId)->willReturn('');
 
         $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'A',
@@ -156,8 +156,8 @@ class CategoryPathProviderTest extends TestCase
         $storeId = 1;
         $category = $this->createCategoryStub([1, 2, 10, 20]);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('getCategorySeparator')->willReturn(' / ');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->with($storeId)->willReturn(' / ');
 
         $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Parent',
@@ -178,8 +178,8 @@ class CategoryPathProviderTest extends TestCase
         $storeId = 1;
         $category = $this->createCategoryStub([1, 2, 10, 20, 30]);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('getCategorySeparator')->willReturn(' /// ');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->with($storeId)->willReturn(' /// ');
 
         $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Root',
@@ -232,11 +232,11 @@ class CategoryPathProviderTest extends TestCase
 
         $category = $this->createCategoryStub([1, 2, 10, 20, 30]);
 
-        $categoryRepository = $this->createStub(CategoryRepositoryInterface::class);
-        $categoryRepository->method('get')->willReturn($category);
+        $categoryRepository = $this->createMock(CategoryRepositoryInterface::class);
+        $categoryRepository->method('get')->with($categoryId, $storeId)->willReturn($category);
 
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('getCategorySeparator')->willReturn(' / ');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->with($storeId)->willReturn(' / ');
 
         $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Root',

--- a/Test/Unit/Service/Category/CategoryPathProviderTest.php
+++ b/Test/Unit/Service/Category/CategoryPathProviderTest.php
@@ -10,28 +10,19 @@ use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollection;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class CategoryPathProviderTest extends TestCase
 {
-    private CategoryPathProvider $categoryPathProvider;
-    private ConfigHelper&MockObject $configHelper;
-    private CategoryRepositoryInterface&MockObject $categoryRepository;
-    private CategoryCollectionFactory&MockObject $categoryCollectionFactory;
-
-    protected function setUp(): void
-    {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->categoryRepository = $this->createMock(CategoryRepositoryInterface::class);
-        $this->categoryCollectionFactory = $this->createMock(CategoryCollectionFactory::class);
-
-        $this->categoryPathProvider = new CategoryPathProvider(
-            $this->configHelper,
-            $this->categoryRepository,
-            $this->categoryCollectionFactory
+    protected function createObjectToTest(
+        ?ConfigHelper $configHelper = null,
+        ?CategoryRepositoryInterface $categoryRepository = null,
+        ?CategoryCollectionFactory $categoryCollectionFactory = null,
+    ): CategoryPathProvider {
+        return new CategoryPathProvider(
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $categoryRepository ?? $this->createStub(CategoryRepositoryInterface::class),
+            $categoryCollectionFactory ?? $this->createStub(CategoryCollectionFactory::class),
         );
     }
 
@@ -39,14 +30,16 @@ class CategoryPathProviderTest extends TestCase
     {
         $storeId = 1;
         // Example paths include root (1) and default category (2) which are filtered out by DB level > 1
-        $category = $this->createCategoryMock([1, 2, 10]);
+        $category = $this->createCategoryStub([1, 2, 10]);
 
         // Only categories at DB level 2+ are returned by the collection
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Electronics',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPathDetails($category, $storeId);
+        $categoryPathProvider = $this->createObjectToTest(categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPathDetails($category, $storeId);
 
         $this->assertEquals('Electronics', $result['path']);
         $this->assertEquals(0, $result['level']); // This is the *visible* level, not the DB level - the "visible" level starts at 0
@@ -56,20 +49,20 @@ class CategoryPathProviderTest extends TestCase
     public function testGetCategoryPathDetailsReturnsMultiLevelPath(): void
     {
         $storeId = 1;
-        $category = $this->createCategoryMock([1, 2, 10, 25, 30]);
+        $category = $this->createCategoryStub([1, 2, 10, 25, 30]);
 
-        $this->configHelper
-            ->method('getCategorySeparator')
-            ->with($storeId)
-            ->willReturn(' /// ');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->willReturn(' /// ');
 
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Electronics',
             25 => 'Laptops',
             30 => 'Gaming Laptops',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPathDetails($category, $storeId);
+        $categoryPathProvider = $this->createObjectToTest($configHelper, categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPathDetails($category, $storeId);
 
         $this->assertEquals('Electronics /// Laptops /// Gaming Laptops', $result['path']);
         $this->assertEquals(2, $result['level']);
@@ -79,33 +72,35 @@ class CategoryPathProviderTest extends TestCase
     public function testGetCategoryPathDetailsSkipsCategoriesNotInCollection(): void
     {
         $storeId = 1;
-        $category = $this->createCategoryMock([1, 2, 10, 25]);
+        $category = $this->createCategoryStub([1, 2, 10, 25]);
 
-        $this->configHelper
-            ->method('getCategorySeparator')
-            ->with($storeId)
-            ->willReturn(' / ');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->willReturn(' / ');
 
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Electronics',
             25 => 'Laptops',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPathDetails($category, $storeId);
+        $categoryPathProvider = $this->createObjectToTest($configHelper, categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPathDetails($category, $storeId);
 
         $this->assertEquals('Electronics / Laptops', $result['path']);
-        $this->assertEquals(1, $result['level']); 
+        $this->assertEquals(1, $result['level']);
         $this->assertEquals('Electronics', $result['parentCategory']);
     }
 
     public function testGetCategoryPathDetailsReturnsEmptyPathWhenNoCategoriesInCollection(): void
     {
         $storeId = 1;
-        $category = $this->createCategoryMock([1, 2]);
+        $category = $this->createCategoryStub([1, 2]);
 
-        $this->setupCategoryCollection([]);
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([]);
 
-        $result = $this->categoryPathProvider->getCategoryPathDetails($category, $storeId);
+        $categoryPathProvider = $this->createObjectToTest(categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPathDetails($category, $storeId);
 
         $this->assertEquals('', $result['path']);
         $this->assertEquals('', $result['level']);
@@ -114,19 +109,19 @@ class CategoryPathProviderTest extends TestCase
 
     public function testGetCategoryPathDetailsUsesDefaultStoreIdWhenNull(): void
     {
-        $category = $this->createCategoryMock([1, 2, 10, 20]);
+        $category = $this->createCategoryStub([1, 2, 10, 20]);
 
-        $this->configHelper
-            ->method('getCategorySeparator')
-            ->with(null)
-            ->willReturn(' > ');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->willReturn(' > ');
 
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Category A',
             20 => 'Category B',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPathDetails($category);
+        $categoryPathProvider = $this->createObjectToTest($configHelper, categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPathDetails($category);
 
         $this->assertEquals('Category A > Category B', $result['path']);
         $this->assertEquals(1, $result['level']);
@@ -136,20 +131,20 @@ class CategoryPathProviderTest extends TestCase
     public function testGetCategoryPathDetailsWithEmptySeparator(): void
     {
         $storeId = 1;
-        $category = $this->createCategoryMock([1, 2, 10, 20, 30]);
+        $category = $this->createCategoryStub([1, 2, 10, 20, 30]);
 
-        $this->configHelper
-            ->method('getCategorySeparator')
-            ->with($storeId)
-            ->willReturn('');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->willReturn('');
 
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'A',
             20 => 'B',
             30 => 'C',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPathDetails($category, $storeId);
+        $categoryPathProvider = $this->createObjectToTest($configHelper, categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPathDetails($category, $storeId);
 
         $this->assertEquals('ABC', $result['path']);
         $this->assertEquals(2, $result['level']);
@@ -159,19 +154,19 @@ class CategoryPathProviderTest extends TestCase
     public function testGetCategoryPathDetailsWithTwoCategoriesReturnsCorrectParent(): void
     {
         $storeId = 1;
-        $category = $this->createCategoryMock([1, 2, 10, 20]);
+        $category = $this->createCategoryStub([1, 2, 10, 20]);
 
-        $this->configHelper
-            ->method('getCategorySeparator')
-            ->with($storeId)
-            ->willReturn(' / ');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->willReturn(' / ');
 
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Parent',
             20 => 'Child',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPathDetails($category, $storeId);
+        $categoryPathProvider = $this->createObjectToTest($configHelper, categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPathDetails($category, $storeId);
 
         $this->assertEquals('Parent / Child', $result['path']);
         $this->assertEquals(1, $result['level']);
@@ -181,33 +176,35 @@ class CategoryPathProviderTest extends TestCase
     public function testGetCategoryPageIdReturnsPath(): void
     {
         $storeId = 1;
-        $category = $this->createCategoryMock([1, 2, 10, 20, 30]);
+        $category = $this->createCategoryStub([1, 2, 10, 20, 30]);
 
-        $this->configHelper
-            ->method('getCategorySeparator')
-            ->with($storeId)
-            ->willReturn(' /// ');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->willReturn(' /// ');
 
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Root',
             20 => 'Parent',
             30 => 'Child',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPageId($category, $storeId);
+        $categoryPathProvider = $this->createObjectToTest($configHelper, categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPageId($category, $storeId);
 
         $this->assertEquals('Root /// Parent /// Child', $result);
     }
 
     public function testGetCategoryPageIdWithNullStoreId(): void
     {
-        $category = $this->createCategoryMock([1, 2, 5]);
+        $category = $this->createCategoryStub([1, 2, 5]);
 
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             5 => 'Single Category',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPageId($category);
+        $categoryPathProvider = $this->createObjectToTest(categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPageId($category);
 
         $this->assertEquals('Single Category', $result);
     }
@@ -215,11 +212,13 @@ class CategoryPathProviderTest extends TestCase
     public function testGetCategoryPathDetailsWithEmptyPathIds(): void
     {
         $storeId = 1;
-        $category = $this->createCategoryMock([]);
+        $category = $this->createCategoryStub([]);
 
-        $this->setupCategoryCollection([]);
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([]);
 
-        $result = $this->categoryPathProvider->getCategoryPathDetails($category, $storeId);
+        $categoryPathProvider = $this->createObjectToTest(categoryCollectionFactory: $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPathDetails($category, $storeId);
 
         $this->assertEquals('', $result['path']);
         $this->assertEquals('', $result['level']);
@@ -231,35 +230,31 @@ class CategoryPathProviderTest extends TestCase
         $storeId = 1;
         $categoryId = 30;
 
-        $category = $this->createCategoryMock([1, 2, 10, 20, 30]);
+        $category = $this->createCategoryStub([1, 2, 10, 20, 30]);
 
-        $this->categoryRepository
-            ->method('get')
-            ->with($categoryId, $storeId)
-            ->willReturn($category);
+        $categoryRepository = $this->createStub(CategoryRepositoryInterface::class);
+        $categoryRepository->method('get')->willReturn($category);
 
-        $this->configHelper
-            ->method('getCategorySeparator')
-            ->with($storeId)
-            ->willReturn(' / ');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getCategorySeparator')->willReturn(' / ');
 
-        $this->setupCategoryCollection([
+        $categoryCollectionFactory = $this->createCategoryCollectionFactoryStub([
             10 => 'Root',
             20 => 'Parent',
             30 => 'Child',
         ]);
 
-        $result = $this->categoryPathProvider->getCategoryPageId($categoryId, $storeId);
+        $categoryPathProvider = $this->createObjectToTest($configHelper, $categoryRepository, $categoryCollectionFactory);
+
+        $result = $categoryPathProvider->getCategoryPageId($categoryId, $storeId);
 
         $this->assertEquals('Root / Parent / Child', $result);
     }
 
-    private function createCategoryMock(array $pathIds): Category&MockObject
+    private function createCategoryStub(array $pathIds): Category
     {
-        $category = $this->createMock(Category::class);
-        $category
-            ->method('getPathIds')
-            ->willReturn($pathIds);
+        $category = $this->createStub(Category::class);
+        $category->method('getPathIds')->willReturn($pathIds);
 
         return $category;
     }
@@ -267,25 +262,25 @@ class CategoryPathProviderTest extends TestCase
     /**
      * @param array<int, string> $categoryNameMap Map of category ID to name
      */
-    private function setupCategoryCollection(array $categoryNameMap): void
+    private function createCategoryCollectionFactoryStub(array $categoryNameMap): CategoryCollectionFactory
     {
-        $categoryMocks = [];
+        $categoryStubs = [];
         foreach ($categoryNameMap as $id => $name) {
-            $categoryMock = $this->createMock(Category::class);
-            $categoryMock->method('getId')->willReturn($id);
-            $categoryMock->method('getName')->willReturn($name);
-            $categoryMocks[] = $categoryMock;
+            $categoryStub = $this->createStub(Category::class);
+            $categoryStub->method('getId')->willReturn($id);
+            $categoryStub->method('getName')->willReturn($name);
+            $categoryStubs[] = $categoryStub;
         }
 
-        $collection = $this->createMock(CategoryCollection::class);
+        $collection = $this->createStub(CategoryCollection::class);
         $collection->method('addAttributeToSelect')->willReturnSelf();
         $collection->method('addFieldToFilter')->willReturnSelf();
         $collection->method('setStoreId')->willReturnSelf();
-        $collection->method('getIterator')->willReturn(new \ArrayIterator($categoryMocks));
+        $collection->method('getIterator')->willReturn(new \ArrayIterator($categoryStubs));
 
-        $this->categoryCollectionFactory
-            ->method('create')
-            ->willReturn($collection);
+        $categoryCollectionFactory = $this->createStub(CategoryCollectionFactory::class);
+        $categoryCollectionFactory->method('create')->willReturn($collection);
+
+        return $categoryCollectionFactory;
     }
 }
-

--- a/Test/Unit/Service/DirectSendStrategyTest.php
+++ b/Test/Unit/Service/DirectSendStrategyTest.php
@@ -8,39 +8,34 @@ use Algolia\AlgoliaSearch\Api\SearchClientProviderInterface;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\DirectSendStrategy;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class DirectSendStrategyTest extends TestCase
 {
-    private null|(SearchClient&MockObject) $searchClient = null;
-    private null|(SearchClientProviderInterface&MockObject) $clientProvider = null;
-    private ?DirectSendStrategy $strategy = null;
-    private null|(IndexOptionsInterface&MockObject) $indexOptions = null;
-
     private const STORE_ID = 1;
     private const INDEX_NAME = 'magento2_default_products';
     private const TASK_ID = 12345;
 
-    protected function setUp(): void
+    protected function createObjectToTest(?SearchClientProviderInterface $clientProvider = null): DirectSendStrategy
     {
-        $this->searchClient = $this->createMock(SearchClient::class);
-        $this->clientProvider = $this->createMock(SearchClientProviderInterface::class);
-        $this->clientProvider->method('getClient')->willReturn($this->searchClient);
+        return new DirectSendStrategy($clientProvider ?? $this->createStub(SearchClientProviderInterface::class));
+    }
 
-        $this->strategy = new DirectSendStrategy($this->clientProvider);
+    private function createIndexOptionsStub(): IndexOptionsInterface
+    {
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
+        $indexOptions->method('getStoreId')->willReturn(self::STORE_ID);
+        $indexOptions->method('getIndexName')->willReturn(self::INDEX_NAME);
 
-        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
-        $this->indexOptions->method('getStoreId')->willReturn(self::STORE_ID);
-        $this->indexOptions->method('getIndexName')->willReturn(self::INDEX_NAME);
+        return $indexOptions;
     }
 
     public function testIsApplicableAlwaysReturnsTrue(): void
     {
-        $this->assertTrue($this->strategy->isApplicable(self::STORE_ID));
-        $this->assertTrue($this->strategy->isApplicable(0));
-        $this->assertTrue($this->strategy->isApplicable(99));
+        $strategy = $this->createObjectToTest();
+
+        $this->assertTrue($strategy->isApplicable(self::STORE_ID));
+        $this->assertTrue($strategy->isApplicable(0));
+        $this->assertTrue($strategy->isApplicable(99));
     }
 
     public function testSendCallsClientBatchWithCorrectIndexNameAndRequests(): void
@@ -50,17 +45,21 @@ class DirectSendStrategyTest extends TestCase
             ['action' => 'addObject', 'body' => ['objectID' => '2', 'name' => 'Product B']],
         ];
 
-        $this->clientProvider->expects($this->once())
-            ->method('getClient')
-            ->with(self::STORE_ID)
-            ->willReturn($this->searchClient);
-
-        $this->searchClient->expects($this->once())
+        $searchClient = $this->createMock(SearchClient::class);
+        $searchClient->expects($this->once())
             ->method('batch')
             ->with(self::INDEX_NAME, ['requests' => $requests])
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->strategy->send($this->indexOptions, $requests);
+        $clientProvider = $this->createMock(SearchClientProviderInterface::class);
+        $clientProvider->expects($this->once())
+            ->method('getClient')
+            ->with(self::STORE_ID)
+            ->willReturn($searchClient);
+
+        $strategy = $this->createObjectToTest($clientProvider);
+
+        $strategy->send($this->createIndexOptionsStub(), $requests);
     }
 
     public function testSendReturnsClientResponse(): void
@@ -70,9 +69,15 @@ class DirectSendStrategyTest extends TestCase
             'objectIDs' => ['1', '2'],
         ];
 
-        $this->searchClient->method('batch')->willReturn($expectedResponse);
+        $searchClient = $this->createStub(SearchClient::class);
+        $searchClient->method('batch')->willReturn($expectedResponse);
 
-        $result = $this->strategy->send($this->indexOptions, []);
+        $clientProvider = $this->createStub(SearchClientProviderInterface::class);
+        $clientProvider->method('getClient')->willReturn($searchClient);
+
+        $strategy = $this->createObjectToTest($clientProvider);
+
+        $result = $strategy->send($this->createIndexOptionsStub(), []);
 
         $this->assertEquals($expectedResponse, $result);
     }
@@ -83,7 +88,8 @@ class DirectSendStrategyTest extends TestCase
             ['action' => 'deleteObject', 'body' => ['objectID' => '100']],
         ];
 
-        $this->searchClient->expects($this->once())
+        $searchClient = $this->createMock(SearchClient::class);
+        $searchClient->expects($this->once())
             ->method('batch')
             ->with(
                 self::INDEX_NAME,
@@ -96,6 +102,11 @@ class DirectSendStrategyTest extends TestCase
             )
             ->willReturn([AlgoliaConnector::ALGOLIA_API_TASK_ID => self::TASK_ID]);
 
-        $this->strategy->send($this->indexOptions, $requests);
+        $clientProvider = $this->createStub(SearchClientProviderInterface::class);
+        $clientProvider->method('getClient')->willReturn($searchClient);
+
+        $strategy = $this->createObjectToTest($clientProvider);
+
+        $strategy->send($this->createIndexOptionsStub(), $requests);
     }
 }

--- a/Test/Unit/Service/Index/IndexOptionsBuilderTest.php
+++ b/Test/Unit/Service/Index/IndexOptionsBuilderTest.php
@@ -10,27 +10,18 @@ use Algolia\AlgoliaSearch\Service\Index\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\Index\IndexOptionsBuilder;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Framework\Exception\NoSuchEntityException;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class IndexOptionsBuilderTest extends TestCase
 {
-    private IndexOptionsBuilder|MockObject $indexOptionsBuilder;
-    private IndexNameFetcher|MockObject $indexNameFetcher;
-    private IndexOptionsInterfaceFactory|MockObject $indexOptionsInterfaceFactory;
-    private DiagnosticsLogger|MockObject $logger;
-
-    protected function setUp(): void
-    {
-        $this->indexNameFetcher = $this->createMock(IndexNameFetcher::class);
-        $this->indexOptionsInterfaceFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
-        $this->logger = $this->createMock(DiagnosticsLogger::class);
-
-        $this->indexOptionsBuilder = new IndexOptionsBuilder(
-            $this->indexNameFetcher,
-            $this->indexOptionsInterfaceFactory,
-            $this->logger
+    protected function createObjectToTest(
+        ?IndexNameFetcher $indexNameFetcher = null,
+        ?IndexOptionsInterfaceFactory $indexOptionsInterfaceFactory = null,
+        ?DiagnosticsLogger $logger = null,
+    ): IndexOptionsBuilder {
+        return new IndexOptionsBuilder(
+            $indexNameFetcher ?? $this->createStub(IndexNameFetcher::class),
+            $indexOptionsInterfaceFactory ?? $this->createStub(IndexOptionsInterfaceFactory::class),
+            $logger ?? $this->createStub(DiagnosticsLogger::class),
         );
     }
 
@@ -51,12 +42,11 @@ class IndexOptionsBuilderTest extends TestCase
         ]);
     }
 
-    private function configureIndexOptionsFactoryMock(
+    private function createIndexOptionsFactoryMock(
         IndexOptionsInterface $indexOptions,
         array $expectedData
-    ): IndexOptionsInterfaceFactory
-    {
-        $factory = $this->indexOptionsInterfaceFactory;
+    ): IndexOptionsInterfaceFactory {
+        $factory = $this->createMock(IndexOptionsInterfaceFactory::class);
         $factory->expects($this->once())
             ->method('create')
             ->with(['data' => $expectedData])
@@ -73,19 +63,21 @@ class IndexOptionsBuilderTest extends TestCase
         $computedIndexName = 'magento2_default_products_tmp';
 
         $indexOptions = $this->createIndexOptionsMock(null, $storeId, $indexSuffix, $isTmp);
-        $this->configureIndexOptionsFactoryMock($indexOptions, [
+        $factory = $this->createIndexOptionsFactoryMock($indexOptions, [
             IndexOptionsInterface::STORE_ID => $storeId,
             IndexOptionsInterface::INDEX_SUFFIX => $indexSuffix,
             IndexOptionsInterface::IS_TMP => $isTmp,
         ]);
 
-        $this->indexNameFetcher
-            ->expects($this->once())
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher->expects($this->once())
             ->method('getIndexName')
             ->with($indexSuffix, $storeId, $isTmp)
             ->willReturn($computedIndexName);
 
-        $result = $this->indexOptionsBuilder->buildWithComputedIndex($indexSuffix, $storeId, $isTmp);
+        $indexOptionsBuilder = $this->createObjectToTest($indexNameFetcher, $factory);
+
+        $result = $indexOptionsBuilder->buildWithComputedIndex($indexSuffix, $storeId, $isTmp);
 
         $this->assertEquals($computedIndexName, $result->getIndexName());
     }
@@ -95,14 +87,18 @@ class IndexOptionsBuilderTest extends TestCase
      */
     public function testBuildWithComputedIndexWithNullParameters(): void
     {
-        $this->indexOptionsInterfaceFactory->expects($this->never())->method('create');
+        $factory = $this->createMock(IndexOptionsInterfaceFactory::class);
+        $factory->expects($this->never())->method('create');
 
-        $this->logger->expects($this->never())->method('error');
+        $logger = $this->createMock(DiagnosticsLogger::class);
+        $logger->expects($this->never())->method('error');
+
+        $indexOptionsBuilder = $this->createObjectToTest(indexOptionsInterfaceFactory: $factory, logger: $logger);
 
         $this->expectException(\ArgumentCountError::class);
         $this->expectExceptionMessageMatches('/^Too few arguments to function/');
 
-        $this->indexOptionsBuilder->buildWithComputedIndex();
+        $indexOptionsBuilder->buildWithComputedIndex();
     }
 
     public function testBuildWithComputedIndexWithIndexNameFetcherException(): void
@@ -113,21 +109,23 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createIndexOptionsMock(null, $storeId, $indexSuffix, $isTmp);
 
-        $this->configureIndexOptionsFactoryMock($indexOptions, [
+        $factory = $this->createIndexOptionsFactoryMock($indexOptions, [
             IndexOptionsInterface::STORE_ID => $storeId,
             IndexOptionsInterface::INDEX_SUFFIX => $indexSuffix,
             IndexOptionsInterface::IS_TMP => $isTmp,
         ]);
 
-        $this->indexNameFetcher
-            ->expects($this->once())
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher->expects($this->once())
             ->method('getIndexName')
             ->with($indexSuffix, $storeId, $isTmp)
             ->willThrowException(new NoSuchEntityException(__('Store not found')));
 
+        $indexOptionsBuilder = $this->createObjectToTest($indexNameFetcher, $factory);
+
         $this->expectException(NoSuchEntityException::class);
 
-        $this->indexOptionsBuilder->buildWithComputedIndex($indexSuffix, $storeId, $isTmp);
+        $indexOptionsBuilder->buildWithComputedIndex($indexSuffix, $storeId, $isTmp);
     }
 
     public function testBuildWithEnforcedIndexWithAllParameters(): void
@@ -137,12 +135,14 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createIndexOptionsMock($indexName, $storeId);
 
-        $this->configureIndexOptionsFactoryMock($indexOptions, [
+        $factory = $this->createIndexOptionsFactoryMock($indexOptions, [
             IndexOptionsInterface::INDEX_NAME => $indexName,
             IndexOptionsInterface::STORE_ID => $storeId,
         ]);
 
-        $result = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
+        $indexOptionsBuilder = $this->createObjectToTest(indexOptionsInterfaceFactory: $factory);
+
+        $result = $indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->assertEquals($indexName, $result->getIndexName());
     }
@@ -151,12 +151,14 @@ class IndexOptionsBuilderTest extends TestCase
     {
         $indexOptions = $this->createIndexOptionsMock(null, null);
 
-        $this->configureIndexOptionsFactoryMock($indexOptions, [
+        $factory = $this->createIndexOptionsFactoryMock($indexOptions, [
             IndexOptionsInterface::INDEX_NAME => null,
             IndexOptionsInterface::STORE_ID => null,
         ]);
 
-        $result = $this->indexOptionsBuilder->buildWithEnforcedIndex();
+        $indexOptionsBuilder = $this->createObjectToTest(indexOptionsInterfaceFactory: $factory);
+
+        $result = $indexOptionsBuilder->buildWithEnforcedIndex();
 
         $this->assertEquals('', $result->getIndexName()); // Should this throw an exception?
     }
@@ -166,8 +168,10 @@ class IndexOptionsBuilderTest extends TestCase
         $enforcedIndexName = 'enforced_index_name';
         $indexOptions = $this->createIndexOptionsMock($enforcedIndexName);
 
+        $indexOptionsBuilder = $this->createObjectToTest();
+
         $result = $this->invokeMethod(
-            $this->indexOptionsBuilder,
+            $indexOptionsBuilder,
             'computeIndexName',
             [$indexOptions]
         );
@@ -184,14 +188,16 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createIndexOptionsMock(null, $storeId, $indexSuffix, $isTmp);
 
-        $this->indexNameFetcher
-            ->expects($this->once())
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher->expects($this->once())
             ->method('getIndexName')
             ->with($indexSuffix, $storeId, $isTmp)
             ->willReturn($computedIndexName);
 
+        $indexOptionsBuilder = $this->createObjectToTest($indexNameFetcher);
+
         $result = $this->invokeMethod(
-            $this->indexOptionsBuilder,
+            $indexOptionsBuilder,
             'computeIndexName',
             [$indexOptions]
         );
@@ -205,8 +211,8 @@ class IndexOptionsBuilderTest extends TestCase
         $isTmp = false;
         $indexOptions = $this->createIndexOptionsMock(null, $storeId, null, $isTmp);
 
-        $this->logger
-            ->expects($this->once())
+        $logger = $this->createMock(DiagnosticsLogger::class);
+        $logger->expects($this->once())
             ->method('error')
             ->with(
                 'Index name could not be computed due to missing suffix.',
@@ -216,11 +222,13 @@ class IndexOptionsBuilderTest extends TestCase
                 ]
             );
 
+        $indexOptionsBuilder = $this->createObjectToTest(logger: $logger);
+
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessage('Index name could not be computed due to missing suffix.');
 
         $this->invokeMethod(
-            $this->indexOptionsBuilder,
+            $indexOptionsBuilder,
             'computeIndexName',
             [$indexOptions]
         );
@@ -234,16 +242,18 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createIndexOptionsMock(null, $storeId, $indexSuffix, $isTmp);
 
-        $this->indexNameFetcher
-            ->expects($this->once())
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher->expects($this->once())
             ->method('getIndexName')
             ->with($indexSuffix, $storeId, $isTmp)
             ->willThrowException(new NoSuchEntityException(__('Store not found')));
 
+        $indexOptionsBuilder = $this->createObjectToTest($indexNameFetcher);
+
         $this->expectException(NoSuchEntityException::class);
 
         $this->invokeMethod(
-            $this->indexOptionsBuilder,
+            $indexOptionsBuilder,
             'computeIndexName',
             [$indexOptions]
         );
@@ -258,19 +268,21 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createIndexOptionsMock(null, $storeId, $indexSuffix, $isTmp);
 
-        $this->configureIndexOptionsFactoryMock($indexOptions, [
+        $factory = $this->createIndexOptionsFactoryMock($indexOptions, [
             IndexOptionsInterface::STORE_ID => $storeId,
             IndexOptionsInterface::INDEX_SUFFIX => $indexSuffix,
             IndexOptionsInterface::IS_TMP => $isTmp,
         ]);
 
-        $this->indexNameFetcher
-            ->expects($this->once())
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher->expects($this->once())
             ->method('getIndexName')
             ->with($indexSuffix, $storeId, $isTmp)
             ->willReturn($computedIndexName);
 
-        $result = $this->indexOptionsBuilder->buildWithComputedIndex($indexSuffix, $storeId, $isTmp);
+        $indexOptionsBuilder = $this->createObjectToTest($indexNameFetcher, $factory);
+
+        $result = $indexOptionsBuilder->buildWithComputedIndex($indexSuffix, $storeId, $isTmp);
 
         $this->assertEquals($computedIndexName, $result->getIndexName());
     }
@@ -284,19 +296,21 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createIndexOptionsMock(null, $storeId, $indexSuffix, $isTmp);
 
-        $this->configureIndexOptionsFactoryMock($indexOptions, [
+        $factory = $this->createIndexOptionsFactoryMock($indexOptions, [
             IndexOptionsInterface::STORE_ID => $storeId,
             IndexOptionsInterface::INDEX_SUFFIX => $indexSuffix,
             IndexOptionsInterface::IS_TMP => $isTmp,
         ]);
 
-        $this->indexNameFetcher
-            ->expects($this->once())
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher->expects($this->once())
             ->method('getIndexName')
             ->with($indexSuffix, $storeId, $isTmp)
             ->willReturn($computedIndexName);
 
-        $result = $this->indexOptionsBuilder->buildWithComputedIndex($indexSuffix, $storeId, $isTmp);
+        $indexOptionsBuilder = $this->createObjectToTest($indexNameFetcher, $factory);
+
+        $result = $indexOptionsBuilder->buildWithComputedIndex($indexSuffix, $storeId, $isTmp);
 
         $this->assertEquals($computedIndexName, $result->getIndexName());
     }
@@ -307,12 +321,14 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createIndexOptionsMock($indexName);
 
-        $this->configureIndexOptionsFactoryMock($indexOptions, [
+        $factory = $this->createIndexOptionsFactoryMock($indexOptions, [
             IndexOptionsInterface::INDEX_NAME => $indexName,
             IndexOptionsInterface::STORE_ID => null,
         ]);
 
-        $result = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName);
+        $indexOptionsBuilder = $this->createObjectToTest(indexOptionsInterfaceFactory: $factory);
+
+        $result = $indexOptionsBuilder->buildWithEnforcedIndex($indexName);
 
         $this->assertEquals($indexName, $result->getIndexName());
     }
@@ -324,12 +340,14 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createIndexOptionsMock($indexName, $storeId);
 
-        $this->configureIndexOptionsFactoryMock($indexOptions, [
+        $factory = $this->createIndexOptionsFactoryMock($indexOptions, [
             IndexOptionsInterface::INDEX_NAME => $indexName,
             IndexOptionsInterface::STORE_ID => $storeId,
         ]);
 
-        $result = $this->indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
+        $indexOptionsBuilder = $this->createObjectToTest(indexOptionsInterfaceFactory: $factory);
+
+        $result = $indexOptionsBuilder->buildWithEnforcedIndex($indexName, $storeId);
 
         $this->assertEquals($indexName, $result->getIndexName()); // Should this throw an exception?
     }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsComparatorTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsComparatorTest.php
@@ -7,16 +7,10 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[AllowMockObjectsWithoutExpectations]
 class IndexSettingsComparatorTest extends TestCase
 {
-    protected ?AlgoliaConnector $connector = null;
-    protected ?IndexOptionsInterface $indexOptions = null;
-
-    protected IndexSettingsComparator $indexSettingsComparator;
-
     protected array $testSettings = [
         'searchableAttributes' => [
             'unordered(name)',
@@ -53,19 +47,20 @@ class IndexSettingsComparatorTest extends TestCase
         ],
     ];
 
-    protected function setUp(): void
+    protected function createObjectToTest(?AlgoliaConnector $connector = null): IndexSettingsComparator
     {
-        $this->connector = $this->createMock(AlgoliaConnector::class);
-        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
-
-        $this->indexSettingsComparator = new IndexSettingsComparator($this->connector);
+        return new IndexSettingsComparator($connector ?? $this->createStub(AlgoliaConnector::class));
     }
 
     public function testWithSameSettings(): void
     {
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($this->testSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($this->testSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be the same
-        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithSameSettingsButOrderedDifferently(): void
@@ -106,9 +101,13 @@ class IndexSettingsComparatorTest extends TestCase
             ],
         ];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be the same (attributes are re-ordered by ksort)
-        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithSameSettingsButWithMixedAssociativeArray(): void
@@ -120,9 +119,13 @@ class IndexSettingsComparatorTest extends TestCase
             'bar' => 'foo',
         ];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be the same (associative arrays are re-ordered by recursive ksort)
-        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithAdditionalSettingsComingFromAlgolia(): void
@@ -130,9 +133,13 @@ class IndexSettingsComparatorTest extends TestCase
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['additionalSettings'] = 'foo';
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be the same (additional settings are ignored by array_intersect_key)
-        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithChangedValue(): void
@@ -140,9 +147,13 @@ class IndexSettingsComparatorTest extends TestCase
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['maxValuesPerFacet'] = 10;
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithChangedTyping(): void
@@ -150,9 +161,13 @@ class IndexSettingsComparatorTest extends TestCase
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['typoTolerance'] = false;
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithMissingValue(): void
@@ -160,9 +175,13 @@ class IndexSettingsComparatorTest extends TestCase
         $algoliaSettings = $this->testSettings;
         unset($algoliaSettings['removeWordsIfNoResults']);
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithRemovedOrderingAttribute(): void
@@ -177,9 +196,13 @@ class IndexSettingsComparatorTest extends TestCase
             // removed color
         ];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithChangedOrdering(): void
@@ -195,37 +218,219 @@ class IndexSettingsComparatorTest extends TestCase
             'unordered(categories_without_path)',
         ];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testInvalidJson(): void
     {
         $algoliaSettings = [INF];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
 
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessageMatches('/Invalid JSON/');
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, [INF]));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), [INF]));
     }
 
     public function testUsesProvidedRemoteSettingsWhenPassed(): void
     {
         // When remote settings are supplied, the connector must not be queried.
-        $this->connector->expects($this->never())->method('getSettings');
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->never())->method('getSettings');
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
 
         $this->assertTrue(
-            $this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings, $this->testSettings)
+            $indexSettingsComparator->matches($indexOptions, $this->testSettings, $this->testSettings)
         );
 
         $changedRemote = $this->testSettings;
         $changedRemote['maxValuesPerFacet'] = 10;
 
         $this->assertFalse(
-            $this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings, $changedRemote)
+            $indexSettingsComparator->matches($indexOptions, $this->testSettings, $changedRemote)
         );
+    }
+
+    // ── reconcileKeys() ──
+
+    #[DataProvider('reconcileKeysProvider')]
+    public function testReconcileKeys(array $remote, array $local, array $expectedRemote, array $expectedLocal): void
+    {
+        $indexSettingsComparator = $this->createObjectToTest();
+
+        [$reconciledRemote, $reconciledLocal] = $this->invokeMethod(
+            $indexSettingsComparator,
+            'reconcileKeys',
+            [$remote, $local]
+        );
+
+        $this->assertSame($expectedRemote, $reconciledRemote);
+        $this->assertSame($expectedLocal, $reconciledLocal);
+    }
+
+    public static function reconcileKeysProvider(): array
+    {
+        return [
+            'remote-only keys are dropped' => [
+                'remote' => ['searchableAttributes' => ['name'], 'algoliaManagedSetting' => 'foo'],
+                'local' => ['searchableAttributes' => ['name']],
+                'expectedRemote' => ['searchableAttributes' => ['name']],
+                'expectedLocal' => ['searchableAttributes' => ['name']],
+            ],
+            'empty local customRanking absent remotely is dropped from local' => [
+                'remote' => ['searchableAttributes' => ['name']],
+                'local' => ['searchableAttributes' => ['name'], 'customRanking' => []],
+                'expectedRemote' => ['searchableAttributes' => ['name']],
+                'expectedLocal' => ['searchableAttributes' => ['name']],
+            ],
+            'empty local unretrievableAttributes absent remotely is dropped from local' => [
+                'remote' => ['searchableAttributes' => ['name']],
+                'local' => ['searchableAttributes' => ['name'], 'unretrievableAttributes' => []],
+                'expectedRemote' => ['searchableAttributes' => ['name']],
+                'expectedLocal' => ['searchableAttributes' => ['name']],
+            ],
+            'empty local customRanking with null remote value is coerced to null' => [
+                'remote' => ['customRanking' => null],
+                'local' => ['customRanking' => []],
+                'expectedRemote' => ['customRanking' => null],
+                'expectedLocal' => ['customRanking' => null],
+            ],
+            'empty local unretrievableAttributes with null remote value is coerced to null' => [
+                'remote' => ['unretrievableAttributes' => null],
+                'local' => ['unretrievableAttributes' => []],
+                'expectedRemote' => ['unretrievableAttributes' => null],
+                'expectedLocal' => ['unretrievableAttributes' => null],
+            ],
+            'empty local value with non-null empty remote value is left untouched' => [
+                'remote' => ['customRanking' => []],
+                'local' => ['customRanking' => []],
+                'expectedRemote' => ['customRanking' => []],
+                'expectedLocal' => ['customRanking' => []],
+            ],
+            'empty local value with real remote value is left untouched (surfaces as a diff)' => [
+                'remote' => ['customRanking' => ['desc(price)']],
+                'local' => ['customRanking' => []],
+                'expectedRemote' => ['customRanking' => ['desc(price)']],
+                'expectedLocal' => ['customRanking' => []],
+            ],
+            'non-empty local value absent remotely is left untouched (surfaces as a diff)' => [
+                'remote' => [],
+                'local' => ['customRanking' => ['desc(price)']],
+                'expectedRemote' => [],
+                'expectedLocal' => ['customRanking' => ['desc(price)']],
+            ],
+        ];
+    }
+
+    // ── customRanking / unretrievableAttributes round-trip omission ──
+
+    public function testMatchesWhenCustomRankingEmptyLocallyAndAbsentFromRemote(): void
+    {
+        $local = ['searchableAttributes' => ['name'], 'customRanking' => []];
+        // Algolia omits customRanking entirely from getSettings() whenever it's empty.
+        $remote = ['searchableAttributes' => ['name']];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $local));
+    }
+
+    public function testMatchesWhenUnretrievableAttributesEmptyLocallyAndAbsentFromRemote(): void
+    {
+        $local = ['searchableAttributes' => ['name'], 'unretrievableAttributes' => []];
+        // Algolia omits unretrievableAttributes until it has been set at least once.
+        $remote = ['searchableAttributes' => ['name']];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $local));
+    }
+
+    public function testMatchesWhenCustomRankingEmptyLocallyAndNullRemotely(): void
+    {
+        $local = ['customRanking' => []];
+        $remote = ['customRanking' => null];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $local));
+    }
+
+    public function testMatchesWhenUnretrievableAttributesEmptyLocallyAndNullRemotely(): void
+    {
+        $local = ['unretrievableAttributes' => []];
+        $remote = ['unretrievableAttributes' => null];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $local));
+    }
+
+    public function testMatchesWhenCustomRankingAndUnretrievableAttributesBothEmptyAndAbsentRemotely(): void
+    {
+        $local = [
+            'searchableAttributes' => ['name'],
+            'customRanking' => [],
+            'unretrievableAttributes' => [],
+        ];
+        $remote = ['searchableAttributes' => ['name']];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $local));
+    }
+
+    public function testDoesNotMatchWhenCustomRankingNonEmptyLocallyButAbsentFromRemote(): void
+    {
+        $local = ['customRanking' => ['desc(price)']];
+        // Not an omitted-because-empty case: the extension proposes a real ranking Algolia doesn't have.
+        $remote = [];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $local));
+    }
+
+    public function testDoesNotMatchWhenUnretrievableAttributesDifferAndBothNonEmpty(): void
+    {
+        $local = ['unretrievableAttributes' => ['in_stock']];
+        $remote = ['unretrievableAttributes' => ['ordered_qty']];
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($remote);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $local));
     }
 }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsComparatorTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsComparatorTest.php
@@ -7,16 +7,9 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class IndexSettingsComparatorTest extends TestCase
 {
-    protected ?AlgoliaConnector $connector = null;
-    protected ?IndexOptionsInterface $indexOptions = null;
-
-    protected IndexSettingsComparator $indexSettingsComparator;
-
     protected array $testSettings = [
         'searchableAttributes' => [
             'unordered(name)',
@@ -53,19 +46,20 @@ class IndexSettingsComparatorTest extends TestCase
         ],
     ];
 
-    protected function setUp(): void
+    protected function createObjectToTest(?AlgoliaConnector $connector = null): IndexSettingsComparator
     {
-        $this->connector = $this->createMock(AlgoliaConnector::class);
-        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
-
-        $this->indexSettingsComparator = new IndexSettingsComparator($this->connector);
+        return new IndexSettingsComparator($connector ?? $this->createStub(AlgoliaConnector::class));
     }
 
     public function testWithSameSettings(): void
     {
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($this->testSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($this->testSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be the same
-        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithSameSettingsButOrderedDifferently(): void
@@ -106,9 +100,13 @@ class IndexSettingsComparatorTest extends TestCase
             ],
         ];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be the same (attributes are re-ordered by ksort)
-        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithSameSettingsButWithMixedAssociativeArray(): void
@@ -120,9 +118,13 @@ class IndexSettingsComparatorTest extends TestCase
             'bar' => 'foo',
         ];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be the same (associative arrays are re-ordered by recursive ksort)
-        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithAdditionalSettingsComingFromAlgolia(): void
@@ -130,9 +132,13 @@ class IndexSettingsComparatorTest extends TestCase
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['additionalSettings'] = 'foo';
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be the same (additional settings are ignored by array_intersect_key)
-        $this->assertTrue($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertTrue($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithChangedValue(): void
@@ -140,9 +146,13 @@ class IndexSettingsComparatorTest extends TestCase
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['maxValuesPerFacet'] = 10;
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithChangedTyping(): void
@@ -150,9 +160,13 @@ class IndexSettingsComparatorTest extends TestCase
         $algoliaSettings = $this->testSettings;
         $algoliaSettings['typoTolerance'] = false;
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithMissingValue(): void
@@ -160,9 +174,13 @@ class IndexSettingsComparatorTest extends TestCase
         $algoliaSettings = $this->testSettings;
         unset($algoliaSettings['removeWordsIfNoResults']);
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithRemovedOrderingAttribute(): void
@@ -177,9 +195,13 @@ class IndexSettingsComparatorTest extends TestCase
             // removed color
         ];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testWithChangedOrdering(): void
@@ -195,37 +217,48 @@ class IndexSettingsComparatorTest extends TestCase
             'unordered(categories_without_path)',
         ];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), $this->testSettings));
     }
 
     public function testInvalidJson(): void
     {
         $algoliaSettings = [INF];
 
-        $this->connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())->method('getSettings')->willReturn($algoliaSettings);
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
 
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessageMatches('/Invalid JSON/');
         // Must be different
-        $this->assertFalse($this->indexSettingsComparator->matches($this->indexOptions, [INF]));
+        $this->assertFalse($indexSettingsComparator->matches($this->createStub(IndexOptionsInterface::class), [INF]));
     }
 
     public function testUsesProvidedRemoteSettingsWhenPassed(): void
     {
         // When remote settings are supplied, the connector must not be queried.
-        $this->connector->expects($this->never())->method('getSettings');
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->never())->method('getSettings');
+
+        $indexSettingsComparator = $this->createObjectToTest($connector);
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
 
         $this->assertTrue(
-            $this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings, $this->testSettings)
+            $indexSettingsComparator->matches($indexOptions, $this->testSettings, $this->testSettings)
         );
 
         $changedRemote = $this->testSettings;
         $changedRemote['maxValuesPerFacet'] = 10;
 
         $this->assertFalse(
-            $this->indexSettingsComparator->matches($this->indexOptions, $this->testSettings, $changedRemote)
+            $indexSettingsComparator->matches($indexOptions, $this->testSettings, $changedRemote)
         );
     }
 }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -10,113 +10,103 @@ use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsHandler;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsPreserver;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
 
-#[AllowMockObjectsWithoutExpectations]
 class IndexSettingsHandlerTest extends TestCase
 {
-    protected ?AlgoliaConnector $connector = null;
+    protected function createObjectToTest(
+        ?AlgoliaConnector $connector = null,
+        ?ConfigHelper $config = null,
+        ?IndexSettingsComparator $comparator = null,
+        ?IndexSettingsPreserver $preserver = null,
+        ?AlgoliaLogger $logger = null,
+    ): IndexSettingsHandler {
+        if ($comparator === null) {
+            $comparator = $this->createStub(IndexSettingsComparator::class);
+            $comparator->method('matches')->willReturn(false);
+        }
 
-    protected ?ConfigHelper $config = null;
-    protected ?IndexSettingsComparator $indexSettingsComparator = null;
-    protected ?IndexSettingsPreserver $indexSettingsPreserver = null;
-    protected ?AlgoliaLogger $logger = null;
+        if ($preserver === null) {
+            $preserver = $this->createStub(IndexSettingsPreserver::class);
+            // By default preservation is a pass-through so existing expectations operate on the original payload
+            $preserver->method('preserve')->willReturnArgument(0);
+        }
 
-    protected ?IndexOptionsInterface $indexOptions = null;
-
-    private ?IndexSettingsHandler $handler = null;
-
-    /**
-     * State machine to track pending operations per store ID
-     * Format: [storeId => ['totalCalls' => int, 'waitCalled' => bool, 'batchesCompleted' => int]]
-     */
-    private array $operationState = [];
-
-    protected function setUp(): void
-    {
-        $this->connector = $this->createMock(AlgoliaConnector::class);
-        $this->config = $this->createMock(ConfigHelper::class);
-        $this->indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
-        $this->indexSettingsComparator->method('matches')->willReturn(false);
-        $this->indexSettingsPreserver = $this->createMock(IndexSettingsPreserver::class);
-        // By default preservation is a pass-through so existing expectations operate on the original payload
-        $this->indexSettingsPreserver->method('preserve')->willReturnArgument(0);
-        $this->logger = $this->createMock(AlgoliaLogger::class);
-        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
-
-        // Configure the mock to use our state machine
-        $this->setupStateMachineMock();
-
-        $this->handler = new IndexSettingsHandler(
-            $this->connector,
-            $this->config,
-            $this->indexSettingsComparator,
-            $this->indexSettingsPreserver,
-            $this->logger,
+        return new IndexSettingsHandler(
+            $connector ?? $this->createStub(AlgoliaConnector::class),
+            $config ?? $this->createStub(ConfigHelper::class),
+            $comparator,
+            $preserver,
+            $logger ?? $this->createStub(AlgoliaLogger::class),
         );
     }
 
-    private function setupStateMachineMock(): void
+    private function createIndexOptionsStub(int $storeId = 1): IndexOptionsInterface
     {
-        $this->connector->method('setSettings')
-            ->willReturnCallback(function($indexOptions, $settings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') {
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
+        $indexOptions->method('getStoreId')->willReturn($storeId);
+
+        return $indexOptions;
+    }
+
+    /**
+     * State machine to track pending operations per store ID, so tests can assert that a
+     * forwarded setSettings() call requires waitLastTask() before the store can be written again.
+     */
+    private function createStateMachineConnector(): AlgoliaConnector&MockObject
+    {
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->method('getSettings')->willReturn([]);
+
+        $operationState = [];
+
+        $connector->method('setSettings')
+            ->willReturnCallback(function ($indexOptions, $settings, $forwardToReplicas, $mergeSettings = false, $mergeFrom = '') use (&$operationState) {
                 $storeId = $indexOptions->getStoreId();
 
-                // Initialize state if not exists
-                if (!isset($this->operationState[$storeId])) {
-                    $this->operationState[$storeId] = [
-                        'setSettingsCalled' => false,
-                        'waitCalled' => false,
-                    ];
+                if (!isset($operationState[$storeId])) {
+                    $operationState[$storeId] = ['setSettingsCalled' => false, 'waitCalled' => false];
                 }
 
-                // Check that setSettings is not stacked for this $storeId
-                if ($this->operationState[$storeId]['setSettingsCalled'] &&
-                    !$this->operationState[$storeId]['waitCalled']) {
+                if ($operationState[$storeId]['setSettingsCalled'] && !$operationState[$storeId]['waitCalled']) {
                     throw new \RuntimeException(
                         // phpcs:ignore
                         "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
                     );
                 }
 
-                // Update state
-                $this->operationState[$storeId]['setSettingsCalled'] = true;
-                $this->operationState[$storeId]['waitCalled'] = false;
+                $operationState[$storeId]['setSettingsCalled'] = true;
+                $operationState[$storeId]['waitCalled'] = false;
             });
 
-        $this->connector->method('waitLastTask')
-            ->willReturnCallback(function($storeId = null) {
-                if ($storeId !== null && isset($this->operationState[$storeId])) {
-                    $this->operationState[$storeId]['waitCalled'] = true;
+        $connector->method('waitLastTask')
+            ->willReturnCallback(function ($storeId = null) use (&$operationState) {
+                if ($storeId !== null && isset($operationState[$storeId])) {
+                    $operationState[$storeId]['waitCalled'] = true;
                 }
             });
-    }
 
-    private function resetOperationState(): void
-    {
-        $this->operationState = [];
+        return $connector;
     }
 
     public function testSetSettingsWithForwardingEnabledAndMixedSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
             'attributesToRetrieve' => ['name', 'price'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->with($storeId)
-            ->willReturn(true);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
+
+        $connector = $this->createStateMachineConnector();
 
         $invocationCount = 0;
-        $this->connector->expects($this->exactly(2))
+        $connector->expects($this->exactly(2))
             ->method('setSettings')
             ->willReturnCallback(
-                function($indexOptions, $indexSettings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') use (&$invocationCount) {
+                function ($indexOptions, $indexSettings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') use (&$invocationCount) {
                     $invocationCount++;
 
                     switch ($invocationCount) {
@@ -136,103 +126,98 @@ class IndexSettingsHandlerTest extends TestCase
             }
             );
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config);
+
+        $this->assertTrue($handler->setSettings($this->createIndexOptionsStub($storeId), $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyExcludedSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'ranking' => ['asc(name)'],
             'customRanking' => ['desc(price)'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
 
+        $indexOptions = $this->createIndexOptionsStub($storeId);
+
+        $connector = $this->createStateMachineConnector();
         // Only one call expected (no forwarded settings since they are sorts)
-        $this->connector->expects($this->once())
+        $connector->expects($this->once())
             ->method('setSettings')
-            ->with(
-                $this->indexOptions,
-                $settings,
-                false
-            );
+            ->with($indexOptions, $settings, false);
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config);
+
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyForwardableSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'attributesToHighlight' => ['title'],
             'attributesToRetrieve' => ['name'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
 
+        $indexOptions = $this->createIndexOptionsStub($storeId);
+
+        $connector = $this->createStateMachineConnector();
         // Only one call expected (all forwarded - no excluded settings)
-        $this->connector->expects($this->once())
+        $connector->expects($this->once())
             ->method('setSettings')
-            ->with(
-                $this->indexOptions,
-                $settings,
-                true
-            );
+            ->with($indexOptions, $settings, true);
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config);
+
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingDisabled(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
             'attributesToRetrieve' => ['name', 'price'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
 
-        $this->connector->expects($this->once())
+        $indexOptions = $this->createIndexOptionsStub($storeId);
+
+        $connector = $this->createStateMachineConnector();
+        $connector->expects($this->once())
             ->method('setSettings')
-            ->with(
-                $this->indexOptions,
-                $settings,
-                false
-            );
+            ->with($indexOptions, $settings, false);
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config);
+
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     public function testForwardSettingsWithEmptyInput(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
 
+        $connector = $this->createStateMachineConnector();
         // Connector should not be called
-        $this->connector->expects($this->never())->method('setSettings');
+        $connector->expects($this->never())->method('setSettings');
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config);
+
+        $this->assertTrue($handler->setSettings($this->createIndexOptionsStub($storeId), $settings));
     }
-
 
     public function testSplitSettings(): void
     {
@@ -242,7 +227,9 @@ class IndexSettingsHandlerTest extends TestCase
             'attributesToRetrieve' => ['name'],
         ];
 
-        [$forward, $noForward] = $this->invokeMethod($this->handler, 'splitSettings', [$settings]);
+        $handler = $this->createObjectToTest();
+
+        [$forward, $noForward] = $this->invokeMethod($handler, 'splitSettings', [$settings]);
 
         $this->assertEquals(['attributesToRetrieve' => ['name']], $forward);
         $this->assertEquals([
@@ -257,25 +244,29 @@ class IndexSettingsHandlerTest extends TestCase
      */
     public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = ['attributesToRetrieve' => ['name']];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-
+        $config = $this->createStub(ConfigHelper::class);
         // Disable forwarding for explicit test
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
+
+        $connector = $this->createStateMachineConnector();
+        // setSettings() is preceded by exactly one getSettings() call per handler->setSettings()
+        // invocation, so this is called exactly twice across the two attempts below.
+        $connector->expects($this->exactly(2))->method('getSettings');
+
+        $handler = $this->createObjectToTest($connector, $config);
+        $indexOptions = $this->createIndexOptionsStub($storeId);
 
         // First call should succeed
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
 
         // Second call without wait should throw exception
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     /**
@@ -284,56 +275,50 @@ class IndexSettingsHandlerTest extends TestCase
      * */
     public function testSubsequentSetSettingsAfterWaitSucceeds(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = ['attributesToRetrieve' => ['name']];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $config = $this->createStub(ConfigHelper::class);
         // Disable forwarding for explicit test
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
 
-        $this->connector->expects($this->exactly(2))
-            ->method('setSettings');
+        $connector = $this->createStateMachineConnector();
+        $connector->expects($this->exactly(2))->method('setSettings');
+        $connector->expects($this->once())->method('waitLastTask')->with($storeId);
 
-        $this->connector->expects($this->once())
-            ->method('waitLastTask')
-            ->with($storeId);
+        $handler = $this->createObjectToTest($connector, $config);
+        $indexOptions = $this->createIndexOptionsStub($storeId);
 
         // First call should succeed
-        $this->handler->setSettings($this->indexOptions, $settings);
+        $handler->setSettings($indexOptions, $settings);
 
         // Wait for the task
-        $this->connector->waitLastTask($storeId);
+        $connector->waitLastTask($storeId);
 
         // Second call after wait should succeed
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     public function testDifferentStoreIdsDontInterfere(): void
     {
-        $this->resetOperationState();
-
         $storeId1 = 1;
         $storeId2 = 2;
         $settings = ['attributesToRetrieve' => ['name']];
 
-        $indexOptions1 = $this->createMock(IndexOptionsInterface::class);
-        $indexOptions1->method('getStoreId')->willReturn($storeId1);
+        $indexOptions1 = $this->createIndexOptionsStub($storeId1);
+        $indexOptions2 = $this->createIndexOptionsStub($storeId2);
 
-        $indexOptions2 = $this->createMock(IndexOptionsInterface::class);
-        $indexOptions2->method('getStoreId')->willReturn($storeId2);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
 
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
-
+        $connector = $this->createStateMachineConnector();
         // Both calls should succeed as they use different store IDs
-        $this->connector->expects($this->exactly(2))
-            ->method('setSettings');
+        $connector->expects($this->exactly(2))->method('setSettings');
 
-        $this->assertTrue($this->handler->setSettings($indexOptions1, $settings));
-        $this->assertTrue($this->handler->setSettings($indexOptions2, $settings));
+        $handler = $this->createObjectToTest($connector, $config);
+
+        $this->assertTrue($handler->setSettings($indexOptions1, $settings));
+        $this->assertTrue($handler->setSettings($indexOptions2, $settings));
     }
 
     /**
@@ -344,56 +329,49 @@ class IndexSettingsHandlerTest extends TestCase
      */
     public function testForwardingEnabledMultipleCallsRequireWait(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
             'attributesToRetrieve' => ['name'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
 
+        $connector = $this->createStateMachineConnector();
         // 2 internal calls + 1 explicit call
-        $this->connector->expects($this->exactly(3))
-            ->method('setSettings');
+        $connector->expects($this->exactly(3))->method('setSettings');
+
+        $handler = $this->createObjectToTest($connector, $config);
+        $indexOptions = $this->createIndexOptionsStub($storeId);
 
         // First call makes two internal setSettings calls
-        $this->handler->setSettings($this->indexOptions, $settings);
+        $handler->setSettings($indexOptions, $settings);
 
         // Second call to handler should fail because no wait was called
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     public function testSkippedSetSettings(): void
     {
-        $this->resetOperationState();
-
-        $indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
-        $indexSettingsComparator->method('matches')->willReturn(true);
-
-        $this->handler = new IndexSettingsHandler(
-            $this->connector,
-            $this->config,
-            $indexSettingsComparator,
-            $this->indexSettingsPreserver,
-            $this->logger,
-        );
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
             'attributesToRetrieve' => ['name'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+        $comparator = $this->createStub(IndexSettingsComparator::class);
+        $comparator->method('matches')->willReturn(true);
 
-        $this->assertFalse($this->handler->setSettings($this->indexOptions, $settings));
+        // matches() = true means setSettings() is never reached, so a plain stub is enough here.
+        $connector = $this->createStub(AlgoliaConnector::class);
+
+        $handler = $this->createObjectToTest($connector, comparator: $comparator);
+
+        $this->assertFalse($handler->setSettings($this->createIndexOptionsStub($storeId), $settings));
     }
 
     public function testGetSettingsCalledExactlyOncePerSetSettings(): void
@@ -403,19 +381,14 @@ class IndexSettingsHandlerTest extends TestCase
             ->method('getSettings')
             ->willReturn(['attributesForFaceting' => ['categories']]);
 
-        $preserver = $this->createMock(IndexSettingsPreserver::class);
-        $preserver->method('preserve')->willReturnArgument(0);
-
-        $comparator = $this->createMock(IndexSettingsComparator::class);
-        $comparator->method('matches')->willReturn(false);
-
-        $config = $this->createMock(ConfigHelper::class);
+        $config = $this->createStub(ConfigHelper::class);
         $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
+        $handler = $this->createObjectToTest($connector, $config);
 
-        $this->assertTrue($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
+        $this->assertTrue(
+            $handler->setSettings($this->createIndexOptionsStub(), ['attributesForFaceting' => ['categories']])
+        );
     }
 
     public function testPreserverInvokedBeforeComparator(): void
@@ -423,7 +396,8 @@ class IndexSettingsHandlerTest extends TestCase
         $order = [];
 
         $connector = $this->createMock(AlgoliaConnector::class);
-        $connector->method('getSettings')->willReturn(['attributesForFaceting' => ['categories']]);
+        // preserve() and matches() must both see the remote settings fetched exactly once.
+        $connector->expects($this->once())->method('getSettings')->willReturn(['attributesForFaceting' => ['categories']]);
 
         $preserver = $this->createMock(IndexSettingsPreserver::class);
         $preserver->expects($this->once())
@@ -443,13 +417,12 @@ class IndexSettingsHandlerTest extends TestCase
                 return true;
             });
 
-        $config = $this->createMock(ConfigHelper::class);
+        $config = $this->createStub(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
+        $handler = $this->createObjectToTest($connector, $config, $comparator, $preserver);
 
-        $handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]);
+        $handler->setSettings($this->createIndexOptionsStub(), ['attributesForFaceting' => ['categories']]);
 
         $this->assertSame(['preserve', 'matches'], $order);
     }
@@ -461,22 +434,20 @@ class IndexSettingsHandlerTest extends TestCase
         $connector = $this->createMock(AlgoliaConnector::class);
         $connector->expects($this->once())->method('getSettings')->willReturn($remote);
 
-        $preserver = $this->createMock(IndexSettingsPreserver::class);
-        $preserver->method('preserve')->willReturnArgument(0);
+        $indexOptions = $this->createIndexOptionsStub();
 
         $comparator = $this->createMock(IndexSettingsComparator::class);
         $comparator->expects($this->once())
             ->method('matches')
-            ->with($this->indexOptions, $this->anything(), $remote)
+            ->with($indexOptions, $this->anything(), $remote)
             ->willReturn(true);
 
-        $config = $this->createMock(ConfigHelper::class);
+        $config = $this->createStub(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
+        $handler = $this->createObjectToTest($connector, $config, $comparator);
 
-        $this->assertFalse($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
+        $this->assertFalse($handler->setSettings($indexOptions, ['attributesForFaceting' => ['categories']]));
     }
 
     public function testNoOpDetectionAccountsForPreservedEntries(): void
@@ -489,18 +460,17 @@ class IndexSettingsHandlerTest extends TestCase
         // The only diff was the preserved entry, so no write should be issued.
         $connector->expects($this->never())->method('setSettings');
 
-        $preserver = $this->createMock(IndexSettingsPreserver::class);
+        $preserver = $this->createStub(IndexSettingsPreserver::class);
         $preserver->method('preserve')->willReturn(['attributesForFaceting' => ['a', 'b', '_x']]);
 
         // Use the real comparator so the no-op detection is genuinely exercised.
         $comparator = new IndexSettingsComparator($connector);
 
-        $config = $this->createMock(ConfigHelper::class);
+        $config = $this->createStub(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
+        $handler = $this->createObjectToTest($connector, $config, $comparator, $preserver);
 
-        $this->assertFalse($handler->setSettings($this->indexOptions, $proposed));
+        $this->assertFalse($handler->setSettings($this->createIndexOptionsStub(), $proposed));
     }
 }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Service\Index\Settings;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
-use Algolia\AlgoliaSearch\Controller\View\Index;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
@@ -123,7 +122,7 @@ class IndexSettingsHandlerTest extends TestCase
                 false
             );
 
-        // IndexSettingsComparator::matches() is called 3 times:
+        // IndexSettingsComparator::matches() is called 2 times:
         // - once for the full payload
         // - once for $noforward
         $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
@@ -154,7 +153,7 @@ class IndexSettingsHandlerTest extends TestCase
                 true
             );
 
-        // IndexSettingsComparator::matches() is called 3 times:
+        // IndexSettingsComparator::matches() is called 2 times:
         // - once for the full payload
         // - once for $forward
         $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -10,42 +10,43 @@ use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsComparator;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsHandler;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsPreserver;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[AllowMockObjectsWithoutExpectations]
 class IndexSettingsHandlerTest extends TestCase
 {
-    protected ?AlgoliaConnector $connector = null;
+    protected function createObjectToTest(
+        ?AlgoliaConnector $connector = null,
+        ?ConfigHelper $config = null,
+        ?IndexSettingsComparator $comparator = null,
+        ?IndexSettingsPreserver $preserver = null,
+        ?AlgoliaLogger $logger = null,
+    ): IndexSettingsHandler {
+        if ($comparator === null) {
+            $comparator = $this->createStub(IndexSettingsComparator::class);
+            $comparator->method('matches')->willReturn(false);
+        }
 
-    protected ?ConfigHelper $config = null;
-    protected ?IndexSettingsComparator $indexSettingsComparator = null;
-    protected ?IndexSettingsPreserver $indexSettingsPreserver = null;
-    protected ?AlgoliaLogger $logger = null;
+        if ($preserver === null) {
+            $preserver = $this->createStub(IndexSettingsPreserver::class);
+            // By default preservation is a pass-through so existing expectations operate on the original payload
+            $preserver->method('preserve')->willReturnArgument(0);
+        }
 
-    protected ?IndexOptionsInterface $indexOptions = null;
-
-    private ?IndexSettingsHandler $handler = null;
-
-    protected function setUp(): void
-    {
-        $this->connector = $this->createMock(AlgoliaConnector::class);
-        $this->config = $this->createMock(ConfigHelper::class);
-        $this->indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
-        $this->indexSettingsComparator->method('matches')->willReturn(false);
-        $this->indexSettingsPreserver = $this->createMock(IndexSettingsPreserver::class);
-        // By default preservation is a pass-through so existing expectations operate on the original payload
-        $this->indexSettingsPreserver->method('preserve')->willReturnArgument(0);
-        $this->logger = $this->createMock(AlgoliaLogger::class);
-        $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
-
-        $this->handler = new IndexSettingsHandler(
-            $this->connector,
-            $this->config,
-            $this->indexSettingsComparator,
-            $this->indexSettingsPreserver,
-            $this->logger,
+        return new IndexSettingsHandler(
+            $connector ?? $this->createStub(AlgoliaConnector::class),
+            $config ?? $this->createStub(ConfigHelper::class),
+            $comparator,
+            $preserver,
+            $logger ?? $this->createStub(AlgoliaLogger::class),
         );
+    }
+
+    private function createIndexOptionsStub(int $storeId = 1): IndexOptionsInterface
+    {
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
+        $indexOptions->method('getStoreId')->willReturn($storeId);
+
+        return $indexOptions;
     }
 
     public function testSetSettingsWithForwardingEnabledAndMixedSettings(): void
@@ -56,16 +57,15 @@ class IndexSettingsHandlerTest extends TestCase
             'attributesToRetrieve' => ['name', 'price'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->with($storeId)
-            ->willReturn(true);
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->with($storeId)->willReturn(true);
 
         $invocationCount = 0;
-        $this->connector->expects($this->exactly(2))
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->exactly(2))
             ->method('setSettings')
             ->willReturnCallback(
-                function($indexOptions, $indexSettings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') use (&$invocationCount) {
+                function ($indexOptions, $indexSettings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') use (&$invocationCount) {
                     $invocationCount++;
 
                     switch ($invocationCount) {
@@ -89,11 +89,14 @@ class IndexSettingsHandlerTest extends TestCase
         // - once for the full payload
         // - once for $forward
         // - once for $noforward
-        $this->indexSettingsComparator->expects($this->exactly(3))->method('matches');
-        // Only two taskIDs are collected ($forward and $noforward
-        $this->connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->exactly(3))->method('matches');
+        // Only two taskIDs are collected ($forward and $noforward)
+        $connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config, $comparator);
+
+        $this->assertTrue($handler->setSettings($this->createIndexOptionsStub($storeId), $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyExcludedSettings(): void
@@ -104,27 +107,28 @@ class IndexSettingsHandlerTest extends TestCase
             'customRanking' => ['desc(price)'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
+
+        $indexOptions = $this->createIndexOptionsStub($storeId);
 
         // Only one call expected (no forwarded settings since they are sorts)
-        $this->connector->expects($this->once())
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())
             ->method('setSettings')
-            ->with(
-                $this->indexOptions,
-                $settings,
-                false
-            );
+            ->with($indexOptions, $settings, false);
 
         // IndexSettingsComparator::matches() is called 2 times:
         // - once for the full payload
         // - once for $noforward
-        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->exactly(2))->method('matches');
         // Only one taskID is collected ($noforward)
-        $this->connector->expects($this->once())->method('collectTaskIdToWaitFor');
+        $connector->expects($this->once())->method('collectTaskIdToWaitFor');
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config, $comparator);
+
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyForwardableSettings(): void
@@ -135,27 +139,28 @@ class IndexSettingsHandlerTest extends TestCase
             'attributesToRetrieve' => ['name'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
+
+        $indexOptions = $this->createIndexOptionsStub($storeId);
 
         // Only one call expected (all forwarded - no excluded settings)
-        $this->connector->expects($this->once())
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())
             ->method('setSettings')
-            ->with(
-                $this->indexOptions,
-                $settings,
-                true
-            );
+            ->with($indexOptions, $settings, true);
 
         // IndexSettingsComparator::matches() is called 2 times:
         // - once for the full payload
         // - once for $forward
-        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->exactly(2))->method('matches');
         // Only one taskID is collected ($forward)
-        $this->connector->expects($this->exactly(1))->method('collectTaskIdToWaitFor');
+        $connector->expects($this->exactly(1))->method('collectTaskIdToWaitFor');
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config, $comparator);
+
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingDisabled(): void
@@ -166,24 +171,25 @@ class IndexSettingsHandlerTest extends TestCase
             'attributesToRetrieve' => ['name', 'price'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
 
-        $this->connector->expects($this->once())
+        $indexOptions = $this->createIndexOptionsStub($storeId);
+
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->once())
             ->method('setSettings')
-            ->with(
-                $this->indexOptions,
-                $settings,
-                false
-            );
+            ->with($indexOptions, $settings, false);
 
         // IndexSettingsComparator::matches() is called once (since we don't split)
-        $this->indexSettingsComparator->expects($this->once())->method('matches');
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->once())->method('matches');
         // Only one taskID is collected (full payload with early return)
-        $this->connector->expects($this->once())->method('collectTaskIdToWaitFor');
+        $connector->expects($this->once())->method('collectTaskIdToWaitFor');
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config, $comparator);
+
+        $this->assertTrue($handler->setSettings($indexOptions, $settings));
     }
 
     public function testForwardSettingsWithEmptyInput(): void
@@ -191,20 +197,22 @@ class IndexSettingsHandlerTest extends TestCase
         $storeId = 1;
         $settings = [];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
 
         // Connector should not be called
-        $this->connector->expects($this->never())->method('setSettings');
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->never())->method('setSettings');
+        $connector->expects($this->never())->method('collectTaskIdToWaitFor');
 
         // IndexSettingsComparator::matches() is called once (empty array will always match and early return)
-        $this->indexSettingsComparator->expects($this->once())->method('matches');
-        $this->connector->expects($this->never())->method('collectTaskIdToWaitFor');
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->once())->method('matches');
 
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, $config, $comparator);
+
+        $this->assertTrue($handler->setSettings($this->createIndexOptionsStub($storeId), $settings));
     }
-
 
     public function testSplitSettings(): void
     {
@@ -214,7 +222,9 @@ class IndexSettingsHandlerTest extends TestCase
             'attributesToRetrieve' => ['name'],
         ];
 
-        [$forward, $noForward] = $this->invokeMethod($this->handler, 'splitSettings', [$settings]);
+        $handler = $this->createObjectToTest();
+
+        [$forward, $noForward] = $this->invokeMethod($handler, 'splitSettings', [$settings]);
 
         $this->assertEquals(['attributesToRetrieve' => ['name']], $forward);
         $this->assertEquals([
@@ -229,56 +239,46 @@ class IndexSettingsHandlerTest extends TestCase
         $storeId2 = 2;
         $settings = ['attributesToRetrieve' => ['name']];
 
-        $indexOptions1 = $this->createMock(IndexOptionsInterface::class);
-        $indexOptions1->method('getStoreId')->willReturn($storeId1);
+        $indexOptions1 = $this->createIndexOptionsStub($storeId1);
+        $indexOptions2 = $this->createIndexOptionsStub($storeId2);
 
-        $indexOptions2 = $this->createMock(IndexOptionsInterface::class);
-        $indexOptions2->method('getStoreId')->willReturn($storeId2);
-
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
 
         // Both calls should succeed as they use different store IDs
-        $this->connector->expects($this->exactly(2))
-            ->method('setSettings');
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->exactly(2))->method('setSettings');
+        $connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
 
         // IndexSettingsComparator::matches() is called 2 times:
-        // - once for the full payload of the 2 stores
-        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        // - once for the full payload of each of the 2 stores
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->exactly(2))->method('matches');
 
-        $this->connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
+        $handler = $this->createObjectToTest($connector, $config, $comparator);
 
-        $this->assertTrue($this->handler->setSettings($indexOptions1, $settings));
-        $this->assertTrue($this->handler->setSettings($indexOptions2, $settings));
+        $this->assertTrue($handler->setSettings($indexOptions1, $settings));
+        $this->assertTrue($handler->setSettings($indexOptions2, $settings));
     }
 
     public function testSkippedSetSettings(): void
     {
-        $indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
-        $indexSettingsComparator->method('matches')->willReturn(true);
-
-        $this->handler = new IndexSettingsHandler(
-            $this->connector,
-            $this->config,
-            $indexSettingsComparator,
-            $this->indexSettingsPreserver,
-            $this->logger,
-        );
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
             'attributesToRetrieve' => ['name'],
         ];
 
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-
         // IndexSettingsComparator::matches() is called once (match = early return)
-        $indexSettingsComparator->expects($this->once())->method('matches');
+        $comparator = $this->createMock(IndexSettingsComparator::class);
+        $comparator->expects($this->once())->method('matches')->willReturn(true);
 
-        $this->connector->expects($this->never())->method('collectTaskIdToWaitFor');
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->expects($this->never())->method('collectTaskIdToWaitFor');
 
-        $this->assertFalse($this->handler->setSettings($this->indexOptions, $settings));
+        $handler = $this->createObjectToTest($connector, comparator: $comparator);
+
+        $this->assertFalse($handler->setSettings($this->createIndexOptionsStub($storeId), $settings));
     }
 
     public function testGetSettingsCalledExactlyOncePerSetSettings(): void
@@ -288,26 +288,22 @@ class IndexSettingsHandlerTest extends TestCase
             ->method('getSettings')
             ->willReturn(['attributesForFaceting' => ['categories']]);
 
-        $preserver = $this->createMock(IndexSettingsPreserver::class);
-        $preserver->method('preserve')->willReturnArgument(0);
-
-        $comparator = $this->createMock(IndexSettingsComparator::class);
-        $comparator->method('matches')->willReturn(false);
-
-        $config = $this->createMock(ConfigHelper::class);
+        $config = $this->createStub(ConfigHelper::class);
         $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
+        $handler = $this->createObjectToTest($connector, $config);
 
-        $this->assertTrue($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
+        $this->assertTrue(
+            $handler->setSettings($this->createIndexOptionsStub(), ['attributesForFaceting' => ['categories']])
+        );
     }
 
     public function testPreserverInvokedBeforeComparator(): void
     {
         $order = [];
 
-        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector = $this->createStub(AlgoliaConnector::class);
+        // preserve() and matches() must both see the remote settings fetched exactly once.
         $connector->method('getSettings')->willReturn(['attributesForFaceting' => ['categories']]);
 
         $preserver = $this->createMock(IndexSettingsPreserver::class);
@@ -328,13 +324,12 @@ class IndexSettingsHandlerTest extends TestCase
                 return true;
             });
 
-        $config = $this->createMock(ConfigHelper::class);
+        $config = $this->createStub(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
+        $handler = $this->createObjectToTest($connector, $config, $comparator, $preserver);
 
-        $handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]);
+        $handler->setSettings($this->createIndexOptionsStub(), ['attributesForFaceting' => ['categories']]);
 
         $this->assertSame(['preserve', 'matches'], $order);
     }
@@ -346,22 +341,20 @@ class IndexSettingsHandlerTest extends TestCase
         $connector = $this->createMock(AlgoliaConnector::class);
         $connector->expects($this->once())->method('getSettings')->willReturn($remote);
 
-        $preserver = $this->createMock(IndexSettingsPreserver::class);
-        $preserver->method('preserve')->willReturnArgument(0);
+        $indexOptions = $this->createIndexOptionsStub();
 
         $comparator = $this->createMock(IndexSettingsComparator::class);
         $comparator->expects($this->once())
             ->method('matches')
-            ->with($this->indexOptions, $this->anything(), $remote)
+            ->with($indexOptions, $this->anything(), $remote)
             ->willReturn(true);
 
-        $config = $this->createMock(ConfigHelper::class);
+        $config = $this->createStub(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
+        $handler = $this->createObjectToTest($connector, $config, $comparator);
 
-        $this->assertFalse($handler->setSettings($this->indexOptions, ['attributesForFaceting' => ['categories']]));
+        $this->assertFalse($handler->setSettings($indexOptions, ['attributesForFaceting' => ['categories']]));
     }
 
     public function testNoOpDetectionAccountsForPreservedEntries(): void
@@ -374,19 +367,18 @@ class IndexSettingsHandlerTest extends TestCase
         // The only diff was the preserved entry, so no write should be issued.
         $connector->expects($this->never())->method('setSettings');
 
-        $preserver = $this->createMock(IndexSettingsPreserver::class);
+        $preserver = $this->createStub(IndexSettingsPreserver::class);
         $preserver->method('preserve')->willReturn(['attributesForFaceting' => ['a', 'b', '_x']]);
 
         // Use the real comparator so the no-op detection is genuinely exercised.
         $comparator = new IndexSettingsComparator($connector);
 
-        $config = $this->createMock(ConfigHelper::class);
+        $config = $this->createStub(ConfigHelper::class);
         $config->method('isLoggingEnabled')->willReturn(false);
 
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
+        $handler = $this->createObjectToTest($connector, $config, $comparator, $preserver);
 
-        $this->assertFalse($handler->setSettings($this->indexOptions, $proposed));
+        $this->assertFalse($handler->setSettings($this->createIndexOptionsStub(), $proposed));
     }
 
     #[DataProvider('settingsProvider')]
@@ -395,26 +387,24 @@ class IndexSettingsHandlerTest extends TestCase
         array $remote,
         bool $forwardToReplicas,
         int $expectedNumberOfTasksCollected
-    ) : void
-    {
+    ): void {
         $connector = $this->createMock(AlgoliaConnector::class);
         $connector->method('getSettings')->willReturn($remote);
-
-        $preserver = $this->createMock(IndexSettingsPreserver::class);
-        $preserver->method('preserve')->willReturn($proposed);
-
-        $comparator = new IndexSettingsComparator($connector);
-
-        $config = $this->createMock(ConfigHelper::class);
-        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn($forwardToReplicas);
-
-        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
-        $this->indexOptions->method('getStoreId')->willReturn(1);
-
         $connector->expects($this->exactly($expectedNumberOfTasksCollected))->method('setSettings');
         $connector->expects($this->exactly($expectedNumberOfTasksCollected))->method('collectTaskIdToWaitFor');
 
-        $handler->setSettings($this->indexOptions, $proposed);
+        $preserver = $this->createStub(IndexSettingsPreserver::class);
+        $preserver->method('preserve')->willReturn($proposed);
+
+        // Use the real comparator so the forward/no-forward split is genuinely exercised.
+        $comparator = new IndexSettingsComparator($connector);
+
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn($forwardToReplicas);
+
+        $handler = $this->createObjectToTest($connector, $config, $comparator, $preserver);
+
+        $handler->setSettings($this->createIndexOptionsStub(), $proposed);
     }
 
     public static function settingsProvider(): array

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -11,6 +11,7 @@ use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsHandler;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsPreserver;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[AllowMockObjectsWithoutExpectations]
 class IndexSettingsHandlerTest extends TestCase
@@ -25,12 +26,6 @@ class IndexSettingsHandlerTest extends TestCase
     protected ?IndexOptionsInterface $indexOptions = null;
 
     private ?IndexSettingsHandler $handler = null;
-
-    /**
-     * State machine to track pending operations per store ID
-     * Format: [storeId => ['totalCalls' => int, 'waitCalled' => bool, 'batchesCompleted' => int]]
-     */
-    private array $operationState = [];
 
     protected function setUp(): void
     {
@@ -392,5 +387,99 @@ class IndexSettingsHandlerTest extends TestCase
         $this->indexOptions->method('getStoreId')->willReturn(1);
 
         $this->assertFalse($handler->setSettings($this->indexOptions, $proposed));
+    }
+
+    #[DataProvider('settingsProvider')]
+    public function testBothForwardAndNoForwardChanged(
+        array $proposed,
+        array $remote,
+        bool $forwardToReplicas,
+        int $expectedNumberOfTasksCollected
+    ) : void
+    {
+        $connector = $this->createMock(AlgoliaConnector::class);
+        $connector->method('getSettings')->willReturn($remote);
+
+        $preserver = $this->createMock(IndexSettingsPreserver::class);
+        $preserver->method('preserve')->willReturn($proposed);
+
+        $comparator = new IndexSettingsComparator($connector);
+
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn($forwardToReplicas);
+
+        $handler = new IndexSettingsHandler($connector, $config, $comparator, $preserver, $this->logger);
+        $this->indexOptions->method('getStoreId')->willReturn(1);
+
+        $connector->expects($this->exactly($expectedNumberOfTasksCollected))->method('setSettings');
+        $connector->expects($this->exactly($expectedNumberOfTasksCollected))->method('collectTaskIdToWaitFor');
+
+        $handler->setSettings($this->indexOptions, $proposed);
+    }
+
+    public static function settingsProvider(): array
+    {
+        return [
+            [ // Both forward and noforward have changes => 2 collected tasks expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 2
+            ],
+            [ // Only forward has changes  => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+            [ // Only noforward has changes => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+            [ // forward and noforward are identical => 0 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'forwardToReplicas' => true,
+                'expectedNumberOfTasksCollected' => 0
+            ],
+            [ // Both forward and noforward have changes but forward to replicas is set to false => 1 collected task expected
+                'proposed' => [
+                    'customRanking' => ['desc(price)'],
+                    'attributesToRetrieve' => ['name']
+                ],
+                'remote' => [
+                    'customRanking' => ['asc(price)'],
+                    'attributesToRetrieve' => ['title']
+                ],
+                'forwardToReplicas' => false,
+                'expectedNumberOfTasksCollected' => 1
+            ],
+        ];
     }
 }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -97,8 +97,8 @@ class IndexSettingsHandlerTest extends TestCase
             'attributesToRetrieve' => ['name', 'price'],
         ];
 
-        $config = $this->createStub(ConfigHelper::class);
-        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->willReturn(true);
+        $config = $this->createMock(ConfigHelper::class);
+        $config->method('shouldForwardPrimaryIndexSettingsToReplicas')->with($storeId)->willReturn(true);
 
         $connector = $this->createStateMachineConnector();
 

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -390,7 +390,7 @@ class IndexSettingsHandlerTest extends TestCase
     }
 
     #[DataProvider('settingsProvider')]
-    public function testBothForwardAndNoForwardChanged(
+    public function testForwardAndNoForwardSettingsChanges(
         array $proposed,
         array $remote,
         bool $forwardToReplicas,

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Algolia\AlgoliaSearch\Test\Unit\Service\Index\Settings;
 
 use Algolia\AlgoliaSearch\Api\Data\IndexOptionsInterface;
+use Algolia\AlgoliaSearch\Controller\View\Index;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
@@ -44,9 +45,6 @@ class IndexSettingsHandlerTest extends TestCase
         $this->logger = $this->createMock(AlgoliaLogger::class);
         $this->indexOptions = $this->createMock(IndexOptionsInterface::class);
 
-        // Configure the mock to use our state machine
-        $this->setupStateMachineMock();
-
         $this->handler = new IndexSettingsHandler(
             $this->connector,
             $this->config,
@@ -56,51 +54,8 @@ class IndexSettingsHandlerTest extends TestCase
         );
     }
 
-    private function setupStateMachineMock(): void
-    {
-        $this->connector->method('setSettings')
-            ->willReturnCallback(function($indexOptions, $settings, $forwardToReplicas, $mergeSettings, $mergeFrom = '') {
-                $storeId = $indexOptions->getStoreId();
-
-                // Initialize state if not exists
-                if (!isset($this->operationState[$storeId])) {
-                    $this->operationState[$storeId] = [
-                        'setSettingsCalled' => false,
-                        'waitCalled' => false,
-                    ];
-                }
-
-//                // Check that setSettings is not stacked for this $storeId
-//                if ($this->operationState[$storeId]['setSettingsCalled'] &&
-//                    !$this->operationState[$storeId]['waitCalled']) {
-//                    throw new \RuntimeException(
-//                        // phpcs:ignore
-//                        "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
-//                    );
-//                }
-
-                // Update state
-                $this->operationState[$storeId]['setSettingsCalled'] = true;
-                $this->operationState[$storeId]['waitCalled'] = false;
-            });
-
-        $this->connector->method('waitLastTask')
-            ->willReturnCallback(function($storeId = null) {
-                if ($storeId !== null && isset($this->operationState[$storeId])) {
-                    $this->operationState[$storeId]['waitCalled'] = true;
-                }
-            });
-    }
-
-    private function resetOperationState(): void
-    {
-        $this->operationState = [];
-    }
-
     public function testSetSettingsWithForwardingEnabledAndMixedSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
@@ -136,13 +91,19 @@ class IndexSettingsHandlerTest extends TestCase
             }
             );
 
+        // IndexSettingsComparator::matches() is called 3 times:
+        // - once for the full payload
+        // - once for $forward
+        // - once for $noforward
+        $this->indexSettingsComparator->expects($this->exactly(3))->method('matches');
+        // Only two taskIDs are collected ($forward and $noforward
+        $this->connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyExcludedSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'ranking' => ['asc(name)'],
@@ -162,13 +123,18 @@ class IndexSettingsHandlerTest extends TestCase
                 false
             );
 
+        // IndexSettingsComparator::matches() is called 3 times:
+        // - once for the full payload
+        // - once for $noforward
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        // Only one taskID is collected ($noforward)
+        $this->connector->expects($this->once())->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingEnabledOnlyForwardableSettings(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'attributesToHighlight' => ['title'],
@@ -188,13 +154,18 @@ class IndexSettingsHandlerTest extends TestCase
                 true
             );
 
+        // IndexSettingsComparator::matches() is called 3 times:
+        // - once for the full payload
+        // - once for $forward
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+        // Only one taskID is collected ($forward)
+        $this->connector->expects($this->exactly(1))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testSetSettingsWithForwardingDisabled(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [
             'customRanking' => ['desc(price)'],
@@ -213,13 +184,16 @@ class IndexSettingsHandlerTest extends TestCase
                 false
             );
 
+        // IndexSettingsComparator::matches() is called once (since we don't split)
+        $this->indexSettingsComparator->expects($this->once())->method('matches');
+        // Only one taskID is collected (full payload with early return)
+        $this->connector->expects($this->once())->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
 
     public function testForwardSettingsWithEmptyInput(): void
     {
-        $this->resetOperationState();
-
         $storeId = 1;
         $settings = [];
 
@@ -229,6 +203,10 @@ class IndexSettingsHandlerTest extends TestCase
 
         // Connector should not be called
         $this->connector->expects($this->never())->method('setSettings');
+
+        // IndexSettingsComparator::matches() is called once (empty array will always match and early return)
+        $this->indexSettingsComparator->expects($this->once())->method('matches');
+        $this->connector->expects($this->never())->method('collectTaskIdToWaitFor');
 
         $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
     }
@@ -251,70 +229,8 @@ class IndexSettingsHandlerTest extends TestCase
         ], $noForward);
     }
 
-//    /**
-//     * Ensure the state machine is working as expected by disabling replica forwarding
-//     * and explicitly invoking subsequent setSettings operations
-//     */
-//    public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
-//    {
-//        $this->resetOperationState();
-//
-//        $storeId = 1;
-//        $settings = ['attributesToRetrieve' => ['name']];
-//
-//        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-//
-//        // Disable forwarding for explicit test
-//        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-//            ->willReturn(false);
-//
-//        // First call should succeed
-//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-//
-//        // Second call without wait should throw exception
-//        $this->expectException(\RuntimeException::class);
-//        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-//
-//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-//    }
-
-    /**
-     * Explicitly test the state machine succeeds by disabling replica forwarding
-     * and explicitly invoking the wait operation
-     * */
-    public function testSubsequentSetSettingsAfterWaitSucceeds(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = ['attributesToRetrieve' => ['name']];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        // Disable forwarding for explicit test
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
-
-        $this->connector->expects($this->exactly(2))
-            ->method('setSettings');
-
-        $this->connector->expects($this->once())
-            ->method('waitLastTask')
-            ->with($storeId);
-
-        // First call should succeed
-        $this->handler->setSettings($this->indexOptions, $settings);
-
-        // Wait for the task
-        $this->connector->waitLastTask($storeId);
-
-        // Second call after wait should succeed
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
-
     public function testDifferentStoreIdsDontInterfere(): void
     {
-        $this->resetOperationState();
-
         $storeId1 = 1;
         $storeId2 = 2;
         $settings = ['attributesToRetrieve' => ['name']];
@@ -332,48 +248,18 @@ class IndexSettingsHandlerTest extends TestCase
         $this->connector->expects($this->exactly(2))
             ->method('setSettings');
 
+        // IndexSettingsComparator::matches() is called 2 times:
+        // - once for the full payload of the 2 stores
+        $this->indexSettingsComparator->expects($this->exactly(2))->method('matches');
+
+        $this->connector->expects($this->exactly(2))->method('collectTaskIdToWaitFor');
+
         $this->assertTrue($this->handler->setSettings($indexOptions1, $settings));
         $this->assertTrue($this->handler->setSettings($indexOptions2, $settings));
     }
 
-//    /**
-//     *  Replica forwarding should abstract the wait operation internally
-//     *  However require caller to invoke wait for subsequent ops
-//     *  This is *by design* to minimize unnecessary IO blocking
-//     *  This test ensures this logic stays in place
-//     */
-//    public function testForwardingEnabledMultipleCallsRequireWait(): void
-//    {
-//        $this->resetOperationState();
-//
-//        $storeId = 1;
-//        $settings = [
-//            'customRanking' => ['desc(price)'],
-//            'attributesToRetrieve' => ['name'],
-//        ];
-//
-//        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-//        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-//            ->willReturn(true);
-//
-//        // 2 internal calls + 1 explicit call
-//        $this->connector->expects($this->exactly(3))
-//            ->method('setSettings');
-//
-//        // First call makes two internal setSettings calls
-//        $this->handler->setSettings($this->indexOptions, $settings);
-//
-//        // Second call to handler should fail because no wait was called
-//        $this->expectException(\RuntimeException::class);
-//        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-//
-//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-//    }
-
     public function testSkippedSetSettings(): void
     {
-        $this->resetOperationState();
-
         $indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
         $indexSettingsComparator->method('matches')->willReturn(true);
 
@@ -392,6 +278,11 @@ class IndexSettingsHandlerTest extends TestCase
         ];
 
         $this->indexOptions->method('getStoreId')->willReturn($storeId);
+
+        // IndexSettingsComparator::matches() is called once (match = early return)
+        $indexSettingsComparator->expects($this->once())->method('matches');
+
+        $this->connector->expects($this->never())->method('collectTaskIdToWaitFor');
 
         $this->assertFalse($this->handler->setSettings($this->indexOptions, $settings));
     }

--- a/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsHandlerTest.php
@@ -70,14 +70,14 @@ class IndexSettingsHandlerTest extends TestCase
                     ];
                 }
 
-                // Check that setSettings is not stacked for this $storeId
-                if ($this->operationState[$storeId]['setSettingsCalled'] &&
-                    !$this->operationState[$storeId]['waitCalled']) {
-                    throw new \RuntimeException(
-                        // phpcs:ignore
-                        "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
-                    );
-                }
+//                // Check that setSettings is not stacked for this $storeId
+//                if ($this->operationState[$storeId]['setSettingsCalled'] &&
+//                    !$this->operationState[$storeId]['waitCalled']) {
+//                    throw new \RuntimeException(
+//                        // phpcs:ignore
+//                        "Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first."
+//                    );
+//                }
 
                 // Update state
                 $this->operationState[$storeId]['setSettingsCalled'] = true;
@@ -251,32 +251,32 @@ class IndexSettingsHandlerTest extends TestCase
         ], $noForward);
     }
 
-    /**
-     * Ensure the state machine is working as expected by disabling replica forwarding
-     * and explicitly invoking subsequent setSettings operations
-     */
-    public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = ['attributesToRetrieve' => ['name']];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-
-        // Disable forwarding for explicit test
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(false);
-
-        // First call should succeed
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-
-        // Second call without wait should throw exception
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
+//    /**
+//     * Ensure the state machine is working as expected by disabling replica forwarding
+//     * and explicitly invoking subsequent setSettings operations
+//     */
+//    public function testSubsequentSetSettingsWithoutWaitThrowsException(): void
+//    {
+//        $this->resetOperationState();
+//
+//        $storeId = 1;
+//        $settings = ['attributesToRetrieve' => ['name']];
+//
+//        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+//
+//        // Disable forwarding for explicit test
+//        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+//            ->willReturn(false);
+//
+//        // First call should succeed
+//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+//
+//        // Second call without wait should throw exception
+//        $this->expectException(\RuntimeException::class);
+//        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
+//
+//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+//    }
 
     /**
      * Explicitly test the state machine succeeds by disabling replica forwarding
@@ -336,39 +336,39 @@ class IndexSettingsHandlerTest extends TestCase
         $this->assertTrue($this->handler->setSettings($indexOptions2, $settings));
     }
 
-    /**
-     *  Replica forwarding should abstract the wait operation internally
-     *  However require caller to invoke wait for subsequent ops
-     *  This is *by design* to minimize unnecessary IO blocking
-     *  This test ensures this logic stays in place
-     */
-    public function testForwardingEnabledMultipleCallsRequireWait(): void
-    {
-        $this->resetOperationState();
-
-        $storeId = 1;
-        $settings = [
-            'customRanking' => ['desc(price)'],
-            'attributesToRetrieve' => ['name'],
-        ];
-
-        $this->indexOptions->method('getStoreId')->willReturn($storeId);
-        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
-            ->willReturn(true);
-
-        // 2 internal calls + 1 explicit call
-        $this->connector->expects($this->exactly(3))
-            ->method('setSettings');
-
-        // First call makes two internal setSettings calls
-        $this->handler->setSettings($this->indexOptions, $settings);
-
-        // Second call to handler should fail because no wait was called
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
-
-        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
-    }
+//    /**
+//     *  Replica forwarding should abstract the wait operation internally
+//     *  However require caller to invoke wait for subsequent ops
+//     *  This is *by design* to minimize unnecessary IO blocking
+//     *  This test ensures this logic stays in place
+//     */
+//    public function testForwardingEnabledMultipleCallsRequireWait(): void
+//    {
+//        $this->resetOperationState();
+//
+//        $storeId = 1;
+//        $settings = [
+//            'customRanking' => ['desc(price)'],
+//            'attributesToRetrieve' => ['name'],
+//        ];
+//
+//        $this->indexOptions->method('getStoreId')->willReturn($storeId);
+//        $this->config->method('shouldForwardPrimaryIndexSettingsToReplicas')
+//            ->willReturn(true);
+//
+//        // 2 internal calls + 1 explicit call
+//        $this->connector->expects($this->exactly(3))
+//            ->method('setSettings');
+//
+//        // First call makes two internal setSettings calls
+//        $this->handler->setSettings($this->indexOptions, $settings);
+//
+//        // Second call to handler should fail because no wait was called
+//        $this->expectException(\RuntimeException::class);
+//        $this->expectExceptionMessage("Cannot call setSettings on store $storeId: previous operation still pending. Call waitLastTask first.");
+//
+//        $this->assertTrue($this->handler->setSettings($this->indexOptions, $settings));
+//    }
 
     public function testSkippedSetSettings(): void
     {

--- a/Test/Unit/Service/Index/Settings/IndexSettingsPreserverTest.php
+++ b/Test/Unit/Service/Index/Settings/IndexSettingsPreserverTest.php
@@ -5,22 +5,24 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Service\Index\Settings;
 use Algolia\AlgoliaSearch\Logger\AlgoliaLogger;
 use Algolia\AlgoliaSearch\Service\Index\Settings\IndexSettingsPreserver;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class IndexSettingsPreserverTest extends TestCase
 {
-    protected ?AlgoliaLogger $logger = null;
-
-    protected function setUp(): void
+    protected function createObjectToTest(?AlgoliaLogger $logger = null, ?array $rules = null): IndexSettingsPreserver
     {
-        $this->logger = $this->createMock(AlgoliaLogger::class);
+        $logger ??= $this->createStub(AlgoliaLogger::class);
+
+        return $rules === null
+            ? new IndexSettingsPreserver($logger)
+            : new IndexSettingsPreserver($logger, $rules);
     }
 
     public function testPreservesUnderscoreEntryAbsentFromProposed(): void
     {
-        $this->logger->expects($this->never())->method('warning');
-        $preserver = new IndexSettingsPreserver($this->logger);
+        $logger = $this->createMock(AlgoliaLogger::class);
+        $logger->expects($this->never())->method('warning');
+
+        $preserver = $this->createObjectToTest($logger);
 
         $proposed = ['attributesForFaceting' => ['categories', 'searchable(color)']];
         $remote = ['attributesForFaceting' => ['categories', 'searchable(color)', '_collections']];
@@ -34,8 +36,10 @@ class IndexSettingsPreserverTest extends TestCase
 
     public function testPreservesDecoratedUnderscoreEntry(): void
     {
-        $this->logger->expects($this->never())->method('warning');
-        $preserver = new IndexSettingsPreserver($this->logger);
+        $logger = $this->createMock(AlgoliaLogger::class);
+        $logger->expects($this->never())->method('warning');
+
+        $preserver = $this->createObjectToTest($logger);
 
         $proposed = ['attributesForFaceting' => ['categories']];
         $remote = ['attributesForFaceting' => ['categories', 'filterOnly(_collections)']];
@@ -48,8 +52,10 @@ class IndexSettingsPreserverTest extends TestCase
 
     public function testReturnsProposedUnchangedWhenNoApplicableKey(): void
     {
-        $this->logger->expects($this->never())->method('warning');
-        $preserver = new IndexSettingsPreserver($this->logger);
+        $logger = $this->createMock(AlgoliaLogger::class);
+        $logger->expects($this->never())->method('warning');
+
+        $preserver = $this->createObjectToTest($logger);
 
         $proposed = ['replicas' => ['magento2_default_products_price_asc']];
         $remote = ['attributesForFaceting' => ['_collections']];
@@ -61,10 +67,12 @@ class IndexSettingsPreserverTest extends TestCase
 
     public function testRemoteWinsAndLogsWhenProposedContainsProtectedEntry(): void
     {
-        $this->logger->expects($this->once())
+        $logger = $this->createMock(AlgoliaLogger::class);
+        $logger->expects($this->once())
             ->method('warning')
             ->with($this->stringContains('_foo'));
-        $preserver = new IndexSettingsPreserver($this->logger);
+
+        $preserver = $this->createObjectToTest($logger);
 
         $proposed = ['attributesForFaceting' => ['categories', '_foo']];
         $remote = ['attributesForFaceting' => ['_foo']];
@@ -79,8 +87,10 @@ class IndexSettingsPreserverTest extends TestCase
 
     public function testEmptyRemoteReturnsProposedUnchanged(): void
     {
-        $this->logger->expects($this->never())->method('warning');
-        $preserver = new IndexSettingsPreserver($this->logger);
+        $logger = $this->createMock(AlgoliaLogger::class);
+        $logger->expects($this->never())->method('warning');
+
+        $preserver = $this->createObjectToTest($logger);
 
         $proposed = ['attributesForFaceting' => ['categories', 'searchable(color)']];
         $remote = [];
@@ -92,8 +102,10 @@ class IndexSettingsPreserverTest extends TestCase
 
     public function testCustomRulesArgumentOverridesDefaults(): void
     {
-        $this->logger->expects($this->never())->method('warning');
-        $preserver = new IndexSettingsPreserver($this->logger, ['searchableAttributes' => '/^algolia_/']);
+        $logger = $this->createMock(AlgoliaLogger::class);
+        $logger->expects($this->never())->method('warning');
+
+        $preserver = $this->createObjectToTest($logger, ['searchableAttributes' => '/^algolia_/']);
 
         $proposed = [
             'searchableAttributes' => ['name'],
@@ -113,7 +125,12 @@ class IndexSettingsPreserverTest extends TestCase
 
     public function testDeduplicatesWhenRemotePreservedEntryAlreadyInProposed(): void
     {
-        $preserver = new IndexSettingsPreserver($this->logger);
+        $logger = $this->createMock(AlgoliaLogger::class);
+        // The decorated entry already present in $proposed matches the protected pattern too,
+        // so it's dropped and logged before being merged back in from $remote.
+        $logger->expects($this->once())->method('warning');
+
+        $preserver = $this->createObjectToTest($logger);
 
         $proposed = ['attributesForFaceting' => ['categories', 'filterOnly(_collections)']];
         $remote = ['attributesForFaceting' => ['filterOnly(_collections)']];

--- a/Test/Unit/Service/Insights/EventProcessorTest.php
+++ b/Test/Unit/Service/Insights/EventProcessorTest.php
@@ -10,46 +10,67 @@ use Algolia\AlgoliaSearch\Service\Insights\EventProcessor;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Catalog\Model\Product;
 use Magento\Directory\Model\Currency;
+use Magento\Framework\Locale\FormatInterface as LocaleFormatInterface;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Quote\Model\Quote\Item;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Item as OrderItem;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Tax\Model\Config as TaxConfig;
-use Magento\Framework\Locale\FormatInterface as LocaleFormatInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class EventProcessorTest extends TestCase
 {
-    protected ?TaxConfig $taxConfig = null;
-    protected ?StoreManagerInterface $storeManager = null;
-    protected ?Store $store = null;
-    protected ?LocaleFormatInterface $localeFormat = null;
-    protected ?Currency $currency = null;
-    protected ?InsightsClient $insightsClient = null;
-    protected ?EventProcessor $eventProcessor = null;
+    protected function createObjectToTest(
+        ?TaxConfig $taxConfig = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?LocaleFormatInterface $localeFormat = null,
+    ): EventProcessor {
+        return new EventProcessor(
+            $taxConfig ?? $this->createStub(TaxConfig::class),
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $localeFormat ?? $this->createStub(LocaleFormatInterface::class),
+        );
+    }
 
-    public function setUp(): void
-    {
-        $this->taxConfig =  $this->createMock(TaxConfig::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->store = $this->createMock(Store::class);
-        $this->localeFormat = $this->createMock(LocaleFormatInterface::class);
-        $this->currency = $this->createMock(Currency::class);
-        $this->insightsClient = $this->createMock(InsightsClient::class);
-        $this->eventProcessor = new EventProcessor($this->taxConfig, $this->storeManager, $this->localeFormat);
+    private function createFullyConfiguredEventProcessor(
+        ?InsightsClient $insightsClient = null,
+        ?TaxConfig $taxConfig = null,
+        int $decimalPrecision = PriceCurrencyInterface::DEFAULT_PRECISION,
+    ): EventProcessor {
+        $currency = $this->createStub(Currency::class);
+        $currency->method('getCode')->willReturn('USD');
+
+        $store = $this->createStub(Store::class);
+        $store->method('getCurrentCurrency')->willReturn($currency);
+        $store->method('getId')->willReturn(1);
+
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $localeFormat = $this->createStub(LocaleFormatInterface::class);
+        $localeFormat->method('getPriceFormat')->willReturn(['requiredPrecision' => $decimalPrecision]);
+
+        $eventProcessor = $this->createObjectToTest($taxConfig, $storeManager, $localeFormat);
+
+        $eventProcessor
+            ->setInsightsClient($insightsClient ?? $this->createStub(InsightsClient::class))
+            ->setAnonymousUserToken('user-token');
+
+        return $eventProcessor;
     }
 
     // Test dependency validation and setup methods
 
     public function testConvertedObjectIDsAfterSearchThrowsExceptionWhenMissingDependencies(): void
     {
+        $eventProcessor = $this->createObjectToTest();
+
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessage('Events model is missing necessary dependencies to function.');
 
-        $this->eventProcessor->convertedObjectIDsAfterSearch(
+        $eventProcessor->convertedObjectIDsAfterSearch(
             'test-event',
             'test-index',
             ['1', '2', '3'],
@@ -59,12 +80,13 @@ class EventProcessorTest extends TestCase
 
     public function testConvertedObjectIDsAfterSearchThrowsExceptionWhenUserTokenMissing(): void
     {
-        $this->eventProcessor->setInsightsClient($this->insightsClient);
+        $eventProcessor = $this->createObjectToTest();
+        $eventProcessor->setInsightsClient($this->createStub(InsightsClient::class));
 
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessage('Events model is missing necessary dependencies to function.');
 
-        $this->eventProcessor->convertedObjectIDsAfterSearch(
+        $eventProcessor->convertedObjectIDsAfterSearch(
             'test-event',
             'test-index',
             ['1', '2', '3'],
@@ -74,13 +96,13 @@ class EventProcessorTest extends TestCase
 
     public function testConvertedObjectIDsAfterSearchThrowsExceptionWhenInsightsClientMissing(): void
     {
-        $this->eventProcessor
-            ->setAnonymousUserToken('user-token');
+        $eventProcessor = $this->createObjectToTest();
+        $eventProcessor->setAnonymousUserToken('user-token');
 
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessage('Events model is missing necessary dependencies to function.');
 
-        $this->eventProcessor->convertedObjectIDsAfterSearch(
+        $eventProcessor->convertedObjectIDsAfterSearch(
             'test-event',
             'test-index',
             ['1', '2', '3'],
@@ -92,9 +114,8 @@ class EventProcessorTest extends TestCase
 
     public function testConvertedObjectIDsAfterSearchWithAllDependencies(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -116,7 +137,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $result = $this->eventProcessor->convertedObjectIDsAfterSearch(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertedObjectIDsAfterSearch(
             'test-event',
             'test-index',
             ['1', '2', '3'],
@@ -126,10 +149,8 @@ class EventProcessorTest extends TestCase
 
     public function testConvertedObjectIDsAfterSearchWithAuthenticatedToken(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-        $this->eventProcessor->setAuthenticatedUserToken('auth-token-123');
-
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -143,7 +164,10 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertedObjectIDsAfterSearch(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+        $eventProcessor->setAuthenticatedUserToken('auth-token-123');
+
+        $eventProcessor->convertedObjectIDsAfterSearch(
             'test-event',
             'test-index',
             ['1'],
@@ -155,9 +179,8 @@ class EventProcessorTest extends TestCase
 
     public function testConvertedObjectIDs(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -175,7 +198,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertedObjectIDs(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertedObjectIDs(
             'test-event',
             'test-index',
             ['1', '2']
@@ -186,12 +211,11 @@ class EventProcessorTest extends TestCase
 
     public function testConvertAddToCart(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
+        $product = $this->createProductStub('123', 100.0);
+        $item = $this->createItemStub($product, 85.0, 2);
 
-        $product = $this->createMockProduct('123', 100.0);
-        $item = $this->createMockItem($product, 85.0, 2);
-
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -210,7 +234,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertAddToCart(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertAddToCart(
             'add-to-cart-event',
             'products-index',
             $item,
@@ -220,12 +246,11 @@ class EventProcessorTest extends TestCase
 
     public function testConvertAddToCartWithoutQueryID(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
+        $product = $this->createProductStub('123', 100.0);
+        $item = $this->createItemStub($product, 80.0, 1);
 
-        $product = $this->createMockProduct('123', 100.0);
-        $item = $this->createMockItem($product, 80.0, 1);
-
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -239,7 +264,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertAddToCart(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertAddToCart(
             'add-to-cart-event',
             'products-index',
             $item
@@ -248,12 +275,11 @@ class EventProcessorTest extends TestCase
 
     public function testConvertAddToCartFloatingPointPrecision(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
+        $product = $this->createProductStub('123', 23.99);
+        $item = $this->createItemStub($product, 23.93, 1);
 
-        $product = $this->createMockProduct('123', 23.99);
-        $item = $this->createMockItem($product, 23.93, 1);
-
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -267,7 +293,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertAddToCart(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertAddToCart(
             'add-to-cart-event',
             'products-index',
             $item
@@ -276,13 +304,11 @@ class EventProcessorTest extends TestCase
 
     public function testConvertAddToCartWithStandardDecimalPrecision(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-        $this->setupCurrencyPrecision(2);
+        $product = $this->createProductStub('123', 23.992);
+        $item = $this->createItemStub($product, 23.931, 1);
 
-        $product = $this->createMockProduct('123', 23.992);
-        $item = $this->createMockItem($product, 23.931, 1);
-
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -296,7 +322,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertAddToCart(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient, decimalPrecision: 2);
+
+        $eventProcessor->convertAddToCart(
             'add-to-cart-event',
             'products-index',
             $item
@@ -305,13 +333,11 @@ class EventProcessorTest extends TestCase
 
     public function testConvertAddToCartWith3PointDecimalPrecision(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-        $this->setupCurrencyPrecision(3);
+        $product = $this->createProductStub('123', 23.992);
+        $item = $this->createItemStub($product, 23.931, 1);
 
-        $product = $this->createMockProduct('123', 23.992);
-        $item = $this->createMockItem($product, 23.931, 1);
-
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -325,7 +351,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertAddToCart(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient, decimalPrecision: 3);
+
+        $eventProcessor->convertAddToCart(
             'add-to-cart-event',
             'products-index',
             $item
@@ -335,14 +363,13 @@ class EventProcessorTest extends TestCase
     // Test convertPurchaseForItems
     public function testConvertPurchaseForItems(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
         $items = $this->createOrderItems([
             ['id' => '1', 'price' => 50.0, 'originalPrice' => 60.0, 'cartDiscountAmount' => 10.0, 'qtyOrdered' => 2],
             ['id' => '2', 'price' => 30.0, 'originalPrice' => 35.0, 'cartDiscountAmount' => 5.0, 'qtyOrdered' => 1],
         ]);
 
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -366,7 +393,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertPurchaseForItems(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertPurchaseForItems(
             'purchase-event',
             'products-index',
             $items,
@@ -376,8 +405,6 @@ class EventProcessorTest extends TestCase
 
     public function testConvertPurchaseForItemsEnforcesObjectLimit(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
         // Create more items than the limit allows
         $itemsData = [];
         for ($i = 1; $i <= 25; $i++) {
@@ -385,13 +412,14 @@ class EventProcessorTest extends TestCase
         }
         $items = $this->createOrderItems($itemsData);
 
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        // Should be limited to MAX_OBJECT_IDS_PER_EVENT (20)
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
                 $this->callback(function ($payload) {
                     $event = $payload['events'][0];
-                    // Should be limited to MAX_OBJECT_IDS_PER_EVENT (20)
                     $this->assertCount(EventProcessorInterface::MAX_OBJECT_IDS_PER_EVENT, $event['objectIDs']);
                     $this->assertCount(EventProcessorInterface::MAX_OBJECT_IDS_PER_EVENT, $event['objectData']);
                     // But value should include all 25 items
@@ -403,7 +431,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertPurchaseForItems(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertPurchaseForItems(
             'purchase-event',
             'products-index',
             $items
@@ -412,15 +442,14 @@ class EventProcessorTest extends TestCase
 
     public function testConvertPurchaseForItemsFloatingPointPrecision(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
         // These additions should trigger floating point precision errors if rounding is not applied
         $items = $this->createOrderItems([
             ['id' => '1', 'price' => 10.10, 'originalPrice' => 15.00, 'cartDiscountAmount' => 0, 'qtyOrdered' => 1],
             ['id' => '2', 'price' => 33.20, 'originalPrice' => 35.00, 'cartDiscountAmount' => 0, 'qtyOrdered' => 1],
         ]);
 
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -438,7 +467,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertPurchaseForItems(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertPurchaseForItems(
             'purchase-event',
             'products-index',
             $items,
@@ -452,14 +483,13 @@ class EventProcessorTest extends TestCase
      */
     public function testConvertPurchaseForItemsFloatingPointPrecisionWithCartDiscount(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
         // These additions should trigger floating point precision errors if rounding is not applied
         $items = $this->createOrderItems([
             ['id' => '1', 'price' => 10.00, 'originalPrice' => 10.00, 'cartDiscountAmount' => .30, 'qtyOrdered' => 3],
         ]);
 
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -476,7 +506,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertPurchaseForItems(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertPurchaseForItems(
             'purchase-event',
             'products-index',
             $items,
@@ -488,9 +520,7 @@ class EventProcessorTest extends TestCase
 
     public function testConvertPurchaseGroupsByQueryID(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
-        $order = $this->createMock(Order::class);
+        $order = $this->createStub(Order::class);
 
         $items = [
             $this->createOrderItemWithQueryId('1', 'query-1', 50.0, 1),
@@ -501,7 +531,8 @@ class EventProcessorTest extends TestCase
 
         $order->method('getAllVisibleItems')->willReturn($items);
 
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -519,7 +550,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $result = $this->eventProcessor->convertPurchase(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $result = $eventProcessor->convertPurchase(
             'purchase-event',
             'products-index',
             $order
@@ -530,9 +563,7 @@ class EventProcessorTest extends TestCase
 
     public function testConvertPurchaseHandlesLargeOrders(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
-        $order = $this->createMock(Order::class);
+        $order = $this->createStub(Order::class);
 
         // Create more events than MAX_EVENTS_PER_REQUEST allows
         $items = [];
@@ -542,13 +573,16 @@ class EventProcessorTest extends TestCase
 
         $order->method('getAllVisibleItems')->willReturn($items);
 
+        $insightsClient = $this->createMock(InsightsClient::class);
         // Should be called twice due to chunking (1000 + 500)
-        $this->insightsClient
+        $insightsClient
             ->expects($this->exactly(2))
             ->method('pushEvents')
             ->willReturn(['status' => 'ok']);
 
-        $result = $this->eventProcessor->convertPurchase(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $result = $eventProcessor->convertPurchase(
             'purchase-event',
             'products-index',
             $order
@@ -562,8 +596,6 @@ class EventProcessorTest extends TestCase
      */
     public function testConvertPurchaseUsesStringIds(): void
     {
-        $this->setupFullyConfiguredEventProcessor();
-
         // These additions should trigger floating point precision errors if rounding is not applied
         $items = $this->createOrderItems([
             ['id' => 10, 'price' => 10.00, 'originalPrice' => 10.00, 'cartDiscountAmount' => 0, 'qtyOrdered' => 1],
@@ -571,7 +603,8 @@ class EventProcessorTest extends TestCase
             ['id' => 30.0, 'price' => 30.00, 'originalPrice' => 30.00, 'cartDiscountAmount' => 0, 'qtyOrdered' => 1],
         ]);
 
-        $this->insightsClient
+        $insightsClient = $this->createMock(InsightsClient::class);
+        $insightsClient
             ->expects($this->once())
             ->method('pushEvents')
             ->with(
@@ -588,7 +621,9 @@ class EventProcessorTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $this->eventProcessor->convertPurchaseForItems(
+        $eventProcessor = $this->createFullyConfiguredEventProcessor($insightsClient);
+
+        $eventProcessor->convertPurchaseForItems(
             'purchase-event',
             'products-index',
             $items,
@@ -596,34 +631,32 @@ class EventProcessorTest extends TestCase
         );
     }
 
-
     // Test protected methods
 
     #[DataProvider('orderItemsProvider')]
     public function testObjectDataForPurchase($priceIncludesTax, $orderItemsData, $expectedResult, $expectedTotalRevenue): void
     {
-        $this->setupFullyConfiguredEventProcessor();
+        $taxConfig = $this->createStub(TaxConfig::class);
+        $taxConfig->method('priceIncludesTax')->willReturn($priceIncludesTax);
 
-        $this->taxConfig->method('priceIncludesTax')->willReturn($priceIncludesTax);
+        $eventProcessor = $this->createFullyConfiguredEventProcessor(taxConfig: $taxConfig);
 
         $orderItems = [];
 
         foreach ($orderItemsData as $orderItemData) {
-            $orderItem = $this->getMockBuilder(OrderItem::class)
-                ->disableOriginalConstructor()
-                ->getMock();
+            $orderItem = $this->createStub(OrderItem::class);
 
-            foreach ($orderItemData as $method => $value){
+            foreach ($orderItemData as $method => $value) {
                 $orderItem->method($method)->willReturn($value);
             }
 
             $orderItems[] = $orderItem;
         }
 
-        $object = $this->invokeMethod($this->eventProcessor, 'getObjectDataForPurchase', [$orderItems]);
+        $object = $this->invokeMethod($eventProcessor, 'getObjectDataForPurchase', [$orderItems]);
         $this->assertEquals($expectedResult, $object);
 
-        $totalRevenue = $this->invokeMethod($this->eventProcessor, 'getTotalRevenueForEvent', [$object]);
+        $totalRevenue = $this->invokeMethod($eventProcessor, 'getTotalRevenueForEvent', [$object]);
         $this->assertEquals($expectedTotalRevenue, $totalRevenue);
     }
 
@@ -749,38 +782,18 @@ class EventProcessorTest extends TestCase
 
     // Helper methods
 
-    protected function setupFullyConfiguredEventProcessor(): void
+    protected function createProductStub(string $id, float $price): Product
     {
-        $this->currency->method('getCode')->willReturn('USD');
-        $this->store->method('getCurrentCurrency')->willReturn($this->currency);
-        $this->store->method('getId')->willReturn(1);
-        $this->storeManager->method('getStore')->willReturn($this->store);
-
-        $this->eventProcessor
-            ->setInsightsClient($this->insightsClient)
-            ->setAnonymousUserToken('user-token');
-    }
-
-    protected function setupCurrencyPrecision(int $decimalPrecision = \Magento\Framework\Pricing\PriceCurrencyInterface::DEFAULT_PRECISION): void
-    {
-        $this->localeFormat->method('getPriceFormat')->willReturn([
-            'requiredPrecision' => $decimalPrecision,
-        ]);
-        $this->invokeMethod($this->eventProcessor, 'initDecimalPrecision');
-    }
-
-    protected function createMockProduct(string $id, float $price): Product
-    {
-        $product = $this->createMock(Product::class);
+        $product = $this->createStub(Product::class);
         $product->method('getId')->willReturn($id);
         $product->method('getPrice')->willReturn($price);
 
         return $product;
     }
 
-    protected function createMockItem(Product $product, float $salePrice, int $qtyToAdd): Item
+    protected function createItemStub(Product $product, float $salePrice, int $qtyToAdd): Item
     {
-        $item = $this->createMock(Item::class);
+        $item = $this->createStub(Item::class);
         $item->method('getProduct')->willReturn($product);
         $item->method('getData')
             ->willReturnMap([
@@ -796,10 +809,10 @@ class EventProcessorTest extends TestCase
     {
         $items = [];
         foreach ($itemsData as $data) {
-            $product = $this->createMock(Product::class);
+            $product = $this->createStub(Product::class);
             $product->method('getId')->willReturn($data['id']);
 
-            $item = $this->createMock(OrderItem::class);
+            $item = $this->createStub(OrderItem::class);
             $item->method('getProduct')->willReturn($product);
             $item->method('getPrice')->willReturn($data['price']);
             $item->method('getOriginalPrice')->willReturn($data['originalPrice']);
@@ -814,10 +827,10 @@ class EventProcessorTest extends TestCase
 
     protected function createOrderItemWithQueryId(string $id, ?string $queryId, float $price, int $qty): OrderItem
     {
-        $product = $this->createMock(Product::class);
+        $product = $this->createStub(Product::class);
         $product->method('getId')->willReturn($id);
 
-        $item = $this->createMock(OrderItem::class);
+        $item = $this->createStub(OrderItem::class);
         $item->method('getProduct')->willReturn($product);
         $item->method('getPrice')->willReturn($price);
         $item->method('getOriginalPrice')->willReturn($price);
@@ -825,10 +838,10 @@ class EventProcessorTest extends TestCase
         $item->method('getQtyOrdered')->willReturn($qty);
 
         if ($queryId !== null) {
-            $item->method('hasData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn(true);
-            $item->method('getData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn($queryId);
+            $item->method('hasData')->willReturn(true);
+            $item->method('getData')->willReturn($queryId);
         } else {
-            $item->method('hasData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn(false);
+            $item->method('hasData')->willReturn(false);
         }
 
         return $item;

--- a/Test/Unit/Service/Insights/EventProcessorTest.php
+++ b/Test/Unit/Service/Insights/EventProcessorTest.php
@@ -830,7 +830,7 @@ class EventProcessorTest extends TestCase
         $product = $this->createStub(Product::class);
         $product->method('getId')->willReturn($id);
 
-        $item = $this->createStub(OrderItem::class);
+        $item = $this->createMock(OrderItem::class);
         $item->method('getProduct')->willReturn($product);
         $item->method('getPrice')->willReturn($price);
         $item->method('getOriginalPrice')->willReturn($price);
@@ -838,10 +838,10 @@ class EventProcessorTest extends TestCase
         $item->method('getQtyOrdered')->willReturn($qty);
 
         if ($queryId !== null) {
-            $item->method('hasData')->willReturn(true);
-            $item->method('getData')->willReturn($queryId);
+            $item->method('hasData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn(true);
+            $item->method('getData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn($queryId);
         } else {
-            $item->method('hasData')->willReturn(false);
+            $item->method('hasData')->with(InsightsHelper::QUOTE_ITEM_QUERY_PARAM)->willReturn(false);
         }
 
         return $item;

--- a/Test/Unit/Service/Product/BatchQueueProcessorTest.php
+++ b/Test/Unit/Service/Product/BatchQueueProcessorTest.php
@@ -20,50 +20,30 @@ use Algolia\AlgoliaSearch\Service\Product\IndexOptionsBuilder;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\Exception\NoSuchEntityException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class BatchQueueProcessorTest extends TestCase
 {
-    protected ?Data $dataHelper;
-    protected ?ConfigHelper $configHelper;
-    protected ?ProductHelper $productHelper;
-    protected ?QueueHelper $queueHelper;
-    protected ?Queue $queue;
-    protected ?DiagnosticsLogger $diag;
-    protected ?AlgoliaCredentialsManager $algoliaCredentialsManager;
-    protected ?IndexBuilder $indexBuilder;
-    protected ?IndexCollectionSize $indexCollectionSizeCache;
-    protected ?BatchQueueProcessor $processor;
-    protected ?IndexOptionsBuilder $indexOptionsBuilder;
-    protected IndexSettingsComparator $indexSettingsComparator;
-
-    protected function setUp(): void
-    {
-        $this->dataHelper = $this->createMock(Data::class);
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->productHelper = $this->createMock(ProductHelper::class);
-        $this->queue = $this->createMock(Queue::class);
-        $this->diag = $this->createMock(DiagnosticsLogger::class);
-        $this->algoliaCredentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
-        $this->indexBuilder = $this->createMock(IndexBuilder::class);
-        $this->indexCollectionSizeCache = $this->createMock(IndexCollectionSize::class);
-        $this->queueHelper = $this->createMock(QueueHelper::class);
-        $this->indexOptionsBuilder = $this->createMock(IndexOptionsBuilder::class);
-        $this->indexSettingsComparator = $this->createMock(IndexSettingsComparator::class);
-
-        $this->processor = new BatchQueueProcessor(
-            $this->dataHelper,
-            $this->configHelper,
-            $this->productHelper,
-            $this->queueHelper,
-            $this->queue,
-            $this->diag,
-            $this->algoliaCredentialsManager,
-            $this->indexBuilder,
-            $this->indexCollectionSizeCache,
-            $this->indexOptionsBuilder,
-            $this->indexSettingsComparator
+    protected function createObjectToTest(
+        ?Data $dataHelper = null,
+        ?ConfigHelper $configHelper = null,
+        ?ProductHelper $productHelper = null,
+        ?QueueHelper $queueHelper = null,
+        ?Queue $queue = null,
+        ?AlgoliaCredentialsManager $algoliaCredentialsManager = null,
+        ?IndexCollectionSize $indexCollectionSizeCache = null,
+    ): BatchQueueProcessor {
+        return new BatchQueueProcessor(
+            $dataHelper ?? $this->createStub(Data::class),
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $productHelper ?? $this->createStub(ProductHelper::class),
+            $queueHelper ?? $this->createStub(QueueHelper::class),
+            $queue ?? $this->createStub(Queue::class),
+            $this->createStub(DiagnosticsLogger::class),
+            $algoliaCredentialsManager ?? $this->createStub(AlgoliaCredentialsManager::class),
+            $this->createStub(IndexBuilder::class),
+            $indexCollectionSizeCache ?? $this->createStub(IndexCollectionSize::class),
+            $this->createStub(IndexOptionsBuilder::class),
+            $this->createStub(IndexSettingsComparator::class),
         );
     }
 
@@ -73,11 +53,15 @@ class BatchQueueProcessorTest extends TestCase
      */
     public function testProcessBatchSkipsWhenIndexingDisabled()
     {
-        $this->dataHelper->method('isIndexingEnabled')->willReturn(false);
+        $dataHelper = $this->createStub(Data::class);
+        $dataHelper->method('isIndexingEnabled')->willReturn(false);
 
-        $this->algoliaCredentialsManager->expects($this->never())->method('checkCredentialsWithSearchOnlyAPIKey');
+        $algoliaCredentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->expects($this->never())->method('checkCredentialsWithSearchOnlyAPIKey');
 
-        $this->processor->processBatch(1);
+        $processor = $this->createObjectToTest($dataHelper, algoliaCredentialsManager: $algoliaCredentialsManager);
+
+        $processor->processBatch(1);
     }
 
     /**
@@ -86,14 +70,18 @@ class BatchQueueProcessorTest extends TestCase
      */
     public function testProcessBatchSkipsWhenCredentialsInvalid()
     {
-        $this->dataHelper->method('isIndexingEnabled')->willReturn(true);
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(false);
+        $dataHelper = $this->createStub(Data::class);
+        $dataHelper->method('isIndexingEnabled')->willReturn(true);
 
-        $this->algoliaCredentialsManager->expects($this->once())
+        $algoliaCredentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(false);
+        $algoliaCredentialsManager->expects($this->once())
             ->method('displayErrorMessage')
             ->with(BatchQueueProcessor::class, 1);
 
-        $this->processor->processBatch(1);
+        $processor = $this->createObjectToTest($dataHelper, algoliaCredentialsManager: $algoliaCredentialsManager);
+
+        $processor->processBatch(1);
     }
 
     /**
@@ -102,10 +90,13 @@ class BatchQueueProcessorTest extends TestCase
      */
     public function testProcessBatchHandlesDeltaIndexing()
     {
-        $this->setupBasicIndexingConfig(10);
-        $this->productHelper->method('getParentProductIds')->willReturn([]);
+        [$dataHelper, $algoliaCredentialsManager, $configHelper] = $this->createBasicIndexingConfig(10);
 
-        $this->queue->expects($this->once())
+        $productHelper = $this->createStub(ProductHelper::class);
+        $productHelper->method('getParentProductIds')->willReturn([]);
+
+        $queue = $this->createMock(Queue::class);
+        $queue->expects($this->once())
             ->method('addToQueue')
             ->with(
                 IndexBuilder::class,
@@ -113,22 +104,27 @@ class BatchQueueProcessorTest extends TestCase
                 $this->arrayHasKey('entityIds')
             );
 
-        $this->processor->processBatch(1, range(1, 5));
+        $processor = $this->createObjectToTest($dataHelper, $configHelper, $productHelper, queue: $queue, algoliaCredentialsManager: $algoliaCredentialsManager);
+
+        $processor->processBatch(1, range(1, 5));
     }
 
     public function testProcessBatchHandlesDeltaIndexingPaged()
     {
         $pageSize = 10;
-        $this->setupBasicIndexingConfig($pageSize);
-        $this->productHelper->method('getParentProductIds')->willReturn([]);
+        [$dataHelper, $algoliaCredentialsManager, $configHelper] = $this->createBasicIndexingConfig($pageSize);
+
+        $productHelper = $this->createStub(ProductHelper::class);
+        $productHelper->method('getParentProductIds')->willReturn([]);
 
         $invocationCount = 0;
-        $this->queue->expects($this->exactly(5))
+        $queue = $this->createMock(Queue::class);
+        $queue->expects($this->exactly(5))
             ->method('addToQueue')
             ->with(
                 IndexBuilder::class,
                 'buildIndexList',
-                $this->callback(function(array $arg) use (&$invocationCount, $pageSize) {
+                $this->callback(function (array $arg) use (&$invocationCount, $pageSize) {
                     $invocationCount++;
 
                     return array_key_exists('storeId', $arg)
@@ -139,7 +135,9 @@ class BatchQueueProcessorTest extends TestCase
                 })
             );
 
-        $this->processor->processBatch(1, range(1, 50));
+        $processor = $this->createObjectToTest($dataHelper, $configHelper, $productHelper, queue: $queue, algoliaCredentialsManager: $algoliaCredentialsManager);
+
+        $processor->processBatch(1, range(1, 50));
     }
 
     /**
@@ -148,17 +146,24 @@ class BatchQueueProcessorTest extends TestCase
      */
     public function testProcessBatchHandlesFullIndexing()
     {
-        $this->setupBasicIndexingConfig(10);
-        $this->configHelper->method('isQueueActive')->willReturn(false);
-        $this->indexCollectionSizeCache->expects($this->once())->method('get')->willReturn(10);
-        $this->productHelper->method('getProductCollectionQuery')->willReturn($this->getMockCollection());
-        $this->queueHelper->method('useTmpIndex')->willReturn(false);
+        [$dataHelper, $algoliaCredentialsManager, $configHelper] = $this->createBasicIndexingConfig(10);
+        $configHelper->method('isQueueActive')->willReturn(false);
+
+        $indexCollectionSizeCache = $this->createMock(IndexCollectionSize::class);
+        $indexCollectionSizeCache->expects($this->once())->method('get')->willReturn(10);
+
+        $productHelper = $this->createStub(ProductHelper::class);
+        $productHelper->method('getProductCollectionQuery')->willReturn($this->getStubCollection());
+
+        $queueHelper = $this->createStub(QueueHelper::class);
+        $queueHelper->method('useTmpIndex')->willReturn(false);
 
         $invocationCount = 0;
-        $this->queue->expects($this->exactly(2))
+        $queue = $this->createMock(Queue::class);
+        $queue->expects($this->exactly(2))
             ->method('addToQueue')
             ->willReturnCallback(
-                function(
+                function (
                     string $className,
                     string $method,
                     array $data,
@@ -180,11 +185,21 @@ class BatchQueueProcessorTest extends TestCase
                             $this->assertArrayHasKey('storeId', $data);
 
                             break;
-                    }
                 }
+            }
             );
 
-        $this->processor->processBatch(1);
+        $processor = $this->createObjectToTest(
+            $dataHelper,
+            $configHelper,
+            $productHelper,
+            $queueHelper,
+            $queue,
+            $algoliaCredentialsManager,
+            $indexCollectionSizeCache,
+        );
+
+        $processor->processBatch(1);
     }
 
     /**
@@ -193,16 +208,32 @@ class BatchQueueProcessorTest extends TestCase
      */
     public function testProcessBatchFullIndexingWithNoCache()
     {
-        $this->setupBasicIndexingConfig(10);
-        $this->configHelper->method('isQueueActive')->willReturn(false);
-        $this->indexCollectionSizeCache->expects($this->once())->method('get')->willReturn(IndexCollectionSize::NOT_FOUND);
-        $this->productHelper->method('getProductCollectionQuery')->willReturn($this->getMockCollection(10, 1));
-        $this->queueHelper->method('useTmpIndex')->willReturn(false);
+        [$dataHelper, $algoliaCredentialsManager, $configHelper] = $this->createBasicIndexingConfig(10);
+        $configHelper->method('isQueueActive')->willReturn(false);
 
-        $this->queue->expects($this->exactly(2))
-            ->method('addToQueue');
+        $indexCollectionSizeCache = $this->createMock(IndexCollectionSize::class);
+        $indexCollectionSizeCache->expects($this->once())->method('get')->willReturn(IndexCollectionSize::NOT_FOUND);
 
-        $this->processor->processBatch(1);
+        $productHelper = $this->createStub(ProductHelper::class);
+        $productHelper->method('getProductCollectionQuery')->willReturn($this->getStubCollection(10, 1));
+
+        $queueHelper = $this->createStub(QueueHelper::class);
+        $queueHelper->method('useTmpIndex')->willReturn(false);
+
+        $queue = $this->createMock(Queue::class);
+        $queue->expects($this->exactly(2))->method('addToQueue');
+
+        $processor = $this->createObjectToTest(
+            $dataHelper,
+            $configHelper,
+            $productHelper,
+            $queueHelper,
+            $queue,
+            $algoliaCredentialsManager,
+            $indexCollectionSizeCache,
+        );
+
+        $processor->processBatch(1);
     }
 
     /**
@@ -212,17 +243,24 @@ class BatchQueueProcessorTest extends TestCase
     public function testProcessBatchHandlesFullIndexingPaged()
     {
         $pageSize = 10;
-        $this->setupBasicIndexingConfig($pageSize);
-        $this->configHelper->method('isQueueActive')->willReturn(false);
-        $this->indexCollectionSizeCache->expects($this->once())->method('get')->willReturn(50);
-        $this->productHelper->method('getProductCollectionQuery')->willReturn($this->getMockCollection());
-        $this->queueHelper->method('useTmpIndex')->willReturn(false);
+        [$dataHelper, $algoliaCredentialsManager, $configHelper] = $this->createBasicIndexingConfig($pageSize);
+        $configHelper->method('isQueueActive')->willReturn(false);
+
+        $indexCollectionSizeCache = $this->createMock(IndexCollectionSize::class);
+        $indexCollectionSizeCache->expects($this->once())->method('get')->willReturn(50);
+
+        $productHelper = $this->createStub(ProductHelper::class);
+        $productHelper->method('getProductCollectionQuery')->willReturn($this->getStubCollection());
+
+        $queueHelper = $this->createStub(QueueHelper::class);
+        $queueHelper->method('useTmpIndex')->willReturn(false);
 
         $invocationCount = 0;
-        $this->queue->expects($this->exactly(6))
+        $queue = $this->createMock(Queue::class);
+        $queue->expects($this->exactly(6))
             ->method('addToQueue')
             ->willReturnCallback(
-                function(
+                function (
                     string $className,
                     string $method,
                     array $data,
@@ -249,7 +287,17 @@ class BatchQueueProcessorTest extends TestCase
                 }
             );
 
-        $this->processor->processBatch(1);
+        $processor = $this->createObjectToTest(
+            $dataHelper,
+            $configHelper,
+            $productHelper,
+            $queueHelper,
+            $queue,
+            $algoliaCredentialsManager,
+            $indexCollectionSizeCache,
+        );
+
+        $processor->processBatch(1);
     }
 
     /**
@@ -258,21 +306,26 @@ class BatchQueueProcessorTest extends TestCase
      */
     public function testProcessBatchMovesTempIndexIfQueueActive()
     {
-        $this->setupBasicIndexingConfig(10);
-        $this->configHelper->method('isQueueActive')->willReturn(true);
-        $this->indexCollectionSizeCache->expects($this->once())->method('get')->willReturn(10);
+        [$dataHelper, $algoliaCredentialsManager, $configHelper] = $this->createBasicIndexingConfig(10);
+        $configHelper->method('isQueueActive')->willReturn(true);
 
-        $this->productHelper->method('getProductCollectionQuery')->willReturn($this->getMockCollection());
-        $this->productHelper->method('getTempIndexName')->willReturn('tmp_index');
-        $this->productHelper->method('getIndexName')->willReturn('main_index');
+        $indexCollectionSizeCache = $this->createMock(IndexCollectionSize::class);
+        $indexCollectionSizeCache->expects($this->once())->method('get')->willReturn(10);
 
-        $this->queueHelper->method('useTmpIndex')->willReturn(true);
+        $productHelper = $this->createStub(ProductHelper::class);
+        $productHelper->method('getProductCollectionQuery')->willReturn($this->getStubCollection());
+        $productHelper->method('getTempIndexName')->willReturn('tmp_index');
+        $productHelper->method('getIndexName')->willReturn('main_index');
+
+        $queueHelper = $this->createStub(QueueHelper::class);
+        $queueHelper->method('useTmpIndex')->willReturn(true);
 
         $invocationCount = 0;
-        $this->queue->expects($this->exactly(3))
+        $queue = $this->createMock(Queue::class);
+        $queue->expects($this->exactly(3))
             ->method('addToQueue')
             ->willReturnCallback(
-                function(
+                function (
                     string $className,
                     string $method,
                     array $data,
@@ -291,22 +344,42 @@ class BatchQueueProcessorTest extends TestCase
                 }
             );
 
-        $this->processor->processBatch(1);
+        $processor = $this->createObjectToTest(
+            $dataHelper,
+            $configHelper,
+            $productHelper,
+            $queueHelper,
+            $queue,
+            $algoliaCredentialsManager,
+            $indexCollectionSizeCache,
+        );
+
+        $processor->processBatch(1);
     }
 
-    protected function setupBasicIndexingConfig(int $elementsPerPage): void
+    /**
+     * @return array{0: Data, 1: AlgoliaCredentialsManager, 2: ConfigHelper}
+     */
+    protected function createBasicIndexingConfig(int $elementsPerPage): array
     {
-        $this->dataHelper->method('isIndexingEnabled')->willReturn(true);
-        $this->algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
-        $this->configHelper->method('getNumberOfElementByPage')->willReturn($elementsPerPage);
-        $this->configHelper->method('includeNonVisibleProductsInIndex')->willReturn(false);
+        $dataHelper = $this->createStub(Data::class);
+        $dataHelper->method('isIndexingEnabled')->willReturn(true);
+
+        $algoliaCredentialsManager = $this->createStub(AlgoliaCredentialsManager::class);
+        $algoliaCredentialsManager->method('checkCredentialsWithSearchOnlyAPIKey')->willReturn(true);
+
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getNumberOfElementByPage')->willReturn($elementsPerPage);
+        $configHelper->method('includeNonVisibleProductsInIndex')->willReturn(false);
+
+        return [$dataHelper, $algoliaCredentialsManager, $configHelper];
     }
 
-    protected function getMockCollection(int $size = 10, int $expectedSizeCalls = 0): Collection
+    protected function getStubCollection(int $size = 10, int $expectedSizeCalls = 0): Collection
     {
-        $mockCollection = $this->createMock(Collection::class);
-        $mockCollection->expects($this->exactly($expectedSizeCalls))->method('getSize')->willReturn($size);
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->exactly($expectedSizeCalls))->method('getSize')->willReturn($size);
 
-        return $mockCollection;
+        return $collection;
     }
 }

--- a/Test/Unit/Service/Product/FacetBuilderTest.php
+++ b/Test/Unit/Service/Product/FacetBuilderTest.php
@@ -43,8 +43,8 @@ class FacetBuilderTest extends TestCase
 
         $instantSearchHelper = $this->createFacetsStub();
         $groupCollection = $this->createGroupsStub();
-        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
-        $configHelper->method('isCustomerGroupsEnabled')->willReturn(true);
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId, configHelperAsMock: true);
+        $configHelper->method('isCustomerGroupsEnabled')->with($storeId)->willReturn(true);
 
         $groupExcludedWebsiteRepository = $this->createStub(GroupExcludedWebsiteRepositoryInterface::class);
         $groupExcludedWebsiteRepository->method('getCustomerGroupExcludedWebsites')->willReturn([]);
@@ -66,8 +66,8 @@ class FacetBuilderTest extends TestCase
 
         $instantSearchHelper = $this->createFacetsStub();
         $groupCollection = $this->createGroupsStub();
-        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
-        $configHelper->method('isCustomerGroupsEnabled')->willReturn(false);
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId, configHelperAsMock: true);
+        $configHelper->method('isCustomerGroupsEnabled')->with($storeId)->willReturn(false);
 
         $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper, $storeManager, $groupCollection);
 
@@ -86,8 +86,8 @@ class FacetBuilderTest extends TestCase
 
         $instantSearchHelper = $this->createFacetsStub();
         $groupCollection = $this->createGroupsStub();
-        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
-        $configHelper->method('isCustomerGroupsEnabled')->willReturn(true);
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId, configHelperAsMock: true);
+        $configHelper->method('isCustomerGroupsEnabled')->with($storeId)->willReturn(true);
 
         $groupExcludedWebsiteRepository = $this->createStub(GroupExcludedWebsiteRepositoryInterface::class);
         $groupExcludedWebsiteRepository->method('getCustomerGroupExcludedWebsites')->willReturn([$websiteId]);
@@ -111,7 +111,7 @@ class FacetBuilderTest extends TestCase
     public function testGetAttributesForFacetingIncludesCategoryLevel0(): void
     {
         $storeId = 1;
-        $instantSearchHelper = $this->createFacetsStub();
+        $instantSearchHelper = $this->createFacetsStub(asMock: true);
         $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
 
         $facetBuilder = $this->createObjectToTest(instantSearchHelper: $instantSearchHelper);
@@ -129,7 +129,7 @@ class FacetBuilderTest extends TestCase
     public function testGetAttributesForFacetingIncludesMerchMetaData(): void
     {
         $storeId = 1;
-        $instantSearchHelper = $this->createFacetsStub();
+        $instantSearchHelper = $this->createFacetsStub(asMock: true);
         $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
 
         $facetBuilder = $this->createObjectToTest(instantSearchHelper: $instantSearchHelper);
@@ -152,7 +152,7 @@ class FacetBuilderTest extends TestCase
     public function testGetAttributesForFacetingIncludesVisualMerchData(): void
     {
         $storeId = 1;
-        $instantSearchHelper = $this->createFacetsStub();
+        $instantSearchHelper = $this->createFacetsStub(asMock: true);
         $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
         $configHelper = $this->createVisualMerchEnablementStub($storeId);
 
@@ -174,8 +174,8 @@ class FacetBuilderTest extends TestCase
 
         $instantSearchHelper = $this->createFacetsStub();
         $groupCollection = $this->createGroupsStub();
-        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
-        $configHelper->method('isCustomerGroupsEnabled')->willReturn(true);
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId, configHelperAsMock: true);
+        $configHelper->method('isCustomerGroupsEnabled')->with($storeId)->willReturn(true);
 
         $groupExcludedWebsiteRepository = $this->createStub(GroupExcludedWebsiteRepositoryInterface::class);
         $groupExcludedWebsiteRepository->method('getCustomerGroupExcludedWebsites')->willReturn([]);
@@ -209,7 +209,7 @@ class FacetBuilderTest extends TestCase
         $storeId = 1;
         $websiteId = 2;
 
-        $instantSearchHelper = $this->createStub(InstantSearchHelper::class);
+        $instantSearchHelper = $this->createMock(InstantSearchHelper::class);
         $instantSearchHelper->method('getFacets')->willReturn([
             [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'color'],
             [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size'],
@@ -239,7 +239,7 @@ class FacetBuilderTest extends TestCase
     public function testGetRenderingContentDoesNotIncludeMetaData(): void
     {
         $storeId = 1;
-        $instantSearchHelper = $this->createFacetsStub();
+        $instantSearchHelper = $this->createFacetsStub(asMock: true);
         $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
         $configHelper = $this->createVisualMerchEnablementStub($storeId);
 
@@ -320,9 +320,9 @@ class FacetBuilderTest extends TestCase
         $this->assertEquals('filterOnly(size)', $result);
     }
 
-    private function createFacetsStub(): InstantSearchHelper
+    private function createFacetsStub(bool $asMock = false): InstantSearchHelper
     {
-        $instantSearchHelper = $this->createStub(InstantSearchHelper::class);
+        $instantSearchHelper = $asMock ? $this->createMock(InstantSearchHelper::class) : $this->createStub(InstantSearchHelper::class);
         $instantSearchHelper->method('getFacets')->willReturn([
             [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'brand', FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_NOT_SEARCHABLE],
             [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'color', FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_SEARCHABLE],
@@ -335,34 +335,34 @@ class FacetBuilderTest extends TestCase
     /**
      * @return array{0: ConfigHelper, 1: StoreManagerInterface}
      */
-    private function createStoreConfigStubs(int $storeId, int $websiteId): array
+    private function createStoreConfigStubs(int $storeId, int $websiteId, bool $configHelperAsMock = false): array
     {
-        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper = $configHelperAsMock ? $this->createMock(ConfigHelper::class) : $this->createStub(ConfigHelper::class);
         $configHelper->method('getAllowedCurrencies')->willReturn(['EUR', 'USD']);
 
         $store = $this->createStub(StoreInterface::class);
         $store->method('getWebsiteId')->willReturn($websiteId);
 
-        $storeManager = $this->createStub(StoreManagerInterface::class);
-        $storeManager->method('getStore')->willReturn($store);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->with($storeId)->willReturn($store);
 
         return [$configHelper, $storeManager];
     }
 
     private function withCategoryConfig(InstantSearchHelper $instantSearchHelper, int $storeId): InstantSearchHelper
     {
-        $instantSearchHelper->method('shouldReplaceCategories')->willReturn(true);
+        $instantSearchHelper->method('shouldReplaceCategories')->with($storeId)->willReturn(true);
 
         return $instantSearchHelper;
     }
 
     private function createGroupsStub(): GroupCollection
     {
-        $group1 = $this->createStub(Group::class);
-        $group1->method('getData')->willReturn(1);
+        $group1 = $this->createMock(Group::class);
+        $group1->method('getData')->with('customer_group_id')->willReturn(1);
 
-        $group2 = $this->createStub(Group::class);
-        $group2->method('getData')->willReturn(2);
+        $group2 = $this->createMock(Group::class);
+        $group2->method('getData')->with('customer_group_id')->willReturn(2);
 
         $groupCollection = $this->createStub(GroupCollection::class);
         $groupCollection->method('getIterator')->willReturn(new \ArrayIterator([$group1, $group2]));
@@ -372,9 +372,9 @@ class FacetBuilderTest extends TestCase
 
     private function createVisualMerchEnablementStub(int $storeId): ConfigHelper
     {
-        $configHelper = $this->createStub(ConfigHelper::class);
-        $configHelper->method('isVisualMerchEnabled')->willReturn(true);
-        $configHelper->method('getCategoryPageIdAttributeName')->willReturn('categoryPageId');
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->method('isVisualMerchEnabled')->with($storeId)->willReturn(true);
+        $configHelper->method('getCategoryPageIdAttributeName')->with($storeId)->willReturn('categoryPageId');
 
         return $configHelper;
     }

--- a/Test/Unit/Service/Product/FacetBuilderTest.php
+++ b/Test/Unit/Service/Product/FacetBuilderTest.php
@@ -6,67 +6,52 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Service\Product;
 
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Configuration\InstantSearchHelper;
-use Algolia\AlgoliaSearch\Model\QuerySuggestions\Facet;
 use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
 use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
+use Magento\Customer\Model\Group;
 use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class FacetBuilderTest extends TestCase
 {
-    protected ?FacetBuilder $facetBuilder;
-    protected ?ConfigHelper $configHelper;
-    protected ?InstantSearchHelper $instantSearchHelper;
-    protected ?StoreManagerInterface $storeManager;
-    protected ?GroupCollection $groupCollection;
-    protected ?GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository;
-
-    protected function setUp(): void
-    {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->instantSearchHelper = $this->createMock(InstantSearchHelper::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->groupCollection = $this->createMock(GroupCollection::class);
-        $this->groupExcludedWebsiteRepository = $this->createMock(GroupExcludedWebsiteRepositoryInterface::class);
-
-        $this->facetBuilder = new FacetBuilder(
-            $this->configHelper,
-            $this->instantSearchHelper,
-            $this->storeManager,
-            $this->groupCollection,
-            $this->groupExcludedWebsiteRepository
+    protected function createObjectToTest(
+        ?ConfigHelper $configHelper = null,
+        ?InstantSearchHelper $instantSearchHelper = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?GroupCollection $groupCollection = null,
+        ?GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository = null,
+    ): FacetBuilder {
+        return new FacetBuilder(
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $instantSearchHelper ?? $this->createStub(InstantSearchHelper::class),
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $groupCollection ?? $this->createStub(GroupCollection::class),
+            $groupExcludedWebsiteRepository ?? $this->createStub(GroupExcludedWebsiteRepositoryInterface::class),
         );
     }
 
     /**
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function testGetAttributesForFacetingReturnsCorrectFacets(): void
     {
         $storeId = 1;
         $websiteId = 2;
 
-        $this->mockFacets();
-        $this->mockGroups();
+        $instantSearchHelper = $this->createFacetsStub();
+        $groupCollection = $this->createGroupsStub();
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
+        $configHelper->method('isCustomerGroupsEnabled')->willReturn(true);
 
-        $this->mockStoreConfig($storeId, $websiteId);
+        $groupExcludedWebsiteRepository = $this->createStub(GroupExcludedWebsiteRepositoryInterface::class);
+        $groupExcludedWebsiteRepository->method('getCustomerGroupExcludedWebsites')->willReturn([]);
 
-        $this->configHelper
-            ->method('isCustomerGroupsEnabled')
-            ->with($storeId)
-            ->willReturn(true);
+        $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper, $storeManager, $groupCollection, $groupExcludedWebsiteRepository);
 
-        $this->groupExcludedWebsiteRepository
-            ->method('getCustomerGroupExcludedWebsites')
-            ->willReturn([]);
-
-        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+        $result = $facetBuilder->getAttributesForFaceting($storeId);
 
         $this->assertContains('brand', $result);
         $this->assertContains('searchable(color)', $result);
@@ -79,17 +64,14 @@ class FacetBuilderTest extends TestCase
         $storeId = 1;
         $websiteId = 2;
 
-        $this->mockFacets();
-        $this->mockGroups();
+        $instantSearchHelper = $this->createFacetsStub();
+        $groupCollection = $this->createGroupsStub();
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
+        $configHelper->method('isCustomerGroupsEnabled')->willReturn(false);
 
-        $this->mockStoreConfig($storeId, $websiteId);
+        $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper, $storeManager, $groupCollection);
 
-        $this->configHelper
-            ->method('isCustomerGroupsEnabled')
-            ->with($storeId)
-            ->willReturn(false);
-
-        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+        $result = $facetBuilder->getAttributesForFaceting($storeId);
 
         $this->assertContains('brand', $result);
         $this->assertContains('searchable(color)', $result);
@@ -102,21 +84,17 @@ class FacetBuilderTest extends TestCase
         $storeId = 1;
         $websiteId = 2;
 
-        $this->mockFacets();
-        $this->mockGroups();
+        $instantSearchHelper = $this->createFacetsStub();
+        $groupCollection = $this->createGroupsStub();
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
+        $configHelper->method('isCustomerGroupsEnabled')->willReturn(true);
 
-        $this->mockStoreConfig($storeId, $websiteId);
+        $groupExcludedWebsiteRepository = $this->createStub(GroupExcludedWebsiteRepositoryInterface::class);
+        $groupExcludedWebsiteRepository->method('getCustomerGroupExcludedWebsites')->willReturn([$websiteId]);
 
-        $this->configHelper
-            ->method('isCustomerGroupsEnabled')
-            ->with($storeId)
-            ->willReturn(true);
+        $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper, $storeManager, $groupCollection, $groupExcludedWebsiteRepository);
 
-        $this->groupExcludedWebsiteRepository
-            ->method('getCustomerGroupExcludedWebsites')
-            ->willReturn([$websiteId]);
-
-        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+        $result = $facetBuilder->getAttributesForFaceting($storeId);
 
         $this->assertContains('brand', $result);
         $this->assertContains('searchable(color)', $result);
@@ -124,35 +102,39 @@ class FacetBuilderTest extends TestCase
         $this->assertNotContains('price.USD.group_2', $result);
     }
 
-
     /**
      * attributesForFaceting must include level0 to be selectable via renderingContent/merch rule UI
      *
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testGetAttributesForFacetingIncludesCategoryLevel0(): void
     {
         $storeId = 1;
-        $this->mockFacets();
-        $this->mockCategoryConfig($storeId);
-        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+        $instantSearchHelper = $this->createFacetsStub();
+        $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
+
+        $facetBuilder = $this->createObjectToTest(instantSearchHelper: $instantSearchHelper);
+
+        $result = $facetBuilder->getAttributesForFaceting($storeId);
         $this->assertContains('categories.level0', $result);
     }
 
     /**
      * If category PLPs are supported then attributesForFaceting must contain category merch meta data
      *
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testGetAttributesForFacetingIncludesMerchMetaData(): void
     {
         $storeId = 1;
-        $this->mockFacets();
-        $this->mockCategoryConfig($storeId);
+        $instantSearchHelper = $this->createFacetsStub();
+        $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
 
-        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+        $facetBuilder = $this->createObjectToTest(instantSearchHelper: $instantSearchHelper);
+
+        $result = $facetBuilder->getAttributesForFaceting($storeId);
 
         $this->assertContains('categories', $result);
         $this->assertContains('categoryIds', $result);
@@ -164,43 +146,43 @@ class FacetBuilderTest extends TestCase
      * category page ID (default categoryPageId) must be added to attributesForFaceting
      *
      * @return void
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testGetAttributesForFacetingIncludesVisualMerchData(): void
     {
         $storeId = 1;
-        $this->mockFacets();
-        $this->mockCategoryConfig($storeId);
-        $this->mockVisualMerchEnablement($storeId);
+        $instantSearchHelper = $this->createFacetsStub();
+        $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
+        $configHelper = $this->createVisualMerchEnablementStub($storeId);
 
-        $result = $this->facetBuilder->getAttributesForFaceting($storeId);
+        $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper);
+
+        $result = $facetBuilder->getAttributesForFaceting($storeId);
 
         $this->assertContains('searchable(categoryPageId)', $result);
     }
 
     /**
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function testGetRenderingContentReturnsExpectedFormat(): void
     {
         $storeId = 1;
         $websiteId = 2;
-        $this->mockFacets();
-        $this->mockGroups();
-        $this->mockStoreConfig($storeId, $websiteId);
 
-        $this->configHelper
-            ->method('isCustomerGroupsEnabled')
-            ->with($storeId)
-            ->willReturn(true);
+        $instantSearchHelper = $this->createFacetsStub();
+        $groupCollection = $this->createGroupsStub();
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
+        $configHelper->method('isCustomerGroupsEnabled')->willReturn(true);
 
-        $this->groupExcludedWebsiteRepository
-            ->method('getCustomerGroupExcludedWebsites')
-            ->willReturn([]);
+        $groupExcludedWebsiteRepository = $this->createStub(GroupExcludedWebsiteRepositoryInterface::class);
+        $groupExcludedWebsiteRepository->method('getCustomerGroupExcludedWebsites')->willReturn([]);
 
-        $result = $this->facetBuilder->getRenderingContent($storeId);
+        $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper, $storeManager, $groupCollection, $groupExcludedWebsiteRepository);
+
+        $result = $facetBuilder->getRenderingContent($storeId);
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('facetOrdering', $result);
@@ -219,25 +201,27 @@ class FacetBuilderTest extends TestCase
      * Categories must be added to renderingContent as level0
      * `categories` Object attribute should not be added as it is not compatible for facet render
      *
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function testGetRenderingContentFormatsCategoriesAttribute(): void
     {
         $storeId = 1;
         $websiteId = 2;
-        $this->instantSearchHelper
-            ->method('getFacets')
-            ->willReturn([
-                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'color'],
-                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size'],
-            ]);
 
-        $this->mockGroups();
-        $this->mockStoreConfig($storeId, $websiteId);
-        $this->mockCategoryConfig($storeId);
+        $instantSearchHelper = $this->createStub(InstantSearchHelper::class);
+        $instantSearchHelper->method('getFacets')->willReturn([
+            [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'color'],
+            [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size'],
+        ]);
+        $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
 
-        $result = $this->facetBuilder->getRenderingContent($storeId);
+        $groupCollection = $this->createGroupsStub();
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
+
+        $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper, $storeManager, $groupCollection);
+
+        $result = $facetBuilder->getRenderingContent($storeId);
 
         $this->assertContains('categories.level0', $result['facetOrdering']['facets']['order']);
 
@@ -246,21 +230,22 @@ class FacetBuilderTest extends TestCase
         $this->assertArrayNotHasKey('categories', $values);
     }
 
-
     /**
      * Category merch meta data should not be included with renderingContent
      *
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testGetRenderingContentDoesNotIncludeMetaData(): void
     {
         $storeId = 1;
-        $this->mockFacets();
-        $this->mockCategoryConfig($storeId);
-        $this->mockVisualMerchEnablement($storeId);
+        $instantSearchHelper = $this->createFacetsStub();
+        $instantSearchHelper = $this->withCategoryConfig($instantSearchHelper, $storeId);
+        $configHelper = $this->createVisualMerchEnablementStub($storeId);
 
-        $result = $this->facetBuilder->getRenderingContent($storeId);
+        $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper);
+
+        $result = $facetBuilder->getRenderingContent($storeId);
 
         $facets = $result['facetOrdering']['facets']['order'];
         $this->assertNotContains('categories', $facets);
@@ -269,115 +254,128 @@ class FacetBuilderTest extends TestCase
     }
 
     /**
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function testGetRawFacetsReturnsCorrectStructure(): void
     {
         $storeId = 1;
         $websiteId = 2;
 
-        $this->instantSearchHelper
-            ->method('getFacets')
-            ->willReturn([
-                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size'],
-                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => FacetBuilder::FACET_ATTRIBUTE_PRICE],
-            ]);
+        $instantSearchHelper = $this->createStub(InstantSearchHelper::class);
+        $instantSearchHelper->method('getFacets')->willReturn([
+            [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size'],
+            [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => FacetBuilder::FACET_ATTRIBUTE_PRICE],
+        ]);
 
-        $this->mockStoreConfig($storeId, $websiteId);
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
 
-        $result = $this->invokeMethod($this->facetBuilder, 'getRawFacets', [$storeId]);
+        $facetBuilder = $this->createObjectToTest($configHelper, $instantSearchHelper, $storeManager);
+
+        $result = $this->invokeMethod($facetBuilder, 'getRawFacets', [$storeId]);
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
         $this->assertEquals('size', $result[0][FacetBuilder::FACET_KEY_ATTRIBUTE_NAME]);
     }
 
     /**
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function testGetPricingAttributesReturnsCorrectValues(): void
     {
         $storeId = 1;
         $websiteId = 2;
 
-        $this->mockStoreConfig($storeId, $websiteId);
+        [$configHelper, $storeManager] = $this->createStoreConfigStubs($storeId, $websiteId);
 
-        $result = $this->invokeMethod($this->facetBuilder, 'getPricingAttributes', [$storeId]);
+        $facetBuilder = $this->createObjectToTest($configHelper, storeManager: $storeManager);
+
+        $result = $this->invokeMethod($facetBuilder, 'getPricingAttributes', [$storeId]);
         $this->assertContains('price.USD.default', $result);
         $this->assertContains('price.EUR.default', $result);
     }
 
     public function testDecorateAttributeForFacetingHandlesSearchableCorrectly(): void
     {
+        $facetBuilder = $this->createObjectToTest();
+
         $facet = [
             FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'brand',
             FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_SEARCHABLE,
         ];
-        $result = $this->invokeMethod($this->facetBuilder, 'decorateAttributeForFaceting', [$facet]);
+        $result = $this->invokeMethod($facetBuilder, 'decorateAttributeForFaceting', [$facet]);
         $this->assertEquals('searchable(brand)', $result);
     }
 
     public function testDecorateAttributeForFacetingHandlesFilterOnlyCorrectly(): void
     {
+        $facetBuilder = $this->createObjectToTest();
+
         $facet = [
             FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'size',
             FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_FILTER_ONLY,
         ];
-        $result = $this->invokeMethod($this->facetBuilder, 'decorateAttributeForFaceting', [$facet]);
+        $result = $this->invokeMethod($facetBuilder, 'decorateAttributeForFaceting', [$facet]);
         $this->assertEquals('filterOnly(size)', $result);
     }
 
-    protected function mockFacets(): void
+    private function createFacetsStub(): InstantSearchHelper
     {
-        $this->instantSearchHelper
-            ->method('getFacets')
-            ->willReturn([
-                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'brand', FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_NOT_SEARCHABLE],
-                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'color', FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_SEARCHABLE],
-                [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => FacetBuilder::FACET_ATTRIBUTE_PRICE],
-            ]);
+        $instantSearchHelper = $this->createStub(InstantSearchHelper::class);
+        $instantSearchHelper->method('getFacets')->willReturn([
+            [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'brand', FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_NOT_SEARCHABLE],
+            [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => 'color', FacetBuilder::FACET_KEY_SEARCHABLE => FacetBuilder::FACET_SEARCHABLE_SEARCHABLE],
+            [FacetBuilder::FACET_KEY_ATTRIBUTE_NAME => FacetBuilder::FACET_ATTRIBUTE_PRICE],
+        ]);
+
+        return $instantSearchHelper;
     }
 
-    protected function mockStoreConfig(int $storeId, int $websiteId): void
+    /**
+     * @return array{0: ConfigHelper, 1: StoreManagerInterface}
+     */
+    private function createStoreConfigStubs(int $storeId, int $websiteId): array
     {
-        $this->configHelper
-            ->method('getAllowedCurrencies')
-            ->willReturn(['EUR', 'USD']);
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getAllowedCurrencies')->willReturn(['EUR', 'USD']);
 
-        $storeMock = $this->createMock(\Magento\Store\Api\Data\StoreInterface::class);
-        $storeMock->method('getWebsiteId')->willReturn($websiteId);
-        $this->storeManager->method('getStore')->with($storeId)->willReturn($storeMock);
+        $store = $this->createStub(StoreInterface::class);
+        $store->method('getWebsiteId')->willReturn($websiteId);
+
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        return [$configHelper, $storeManager];
     }
 
-    protected function mockCategoryConfig(int $storeId): void
+    private function withCategoryConfig(InstantSearchHelper $instantSearchHelper, int $storeId): InstantSearchHelper
     {
-        $this->instantSearchHelper
-            ->method('shouldReplaceCategories')
-            ->with($storeId)
-            ->willReturn(true);
+        $instantSearchHelper->method('shouldReplaceCategories')->willReturn(true);
+
+        return $instantSearchHelper;
     }
 
-    protected function mockGroups(): void
+    private function createGroupsStub(): GroupCollection
     {
-        $groupMock1 = $this->createMock(\Magento\Customer\Model\Group::class);
-        $groupMock1->method('getData')->with('customer_group_id')->willReturn(1);
+        $group1 = $this->createStub(Group::class);
+        $group1->method('getData')->willReturn(1);
 
-        $groupMock2 = $this->createMock(\Magento\Customer\Model\Group::class);
-        $groupMock2->method('getData')->with('customer_group_id')->willReturn(2);
+        $group2 = $this->createStub(Group::class);
+        $group2->method('getData')->willReturn(2);
 
-        $this->groupCollection->method('getIterator')->willReturn(new \ArrayIterator([$groupMock1, $groupMock2]));
+        $groupCollection = $this->createStub(GroupCollection::class);
+        $groupCollection->method('getIterator')->willReturn(new \ArrayIterator([$group1, $group2]));
+
+        return $groupCollection;
     }
 
-    protected function mockVisualMerchEnablement(int $storeId): void
+    private function createVisualMerchEnablementStub(int $storeId): ConfigHelper
     {
-        $this->configHelper
-            ->method('isVisualMerchEnabled')
-            ->with($storeId)
-            ->willReturn(true);
-        $this->configHelper
-            ->method('getCategoryPageIdAttributeName')
-            ->with($storeId)
-            ->willReturn('categoryPageId');
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('isVisualMerchEnabled')->willReturn(true);
+        $configHelper->method('getCategoryPageIdAttributeName')->willReturn('categoryPageId');
+
+        return $configHelper;
     }
 }

--- a/Test/Unit/Service/Product/IndexOptionsBuilderTest.php
+++ b/Test/Unit/Service/Product/IndexOptionsBuilderTest.php
@@ -15,35 +15,21 @@ use Magento\Customer\Model\Context as CustomerContext;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class IndexOptionsBuilderTest extends TestCase
 {
-    private IndexOptionsBuilder $indexOptionsBuilder;
-    private SortingTransformer|MockObject $sortingTransformer;
-    private HttpContext|MockObject $httpContext;
-    private IndexNameFetcher|MockObject $indexNameFetcher;
-    private IndexOptionsInterfaceFactory|MockObject $indexOptionsFactory;
-    private DiagnosticsLogger|MockObject $logger;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->sortingTransformer = $this->createMock(SortingTransformer::class);
-        $this->httpContext = $this->createMock(HttpContext::class);
-        $this->indexNameFetcher = $this->createMock(IndexNameFetcher::class);
-        $this->indexOptionsFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
-        $this->logger = $this->createMock(DiagnosticsLogger::class);
-
-        $this->indexOptionsBuilder = new IndexOptionsBuilder(
-            $this->sortingTransformer,
-            $this->httpContext,
-            $this->indexNameFetcher,
-            $this->indexOptionsFactory,
-            $this->logger
+    protected function createObjectToTest(
+        ?SortingTransformer $sortingTransformer = null,
+        ?HttpContext $httpContext = null,
+        ?IndexNameFetcher $indexNameFetcher = null,
+        ?IndexOptionsInterfaceFactory $indexOptionsFactory = null,
+    ): IndexOptionsBuilder {
+        return new IndexOptionsBuilder(
+            $sortingTransformer ?? $this->createStub(SortingTransformer::class),
+            $httpContext ?? $this->createStub(HttpContext::class),
+            $indexNameFetcher ?? $this->createStub(IndexNameFetcher::class),
+            $indexOptionsFactory ?? $this->createStub(IndexOptionsInterfaceFactory::class),
+            $this->createStub(DiagnosticsLogger::class),
         );
     }
 
@@ -54,7 +40,8 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createMock(IndexOptionsInterface::class);
 
-        $this->indexOptionsFactory
+        $indexOptionsFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
+        $indexOptionsFactory
             ->expects($this->once())
             ->method('create')
             ->with([
@@ -86,7 +73,8 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('isTemporaryIndex')
             ->willReturn(false);
 
-        $this->indexNameFetcher
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher
             ->expects($this->once())
             ->method('getIndexName')
             ->with(ProductHelper::INDEX_NAME_SUFFIX, $storeId, false)
@@ -97,7 +85,9 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('setIndexName')
             ->with($expectedIndexName);
 
-        $result = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $indexOptionsBuilder = $this->createObjectToTest(indexNameFetcher: $indexNameFetcher, indexOptionsFactory: $indexOptionsFactory);
+
+        $result = $indexOptionsBuilder->buildEntityIndexOptions($storeId);
 
         $this->assertSame($indexOptions, $result);
     }
@@ -110,7 +100,8 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createMock(IndexOptionsInterface::class);
 
-        $this->indexOptionsFactory
+        $indexOptionsFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
+        $indexOptionsFactory
             ->expects($this->once())
             ->method('create')
             ->with([
@@ -142,7 +133,8 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('isTemporaryIndex')
             ->willReturn($isTmp);
 
-        $this->indexNameFetcher
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher
             ->expects($this->once())
             ->method('getIndexName')
             ->with(ProductHelper::INDEX_NAME_SUFFIX, $storeId, $isTmp)
@@ -153,7 +145,9 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('setIndexName')
             ->with($expectedIndexName);
 
-        $result = $this->indexOptionsBuilder->buildEntityIndexOptions($storeId, $isTmp);
+        $indexOptionsBuilder = $this->createObjectToTest(indexNameFetcher: $indexNameFetcher, indexOptionsFactory: $indexOptionsFactory);
+
+        $result = $indexOptionsBuilder->buildEntityIndexOptions($storeId, $isTmp);
 
         $this->assertSame($indexOptions, $result);
     }
@@ -165,7 +159,8 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createMock(IndexOptionsInterface::class);
 
-        $this->indexOptionsFactory
+        $indexOptionsFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
+        $indexOptionsFactory
             ->expects($this->once())
             ->method('create')
             ->with([
@@ -197,16 +192,19 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('isTemporaryIndex')
             ->willReturn(false);
 
-        $this->indexNameFetcher
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher
             ->expects($this->once())
             ->method('getIndexName')
             ->with(ProductHelper::INDEX_NAME_SUFFIX, $storeId, false)
             ->willThrowException($exception);
 
+        $indexOptionsBuilder = $this->createObjectToTest(indexNameFetcher: $indexNameFetcher, indexOptionsFactory: $indexOptionsFactory);
+
         $this->expectException(NoSuchEntityException::class);
         $this->expectExceptionMessage('Store not found');
 
-        $this->indexOptionsBuilder->buildEntityIndexOptions($storeId);
+        $indexOptionsBuilder->buildEntityIndexOptions($storeId);
     }
 
     public function testBuildReplicaIndexOptionsWithValidReplica(): void
@@ -230,21 +228,24 @@ class IndexOptionsBuilderTest extends TestCase
             ],
         ];
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->sortingTransformer
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $sortingTransformer
             ->expects($this->once())
             ->method('getSortingIndices')
             ->with($storeId, $customerGroupId)
             ->willReturn($availableSorts);
 
-        $indexOptions = $this->createMock(IndexOptionsInterface::class);
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
 
-        $this->indexOptionsFactory
+        $indexOptionsFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
+        $indexOptionsFactory
             ->expects($this->once())
             ->method('create')
             ->with([
@@ -255,7 +256,9 @@ class IndexOptionsBuilderTest extends TestCase
             ])
             ->willReturn($indexOptions);
 
-        $result = $this->indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
+        $indexOptionsBuilder = $this->createObjectToTest($sortingTransformer, $httpContext, indexOptionsFactory: $indexOptionsFactory);
+
+        $result = $indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
 
         $this->assertSame($indexOptions, $result);
     }
@@ -276,21 +279,24 @@ class IndexOptionsBuilderTest extends TestCase
             ],
         ];
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->sortingTransformer
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $sortingTransformer
             ->expects($this->once())
             ->method('getSortingIndices')
             ->with($storeId, $customerGroupId)
             ->willReturn($availableSorts);
 
-        $indexOptions = $this->createMock(IndexOptionsInterface::class);
+        $indexOptions = $this->createStub(IndexOptionsInterface::class);
 
-        $this->indexOptionsFactory
+        $indexOptionsFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
+        $indexOptionsFactory
             ->expects($this->once())
             ->method('create')
             ->with([
@@ -301,7 +307,9 @@ class IndexOptionsBuilderTest extends TestCase
             ])
             ->willReturn($indexOptions);
 
-        $result = $this->indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
+        $indexOptionsBuilder = $this->createObjectToTest($sortingTransformer, $httpContext, indexOptionsFactory: $indexOptionsFactory);
+
+        $result = $indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
 
         $this->assertSame($indexOptions, $result);
     }
@@ -322,13 +330,15 @@ class IndexOptionsBuilderTest extends TestCase
             ],
         ];
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->sortingTransformer
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $sortingTransformer
             ->expects($this->once())
             ->method('getSortingIndices')
             ->with($storeId, $customerGroupId)
@@ -336,7 +346,8 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createMock(IndexOptionsInterface::class);
 
-        $this->indexOptionsFactory
+        $indexOptionsFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
+        $indexOptionsFactory
             ->expects($this->once())
             ->method('create')
             ->with([
@@ -368,7 +379,8 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('isTemporaryIndex')
             ->willReturn(false);
 
-        $this->indexNameFetcher
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher
             ->expects($this->once())
             ->method('getIndexName')
             ->with(ProductHelper::INDEX_NAME_SUFFIX, $storeId, false)
@@ -379,7 +391,9 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('setIndexName')
             ->with($entityIndexName);
 
-        $result = $this->indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
+        $indexOptionsBuilder = $this->createObjectToTest($sortingTransformer, $httpContext, $indexNameFetcher, $indexOptionsFactory);
+
+        $result = $indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
 
         $this->assertSame($indexOptions, $result);
     }
@@ -392,13 +406,15 @@ class IndexOptionsBuilderTest extends TestCase
         $customerGroupId = 0;
         $entityIndexName = 'store_1_products';
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->sortingTransformer
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $sortingTransformer
             ->expects($this->once())
             ->method('getSortingIndices')
             ->with($storeId, $customerGroupId)
@@ -406,7 +422,8 @@ class IndexOptionsBuilderTest extends TestCase
 
         $indexOptions = $this->createMock(IndexOptionsInterface::class);
 
-        $this->indexOptionsFactory
+        $indexOptionsFactory = $this->createMock(IndexOptionsInterfaceFactory::class);
+        $indexOptionsFactory
             ->expects($this->once())
             ->method('create')
             ->with([
@@ -438,7 +455,8 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('isTemporaryIndex')
             ->willReturn(false);
 
-        $this->indexNameFetcher
+        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
+        $indexNameFetcher
             ->expects($this->once())
             ->method('getIndexName')
             ->with(ProductHelper::INDEX_NAME_SUFFIX, $storeId, false)
@@ -449,7 +467,9 @@ class IndexOptionsBuilderTest extends TestCase
             ->method('setIndexName')
             ->with($entityIndexName);
 
-        $result = $this->indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
+        $indexOptionsBuilder = $this->createObjectToTest($sortingTransformer, $httpContext, $indexNameFetcher, $indexOptionsFactory);
+
+        $result = $indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
 
         $this->assertSame($indexOptions, $result);
     }
@@ -462,22 +482,26 @@ class IndexOptionsBuilderTest extends TestCase
         $customerGroupId = 0;
         $exception = new LocalizedException(__('Configuration error'));
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->sortingTransformer
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $sortingTransformer
             ->expects($this->once())
             ->method('getSortingIndices')
             ->with($storeId, $customerGroupId)
             ->willThrowException($exception);
 
+        $indexOptionsBuilder = $this->createObjectToTest($sortingTransformer, $httpContext);
+
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Configuration error');
 
-        $this->indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
+        $indexOptionsBuilder->buildReplicaIndexOptions($storeId, $sortField, $sortDirection);
     }
 
     public function testGetReplicaIndexNameReturnsIndexName(): void
@@ -501,19 +525,23 @@ class IndexOptionsBuilderTest extends TestCase
             ],
         ];
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->sortingTransformer
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $sortingTransformer
             ->expects($this->once())
             ->method('getSortingIndices')
             ->with($storeId, $customerGroupId)
             ->willReturn($availableSorts);
 
-        $result = $this->indexOptionsBuilder->getReplicaIndexName($storeId, $sortField, $sortDirection);
+        $indexOptionsBuilder = $this->createObjectToTest($sortingTransformer, $httpContext);
+
+        $result = $indexOptionsBuilder->getReplicaIndexName($storeId, $sortField, $sortDirection);
 
         $this->assertSame($expectedIndexName, $result);
     }
@@ -533,19 +561,23 @@ class IndexOptionsBuilderTest extends TestCase
             ],
         ];
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->sortingTransformer
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $sortingTransformer
             ->expects($this->once())
             ->method('getSortingIndices')
             ->with($storeId, $customerGroupId)
             ->willReturn($availableSorts);
 
-        $result = $this->indexOptionsBuilder->getReplicaIndexName($storeId, $sortField, $sortDirection);
+        $indexOptionsBuilder = $this->createObjectToTest($sortingTransformer, $httpContext);
+
+        $result = $indexOptionsBuilder->getReplicaIndexName($storeId, $sortField, $sortDirection);
 
         $this->assertNull($result);
     }
@@ -565,19 +597,23 @@ class IndexOptionsBuilderTest extends TestCase
             ],
         ];
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->sortingTransformer
+        $sortingTransformer = $this->createMock(SortingTransformer::class);
+        $sortingTransformer
             ->expects($this->once())
             ->method('getSortingIndices')
             ->with($storeId, $customerGroupId)
             ->willReturn($availableSorts);
 
-        $result = $this->indexOptionsBuilder->getReplicaIndexName($storeId, $sortField, $sortDirection);
+        $indexOptionsBuilder = $this->createObjectToTest($sortingTransformer, $httpContext);
+
+        $result = $indexOptionsBuilder->getReplicaIndexName($storeId, $sortField, $sortDirection);
 
         $this->assertNull($result);
     }
@@ -586,28 +622,33 @@ class IndexOptionsBuilderTest extends TestCase
     {
         $expectedGroupId = 3;
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($expectedGroupId);
 
-        $result = $this->invokeMethod($this->indexOptionsBuilder, 'getCustomerGroupId');
+        $indexOptionsBuilder = $this->createObjectToTest(httpContext: $httpContext);
+
+        $result = $this->invokeMethod($indexOptionsBuilder, 'getCustomerGroupId');
 
         $this->assertSame($expectedGroupId, $result);
     }
 
     public function testGetCustomerGroupIdReturnsNull(): void
     {
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext
             ->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn(null);
 
-        $result = $this->invokeMethod($this->indexOptionsBuilder, 'getCustomerGroupId');
+        $indexOptionsBuilder = $this->createObjectToTest(httpContext: $httpContext);
+
+        $result = $this->invokeMethod($indexOptionsBuilder, 'getCustomerGroupId');
 
         $this->assertNull($result);
     }
 }
-

--- a/Test/Unit/Service/Product/PriceKeyResolverTest.php
+++ b/Test/Unit/Service/Product/PriceKeyResolverTest.php
@@ -8,31 +8,21 @@ use Algolia\AlgoliaSearch\Test\TestCase;
 use Magento\Customer\Model\Context as CustomerContext;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class PriceKeyResolverTest extends TestCase
 {
-    private PriceKeyResolver $priceKeyResolver;
-    private ConfigHelper|MockObject $configHelper;
-    private StoreManagerInterface|MockObject $storeManager;
-    private HttpContext|MockObject $httpContext;
-
-    protected function setUp(): void
-    {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $this->storeManager = $this->createMock(StoreManagerInterface::class);
-        $this->httpContext = $this->createMock(HttpContext::class);
-
-        $this->priceKeyResolver = new PriceKeyResolver(
-            $this->configHelper,
-            $this->storeManager,
-            $this->httpContext
+    protected function createObjectToTest(
+        ?ConfigHelper $configHelper = null,
+        ?StoreManagerInterface $storeManager = null,
+        ?HttpContext $httpContext = null,
+    ): PriceKeyResolver {
+        return new PriceKeyResolver(
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $storeManager ?? $this->createStub(StoreManagerInterface::class),
+            $httpContext ?? $this->createStub(HttpContext::class),
         );
     }
 
@@ -45,30 +35,30 @@ class PriceKeyResolverTest extends TestCase
         string $expectedPriceKey
     ): void {
         $storeMock = $this->createMock(Store::class);
+        $storeMock->expects($this->once())->method('getCurrentCurrencyCode')->willReturn($currencyCode);
 
-        $this->configHelper
-            ->expects($this->once())
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->once())
             ->method('isCustomerGroupsEnabled')
             ->with($storeId)
             ->willReturn($isCustomerGroupsEnabled);
 
-        $this->httpContext
+        // getGroupId() only calls the http context when customer groups are enabled.
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->expects($isCustomerGroupsEnabled ? $this->once() : $this->never())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->storeManager
-            ->expects($this->once())
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->expects($this->once())
             ->method('getStore')
             ->with($storeId)
             ->willReturn($storeMock);
 
-        $storeMock
-            ->expects($this->once())
-            ->method('getCurrentCurrencyCode')
-            ->willReturn($currencyCode);
+        $priceKeyResolver = $this->createObjectToTest($configHelper, $storeManager, $httpContext);
 
-        $result = $this->priceKeyResolver->getPriceKey($storeId);
+        $result = $priceKeyResolver->getPriceKey($storeId);
 
         $this->assertEquals($expectedPriceKey, $result);
     }
@@ -156,34 +146,32 @@ class PriceKeyResolverTest extends TestCase
         $currencyCode = 'USD';
 
         $storeMock = $this->createMock(Store::class);
+        // Store and currency are only fetched once due to caching
+        $storeMock->expects($this->once())->method('getCurrentCurrencyCode')->willReturn($currencyCode);
 
         // getGroupId() is called twice (once per getPriceKey call) to determine the cache key
-        $this->configHelper
-            ->expects($this->exactly(2))
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->exactly(2))
             ->method('isCustomerGroupsEnabled')
             ->with($storeId)
             ->willReturn(true);
 
-        $this->httpContext
-            ->expects($this->exactly(2))
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->expects($this->exactly(2))
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        // Store and currency are only fetched once due to caching
-        $this->storeManager
-            ->expects($this->once())
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->expects($this->once())
             ->method('getStore')
             ->with($storeId)
             ->willReturn($storeMock);
 
-        $storeMock
-            ->expects($this->once())
-            ->method('getCurrentCurrencyCode')
-            ->willReturn($currencyCode);
+        $priceKeyResolver = $this->createObjectToTest($configHelper, $storeManager, $httpContext);
 
-        $result1 = $this->priceKeyResolver->getPriceKey($storeId);
-        $result2 = $this->priceKeyResolver->getPriceKey($storeId);
+        $result1 = $priceKeyResolver->getPriceKey($storeId);
+        $result2 = $priceKeyResolver->getPriceKey($storeId);
 
         $this->assertEquals('.USD.group_2', $result1);
         $this->assertEquals('.USD.group_2', $result2);
@@ -197,37 +185,32 @@ class PriceKeyResolverTest extends TestCase
         $customerGroupId = 1;
 
         $storeMock1 = $this->createMock(Store::class);
+        $storeMock1->expects($this->once())->method('getCurrentCurrencyCode')->willReturn('USD');
 
         $storeMock2 = $this->createMock(Store::class);
+        $storeMock2->expects($this->once())->method('getCurrentCurrencyCode')->willReturn('EUR');
 
-        $this->configHelper
-            ->method('isCustomerGroupsEnabled')
-            ->willReturn(true);
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->exactly(2))->method('isCustomerGroupsEnabled')->willReturn(true);
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->expects($this->exactly(2))
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->storeManager
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->expects($this->exactly(2))
             ->method('getStore')
             ->willReturnMap([
                 [$storeId1, $storeMock1],
                 [$storeId2, $storeMock2],
             ]);
 
-        $storeMock1
-            ->expects($this->once())
-            ->method('getCurrentCurrencyCode')
-            ->willReturn('USD');
+        $priceKeyResolver = $this->createObjectToTest($configHelper, $storeManager, $httpContext);
 
-        $storeMock2
-            ->expects($this->once())
-            ->method('getCurrentCurrencyCode')
-            ->willReturn('EUR');
-
-        $result1 = $this->priceKeyResolver->getPriceKey($storeId1);
-        $result2 = $this->priceKeyResolver->getPriceKey($storeId2);
+        $result1 = $priceKeyResolver->getPriceKey($storeId1);
+        $result2 = $priceKeyResolver->getPriceKey($storeId2);
 
         $this->assertEquals('.USD.group_1', $result1);
         $this->assertEquals('.EUR.group_1', $result2);
@@ -242,37 +225,33 @@ class PriceKeyResolverTest extends TestCase
         $currencyCode = 'USD';
 
         $storeMock1 = $this->createMock(Store::class);
+        $storeMock1->expects($this->once())->method('getCurrentCurrencyCode')->willReturn($currencyCode);
 
         $storeMock2 = $this->createMock(Store::class);
+        $storeMock2->expects($this->once())->method('getCurrentCurrencyCode')->willReturn($currencyCode);
 
-        $this->configHelper
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->exactly(2))
             ->method('isCustomerGroupsEnabled')
             ->with($storeId)
             ->willReturn(true);
 
-        $this->httpContext
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->expects($this->exactly(2))
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturnOnConsecutiveCalls($customerGroupId1, $customerGroupId2);
 
-        $this->storeManager
-            ->expects($this->exactly(2))
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->expects($this->exactly(2))
             ->method('getStore')
             ->with($storeId)
             ->willReturnOnConsecutiveCalls($storeMock1, $storeMock2);
 
-        $storeMock1
-            ->expects($this->once())
-            ->method('getCurrentCurrencyCode')
-            ->willReturn($currencyCode);
+        $priceKeyResolver = $this->createObjectToTest($configHelper, $storeManager, $httpContext);
 
-        $storeMock2
-            ->expects($this->once())
-            ->method('getCurrentCurrencyCode')
-            ->willReturn($currencyCode);
-
-        $result1 = $this->priceKeyResolver->getPriceKey($storeId);
-        $result2 = $this->priceKeyResolver->getPriceKey($storeId);
+        $result1 = $priceKeyResolver->getPriceKey($storeId);
+        $result2 = $priceKeyResolver->getPriceKey($storeId);
 
         $this->assertEquals('.USD.group_1', $result1);
         $this->assertEquals('.USD.group_2', $result2);
@@ -284,44 +263,49 @@ class PriceKeyResolverTest extends TestCase
         $storeId = 999;
         $customerGroupId = 1;
 
-        $this->configHelper
-            ->expects($this->once())
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->once())
             ->method('isCustomerGroupsEnabled')
             ->with($storeId)
             ->willReturn(true);
 
-        $this->httpContext
+        // getGroupId() runs (and calls the http context) before getStore() is reached and throws.
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $this->storeManager
-            ->expects($this->once())
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->expects($this->once())
             ->method('getStore')
             ->with($storeId)
             ->willThrowException(new NoSuchEntityException(__('Store not found')));
 
+        $priceKeyResolver = $this->createObjectToTest($configHelper, $storeManager, $httpContext);
+
         $this->expectException(NoSuchEntityException::class);
         $this->expectExceptionMessage('Store not found');
 
-        $this->priceKeyResolver->getPriceKey($storeId);
+        $priceKeyResolver->getPriceKey($storeId);
     }
 
     public function testGetGroupIdReturnsDefaultWhenCustomerGroupsDisabled(): void
     {
         $storeId = 1;
 
-        $this->configHelper
-            ->expects($this->once())
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->once())
             ->method('isCustomerGroupsEnabled')
             ->with($storeId)
             ->willReturn(false);
 
-        $this->httpContext
-            ->expects($this->never())
-            ->method('getValue');
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->expects($this->never())->method('getValue');
 
-        $result = $this->invokeMethod($this->priceKeyResolver, 'getGroupId', [$storeId]);
+        $priceKeyResolver = $this->createObjectToTest($configHelper, httpContext: $httpContext);
+
+        $result = $this->invokeMethod($priceKeyResolver, 'getGroupId', [$storeId]);
 
         $this->assertEquals('default', $result);
     }
@@ -331,19 +315,21 @@ class PriceKeyResolverTest extends TestCase
         $storeId = 1;
         $customerGroupId = 5;
 
-        $this->configHelper
-            ->expects($this->once())
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->once())
             ->method('isCustomerGroupsEnabled')
             ->with($storeId)
             ->willReturn(true);
 
-        $this->httpContext
-            ->expects($this->once())
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $result = $this->invokeMethod($this->priceKeyResolver, 'getGroupId', [$storeId]);
+        $priceKeyResolver = $this->createObjectToTest($configHelper, httpContext: $httpContext);
+
+        $result = $this->invokeMethod($priceKeyResolver, 'getGroupId', [$storeId]);
 
         $this->assertEquals('group_5', $result);
     }
@@ -353,19 +339,21 @@ class PriceKeyResolverTest extends TestCase
         $storeId = 1;
         $customerGroupId = '3';
 
-        $this->configHelper
-            ->expects($this->once())
+        $configHelper = $this->createMock(ConfigHelper::class);
+        $configHelper->expects($this->once())
             ->method('isCustomerGroupsEnabled')
             ->with($storeId)
             ->willReturn(true);
 
-        $this->httpContext
-            ->expects($this->once())
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->expects($this->once())
             ->method('getValue')
             ->with(CustomerContext::CONTEXT_GROUP)
             ->willReturn($customerGroupId);
 
-        $result = $this->invokeMethod($this->priceKeyResolver, 'getGroupId', [$storeId]);
+        $priceKeyResolver = $this->createObjectToTest($configHelper, httpContext: $httpContext);
+
+        $result = $this->invokeMethod($priceKeyResolver, 'getGroupId', [$storeId]);
 
         $this->assertEquals('group_3', $result);
     }

--- a/Test/Unit/Service/RenderingManagerTest.php
+++ b/Test/Unit/Service/RenderingManagerTest.php
@@ -11,40 +11,31 @@ use Magento\Framework\View\Layout;
 use Magento\Framework\View\Layout\ProcessorInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class RenderingManagerTest extends TestCase
 {
-    protected ?AutocompleteHelper $autocompleteConfigHelper;
-    protected ?InstantSearchHelper $instantSearchConfigHelper;
-    protected ?CurrentCategory $category;
-
-    protected ?RenderingManager $renderingManager;
-
-    public function setUp(): void
-    {
-        $this->autocompleteConfigHelper = $this->createMock(AutocompleteHelper::class);
-        $this->instantSearchConfigHelper = $this->createMock(InstantSearchHelper::class);
-        $this->category = $this->createMock(CurrentCategory::class);
-
-        $this->renderingManager = new RenderingManager(
-            $this->autocompleteConfigHelper,
-            $this->instantSearchConfigHelper,
-            $this->category
+    protected function createObjectToTest(
+        ?AutocompleteHelper $autocompleteConfigHelper = null,
+        ?InstantSearchHelper $instantSearchConfigHelper = null,
+        ?CurrentCategory $category = null,
+    ): RenderingManager {
+        return new RenderingManager(
+            $autocompleteConfigHelper ?? $this->createStub(AutocompleteHelper::class),
+            $instantSearchConfigHelper ?? $this->createStub(InstantSearchHelper::class),
+            $category ?? $this->createStub(CurrentCategory::class),
         );
     }
 
     #[DataProvider('backendValuesProvider')]
     public function testBackendRendering($actionName, $isLayoutUpdated): void
     {
-        $this->autocompleteConfigHelper->method('isEnabled')->willReturn(true);
-        $this->instantSearchConfigHelper->method('isEnabled')->willReturn(true);
+        $autocompleteConfigHelper = $this->createStub(AutocompleteHelper::class);
+        $autocompleteConfigHelper->method('isEnabled')->willReturn(true);
 
-        $layout = $this->createMock(Layout::class);
+        $instantSearchConfigHelper = $this->createStub(InstantSearchHelper::class);
+        $instantSearchConfigHelper->method('isEnabled')->willReturn(true);
+
         $update = $this->createMock(ProcessorInterface::class);
-        $layout->method('getUpdate')->willReturn($update);
-
         if ($isLayoutUpdated) {
             $update->expects($this->once())
                 ->method('addHandle')
@@ -54,7 +45,12 @@ class RenderingManagerTest extends TestCase
                 ->method('addHandle');
         }
 
-        $this->renderingManager->handleBackendRendering($layout, $actionName, 0);
+        $layout = $this->createStub(Layout::class);
+        $layout->method('getUpdate')->willReturn($update);
+
+        $renderingManager = $this->createObjectToTest($autocompleteConfigHelper, $instantSearchConfigHelper);
+
+        $renderingManager->handleBackendRendering($layout, $actionName, 0);
     }
 
     #[DataProvider('shouldPreventBackendRenderingProvider')]
@@ -66,15 +62,20 @@ class RenderingManagerTest extends TestCase
         ?string $categoryDisplayMode,
         bool $expectedResult
     ): void {
-        $this->instantSearchConfigHelper->method('isEnabled')->willReturn($isInstantSearchEnabled);
-        $this->instantSearchConfigHelper->method('shouldReplaceCategories')->willReturn($shouldReplaceCategories);
+        $instantSearchConfigHelper = $this->createStub(InstantSearchHelper::class);
+        $instantSearchConfigHelper->method('isEnabled')->willReturn($isInstantSearchEnabled);
+        $instantSearchConfigHelper->method('shouldReplaceCategories')->willReturn($shouldReplaceCategories);
 
-        $currentCategory = $this->createMock(Category::class);
-        $this->category->method('get')->willReturn($currentCategory);
+        $currentCategory = $this->createStub(Category::class);
         $currentCategory->method('getId')->willReturn($categoryId);
         $currentCategory->method('getDisplayMode')->willReturn($categoryDisplayMode);
 
-        $this->assertSame($expectedResult, $this->renderingManager->shouldPreventBackendRendering($actionName, 0));
+        $category = $this->createStub(CurrentCategory::class);
+        $category->method('get')->willReturn($currentCategory);
+
+        $renderingManager = $this->createObjectToTest(instantSearchConfigHelper: $instantSearchConfigHelper, category: $category);
+
+        $this->assertSame($expectedResult, $renderingManager->shouldPreventBackendRendering($actionName, 0));
     }
 
     public static function shouldPreventBackendRenderingProvider(): array

--- a/Test/Unit/Service/ReplicaManagerTest.php
+++ b/Test/Unit/Service/ReplicaManagerTest.php
@@ -16,40 +16,23 @@ use Algolia\AlgoliaSearch\Test\TestCase;
 use Algolia\AlgoliaSearch\Validator\VirtualReplicaValidatorFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use ReflectionException;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class ReplicaManagerTest extends TestCase
 {
-    protected ?ConfigHelper $configHelper;
-    protected ?ReplicaManager $replicaManager;
-
-    public function setUp(): void
+    protected function createObjectToTest(?ConfigHelper $configHelper = null): ReplicaManager
     {
-        $this->configHelper = $this->createMock(ConfigHelper::class);
-        $instantSearchHelper = $this->createMock(InstantSearchHelper::class);
-        $algoliaConnector = $this->createMock(AlgoliaConnector::class);
-        $indexOptionsBuilder = $this->createMock(IndexOptionsBuilder::class);
-        $replicaState = $this->createMock(ReplicaState::class);
-        $virtualReplicaValidatorFactory = $this->createMock(VirtualReplicaValidatorFactory::class);
-        $indexNameFetcher = $this->createMock(IndexNameFetcher::class);
-        $storeNameFetcher = $this->createMock(StoreNameFetcher::class);
-        $sortingTransformer = $this->createMock(SortingTransformer::class);
-        $storeManager = $this->createMock(StoreManagerInterface::class);
-        $logger = $this->createMock(DiagnosticsLogger::class);
-
-        $this->replicaManager = new ReplicaManager(
-            $this->configHelper,
-            $instantSearchHelper,
-            $algoliaConnector,
-            $indexOptionsBuilder,
-            $replicaState,
-            $virtualReplicaValidatorFactory,
-            $indexNameFetcher,
-            $storeNameFetcher,
-            $sortingTransformer,
-            $storeManager,
-            $logger
+        return new ReplicaManager(
+            $configHelper ?? $this->createStub(ConfigHelper::class),
+            $this->createStub(InstantSearchHelper::class),
+            $this->createStub(AlgoliaConnector::class),
+            $this->createStub(IndexOptionsBuilder::class),
+            $this->createStub(ReplicaState::class),
+            $this->createStub(VirtualReplicaValidatorFactory::class),
+            $this->createStub(IndexNameFetcher::class),
+            $this->createStub(StoreNameFetcher::class),
+            $this->createStub(SortingTransformer::class),
+            $this->createStub(StoreManagerInterface::class),
+            $this->createStub(DiagnosticsLogger::class),
         );
     }
 
@@ -66,7 +49,7 @@ class ReplicaManagerTest extends TestCase
         $replicaToRemove = 'replica2';
 
         $newReplicas = $this->invokeMethod(
-            $this->replicaManager,
+            $this->createObjectToTest(),
             'removeReplicaFromReplicaSetting',
             [$replicaSetting, $replicaToRemove]
         );
@@ -89,7 +72,7 @@ class ReplicaManagerTest extends TestCase
         $replicaToRemove = 'replica2';
 
         $newReplicas = $this->invokeMethod(
-            $this->replicaManager,
+            $this->createObjectToTest(),
             'removeReplicaFromReplicaSetting',
             [$replicaSetting, $replicaToRemove]
         );
@@ -101,9 +84,13 @@ class ReplicaManagerTest extends TestCase
 
     public function testMaxReplicasLimit(): void
     {
-        $this->assertEquals(20, $this->replicaManager->getMaxVirtualReplicasPerIndex());
+        $replicaManager = $this->createObjectToTest();
+        $this->assertEquals(20, $replicaManager->getMaxVirtualReplicasPerIndex());
 
-        $this->configHelper->method('getMaxReplicasLimit')->willReturn(10);
-        $this->assertEquals(10, $this->replicaManager->getMaxVirtualReplicasPerIndex());
+        $configHelper = $this->createStub(ConfigHelper::class);
+        $configHelper->method('getMaxReplicasLimit')->willReturn(10);
+
+        $replicaManager = $this->createObjectToTest($configHelper);
+        $this->assertEquals(10, $replicaManager->getMaxVirtualReplicasPerIndex());
     }
 }

--- a/Test/Unit/Service/SearchClientProviderTest.php
+++ b/Test/Unit/Service/SearchClientProviderTest.php
@@ -7,66 +7,71 @@ use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Service\AlgoliaCredentialsManager;
 use Algolia\AlgoliaSearch\Service\SearchClientProvider;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class SearchClientProviderTest extends TestCase
 {
-    private null|(ConfigHelper&MockObject) $config = null;
-    private null|(AlgoliaCredentialsManager&MockObject) $credentialsManager = null;
-    private ?SearchClientProvider $provider = null;
+    protected function createObjectToTest(
+        ?ConfigHelper $config = null,
+        ?AlgoliaCredentialsManager $credentialsManager = null,
+    ): SearchClientProvider {
+        $config ??= $this->createStub(ConfigHelper::class);
+        $config->method('getExtensionVersion')->willReturn('3.19.0');
+        $config->method('getMagentoVersion')->willReturn('2.4.8');
+        $config->method('getMagentoEdition')->willReturn('Community');
 
-    protected function setUp(): void
-    {
-        $this->config = $this->createMock(ConfigHelper::class);
-        $this->config->method('getExtensionVersion')->willReturn('3.19.0');
-        $this->config->method('getMagentoVersion')->willReturn('2.4.8');
-        $this->config->method('getMagentoEdition')->willReturn('Community');
-
-        $this->credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
-
-        $this->provider = new SearchClientProvider(
-            $this->config,
-            $this->credentialsManager
+        return new SearchClientProvider(
+            $config,
+            $credentialsManager ?? $this->createStub(AlgoliaCredentialsManager::class),
         );
     }
 
     public function testGetClientThrowsWhenCredentialsInvalid(): void
     {
-        $this->credentialsManager->method('checkCredentials')->willReturn(false);
+        $credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $credentialsManager->expects($this->once())->method('checkCredentials')->willReturn(false);
+
+        $provider = $this->createObjectToTest(credentialsManager: $credentialsManager);
 
         $this->expectException(AlgoliaException::class);
         $this->expectExceptionMessage('Algolia credentials were not provided');
 
-        $this->provider->getClient(1);
+        $provider->getClient(1);
     }
 
     public function testGetClientWithNullStoreIdDefaultsToZero(): void
     {
-        $this->credentialsManager->method('checkCredentials')
+        $credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $credentialsManager->expects($this->once())
+            ->method('checkCredentials')
             ->with(0)
             ->willReturn(false);
 
+        $provider = $this->createObjectToTest(credentialsManager: $credentialsManager);
+
         $this->expectException(AlgoliaException::class);
 
-        $this->provider->getClient(null);
+        $provider->getClient(null);
     }
 
     public function testGetClientCachesPerStore(): void
     {
-        $this->credentialsManager->expects($this->once())
+        $credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $credentialsManager->expects($this->once())
             ->method('checkCredentials')
             ->with(1)
             ->willReturn(true);
-        $this->config->method('getApplicationID')->willReturn('test-app-id');
-        $this->config->method('getAPIKey')->willReturn('test-api-key');
-        $this->config->method('getConnectionTimeout')->willReturn(5);
-        $this->config->method('getReadTimeout')->willReturn(10);
-        $this->config->method('getWriteTimeout')->willReturn(30);
 
-        $client1 = $this->provider->getClient(1);
-        $client1Again = $this->provider->getClient(1);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('getApplicationID')->willReturn('test-app-id');
+        $config->method('getAPIKey')->willReturn('test-api-key');
+        $config->method('getConnectionTimeout')->willReturn(5);
+        $config->method('getReadTimeout')->willReturn(10);
+        $config->method('getWriteTimeout')->willReturn(30);
+
+        $provider = $this->createObjectToTest($config, $credentialsManager);
+
+        $client1 = $provider->getClient(1);
+        $client1Again = $provider->getClient(1);
 
         $this->assertSame($client1, $client1Again);
     }
@@ -74,21 +79,26 @@ class SearchClientProviderTest extends TestCase
     public function testGetClientReturnsDifferentClientsPerStore(): void
     {
         $storeIds = [];
-        $this->credentialsManager->expects($this->exactly(2))
+        $credentialsManager = $this->createMock(AlgoliaCredentialsManager::class);
+        $credentialsManager->expects($this->exactly(2))
             ->method('checkCredentials')
             ->with($this->callback(function (int $storeId) use (&$storeIds) {
                 $storeIds[] = $storeId;
                 return true;
             }))
             ->willReturn(true);
-        $this->config->method('getApplicationID')->willReturn('test-app-id');
-        $this->config->method('getAPIKey')->willReturn('test-api-key');
-        $this->config->method('getConnectionTimeout')->willReturn(5);
-        $this->config->method('getReadTimeout')->willReturn(10);
-        $this->config->method('getWriteTimeout')->willReturn(30);
 
-        $client1 = $this->provider->getClient(1);
-        $client2 = $this->provider->getClient(2);
+        $config = $this->createStub(ConfigHelper::class);
+        $config->method('getApplicationID')->willReturn('test-app-id');
+        $config->method('getAPIKey')->willReturn('test-api-key');
+        $config->method('getConnectionTimeout')->willReturn(5);
+        $config->method('getReadTimeout')->willReturn(10);
+        $config->method('getWriteTimeout')->willReturn(30);
+
+        $provider = $this->createObjectToTest($config, $credentialsManager);
+
+        $client1 = $provider->getClient(1);
+        $client2 = $provider->getClient(2);
 
         $this->assertNotSame($client1, $client2);
         $this->assertEquals([1, 2], $storeIds);

--- a/Test/Unit/Service/SendStrategyResolverTest.php
+++ b/Test/Unit/Service/SendStrategyResolverTest.php
@@ -32,8 +32,8 @@ class SendStrategyResolverTest extends TestCase
 
     public function testResolveReturnsFirstApplicableStrategy(): void
     {
-        $applicable = $this->createStub(SendStrategyInterface::class);
-        $applicable->method('isApplicable')->willReturn(true);
+        $applicable = $this->createMock(SendStrategyInterface::class);
+        $applicable->method('isApplicable')->with(self::STORE_ID)->willReturn(true);
 
         $resolver = new SendStrategyResolver($this->createStub(SendStrategyInterface::class), [$applicable]);
 

--- a/Test/Unit/Service/SendStrategyResolverTest.php
+++ b/Test/Unit/Service/SendStrategyResolverTest.php
@@ -5,70 +5,63 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Service;
 use Algolia\AlgoliaSearch\Api\SendStrategyInterface;
 use Algolia\AlgoliaSearch\Service\SendStrategyResolver;
 use Algolia\AlgoliaSearch\Test\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class SendStrategyResolverTest extends TestCase
 {
     private const STORE_ID = 1;
 
-    private null|(SendStrategyInterface&MockObject) $defaultStrategy = null;
-
-    protected function setUp(): void
-    {
-        $this->defaultStrategy = $this->createMock(SendStrategyInterface::class);
-    }
-
     public function testResolveReturnsDefaultStrategyWhenNoStrategiesConfigured(): void
     {
-        $resolver = new SendStrategyResolver($this->defaultStrategy);
+        $defaultStrategy = $this->createStub(SendStrategyInterface::class);
+        $resolver = new SendStrategyResolver($defaultStrategy);
 
-        $this->assertSame($this->defaultStrategy, $resolver->resolve(self::STORE_ID));
+        $this->assertSame($defaultStrategy, $resolver->resolve(self::STORE_ID));
     }
 
     public function testResolveReturnsDefaultStrategyWhenNoStrategyIsApplicable(): void
     {
-        $inapplicable = $this->createMock(SendStrategyInterface::class);
+        $defaultStrategy = $this->createStub(SendStrategyInterface::class);
+
+        $inapplicable = $this->createStub(SendStrategyInterface::class);
         $inapplicable->method('isApplicable')->willReturn(false);
 
-        $resolver = new SendStrategyResolver($this->defaultStrategy, [$inapplicable]);
+        $resolver = new SendStrategyResolver($defaultStrategy, [$inapplicable]);
 
-        $this->assertSame($this->defaultStrategy, $resolver->resolve(self::STORE_ID));
+        $this->assertSame($defaultStrategy, $resolver->resolve(self::STORE_ID));
     }
 
     public function testResolveReturnsFirstApplicableStrategy(): void
     {
-        $applicable = $this->createMock(SendStrategyInterface::class);
-        $applicable->method('isApplicable')->with(self::STORE_ID)->willReturn(true);
+        $applicable = $this->createStub(SendStrategyInterface::class);
+        $applicable->method('isApplicable')->willReturn(true);
 
-        $resolver = new SendStrategyResolver($this->defaultStrategy, [$applicable]);
+        $resolver = new SendStrategyResolver($this->createStub(SendStrategyInterface::class), [$applicable]);
 
         $this->assertSame($applicable, $resolver->resolve(self::STORE_ID));
     }
 
     public function testResolveReturnsFirstApplicableWhenMultipleMatch(): void
     {
-        $first = $this->createMock(SendStrategyInterface::class);
+        $first = $this->createStub(SendStrategyInterface::class);
         $first->method('isApplicable')->willReturn(true);
 
-        $second = $this->createMock(SendStrategyInterface::class);
+        $second = $this->createStub(SendStrategyInterface::class);
         $second->method('isApplicable')->willReturn(true);
 
-        $resolver = new SendStrategyResolver($this->defaultStrategy, [$first, $second]);
+        $resolver = new SendStrategyResolver($this->createStub(SendStrategyInterface::class), [$first, $second]);
 
         $this->assertSame($first, $resolver->resolve(self::STORE_ID));
     }
 
     public function testResolveSkipsInapplicableAndReturnsFirstApplicable(): void
     {
-        $inapplicable = $this->createMock(SendStrategyInterface::class);
+        $inapplicable = $this->createStub(SendStrategyInterface::class);
         $inapplicable->method('isApplicable')->willReturn(false);
 
-        $applicable = $this->createMock(SendStrategyInterface::class);
+        $applicable = $this->createStub(SendStrategyInterface::class);
         $applicable->method('isApplicable')->willReturn(true);
 
-        $resolver = new SendStrategyResolver($this->defaultStrategy, [$inapplicable, $applicable]);
+        $resolver = new SendStrategyResolver($this->createStub(SendStrategyInterface::class), [$inapplicable, $applicable]);
 
         $this->assertSame($applicable, $resolver->resolve(self::STORE_ID));
     }
@@ -83,29 +76,32 @@ class SendStrategyResolverTest extends TestCase
             ->with($storeId)
             ->willReturn(false);
 
-        $resolver = new SendStrategyResolver($this->defaultStrategy, [$strategy]);
+        $resolver = new SendStrategyResolver($this->createStub(SendStrategyInterface::class), [$strategy]);
         $resolver->resolve($storeId);
     }
 
     public function testResolveDoesNotCallIsApplicableOnDefaultStrategy(): void
     {
-        $this->defaultStrategy->expects($this->never())->method('isApplicable');
+        $defaultStrategy = $this->createMock(SendStrategyInterface::class);
+        $defaultStrategy->expects($this->never())->method('isApplicable');
 
-        $resolver = new SendStrategyResolver($this->defaultStrategy);
+        $resolver = new SendStrategyResolver($defaultStrategy);
         $resolver->resolve(self::STORE_ID);
     }
 
     public function testResolveIsPerStoreForTheSameStrategy(): void
     {
-        $storeSpecific = $this->createMock(SendStrategyInterface::class);
+        $defaultStrategy = $this->createStub(SendStrategyInterface::class);
+
+        $storeSpecific = $this->createStub(SendStrategyInterface::class);
         $storeSpecific->method('isApplicable')->willReturnMap([
             [self::STORE_ID, true],
             [self::STORE_ID + 1, false],
         ]);
 
-        $resolver = new SendStrategyResolver($this->defaultStrategy, [$storeSpecific]);
+        $resolver = new SendStrategyResolver($defaultStrategy, [$storeSpecific]);
 
         $this->assertSame($storeSpecific, $resolver->resolve(self::STORE_ID));
-        $this->assertSame($this->defaultStrategy, $resolver->resolve(self::STORE_ID + 1));
+        $this->assertSame($defaultStrategy, $resolver->resolve(self::STORE_ID + 1));
     }
 }

--- a/Test/Unit/Service/SerializerTest.php
+++ b/Test/Unit/Service/SerializerTest.php
@@ -5,86 +5,93 @@ namespace Algolia\AlgoliaSearch\Test\Unit\Service;
 use Algolia\AlgoliaSearch\Service\Serializer;
 use Magento\Framework\Serialize\SerializerInterface;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
-#[AllowMockObjectsWithoutExpectations]
 class SerializerTest extends TestCase
 {
-    private ?SerializerInterface $serializerMock = null;
-    protected ?Serializer $serializer = null;
-
-    protected function setUp(): void
+    protected function createObjectToTest(?SerializerInterface $serializerMock = null): Serializer
     {
-        $this->serializerMock = $this->createMock(SerializerInterface::class);
-
-        $this->serializer = new Serializer($this->serializerMock);
+        return new Serializer($serializerMock ?? $this->createStub(SerializerInterface::class));
     }
 
-    /**
-     * Add data provider?
-     */
     public function testSerializeReturnsString(): void
     {
         $unserialized = ['foo' => 'bar'];
-        $this->serializerMock
-            ->expects($this->once())
+
+        $serializerMock = $this->createMock(SerializerInterface::class);
+        $serializerMock->expects($this->once())
             ->method('serialize')
             ->with($unserialized)
             ->willReturn('{"foo":"bar"}');
-        $result = $this->serializer->serialize($unserialized);
+
+        $serializer = $this->createObjectToTest($serializerMock);
+
+        $result = $serializer->serialize($unserialized);
         $this->assertEquals('{"foo":"bar"}', $result);
     }
 
     public function testSerializeFailure(): void
     {
         $unserialized = [];
-        $this->serializerMock
-            ->expects($this->once())
+
+        $serializerMock = $this->createMock(SerializerInterface::class);
+        $serializerMock->expects($this->once())
             ->method('serialize')
             ->with($unserialized)
             ->willReturn(false);
-        $result = $this->serializer->serialize($unserialized);
+
+        $serializer = $this->createObjectToTest($serializerMock);
+
+        $result = $serializer->serialize($unserialized);
         $this->assertEquals('', $result);
     }
 
     public function testUnserializeReturnsFalseOnEmptyValues(): void
     {
-        $this->assertFalse($this->serializer->unserialize(null));
-        $this->assertFalse($this->serializer->unserialize(false));
-        $this->assertFalse($this->serializer->unserialize(''));
+        $serializer = $this->createObjectToTest();
+
+        $this->assertFalse($serializer->unserialize(null));
+        $this->assertFalse($serializer->unserialize(false));
+        $this->assertFalse($serializer->unserialize(''));
     }
 
     public function testUnserializeHandlesValidJson(): void
     {
         $json = '{"key":"value"}';
-        $this->assertEquals(['key' => 'value'], $this->serializer->unserialize($json));
+
+        $serializer = $this->createObjectToTest();
+
+        $this->assertEquals(['key' => 'value'], $serializer->unserialize($json));
     }
 
     public function testUnserializeFallsBackToSerializer(): void
     {
         $serialized = 'a:1:{s:3:"foo";s:3:"bar";}'; // PHP serialized data
 
-        $this->serializerMock
-            ->expects($this->once())
+        $serializerMock = $this->createMock(SerializerInterface::class);
+        $serializerMock->expects($this->once())
             ->method('unserialize')
             ->with($serialized)
             ->willReturn(['foo' => 'bar']);
 
-        $this->assertEquals(['foo' => 'bar'], $this->serializer->unserialize($serialized));
+        $serializer = $this->createObjectToTest($serializerMock);
+
+        $this->assertEquals(['foo' => 'bar'], $serializer->unserialize($serialized));
     }
 
     public function testUnserializeFailsBothJsonAndSerializer(): void
     {
         $badData = 'not_serialized_at_all';
 
-        $this->serializerMock
-            ->expects($this->once())
+        $serializerMock = $this->createMock(SerializerInterface::class);
+        $serializerMock->expects($this->once())
             ->method('unserialize')
             ->with($badData)
             ->willThrowException(new \InvalidArgumentException());
 
+        $serializer = $this->createObjectToTest($serializerMock);
+
         $this->expectException(\InvalidArgumentException::class);
 
-        $this->serializer->unserialize($badData);
+        $serializer->unserialize($badData);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.19.1-dev",
+  "version": "3.19.1",
   "require": {
     "php": "~8.3|~8.4|~8.5",
     "magento/framework": "~103.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search & Discovery extension for Magento 2",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "3.19.0",
+  "version": "3.19.1-dev",
   "require": {
     "php": "~8.3|~8.4|~8.5",
     "magento/framework": "~103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.19.1-dev">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.19.1">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearch" setup_version="3.19.0">
+    <module name="Algolia_AlgoliaSearch" setup_version="3.19.1-dev">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Backend"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,12 +6,4 @@ parameters:
     excludePaths:
         - dev
     ignoreErrors:
-        - '#Call to static method getObjectManager\(\) on an unknown class Magento\\TestFramework\\Helper\\Bootstrap.#'
-        # Temporary: attribute exists only in PHPUnit 12, which the extension supports but is not yet
-        # the analysis/CI runtime. Remove once the PHPUnit 12 upgrade lands (tracked separately).
-        - '#Attribute class PHPUnit\\Framework\\Attributes\\AllowMockObjectsWithoutExpectations does not exist.#'
-        # Model\Job self-persists via the deprecated save() inside its own execute(). 
-        # This violates SRP as the entity also drives job processing so the fix is to extract a
-        # JobProcessor from the persistence layer rather than inject a resource model into the model.
-        # That refactor is deferred to a future release (see MAGE-1589 notes). Remove this then.
         - '#Use service contracts to persist entities in favour of \$this\(Algolia\\AlgoliaSearch\\Model\\Job\)::save\(\) method#'


### PR DESCRIPTION
## 3.19.1

### Updates
- Updated `IndexSettingsHandler::setSettings`:
    - It now fetches the remote settings once, runs preservation, then threads that same payload into the comparator.
    - It now use multiple `IndexSettingsComparator::matches()` for settings both forwarded and non-forwarded to replicas to ensure no no-op operations are sent to the dashboard.
    - Removed `waitLastTask` occurrences in favor of `collectTaskIdToWaitFor` ones to ensure waiting at the end of the process.
    - Updated unit tests related to those classes.
- Updated all unit and integration tests to be compatible with PHPUnit 12.

### Bug fixes
- Updated `IndexSettingsComparator` to include a protected method `reconcileKeys` to ensure empty attributes such as `customRanking` or `unretrievableAttributes` are handled properly.